### PR TITLE
refactor: unify naming to rdbs (FE + BE)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ cargo build --release -p storix   # release binary
 ## Architecture
 
 - `app/` — Slint UI binary (main entry point)
-- `crates/core/` — `Driver` trait, `Query`, `ResultSet`, `Schema`, `DbmError`
+- `crates/core/` — `Driver` trait, `Query`, `ResultSet`, `Schema`, `RdbsError`
 - `crates/connstore/` — saved connections + OS keychain / AES-GCM
 - `crates/driver-postgres/` — tokio-postgres
 - `crates/driver-mysql/` — mysql_async
@@ -34,7 +34,7 @@ cargo build --release -p storix   # release binary
 
 ## Key Rules
 
-- UI (`app/`) names a concrete driver crate only in `app/src/dispatch.rs` (the `AnyDriver` enum); the rest of the app depends on `dbm-core`.
+- UI (`app/`) names a concrete driver crate only in `app/src/dispatch.rs` (the `AnyDriver` enum); the rest of the app depends on `rdbs-core`.
 - Adding new engine = new `driver-*` crate implementing `Driver` trait + a variant in `AnyDriver`.
 - Async I/O on tokio runtime, results bridge back to Slint main thread via `invoke_from_event_loop`.
 - Release profile: `opt-level=z`, LTO, `panic=abort`, strip.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,11 +7,11 @@ Native cross-platform database manager (PostgreSQL, MySQL, Redis, MongoDB) built
 ## Build, Lint, Test
 
 A root `Makefile` wraps the common cargo invocations and splits FE (the
-`storix` UI binary) from BE (the `crates/*` libraries) so each side builds and
+`rdbs` UI binary) from BE (the `crates/*` libraries) so each side builds and
 tests independently. Run `make help` for the full target list.
 
 ```bash
-make fe-build     # build the storix UI (FE)
+make fe-build     # build the rdbs UI (FE)
 make fe-run       # run the UI
 make be-build     # build backend crates only (no FE)
 make be-test      # test backend crates only
@@ -19,7 +19,7 @@ make fmt-check    # format check   (make fmt to apply)
 make lint         # clippy, warnings as errors
 make test         # test the whole workspace
 make all          # fmt-check + lint + test + build (CI gate)
-cargo build --release -p storix   # release binary
+cargo build --release -p rdbs   # release binary
 ```
 
 ## Architecture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5454,6 +5454,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rdbs"
+version = "0.1.0"
+dependencies = [
+ "rdbs-connstore",
+ "rdbs-core",
+ "rdbs-driver-mongo",
+ "rdbs-driver-mysql",
+ "rdbs-driver-postgres",
+ "rdbs-driver-redis",
+ "serde_json",
+ "slint",
+ "slint-build",
+ "tokio",
+]
+
+[[package]]
 name = "rdbs-connstore"
 version = "0.1.0"
 dependencies = [
@@ -6564,22 +6580,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "storix"
-version = "0.1.0"
-dependencies = [
- "rdbs-connstore",
- "rdbs-core",
- "rdbs-driver-mongo",
- "rdbs-driver-mysql",
- "rdbs-driver-postgres",
- "rdbs-driver-redis",
- "serde_json",
- "slint",
- "slint-build",
- "tokio",
-]
 
 [[package]]
 name = "strict-num"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,86 +1434,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
-name = "dbm-connstore"
-version = "0.1.0"
-dependencies = [
- "aes-gcm",
- "dbm-core",
- "directories",
- "keyring",
- "rand 0.8.6",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror 2.0.18",
- "uuid",
-]
-
-[[package]]
-name = "dbm-core"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
-]
-
-[[package]]
-name = "dbm-driver-mongo"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "dbm-core",
- "futures",
- "mongodb",
- "serde_json",
- "testcontainers",
- "testcontainers-modules",
- "tokio",
-]
-
-[[package]]
-name = "dbm-driver-mysql"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "dbm-core",
- "mysql_async",
- "testcontainers",
- "testcontainers-modules",
- "tokio",
-]
-
-[[package]]
-name = "dbm-driver-postgres"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "dbm-core",
- "native-tls",
- "postgres-native-tls",
- "serde_json",
- "testcontainers",
- "testcontainers-modules",
- "tokio",
- "tokio-postgres",
-]
-
-[[package]]
-name = "dbm-driver-redis"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "dbm-core",
- "redis",
- "testcontainers",
- "testcontainers-modules",
- "tokio",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5534,6 +5454,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "rdbs-connstore"
+version = "0.1.0"
+dependencies = [
+ "aes-gcm",
+ "directories",
+ "keyring",
+ "rand 0.8.6",
+ "rdbs-core",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
+name = "rdbs-core"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "rdbs-driver-mongo"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "futures",
+ "mongodb",
+ "rdbs-core",
+ "serde_json",
+ "testcontainers",
+ "testcontainers-modules",
+ "tokio",
+]
+
+[[package]]
+name = "rdbs-driver-mysql"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "mysql_async",
+ "rdbs-core",
+ "testcontainers",
+ "testcontainers-modules",
+ "tokio",
+]
+
+[[package]]
+name = "rdbs-driver-postgres"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "native-tls",
+ "postgres-native-tls",
+ "rdbs-core",
+ "serde_json",
+ "testcontainers",
+ "testcontainers-modules",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "rdbs-driver-redis"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "rdbs-core",
+ "redis",
+ "testcontainers",
+ "testcontainers-modules",
+ "tokio",
+]
+
+[[package]]
 name = "read-fonts"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6569,12 +6569,12 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "storix"
 version = "0.1.0"
 dependencies = [
- "dbm-connstore",
- "dbm-core",
- "dbm-driver-mongo",
- "dbm-driver-mysql",
- "dbm-driver-postgres",
- "dbm-driver-redis",
+ "rdbs-connstore",
+ "rdbs-core",
+ "rdbs-driver-mongo",
+ "rdbs-driver-mysql",
+ "rdbs-driver-postgres",
+ "rdbs-driver-redis",
  "serde_json",
  "slint",
  "slint-build",

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-# Split FE/BE build entry points. BE = crates/* libs, FE = storix (app/).
+# Split FE/BE build entry points. BE = crates/* libs, FE = rdbs (app/).
 # Run `make` or `make help` for the target list.
 
 BE_PKGS = rdbs-core rdbs-connstore rdbs-driver-postgres rdbs-driver-mysql rdbs-driver-redis rdbs-driver-mongo
-FE_PKG  = storix
+FE_PKG  = rdbs
 BE_FLAGS = $(addprefix -p ,$(BE_PKGS))
 
 .DEFAULT_GOAL := help
@@ -21,10 +21,10 @@ be-test: ## Test backend crate unit tests (no FE, no Docker)
 be-check: ## Type-check backend crates only
 	cargo check $(BE_FLAGS)
 
-fe-build: ## Build the storix UI binary
+fe-build: ## Build the rdbs UI binary
 	cargo build -p $(FE_PKG)
 
-fe-run: ## Run the storix UI binary
+fe-run: ## Run the rdbs UI binary
 	cargo run -p $(FE_PKG)
 
 fmt: ## Format the whole workspace

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Split FE/BE build entry points. BE = crates/* libs, FE = storix (app/).
 # Run `make` or `make help` for the target list.
 
-BE_PKGS = dbm-core dbm-connstore dbm-driver-postgres dbm-driver-mysql dbm-driver-redis dbm-driver-mongo
+BE_PKGS = rdbs-core rdbs-connstore rdbs-driver-postgres rdbs-driver-mysql rdbs-driver-redis rdbs-driver-mongo
 FE_PKG  = storix
 BE_FLAGS = $(addprefix -p ,$(BE_PKGS))
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A native, lightweight, cross-platform database manager built with Rust and Slint
 Cargo workspace (monorepo):
 
 ```
-storix/
+rdbs/
 ├── Cargo.toml                  # workspace root
 ├── app/                        # binary: Slint UI + event handlers
 │   ├── build.rs                # slint-build codegen
@@ -116,10 +116,10 @@ curl -fsSL https://raw.githubusercontent.com/suiflex/rdb/develop/scripts/install
 Optional:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/suiflex/rdb/develop/scripts/install.sh | STORIX_VERSION=v0.1.0 INSTALL_DIR="$HOME/.local/bin" bash
+curl -fsSL https://raw.githubusercontent.com/suiflex/rdb/develop/scripts/install.sh | RDBS_VERSION=v0.1.0 INSTALL_DIR="$HOME/.local/bin" bash
 ```
 
-The script installs `storix` into `/usr/local/bin` when writable, otherwise it falls back to `~/.local/bin`.
+The script installs `rdbs` into `/usr/local/bin` when writable, otherwise it falls back to `~/.local/bin`.
 
 ## Build from source
 
@@ -144,22 +144,22 @@ sudo dnf install libxkbcommon-devel fontconfig-devel mesa-libGL-devel
 
 ```bash
 # Development
-cargo build -p storix
+cargo build -p rdbs
 
 # Optimized release (~smaller binary)
-cargo build --release -p storix
+cargo build --release -p rdbs
 
 # Run directly
-cargo run -p storix
+cargo run -p rdbs
 ```
 
-The release binary lands at `target/release/storix`.
+The release binary lands at `target/release/rdbs`.
 
 ## Usage
 
 ### Add a connection
 
-1. Launch Storix — connection picker opens.
+1. Launch RDBS — connection picker opens.
 2. Click **+** → fill in host, port, credentials, database.
 3. Or paste a DSN URL into the **Import URL** field — fields auto-fill.
 4. Click **Test** to verify, then **Save**.
@@ -187,7 +187,7 @@ Active development. MVP covers 4 engines; planned expansion to ~20 (SQLite, Clic
 
 | Crate | Description |
 |-------|-------------|
-| `storix` | Desktop binary (app/) |
+| `rdbs` | Desktop binary (app/) |
 | `rdbs-core` | `Driver` trait, `Query`, `ResultSet`, `Schema`, `RdbsError` |
 | `rdbs-connstore` | Saved connections — JSON on disk + OS keychain / AES-GCM file |
 | `rdbs-driver-postgres` | PostgreSQL driver via `tokio-postgres` |

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ storix/
 
 ### Core design rule
 
-The UI (`app/`) depends only on `dbm-core`. It never imports a concrete driver crate. Adding a new engine = a new `driver-*` crate that implements the `Driver` trait; the UI is untouched.
+The UI (`app/`) depends only on `rdbs-core`. It never imports a concrete driver crate. Adding a new engine = a new `driver-*` crate that implements the `Driver` trait; the UI is untouched.
 
 ### Async bridge
 
@@ -188,12 +188,12 @@ Active development. MVP covers 4 engines; planned expansion to ~20 (SQLite, Clic
 | Crate | Description |
 |-------|-------------|
 | `storix` | Desktop binary (app/) |
-| `dbm-core` | `Driver` trait, `Query`, `ResultSet`, `Schema`, `DbmError` |
-| `dbm-connstore` | Saved connections — JSON on disk + OS keychain / AES-GCM file |
-| `dbm-driver-postgres` | PostgreSQL driver via `tokio-postgres` |
-| `dbm-driver-mysql` | MySQL/MariaDB driver via `mysql_async` |
-| `dbm-driver-redis` | Redis driver via `redis` crate |
-| `dbm-driver-mongo` | MongoDB driver via `mongodb` crate |
+| `rdbs-core` | `Driver` trait, `Query`, `ResultSet`, `Schema`, `RdbsError` |
+| `rdbs-connstore` | Saved connections — JSON on disk + OS keychain / AES-GCM file |
+| `rdbs-driver-postgres` | PostgreSQL driver via `tokio-postgres` |
+| `rdbs-driver-mysql` | MySQL/MariaDB driver via `mysql_async` |
+| `rdbs-driver-redis` | Redis driver via `redis` crate |
+| `rdbs-driver-mongo` | MongoDB driver via `mongodb` crate |
 
 ## License
 

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "storix"
+name = "rdbs"
 version = "0.1.0"
 edition = "2021"
 
 [[bin]]
-name = "storix"
+name = "rdbs"
 path = "src/main.rs"
 
 [dependencies]

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -9,12 +9,12 @@ path = "src/main.rs"
 
 [dependencies]
 slint = { version = "1.8", default-features = false, features = ["compat-1-2", "std", "backend-winit", "renderer-femtovg"] }
-dbm-core = { path = "../crates/core" }
-dbm-connstore = { path = "../crates/connstore" }
-dbm-driver-postgres = { path = "../crates/driver-postgres" }
-dbm-driver-mysql = { path = "../crates/driver-mysql" }
-dbm-driver-redis = { path = "../crates/driver-redis" }
-dbm-driver-mongo = { path = "../crates/driver-mongo" }
+rdbs-core = { path = "../crates/core" }
+rdbs-connstore = { path = "../crates/connstore" }
+rdbs-driver-postgres = { path = "../crates/driver-postgres" }
+rdbs-driver-mysql = { path = "../crates/driver-mysql" }
+rdbs-driver-redis = { path = "../crates/driver-redis" }
+rdbs-driver-mongo = { path = "../crates/driver-mongo" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 serde_json = "1"
 

--- a/app/src/dispatch.rs
+++ b/app/src/dispatch.rs
@@ -4,17 +4,17 @@
 //! async trait methods. Construction is the ONLY place the app names a concrete
 //! driver crate.
 
-use dbm_connstore::Engine;
-use dbm_core::conn::ConnConfig;
-use dbm_core::driver::Driver;
-use dbm_core::error::Result;
-use dbm_core::query::Query;
-use dbm_core::result::ResultSet;
-use dbm_core::schema::Schema;
-use dbm_driver_mongo::MongoDriver;
-use dbm_driver_mysql::MysqlDriver;
-use dbm_driver_postgres::PostgresDriver;
-use dbm_driver_redis::RedisDriver;
+use rdbs_connstore::Engine;
+use rdbs_core::conn::ConnConfig;
+use rdbs_core::driver::Driver;
+use rdbs_core::error::Result;
+use rdbs_core::query::Query;
+use rdbs_core::result::ResultSet;
+use rdbs_core::schema::Schema;
+use rdbs_driver_mongo::MongoDriver;
+use rdbs_driver_mysql::MysqlDriver;
+use rdbs_driver_postgres::PostgresDriver;
+use rdbs_driver_redis::RedisDriver;
 
 pub enum AnyDriver {
     Postgres(PostgresDriver),
@@ -77,7 +77,7 @@ impl AnyDriver {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dbm_connstore::Engine;
+    use rdbs_connstore::Engine;
 
     #[test]
     fn engine_maps_to_human_label() {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1,4 +1,4 @@
-//! dbm-app: Slint desktop binary.
+//! rdbs-app: Slint desktop binary.
 //!
 //! Async bridge pattern (canonical):
 //!   - A `tokio` multi-thread runtime (`Arc<Runtime>`) lives for the whole
@@ -35,7 +35,7 @@ const UNGROUPED: &str = "Ungrouped";
 /// regardless of grouping or ordering. `collapsed` holds the set of group labels
 /// currently folded shut.
 fn build_conn_items(
-    store: &dbm_connstore::ConnStore,
+    store: &rdbs_connstore::ConnStore,
     collapsed: &HashSet<String>,
     filter: &str,
 ) -> Vec<ConnItem> {
@@ -223,17 +223,17 @@ fn main() -> Result<(), slint::PlatformError> {
     let window = MainWindow::new()?;
 
     // One store for the app lifetime; all CRUD + password ops go through it.
-    let store: Rc<RefCell<dbm_connstore::ConnStore>> = Rc::new(RefCell::new(
-        dbm_connstore::ConnStore::open_default().unwrap_or_else(|_| {
+    let store: Rc<RefCell<rdbs_connstore::ConnStore>> = Rc::new(RefCell::new(
+        rdbs_connstore::ConnStore::open_default().unwrap_or_else(|_| {
             let dir = std::env::temp_dir().join("dbm");
             let _ = std::fs::create_dir_all(&dir);
-            let backend = dbm_connstore::secret::select_backend(&dir).expect("secret backend");
-            dbm_connstore::ConnStore::new(dir.join("connections.json"), backend)
+            let backend = rdbs_connstore::secret::select_backend(&dir).expect("secret backend");
+            rdbs_connstore::ConnStore::new(dir.join("connections.json"), backend)
         }),
     ));
 
     // (engine, driver) so run-query can parse text for the right paradigm.
-    let current: Arc<tokio::sync::Mutex<Option<(dbm_connstore::Engine, AnyDriver)>>> =
+    let current: Arc<tokio::sync::Mutex<Option<(rdbs_connstore::Engine, AnyDriver)>>> =
         Arc::new(tokio::sync::Mutex::new(None));
 
     // Set of group labels the user has collapsed in the sidebar.
@@ -250,7 +250,7 @@ fn main() -> Result<(), slint::PlatformError> {
     let collapsed_categories: Rc<RefCell<HashSet<String>>> = Rc::new(RefCell::new(HashSet::new()));
     // Engine of the live connection, kept on the UI thread so table clicks can
     // build an engine-appropriate "browse this table" query synchronously.
-    let cur_engine: Rc<RefCell<Option<dbm_connstore::Engine>>> = Rc::new(RefCell::new(None));
+    let cur_engine: Rc<RefCell<Option<rdbs_connstore::Engine>>> = Rc::new(RefCell::new(None));
 
     // Reusable sidebar rebuild: buckets the store's list into grouped rows.
     let rebuild_sidebar = {
@@ -426,10 +426,10 @@ fn main() -> Result<(), slint::PlatformError> {
             rt.spawn(async move {
                 let result = async {
                     let cfg =
-                        cfg.map_err(|e| dbm_core::error::DbmError::Connection(e.to_string()))?;
+                        cfg.map_err(|e| rdbs_core::error::RdbsError::Connection(e.to_string()))?;
                     let driver = AnyDriver::connect(engine, &cfg).await?;
                     let schema = driver.schema().await?;
-                    Ok::<_, dbm_core::error::DbmError>((driver, schema))
+                    Ok::<_, rdbs_core::error::RdbsError>((driver, schema))
                 }
                 .await;
 
@@ -519,10 +519,10 @@ fn main() -> Result<(), slint::PlatformError> {
                     Some((engine, driver)) => {
                         match crate::query_parse::parse_query(*engine, &sql) {
                             Ok(q) => driver.query(&q).await,
-                            Err(msg) => Err(dbm_core::error::DbmError::Query(msg)),
+                            Err(msg) => Err(rdbs_core::error::RdbsError::Query(msg)),
                         }
                     }
-                    None => Err(dbm_core::error::DbmError::Connection(
+                    None => Err(rdbs_core::error::RdbsError::Connection(
                         "not connected".into(),
                     )),
                 };
@@ -580,16 +580,16 @@ fn main() -> Result<(), slint::PlatformError> {
             };
             let label = label.to_string();
             let text = match *cur_engine.borrow() {
-                Some(dbm_connstore::Engine::Postgres) => {
+                Some(rdbs_connstore::Engine::Postgres) => {
                     format!("SELECT * FROM \"{label}\" LIMIT 300")
                 }
-                Some(dbm_connstore::Engine::MySql) => {
+                Some(rdbs_connstore::Engine::MySql) => {
                     format!("SELECT * FROM `{label}` LIMIT 300")
                 }
-                Some(dbm_connstore::Engine::Mongo) => {
+                Some(rdbs_connstore::Engine::Mongo) => {
                     format!("{{\"collection\":\"{label}\",\"op\":\"find\",\"body\":{{}}}}")
                 }
-                Some(dbm_connstore::Engine::Redis) => {
+                Some(rdbs_connstore::Engine::Redis) => {
                     w.set_result_status(SharedString::from(
                         "click a key in the SQL panel for Redis",
                     ));
@@ -830,12 +830,12 @@ fn main() -> Result<(), slint::PlatformError> {
             _ => "5432",
         }
     }
-    fn label_to_engine(label: &str) -> dbm_connstore::Engine {
+    fn label_to_engine(label: &str) -> rdbs_connstore::Engine {
         match label {
-            "MySQL" => dbm_connstore::Engine::MySql,
-            "Redis" => dbm_connstore::Engine::Redis,
-            "MongoDB" => dbm_connstore::Engine::Mongo,
-            _ => dbm_connstore::Engine::Postgres,
+            "MySQL" => rdbs_connstore::Engine::MySql,
+            "Redis" => rdbs_connstore::Engine::Redis,
+            "MongoDB" => rdbs_connstore::Engine::Mongo,
+            _ => rdbs_connstore::Engine::Postgres,
         }
     }
     let editing_id: Rc<RefCell<String>> = Rc::new(RefCell::new(String::new()));
@@ -890,9 +890,9 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_f_database(SharedString::from(sc.database.unwrap_or_default()));
             w.set_f_password(SharedString::default());
             w.set_f_sslmode(SharedString::from(match sc.sslmode {
-                dbm_core::conn::SslMode::Disable => "Disable",
-                dbm_core::conn::SslMode::Prefer => "Prefer",
-                dbm_core::conn::SslMode::Require => "Require",
+                rdbs_core::conn::SslMode::Disable => "Disable",
+                rdbs_core::conn::SslMode::Prefer => "Prefer",
+                rdbs_core::conn::SslMode::Require => "Require",
             }));
             w.set_f_color(SharedString::from(
                 sc.color.unwrap_or_else(|| "#3b82f6".into()),
@@ -925,7 +925,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 return;
             };
             let raw = w.get_f_import_url().to_string();
-            match dbm_connstore::parse_conn_url(&raw) {
+            match rdbs_connstore::parse_conn_url(&raw) {
                 Ok(parsed) => {
                     if let Some(engine) = parsed.engine {
                         w.set_f_engine(SharedString::from(AnyDriver::label(engine)));
@@ -951,9 +951,9 @@ fn main() -> Result<(), slint::PlatformError> {
                     }
                     if let Some(sslmode) = parsed.sslmode {
                         w.set_f_sslmode(SharedString::from(match sslmode {
-                            dbm_core::conn::SslMode::Disable => "Disable",
-                            dbm_core::conn::SslMode::Prefer => "Prefer",
-                            dbm_core::conn::SslMode::Require => "Require",
+                            rdbs_core::conn::SslMode::Disable => "Disable",
+                            rdbs_core::conn::SslMode::Prefer => "Prefer",
+                            rdbs_core::conn::SslMode::Require => "Require",
                         }));
                     }
                     w.set_form_error(SharedString::default());
@@ -999,9 +999,9 @@ fn main() -> Result<(), slint::PlatformError> {
             };
             let engine = label_to_engine(w.get_f_engine().as_ref());
             let sslmode = match w.get_f_sslmode().to_string().as_str() {
-                "Disable" => dbm_core::conn::SslMode::Disable,
-                "Require" => dbm_core::conn::SslMode::Require,
-                _ => dbm_core::conn::SslMode::Prefer,
+                "Disable" => rdbs_core::conn::SslMode::Disable,
+                "Require" => rdbs_core::conn::SslMode::Require,
+                _ => rdbs_core::conn::SslMode::Prefer,
             };
             let database = {
                 let d = w.get_f_database().to_string();
@@ -1019,7 +1019,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     Some(p)
                 }
             };
-            let cfg = dbm_core::conn::ConnConfig {
+            let cfg = rdbs_core::conn::ConnConfig {
                 host,
                 port,
                 user: w.get_f_user().to_string(),
@@ -1038,7 +1038,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 let result = async {
                     let driver = AnyDriver::connect(engine, &cfg).await?;
                     driver.ping().await?;
-                    Ok::<_, dbm_core::error::DbmError>(())
+                    Ok::<_, rdbs_core::error::RdbsError>(())
                 }
                 .await;
                 let _ = slint::invoke_from_event_loop(move || {
@@ -1101,9 +1101,9 @@ fn main() -> Result<(), slint::PlatformError> {
             };
             let engine = label_to_engine(w.get_f_engine().as_ref());
             let sslmode = match w.get_f_sslmode().to_string().as_str() {
-                "Disable" => dbm_core::conn::SslMode::Disable,
-                "Require" => dbm_core::conn::SslMode::Require,
-                _ => dbm_core::conn::SslMode::Prefer,
+                "Disable" => rdbs_core::conn::SslMode::Disable,
+                "Require" => rdbs_core::conn::SslMode::Require,
+                _ => rdbs_core::conn::SslMode::Prefer,
             };
             let database = {
                 let d = w.get_f_database().to_string();
@@ -1117,10 +1117,10 @@ fn main() -> Result<(), slint::PlatformError> {
             let password = w.get_f_password().to_string();
             let id = editing_id.borrow().clone();
 
-            let result: dbm_connstore::Result<()> = (|| {
+            let result: rdbs_connstore::Result<()> = (|| {
                 let mut st = store.borrow_mut();
                 let conn_id = if id.is_empty() {
-                    let mut sc = dbm_connstore::SavedConnection::new(
+                    let mut sc = rdbs_connstore::SavedConnection::new(
                         name,
                         engine,
                         host,
@@ -1137,7 +1137,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     let mut sc = st
                         .get(&id)
                         .cloned()
-                        .ok_or_else(|| dbm_connstore::ConnStoreError::NotFound(id.clone()))?;
+                        .ok_or_else(|| rdbs_connstore::ConnStoreError::NotFound(id.clone()))?;
                     sc.name = name;
                     sc.engine = engine;
                     sc.host = host;

--- a/app/src/model.rs
+++ b/app/src/model.rs
@@ -1,9 +1,9 @@
-//! Pure conversion from dbm-core result/schema types into flat view-model
+//! Pure conversion from rdbs-core result/schema types into flat view-model
 //! structs the UI binds to. No Slint imports here so it stays unit-testable;
 //! `main.rs` maps these into the Slint-generated structs.
 
-use dbm_core::result::{Cell, RedisValue, ResultSet};
-use dbm_core::schema::{ContainerKind, Schema};
+use rdbs_core::result::{Cell, RedisValue, ResultSet};
+use rdbs_core::schema::{ContainerKind, Schema};
 
 #[derive(Debug, Default, Clone)]
 pub struct VmCell {
@@ -182,8 +182,8 @@ pub fn to_tree_model(schema: &Schema) -> Vec<VmTreeNode> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dbm_core::result::{Cell, Column, RedisValue, ResultSet};
-    use dbm_core::schema::{Container, ContainerKind, Database, Field, Schema};
+    use rdbs_core::result::{Cell, Column, RedisValue, ResultSet};
+    use rdbs_core::schema::{Container, ContainerKind, Database, Field, Schema};
 
     #[test]
     fn tabular_maps_cols_and_rows_with_null_flag() {

--- a/app/src/query_parse.rs
+++ b/app/src/query_parse.rs
@@ -1,9 +1,9 @@
-//! Pure seam between the editor text box and a typed `dbm_core::Query`.
+//! Pure seam between the editor text box and a typed `rdbs_core::Query`.
 //! The connected `Engine` decides how the text is interpreted, so a single
 //! editor drives all four paradigms.
 
-use dbm_connstore::Engine;
-use dbm_core::query::{MongoKind, MongoOp, Query};
+use rdbs_connstore::Engine;
+use rdbs_core::query::{MongoKind, MongoOp, Query};
 
 /// Turn raw editor text into a typed `Query` for the connected engine.
 /// Returns a human-readable error string on malformed input (shown in the
@@ -67,8 +67,8 @@ fn parse_mongo(text: &str) -> Result<Query, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dbm_connstore::Engine;
-    use dbm_core::query::{MongoKind, Query};
+    use rdbs_connstore::Engine;
+    use rdbs_core::query::{MongoKind, Query};
 
     #[test]
     fn sql_engines_pass_text_through() {

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -16,7 +16,7 @@ import {
 } from "structs.slint";
 
 export component MainWindow inherits Window {
-    title: "Storix";
+    title: "RDBS";
     preferred-width: 1100px;
     preferred-height: 720px;
     min-width: 400px;

--- a/crates/connstore/Cargo.toml
+++ b/crates/connstore/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "dbm-connstore"
+name = "rdbs-connstore"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-dbm-core = { path = "../core" }
+rdbs-core = { path = "../core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 keyring = "3"

--- a/crates/connstore/src/conn_url.rs
+++ b/crates/connstore/src/conn_url.rs
@@ -10,7 +10,7 @@
 //! UI can fall back to its per-engine defaults.
 
 use crate::model::Engine;
-use dbm_core::conn::SslMode;
+use rdbs_core::conn::SslMode;
 use thiserror::Error;
 
 /// Error returned when a connection URL cannot be parsed.

--- a/crates/connstore/src/lib.rs
+++ b/crates/connstore/src/lib.rs
@@ -1,4 +1,4 @@
-//! dbm-connstore: saved connections (JSON, no passwords) + OS keychain secrets
+//! rdbs-connstore: saved connections (JSON, no passwords) + OS keychain secrets
 //! with an encrypted-file fallback for headless Linux.
 
 pub mod conn_url;

--- a/crates/connstore/src/model.rs
+++ b/crates/connstore/src/model.rs
@@ -1,4 +1,4 @@
-use dbm_core::conn::{ConnConfig, SslMode};
+use rdbs_core::conn::{ConnConfig, SslMode};
 use serde::{Deserialize, Serialize};
 
 /// Database engine of a saved connection. The MVP ships four; the variant set
@@ -58,7 +58,7 @@ impl SavedConnection {
         }
     }
 
-    /// Rebuild a `dbm-core::ConnConfig`, injecting the password fetched from the
+    /// Rebuild a `rdbs-core::ConnConfig`, injecting the password fetched from the
     /// secret backend. The password is the only secret that ever lives in memory.
     pub fn to_conn_config(&self, password: Option<String>) -> ConnConfig {
         ConnConfig {

--- a/crates/connstore/src/secret/keyring.rs
+++ b/crates/connstore/src/secret/keyring.rs
@@ -57,12 +57,12 @@ mod tests {
     use crate::secret::SecretBackend;
 
     // Requires a real OS keychain / desktop session. Run locally with:
-    //   cargo test -p dbm-connstore keyring -- --ignored
+    //   cargo test -p rdbs-connstore keyring -- --ignored
     #[test]
     #[ignore]
     fn keyring_roundtrip_on_a_real_desktop_session() {
         let backend = KeyringBackend::new();
-        let id = "dbm-test-keyring-roundtrip";
+        let id = "rdbs-test-keyring-roundtrip";
         backend.set(id, "hunter2").unwrap();
         assert_eq!(backend.get(id).unwrap().as_deref(), Some("hunter2"));
         backend.delete(id).unwrap();

--- a/crates/connstore/src/secret/mod.rs
+++ b/crates/connstore/src/secret/mod.rs
@@ -33,8 +33,8 @@ pub fn select_backend(fallback_dir: &Path) -> crate::error::Result<Box<dyn Secre
     // value never persists, so `get` keeps returning None and every saved
     // password is silently lost. Only trust the keychain if a written sentinel
     // reads back identical; otherwise fall back to the encrypted file.
-    const PROBE_ID: &str = "__dbm_probe__";
-    const PROBE_VAL: &str = "dbm-probe-value";
+    const PROBE_ID: &str = "__rdbs_probe__";
+    const PROBE_VAL: &str = "rdbs-probe-value";
     let keyring_ok = keyring.set(PROBE_ID, PROBE_VAL).is_ok()
         && matches!(keyring.get(PROBE_ID), Ok(Some(v)) if v == PROBE_VAL);
     let _ = keyring.delete(PROBE_ID);

--- a/crates/connstore/src/store.rs
+++ b/crates/connstore/src/store.rs
@@ -127,9 +127,9 @@ impl ConnStore {
         self.secrets.delete(id)
     }
 
-    /// Build a `dbm-core::ConnConfig` for a saved connection with its stored
+    /// Build a `rdbs-core::ConnConfig` for a saved connection with its stored
     /// password injected. Errors if the connection id is unknown.
-    pub fn conn_config_for(&self, id: &str) -> Result<dbm_core::conn::ConnConfig> {
+    pub fn conn_config_for(&self, id: &str) -> Result<rdbs_core::conn::ConnConfig> {
         let conn = self
             .get(id)
             .ok_or_else(|| ConnStoreError::NotFound(id.to_string()))?;

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "dbm-core"
+name = "rdbs-core"
 version = "0.1.0"
 edition = "2021"
 

--- a/crates/core/src/driver.rs
+++ b/crates/core/src/driver.rs
@@ -23,7 +23,7 @@ pub trait Driver: Send + Sync {
     async fn schema(&self) -> Result<Schema>;
 
     /// Run a query. Drivers handle the `Query` variant(s) they support and
-    /// return `DbmError::UnsupportedQuery` for the rest.
+    /// return `RdbsError::UnsupportedQuery` for the rest.
     async fn query(&self, q: &Query) -> Result<ResultSet>;
 
     /// Close the connection, consuming the driver.
@@ -55,7 +55,7 @@ mod tests {
         async fn query(&self, q: &Query) -> crate::error::Result<ResultSet> {
             match q {
                 Query::Sql(_) => Ok(ResultSet::Affected(0)),
-                _ => Err(crate::error::DbmError::UnsupportedQuery),
+                _ => Err(crate::error::RdbsError::UnsupportedQuery),
             }
         }
         async fn close(self) -> crate::error::Result<()> {

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 /// All fallible operations in dbm return this error.
 #[derive(Error, Debug)]
-pub enum DbmError {
+pub enum RdbsError {
     #[error("connection failed: {0}")]
     Connection(String),
     #[error("query failed: {0}")]
@@ -13,7 +13,7 @@ pub enum DbmError {
     Schema(String),
 }
 
-pub type Result<T> = std::result::Result<T, DbmError>;
+pub type Result<T> = std::result::Result<T, RdbsError>;
 
 #[cfg(test)]
 mod tests {
@@ -21,13 +21,13 @@ mod tests {
 
     #[test]
     fn unsupported_query_has_stable_message() {
-        let e = DbmError::UnsupportedQuery;
+        let e = RdbsError::UnsupportedQuery;
         assert_eq!(e.to_string(), "unsupported query for this driver");
     }
 
     #[test]
     fn connection_error_includes_detail() {
-        let e = DbmError::Connection("refused".into());
+        let e = RdbsError::Connection("refused".into());
         assert_eq!(e.to_string(), "connection failed: refused");
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,4 +1,4 @@
-//! dbm-core: paradigm-agnostic Driver trait + unified result model.
+//! rdbs-core: paradigm-agnostic Driver trait + unified result model.
 
 pub mod conn;
 pub mod driver;

--- a/crates/core/src/query.rs
+++ b/crates/core/src/query.rs
@@ -3,7 +3,7 @@ use serde_json::Value as Json;
 /// A request to a driver. An enum (not a string) so non-SQL engines are
 /// first-class and SQL assumptions never leak into the abstraction. Each
 /// driver handles the variant it understands and returns
-/// `DbmError::UnsupportedQuery` for the rest.
+/// `RdbsError::UnsupportedQuery` for the rest.
 #[derive(Debug, Clone)]
 pub enum Query {
     /// SQL text — Postgres, MySQL.

--- a/crates/driver-mongo/Cargo.toml
+++ b/crates/driver-mongo/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "dbm-driver-mongo"
+name = "rdbs-driver-mongo"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-dbm-core = { path = "../core" }
+rdbs-core = { path = "../core" }
 async-trait = "0.1"
 mongodb = "3"
 serde_json = "1"

--- a/crates/driver-mongo/src/convert.rs
+++ b/crates/driver-mongo/src/convert.rs
@@ -1,16 +1,16 @@
 use mongodb::bson::{Bson, Document};
 
-use dbm_core::error::{DbmError, Result};
+use rdbs_core::error::{RdbsError, Result};
 
 /// Convert a JSON object into a BSON `Document`. Filters, insert payloads, and
 /// aggregation stages all arrive as JSON objects, so a non-object is a usage
 /// error and is rejected.
 pub fn json_to_document(value: &serde_json::Value) -> Result<Document> {
     let bson: Bson =
-        mongodb::bson::to_bson(value).map_err(|e| DbmError::Query(format!("invalid BSON: {e}")))?;
+        mongodb::bson::to_bson(value).map_err(|e| RdbsError::Query(format!("invalid BSON: {e}")))?;
     match bson {
         Bson::Document(d) => Ok(d),
-        other => Err(DbmError::Query(format!(
+        other => Err(RdbsError::Query(format!(
             "expected a JSON object, got {:?}",
             other.element_type()
         ))),

--- a/crates/driver-mongo/src/convert.rs
+++ b/crates/driver-mongo/src/convert.rs
@@ -6,8 +6,8 @@ use rdbs_core::error::{RdbsError, Result};
 /// aggregation stages all arrive as JSON objects, so a non-object is a usage
 /// error and is rejected.
 pub fn json_to_document(value: &serde_json::Value) -> Result<Document> {
-    let bson: Bson =
-        mongodb::bson::to_bson(value).map_err(|e| RdbsError::Query(format!("invalid BSON: {e}")))?;
+    let bson: Bson = mongodb::bson::to_bson(value)
+        .map_err(|e| RdbsError::Query(format!("invalid BSON: {e}")))?;
     match bson {
         Bson::Document(d) => Ok(d),
         other => Err(RdbsError::Query(format!(

--- a/crates/driver-mongo/src/driver.rs
+++ b/crates/driver-mongo/src/driver.rs
@@ -3,12 +3,12 @@ use futures::stream::TryStreamExt;
 use mongodb::bson::{doc, Document};
 use mongodb::{Client, Collection};
 
-use dbm_core::conn::{ConnConfig, SslMode};
-use dbm_core::driver::Driver;
-use dbm_core::error::{DbmError, Result};
-use dbm_core::query::{MongoKind, MongoOp, Query};
-use dbm_core::result::ResultSet;
-use dbm_core::schema::{Container, ContainerKind, Database, Schema};
+use rdbs_core::conn::{ConnConfig, SslMode};
+use rdbs_core::driver::Driver;
+use rdbs_core::error::{RdbsError, Result};
+use rdbs_core::query::{MongoKind, MongoOp, Query};
+use rdbs_core::result::ResultSet;
+use rdbs_core::schema::{Container, ContainerKind, Database, Schema};
 
 use crate::convert::{document_to_json, json_to_document};
 
@@ -47,7 +47,7 @@ impl Driver for MongoDriver {
     async fn connect(cfg: &ConnConfig) -> Result<Self> {
         let client = Client::with_uri_str(build_uri(cfg))
             .await
-            .map_err(|e| DbmError::Connection(e.to_string()))?;
+            .map_err(|e| RdbsError::Connection(e.to_string()))?;
         let default_db = cfg.database.clone().unwrap_or_else(|| "admin".to_string());
         Ok(MongoDriver { client, default_db })
     }
@@ -57,7 +57,7 @@ impl Driver for MongoDriver {
             .database("admin")
             .run_command(doc! { "ping": 1 })
             .await
-            .map_err(|e| DbmError::Connection(e.to_string()))?;
+            .map_err(|e| RdbsError::Connection(e.to_string()))?;
         Ok(())
     }
 
@@ -66,7 +66,7 @@ impl Driver for MongoDriver {
             .client
             .list_database_names()
             .await
-            .map_err(|e| DbmError::Schema(e.to_string()))?;
+            .map_err(|e| RdbsError::Schema(e.to_string()))?;
 
         let mut databases = Vec::new();
         for db_name in db_names {
@@ -74,7 +74,7 @@ impl Driver for MongoDriver {
             let coll_names = db
                 .list_collection_names()
                 .await
-                .map_err(|e| DbmError::Schema(e.to_string()))?;
+                .map_err(|e| RdbsError::Schema(e.to_string()))?;
             let containers = coll_names
                 .into_iter()
                 .map(|name| Container {
@@ -95,7 +95,7 @@ impl Driver for MongoDriver {
     async fn query(&self, q: &Query) -> Result<ResultSet> {
         let op: &MongoOp = match q {
             Query::Mongo(op) => op,
-            _ => return Err(DbmError::UnsupportedQuery),
+            _ => return Err(RdbsError::UnsupportedQuery),
         };
         let coll = self.collection(&op.collection);
 
@@ -105,11 +105,11 @@ impl Driver for MongoDriver {
                 let cursor = coll
                     .find(filter_doc)
                     .await
-                    .map_err(|e| DbmError::Query(e.to_string()))?;
+                    .map_err(|e| RdbsError::Query(e.to_string()))?;
                 let docs: Vec<Document> = cursor
                     .try_collect()
                     .await
-                    .map_err(|e| DbmError::Query(e.to_string()))?;
+                    .map_err(|e| RdbsError::Query(e.to_string()))?;
                 Ok(ResultSet::Documents(
                     docs.into_iter().map(document_to_json).collect(),
                 ))
@@ -118,7 +118,7 @@ impl Driver for MongoDriver {
                 let doc = json_to_document(payload)?;
                 coll.insert_one(doc)
                     .await
-                    .map_err(|e| DbmError::Query(e.to_string()))?;
+                    .map_err(|e| RdbsError::Query(e.to_string()))?;
                 Ok(ResultSet::Affected(1))
             }
             MongoKind::Aggregate(stages) => {
@@ -129,11 +129,11 @@ impl Driver for MongoDriver {
                 let cursor = coll
                     .aggregate(pipeline)
                     .await
-                    .map_err(|e| DbmError::Query(e.to_string()))?;
+                    .map_err(|e| RdbsError::Query(e.to_string()))?;
                 let docs: Vec<Document> = cursor
                     .try_collect()
                     .await
-                    .map_err(|e| DbmError::Query(e.to_string()))?;
+                    .map_err(|e| RdbsError::Query(e.to_string()))?;
                 Ok(ResultSet::Documents(
                     docs.into_iter().map(document_to_json).collect(),
                 ))

--- a/crates/driver-mongo/src/lib.rs
+++ b/crates/driver-mongo/src/lib.rs
@@ -1,4 +1,4 @@
-//! dbm-driver-mongo: MongoDB Driver impl via the mongodb crate.
+//! rdbs-driver-mongo: MongoDB Driver impl via the mongodb crate.
 
 mod convert;
 

--- a/crates/driver-mongo/tests/integration.rs
+++ b/crates/driver-mongo/tests/integration.rs
@@ -1,12 +1,12 @@
 //! Real-engine test: spins a MongoDB container, then exercises the driver.
 //! Requires Docker. Ignored by default; run with
-//! `cargo test -p dbm-driver-mongo -- --ignored`.
+//! `cargo test -p rdbs-driver-mongo -- --ignored`.
 
-use dbm_core::conn::{ConnConfig, SslMode};
-use dbm_core::driver::Driver;
-use dbm_core::query::{MongoKind, MongoOp, Query};
-use dbm_core::result::ResultSet;
-use dbm_driver_mongo::MongoDriver;
+use rdbs_core::conn::{ConnConfig, SslMode};
+use rdbs_core::driver::Driver;
+use rdbs_core::query::{MongoKind, MongoOp, Query};
+use rdbs_core::result::ResultSet;
+use rdbs_driver_mongo::MongoDriver;
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::mongo::Mongo;
 

--- a/crates/driver-mysql/Cargo.toml
+++ b/crates/driver-mysql/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "dbm-driver-mysql"
+name = "rdbs-driver-mysql"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-dbm-core = { path = "../core" }
+rdbs-core = { path = "../core" }
 async-trait = "0.1"
 mysql_async = "0.34"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/crates/driver-mysql/src/convert.rs
+++ b/crates/driver-mysql/src/convert.rs
@@ -1,6 +1,6 @@
-use rdbs_core::result::Cell;
 use mysql_async::consts::ColumnType;
 use mysql_async::Value;
+use rdbs_core::result::Cell;
 
 /// Map a mysql_async cell value into rdbs-core's `Cell`.
 ///
@@ -32,8 +32,8 @@ pub fn column_type_name(ct: ColumnType) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rdbs_core::result::Cell;
     use mysql_async::Value;
+    use rdbs_core::result::Cell;
 
     #[test]
     fn null_maps_to_cell_null() {

--- a/crates/driver-mysql/src/convert.rs
+++ b/crates/driver-mysql/src/convert.rs
@@ -1,8 +1,8 @@
-use dbm_core::result::Cell;
+use rdbs_core::result::Cell;
 use mysql_async::consts::ColumnType;
 use mysql_async::Value;
 
-/// Map a mysql_async cell value into dbm-core's `Cell`.
+/// Map a mysql_async cell value into rdbs-core's `Cell`.
 ///
 /// Bytes are treated as text when valid UTF-8 (covers CHAR/VARCHAR/TEXT and
 /// DECIMAL, which mysql returns as bytes), otherwise as raw `Bytes`
@@ -32,7 +32,7 @@ pub fn column_type_name(ct: ColumnType) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dbm_core::result::Cell;
+    use rdbs_core::result::Cell;
     use mysql_async::Value;
 
     #[test]

--- a/crates/driver-mysql/src/driver.rs
+++ b/crates/driver-mysql/src/driver.rs
@@ -2,12 +2,12 @@ use async_trait::async_trait;
 use mysql_async::prelude::Queryable;
 use mysql_async::{OptsBuilder, Pool, Row, SslOpts};
 
-use dbm_core::conn::{ConnConfig, SslMode};
-use dbm_core::driver::Driver;
-use dbm_core::error::{DbmError, Result};
-use dbm_core::query::Query;
-use dbm_core::result::{Column, ResultSet};
-use dbm_core::schema::Schema;
+use rdbs_core::conn::{ConnConfig, SslMode};
+use rdbs_core::driver::Driver;
+use rdbs_core::error::{RdbsError, Result};
+use rdbs_core::query::Query;
+use rdbs_core::result::{Column, ResultSet};
+use rdbs_core::schema::Schema;
 
 use crate::convert::{column_type_name, value_to_cell};
 use crate::schema::{columns_query, fold_rows, SchemaRow};
@@ -46,7 +46,7 @@ impl Driver for MysqlDriver {
         let mut conn = pool
             .get_conn()
             .await
-            .map_err(|e| DbmError::Connection(e.to_string()))?;
+            .map_err(|e| RdbsError::Connection(e.to_string()))?;
         drop(conn.ping().await);
         Ok(MysqlDriver { pool })
     }
@@ -56,11 +56,11 @@ impl Driver for MysqlDriver {
             .pool
             .get_conn()
             .await
-            .map_err(|e| DbmError::Connection(e.to_string()))?;
+            .map_err(|e| RdbsError::Connection(e.to_string()))?;
         let _: Vec<i64> = conn
             .query("SELECT 1")
             .await
-            .map_err(|e| DbmError::Query(e.to_string()))?;
+            .map_err(|e| RdbsError::Query(e.to_string()))?;
         Ok(())
     }
 
@@ -69,7 +69,7 @@ impl Driver for MysqlDriver {
             .pool
             .get_conn()
             .await
-            .map_err(|e| DbmError::Connection(e.to_string()))?;
+            .map_err(|e| RdbsError::Connection(e.to_string()))?;
         let rows: Vec<SchemaRow> = conn
             .query_map(
                 columns_query(),
@@ -84,26 +84,26 @@ impl Driver for MysqlDriver {
                 },
             )
             .await
-            .map_err(|e| DbmError::Schema(e.to_string()))?;
+            .map_err(|e| RdbsError::Schema(e.to_string()))?;
         Ok(fold_rows(rows))
     }
 
     async fn query(&self, q: &Query) -> Result<ResultSet> {
         let sql = match q {
             Query::Sql(s) => s,
-            _ => return Err(DbmError::UnsupportedQuery),
+            _ => return Err(RdbsError::UnsupportedQuery),
         };
 
         let mut conn = self
             .pool
             .get_conn()
             .await
-            .map_err(|e| DbmError::Connection(e.to_string()))?;
+            .map_err(|e| RdbsError::Connection(e.to_string()))?;
 
         let mut result = conn
             .query_iter(sql.as_str())
             .await
-            .map_err(|e| DbmError::Query(e.to_string()))?;
+            .map_err(|e| RdbsError::Query(e.to_string()))?;
 
         // A statement with no result set (INSERT/UPDATE/DELETE/DDL) reports
         // affected rows and yields no columns.
@@ -116,7 +116,7 @@ impl Driver for MysqlDriver {
             result
                 .drop_result()
                 .await
-                .map_err(|e| DbmError::Query(e.to_string()))?;
+                .map_err(|e| RdbsError::Query(e.to_string()))?;
             return Ok(ResultSet::Affected(affected));
         }
 
@@ -135,7 +135,7 @@ impl Driver for MysqlDriver {
         let mysql_rows: Vec<Row> = result
             .collect()
             .await
-            .map_err(|e| DbmError::Query(e.to_string()))?;
+            .map_err(|e| RdbsError::Query(e.to_string()))?;
 
         let rows = mysql_rows
             .into_iter()
@@ -143,7 +143,7 @@ impl Driver for MysqlDriver {
                 (0..r.len())
                     .map(|i| match r.as_ref(i) {
                         Some(v) => value_to_cell(v),
-                        None => dbm_core::result::Cell::Null,
+                        None => rdbs_core::result::Cell::Null,
                     })
                     .collect::<Vec<_>>()
             })
@@ -156,7 +156,7 @@ impl Driver for MysqlDriver {
         self.pool
             .disconnect()
             .await
-            .map_err(|e| DbmError::Connection(e.to_string()))?;
+            .map_err(|e| RdbsError::Connection(e.to_string()))?;
         Ok(())
     }
 }

--- a/crates/driver-mysql/src/lib.rs
+++ b/crates/driver-mysql/src/lib.rs
@@ -1,4 +1,4 @@
-//! dbm-driver-mysql: MySQL/MariaDB Driver impl via mysql_async.
+//! rdbs-driver-mysql: MySQL/MariaDB Driver impl via mysql_async.
 
 mod convert;
 mod schema;

--- a/crates/driver-mysql/src/schema.rs
+++ b/crates/driver-mysql/src/schema.rs
@@ -1,4 +1,4 @@
-use dbm_core::schema::{Container, ContainerKind, Database, Field, Schema};
+use rdbs_core::schema::{Container, ContainerKind, Database, Field, Schema};
 
 /// One row of the schema query: (database, table, column, type_name, nullable).
 pub type SchemaRow = (String, String, String, String, bool);
@@ -55,7 +55,7 @@ pub fn fold_rows(rows: Vec<SchemaRow>) -> Schema {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dbm_core::schema::ContainerKind;
+    use rdbs_core::schema::ContainerKind;
 
     #[test]
     fn columns_query_targets_information_schema() {

--- a/crates/driver-mysql/tests/integration.rs
+++ b/crates/driver-mysql/tests/integration.rs
@@ -1,12 +1,12 @@
 //! Real-engine test: spins a MySQL container, then exercises the driver.
 //! Requires a running Docker daemon. Ignored by default so plain `cargo test`
-//! stays offline; run with `cargo test -p dbm-driver-mysql -- --ignored`.
+//! stays offline; run with `cargo test -p rdbs-driver-mysql -- --ignored`.
 
-use dbm_core::conn::{ConnConfig, SslMode};
-use dbm_core::driver::Driver;
-use dbm_core::query::Query;
-use dbm_core::result::{Cell, ResultSet};
-use dbm_driver_mysql::MysqlDriver;
+use rdbs_core::conn::{ConnConfig, SslMode};
+use rdbs_core::driver::Driver;
+use rdbs_core::query::Query;
+use rdbs_core::result::{Cell, ResultSet};
+use rdbs_driver_mysql::MysqlDriver;
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::mysql::Mysql;
 

--- a/crates/driver-postgres/Cargo.toml
+++ b/crates/driver-postgres/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "dbm-driver-postgres"
+name = "rdbs-driver-postgres"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-dbm-core = { path = "../core" }
+rdbs-core = { path = "../core" }
 async-trait = "0.1"
 tokio = { version = "1", features = ["full"] }
 tokio-postgres = "0.7"

--- a/crates/driver-postgres/src/conn_string.rs
+++ b/crates/driver-postgres/src/conn_string.rs
@@ -1,4 +1,4 @@
-use dbm_core::conn::{ConnConfig, SslMode};
+use rdbs_core::conn::{ConnConfig, SslMode};
 
 /// Map our `SslMode` to a libpq `sslmode` token.
 ///
@@ -35,7 +35,7 @@ pub fn build_conn_string(cfg: &ConnConfig) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dbm_core::conn::{ConnConfig, SslMode};
+    use rdbs_core::conn::{ConnConfig, SslMode};
 
     fn base() -> ConnConfig {
         ConnConfig {

--- a/crates/driver-postgres/src/driver.rs
+++ b/crates/driver-postgres/src/driver.rs
@@ -4,12 +4,12 @@ use postgres_native_tls::MakeTlsConnector;
 use tokio::task::JoinHandle;
 use tokio_postgres::{Client, NoTls};
 
-use dbm_core::conn::{ConnConfig, SslMode};
-use dbm_core::driver::Driver;
-use dbm_core::error::{DbmError, Result};
-use dbm_core::query::Query;
-use dbm_core::result::{Column, ResultSet, Row};
-use dbm_core::schema::{Container, ContainerKind, Database, Field, Schema};
+use rdbs_core::conn::{ConnConfig, SslMode};
+use rdbs_core::driver::Driver;
+use rdbs_core::error::{RdbsError, Result};
+use rdbs_core::query::Query;
+use rdbs_core::result::{Column, ResultSet, Row};
+use rdbs_core::schema::{Container, ContainerKind, Database, Field, Schema};
 
 use crate::conn_string::build_conn_string;
 
@@ -36,7 +36,7 @@ impl Driver for PostgresDriver {
         let (client, conn_task) = if matches!(cfg.sslmode, SslMode::Disable) {
             let (client, connection) = tokio_postgres::connect(&conn_str, NoTls)
                 .await
-                .map_err(|e| DbmError::Connection(e.to_string()))?;
+                .map_err(|e| RdbsError::Connection(e.to_string()))?;
             let conn_task = tokio::spawn(async move {
                 let _ = connection.await;
             });
@@ -46,11 +46,11 @@ impl Driver for PostgresDriver {
                 .danger_accept_invalid_certs(true)
                 .danger_accept_invalid_hostnames(true)
                 .build()
-                .map_err(|e| DbmError::Connection(e.to_string()))?;
+                .map_err(|e| RdbsError::Connection(e.to_string()))?;
             let connector = MakeTlsConnector::new(tls);
             let (client, connection) = tokio_postgres::connect(&conn_str, connector)
                 .await
-                .map_err(|e| DbmError::Connection(e.to_string()))?;
+                .map_err(|e| RdbsError::Connection(e.to_string()))?;
             let conn_task = tokio::spawn(async move {
                 let _ = connection.await;
             });
@@ -63,7 +63,7 @@ impl Driver for PostgresDriver {
         self.client
             .query("SELECT 1", &[])
             .await
-            .map_err(|e| DbmError::Connection(e.to_string()))?;
+            .map_err(|e| RdbsError::Connection(e.to_string()))?;
         Ok(())
     }
 
@@ -88,14 +88,14 @@ impl Driver for PostgresDriver {
 async fn query_impl(client: &Client, q: &Query) -> Result<ResultSet> {
     let sql = match q {
         Query::Sql(s) => s,
-        Query::Command(_) | Query::Mongo(_) => return Err(DbmError::UnsupportedQuery),
+        Query::Command(_) | Query::Mongo(_) => return Err(RdbsError::UnsupportedQuery),
     };
 
     if is_row_returning(sql) {
         let rows = client
             .query(sql, &[])
             .await
-            .map_err(|e| DbmError::Query(e.to_string()))?;
+            .map_err(|e| RdbsError::Query(e.to_string()))?;
         let cols = column_meta(&rows);
         let mut out_rows: Vec<Row> = Vec::with_capacity(rows.len());
         for row in &rows {
@@ -113,7 +113,7 @@ async fn query_impl(client: &Client, q: &Query) -> Result<ResultSet> {
         let affected = client
             .execute(sql, &[])
             .await
-            .map_err(|e| DbmError::Query(e.to_string()))?;
+            .map_err(|e| RdbsError::Query(e.to_string()))?;
         Ok(ResultSet::Affected(affected))
     }
 }
@@ -151,10 +151,10 @@ async fn schema_impl(client: &Client) -> Result<Schema> {
     let db_row = client
         .query_one("SELECT current_database()", &[])
         .await
-        .map_err(|e| DbmError::Schema(e.to_string()))?;
+        .map_err(|e| RdbsError::Schema(e.to_string()))?;
     let db_name: String = db_row
         .try_get(0)
-        .map_err(|e| DbmError::Schema(e.to_string()))?;
+        .map_err(|e| RdbsError::Schema(e.to_string()))?;
 
     // User tables + columns from information_schema, public schema only.
     // Ordered so columns of the same table are contiguous for grouping.
@@ -169,7 +169,7 @@ async fn schema_impl(client: &Client) -> Result<Schema> {
             &[],
         )
         .await
-        .map_err(|e| DbmError::Schema(e.to_string()))?;
+        .map_err(|e| RdbsError::Schema(e.to_string()))?;
 
     let mut containers: Vec<Container> = Vec::new();
     for row in &rows {

--- a/crates/driver-postgres/src/lib.rs
+++ b/crates/driver-postgres/src/lib.rs
@@ -1,4 +1,4 @@
-//! dbm-driver-postgres: a `dbm_core::driver::Driver` backed by tokio-postgres.
+//! rdbs-driver-postgres: a `rdbs_core::driver::Driver` backed by tokio-postgres.
 
 mod conn_string;
 mod driver;

--- a/crates/driver-postgres/src/type_map.rs
+++ b/crates/driver-postgres/src/type_map.rs
@@ -1,4 +1,4 @@
-use dbm_core::result::Cell;
+use rdbs_core::result::Cell;
 use tokio_postgres::types::Type;
 use tokio_postgres::Row;
 

--- a/crates/driver-postgres/tests/integration.rs
+++ b/crates/driver-postgres/tests/integration.rs
@@ -3,9 +3,9 @@
 // is present (CI, dev with Docker Desktop) they run; without Docker they fail
 // fast at container start, which is the intended signal.
 
-use dbm_core::conn::{ConnConfig, SslMode};
-use dbm_core::driver::Driver;
-use dbm_driver_postgres::PostgresDriver;
+use rdbs_core::conn::{ConnConfig, SslMode};
+use rdbs_core::driver::Driver;
+use rdbs_driver_postgres::PostgresDriver;
 use testcontainers::runners::AsyncRunner;
 use testcontainers::ContainerAsync;
 use testcontainers_modules::postgres::Postgres;
@@ -43,8 +43,8 @@ async fn connect_ping_close() {
 
 #[tokio::test]
 async fn select_returns_tabular_rows() {
-    use dbm_core::query::Query;
-    use dbm_core::result::{Cell, ResultSet};
+    use rdbs_core::query::Query;
+    use rdbs_core::result::{Cell, ResultSet};
 
     let (_container, cfg) = start_pg().await;
     let driver = PostgresDriver::connect(&cfg).await.expect("connect");
@@ -88,8 +88,8 @@ async fn select_returns_tabular_rows() {
 
 #[tokio::test]
 async fn non_sql_queries_are_unsupported() {
-    use dbm_core::error::DbmError;
-    use dbm_core::query::{MongoKind, MongoOp, Query};
+    use rdbs_core::error::RdbsError;
+    use rdbs_core::query::{MongoKind, MongoOp, Query};
 
     let (_container, cfg) = start_pg().await;
     let driver = PostgresDriver::connect(&cfg).await.expect("connect");
@@ -97,7 +97,7 @@ async fn non_sql_queries_are_unsupported() {
     let cmd = driver
         .query(&Query::Command(vec!["GET".into(), "k".into()]))
         .await;
-    assert!(matches!(cmd, Err(DbmError::UnsupportedQuery)));
+    assert!(matches!(cmd, Err(RdbsError::UnsupportedQuery)));
 
     let mongo = driver
         .query(&Query::Mongo(MongoOp {
@@ -105,15 +105,15 @@ async fn non_sql_queries_are_unsupported() {
             kind: MongoKind::Find(serde_json::json!({})),
         }))
         .await;
-    assert!(matches!(mongo, Err(DbmError::UnsupportedQuery)));
+    assert!(matches!(mongo, Err(RdbsError::UnsupportedQuery)));
 
     driver.close().await.expect("close");
 }
 
 #[tokio::test]
 async fn schema_lists_created_table_and_fields() {
-    use dbm_core::query::Query;
-    use dbm_core::schema::ContainerKind;
+    use rdbs_core::query::Query;
+    use rdbs_core::schema::ContainerKind;
 
     let (_container, cfg) = start_pg().await;
     let driver = PostgresDriver::connect(&cfg).await.expect("connect");

--- a/crates/driver-redis/Cargo.toml
+++ b/crates/driver-redis/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "dbm-driver-redis"
+name = "rdbs-driver-redis"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-dbm-core = { path = "../core" }
+rdbs-core = { path = "../core" }
 async-trait = "0.1"
 redis = { version = "0.27", features = ["tokio-comp", "tls-native-tls", "tokio-native-tls-comp"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/crates/driver-redis/src/convert.rs
+++ b/crates/driver-redis/src/convert.rs
@@ -1,5 +1,5 @@
-use dbm_core::conn::{ConnConfig, SslMode};
-use dbm_core::result::{RedisValue, ResultSet};
+use rdbs_core::conn::{ConnConfig, SslMode};
+use rdbs_core::result::{RedisValue, ResultSet};
 use redis::Value;
 
 /// Build a `redis://[:password@]host:port[/db]` URL from connection config.
@@ -66,8 +66,8 @@ fn scalar_to_string(value: Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dbm_core::conn::{ConnConfig, SslMode};
-    use dbm_core::result::{RedisValue, ResultSet};
+    use rdbs_core::conn::{ConnConfig, SslMode};
+    use rdbs_core::result::{RedisValue, ResultSet};
     use redis::Value;
 
     fn cfg(pw: Option<&str>, db: Option<&str>) -> ConnConfig {

--- a/crates/driver-redis/src/driver.rs
+++ b/crates/driver-redis/src/driver.rs
@@ -3,12 +3,12 @@ use redis::aio::MultiplexedConnection;
 use redis::{Client, Value};
 use tokio::sync::Mutex;
 
-use dbm_core::conn::ConnConfig;
-use dbm_core::driver::Driver;
-use dbm_core::error::{DbmError, Result};
-use dbm_core::query::Query;
-use dbm_core::result::ResultSet;
-use dbm_core::schema::{Container, ContainerKind, Database, Field, Schema};
+use rdbs_core::conn::ConnConfig;
+use rdbs_core::driver::Driver;
+use rdbs_core::error::{RdbsError, Result};
+use rdbs_core::query::Query;
+use rdbs_core::result::ResultSet;
+use rdbs_core::schema::{Container, ContainerKind, Database, Field, Schema};
 
 use crate::convert::{connection_url, value_to_resultset};
 
@@ -24,11 +24,11 @@ pub struct RedisDriver {
 impl Driver for RedisDriver {
     async fn connect(cfg: &ConnConfig) -> Result<Self> {
         let client =
-            Client::open(connection_url(cfg)).map_err(|e| DbmError::Connection(e.to_string()))?;
+            Client::open(connection_url(cfg)).map_err(|e| RdbsError::Connection(e.to_string()))?;
         let conn = client
             .get_multiplexed_async_connection()
             .await
-            .map_err(|e| DbmError::Connection(e.to_string()))?;
+            .map_err(|e| RdbsError::Connection(e.to_string()))?;
         let db = cfg.database.clone().unwrap_or_else(|| "0".to_string());
         Ok(RedisDriver {
             conn: Mutex::new(conn),
@@ -41,11 +41,11 @@ impl Driver for RedisDriver {
         let reply: String = redis::cmd("PING")
             .query_async(&mut *conn)
             .await
-            .map_err(|e| DbmError::Connection(e.to_string()))?;
+            .map_err(|e| RdbsError::Connection(e.to_string()))?;
         if reply == "PONG" {
             Ok(())
         } else {
-            Err(DbmError::Connection(format!(
+            Err(RdbsError::Connection(format!(
                 "unexpected PING reply: {reply}"
             )))
         }
@@ -56,7 +56,7 @@ impl Driver for RedisDriver {
         let size: i64 = redis::cmd("DBSIZE")
             .query_async(&mut *conn)
             .await
-            .map_err(|e| DbmError::Schema(e.to_string()))?;
+            .map_err(|e| RdbsError::Schema(e.to_string()))?;
         drop(conn);
 
         // Redis is schemaless: surface one keyspace container summarizing key count.
@@ -76,10 +76,10 @@ impl Driver for RedisDriver {
     async fn query(&self, q: &Query) -> Result<ResultSet> {
         let tokens = match q {
             Query::Command(tokens) => tokens,
-            _ => return Err(DbmError::UnsupportedQuery),
+            _ => return Err(RdbsError::UnsupportedQuery),
         };
         if tokens.is_empty() {
-            return Err(DbmError::Query("empty command".into()));
+            return Err(RdbsError::Query("empty command".into()));
         }
 
         let mut cmd = redis::cmd(&tokens[0]);
@@ -91,7 +91,7 @@ impl Driver for RedisDriver {
         let value: Value = cmd
             .query_async(&mut *conn)
             .await
-            .map_err(|e| DbmError::Query(e.to_string()))?;
+            .map_err(|e| RdbsError::Query(e.to_string()))?;
 
         Ok(value_to_resultset(tokens[0].to_uppercase(), value))
     }

--- a/crates/driver-redis/src/lib.rs
+++ b/crates/driver-redis/src/lib.rs
@@ -1,4 +1,4 @@
-//! dbm-driver-redis: Redis Driver impl via the redis crate.
+//! rdbs-driver-redis: Redis Driver impl via the redis crate.
 
 mod convert;
 

--- a/crates/driver-redis/tests/integration.rs
+++ b/crates/driver-redis/tests/integration.rs
@@ -1,13 +1,13 @@
 //! Real-engine test: spins a Redis container, then exercises the driver.
 //! Requires Docker. Ignored by default; run with
-//! `cargo test -p dbm-driver-redis -- --ignored`.
+//! `cargo test -p rdbs-driver-redis -- --ignored`.
 
-use dbm_core::conn::{ConnConfig, SslMode};
-use dbm_core::driver::Driver;
-use dbm_core::query::Query;
-use dbm_core::result::{RedisValue, ResultSet};
-use dbm_core::schema::ContainerKind;
-use dbm_driver_redis::RedisDriver;
+use rdbs_core::conn::{ConnConfig, SslMode};
+use rdbs_core::driver::Driver;
+use rdbs_core::query::Query;
+use rdbs_core::result::{RedisValue, ResultSet};
+use rdbs_core::schema::ContainerKind;
+use rdbs_driver_redis::RedisDriver;
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::redis::Redis;
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 REPO="suiflex/rdb"
-BINARY="storix"
-VERSION="${STORIX_VERSION:-latest}"
+BINARY="rdbs"
+VERSION="${RDBS_VERSION:-latest}"
 
 log() {
   printf '==> %s\n' "$*"


### PR DESCRIPTION
## Summary

- Repo mixed three naming schemes — `rdbs` (project), `storix` (FE binary), `dbm-` (BE crates). Unified all under one `rdbs` prefix.
- FE and BE stay distinguishable: FE = `rdbs`, BE = `rdbs-*`, split kept via `app/` vs `crates/` and the `fe-*`/`be-*` Make targets.

## Changes

- **BE crates**: `dbm-core`/`dbm-connstore`/`dbm-driver-*` → `rdbs-*`; `DbmError` → `RdbsError`; all `dbm_*` import paths and keyring probe identifiers follow.
- **FE binary**: package + bin `storix` → `rdbs`; window title `Storix` → `RDBS`; installer env `STORIX_VERSION` → `RDBS_VERSION`.
- **Docs/build**: README, CLAUDE.md, Makefile, `scripts/install.sh` aligned.
- **Style**: rustfmt re-sorted use lists where rename changed alphabetical order.

## Test plan

- [x] `grep` for `storix|Storix|STORIX|dbm[-_]|DbmError` → 0 hits (outside Cargo.lock)
- [x] `make all` (fmt-check + clippy -D warnings + test + build) green
- [x] FE binary builds as `rdbs`