### PR TITLE
fix: drop invalid ../ changelog path in release-please config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ plus one per crate (`rdbs-core`, `rdbs-connstore`, `rdbs-driver-*`). Each has a
 
 Releases are handled separately by `release-please.yml` (single workspace
 release on `develop`): conventional commits drive an auto-maintained release
-PR that bumps the version and root `CHANGELOG.md`; merging it tags `vX.Y.Z`
+PR that bumps the version and `app/CHANGELOG.md`; merging it tags `vX.Y.Z`
 and cuts a GitHub Release. The `app` package (`rdbs`) is the tracked version.
 
 ## Architecture

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,8 +4,7 @@
   "include-component-in-tag": false,
   "packages": {
     "app": {
-      "package-name": "rdbs",
-      "changelog-path": "../CHANGELOG.md"
+      "package-name": "rdbs"
     }
   }
 }


### PR DESCRIPTION
## Summary

- release-please failed on every push to `develop` with `illegal pathing characters in path: app/../CHANGELOG.md`.
- The `../CHANGELOG.md` trick to place the changelog at repo root is rejected by release-please.

## Changes

- `release-please-config.json` — remove `changelog-path`; the changelog now defaults to `app/CHANGELOG.md` for the tracked `app` (`rdbs`) package.
- `CLAUDE.md` — update the CI note to say `app/CHANGELOG.md`.

## Test plan

- [x] `release-please-config.json` is valid JSON
- [ ] After merge to `develop`: `release-please` run succeeds and opens a release PR