### PR TITLE
fix: connection dialog + MongoDB database/collection browser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ BE_FLAGS = $(addprefix -p ,$(BE_PKGS))
 
 .DEFAULT_GOAL := help
 
-.PHONY: help be-build be-test be-check fe-build fe-run fmt fmt-check lint test test-it build all clean
+.PHONY: help be-build be-test be-check fe-build fe-run fe-build-run fe-show fmt fmt-check lint test test-it build all clean
+
+FE_BIN = target/debug/$(FE_PKG)
 
 help: ## List available targets
 	@awk 'BEGIN{FS=":.*## "} /^[a-z][a-zA-Z0-9_-]*:.*## /{printf "  %-12s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -26,6 +28,14 @@ fe-build: ## Build the rdbs UI binary
 
 fe-run: ## Run the rdbs UI binary
 	cargo run -p $(FE_PKG)
+
+fe-build-run: ## Build the rdbs UI then launch it (GUI shows after build)
+	cargo build -p $(FE_PKG)
+	./$(FE_BIN)
+
+fe-show: ## Launch the rdbs UI; build it first only if missing
+	@test -x $(FE_BIN) || cargo build -p $(FE_PKG)
+	./$(FE_BIN)
 
 fmt: ## Format the whole workspace
 	cargo fmt --all

--- a/app/src/dispatch.rs
+++ b/app/src/dispatch.rs
@@ -10,7 +10,7 @@ use rdbs_core::driver::Driver;
 use rdbs_core::error::Result;
 use rdbs_core::query::Query;
 use rdbs_core::result::ResultSet;
-use rdbs_core::schema::Schema;
+use rdbs_core::schema::{Container, Schema};
 use rdbs_driver_mongo::MongoDriver;
 use rdbs_driver_mysql::MysqlDriver;
 use rdbs_driver_postgres::PostgresDriver;
@@ -61,6 +61,15 @@ impl AnyDriver {
             AnyDriver::Mysql(d) => d.schema().await,
             AnyDriver::Redis(d) => d.schema().await,
             AnyDriver::Mongo(d) => d.schema().await,
+        }
+    }
+
+    pub async fn containers(&self, database: &str) -> Result<Vec<Container>> {
+        match self {
+            AnyDriver::Postgres(d) => d.containers(database).await,
+            AnyDriver::Mysql(d) => d.containers(database).await,
+            AnyDriver::Redis(d) => d.containers(database).await,
+            AnyDriver::Mongo(d) => d.containers(database).await,
         }
     }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -128,8 +128,9 @@ fn schema_display_rows(
 ) -> Vec<TreeNode> {
     // Mongo is database→collection: render each database as a collapsible header
     // and nest only its own collections, so system DBs never mix with the app's.
+    // `expanded_tables` is the set of OPEN databases (default closed).
     if engine == Some(rdbs_connstore::Engine::Mongo) {
-        return mongo_display_rows(nodes, collapsed_cats);
+        return mongo_display_rows(nodes, expanded_tables);
     }
 
     let categories = sidebar_categories(engine);
@@ -181,11 +182,11 @@ fn schema_display_rows(
 }
 
 /// Build database→collection rows for Mongo. Each database is a depth-0
-/// collapsible header (collapsed when its name is in `collapsed_cats`); its
-/// collections are depth-1 rows tagged with the owning database.
+/// collapsible header (open when its name is in `expanded_dbs`, default closed);
+/// its collections are depth-1 rows tagged with the owning database.
 fn mongo_display_rows(
     nodes: &[model::VmTreeNode],
-    collapsed_cats: &HashSet<String>,
+    expanded_dbs: &HashSet<String>,
 ) -> Vec<TreeNode> {
     let mut rows: Vec<TreeNode> = Vec::new();
     let mut current_db = String::new();
@@ -194,7 +195,7 @@ fn mongo_display_rows(
         match n.kind.as_str() {
             "database" => {
                 current_db = n.label.clone();
-                db_open = !collapsed_cats.contains(&current_db);
+                db_open = expanded_dbs.contains(&current_db);
                 rows.push(TreeNode {
                     label: n.label.clone().into(),
                     depth: 0,
@@ -304,7 +305,14 @@ fn main() -> Result<(), slint::PlatformError> {
     // connect task can fill it) + the set of expanded table labels.
     let raw_nodes: Arc<std::sync::Mutex<Vec<model::VmTreeNode>>> =
         Arc::new(std::sync::Mutex::new(Vec::new()));
-    let expanded_tables: Rc<RefCell<HashSet<String>>> = Rc::new(RefCell::new(HashSet::new()));
+    // Expanded sidebar nodes. For Mongo this is the set of OPEN databases
+    // (default closed → collections load lazily on expand). Arc<Mutex> so the
+    // lazy-load task can read it off the UI thread.
+    let expanded_tables: Arc<std::sync::Mutex<HashSet<String>>> =
+        Arc::new(std::sync::Mutex::new(HashSet::new()));
+    // Mongo databases whose collections have already been fetched.
+    let loaded_dbs: Arc<std::sync::Mutex<HashSet<String>>> =
+        Arc::new(std::sync::Mutex::new(HashSet::new()));
     // Sidebar category headers the user has collapsed (Tables/Views/Functions).
     let collapsed_categories: Rc<RefCell<HashSet<String>>> = Rc::new(RefCell::new(HashSet::new()));
     // Engine of the live connection, kept on the UI thread so table clicks can
@@ -388,6 +396,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let rt = rt.clone();
         let cur_engine = cur_engine.clone();
         let expanded_tables = expanded_tables.clone();
+        let loaded_dbs = loaded_dbs.clone();
         let collapsed_categories = collapsed_categories.clone();
         let raw_nodes = raw_nodes.clone();
         window.on_disconnect(move || {
@@ -402,7 +411,8 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_schema_tree(ModelRc::from(Rc::new(VecModel::<TreeNode>::default())));
             w.set_structure_columns(ModelRc::from(Rc::new(VecModel::<StructField>::default())));
             *cur_engine.borrow_mut() = None;
-            expanded_tables.borrow_mut().clear();
+            expanded_tables.lock().unwrap().clear();
+            loaded_dbs.lock().unwrap().clear();
             collapsed_categories.borrow_mut().clear();
             raw_nodes.lock().unwrap().clear();
             let current = current.clone();
@@ -451,6 +461,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let current = current.clone();
         let raw_nodes = raw_nodes.clone();
         let expanded_tables = expanded_tables.clone();
+        let loaded_dbs = loaded_dbs.clone();
         let collapsed_categories = collapsed_categories.clone();
         let cur_engine = cur_engine.clone();
         window.on_connect_clicked(move |idx| {
@@ -476,7 +487,8 @@ fn main() -> Result<(), slint::PlatformError> {
             }
             // Fresh connection: nothing browsed, nothing expanded.
             *cur_engine.borrow_mut() = Some(sc.engine);
-            expanded_tables.borrow_mut().clear();
+            expanded_tables.lock().unwrap().clear();
+            loaded_dbs.lock().unwrap().clear();
             collapsed_categories.borrow_mut().clear();
             let weak2 = weak.clone();
             let store_driver = current.clone();
@@ -686,21 +698,103 @@ fn main() -> Result<(), slint::PlatformError> {
         });
     }
 
-    // ----- toggle a schema table's column rows (expand/collapse) -----
+    // ----- toggle a schema header (expand/collapse) -----
     {
         let weak = window.as_weak();
         let raw_nodes = raw_nodes.clone();
         let expanded_tables = expanded_tables.clone();
+        let loaded_dbs = loaded_dbs.clone();
         let collapsed_categories = collapsed_categories.clone();
         let cur_engine = cur_engine.clone();
+        let current = current.clone();
+        let rt = rt.clone();
         window.on_toggle_schema_node(move |label| {
             let Some(w) = weak.upgrade() else {
                 return;
             };
             let engine = *cur_engine.borrow();
             let label = label.to_string();
-            // Only headers (SQL categories and Mongo database names) invoke this;
-            // toggle the collapsed set for the clicked header (open by default).
+
+            // Mongo: database headers open an opt-in set (default closed) and load
+            // their collections lazily the first time they are expanded.
+            if engine == Some(rdbs_connstore::Engine::Mongo) {
+                let now_open = {
+                    let mut e = expanded_tables.lock().unwrap();
+                    if e.remove(&label) {
+                        false
+                    } else {
+                        e.insert(label.clone());
+                        true
+                    }
+                };
+                // Fetch this database's collections once, on first open.
+                let need_fetch = now_open && {
+                    let mut l = loaded_dbs.lock().unwrap();
+                    if l.contains(&label) {
+                        false
+                    } else {
+                        l.insert(label.clone());
+                        true
+                    }
+                };
+                if need_fetch {
+                    let driver = current.clone();
+                    let raw_nodes = raw_nodes.clone();
+                    let expanded_tables = expanded_tables.clone();
+                    let weak2 = weak.clone();
+                    let db = label.clone();
+                    rt.spawn(async move {
+                        let containers = {
+                            let guard = driver.lock().await;
+                            match &*guard {
+                                Some((_, drv)) => drv.containers(&db).await.unwrap_or_default(),
+                                None => return,
+                            }
+                        };
+                        let rows = {
+                            let mut nodes = raw_nodes.lock().unwrap();
+                            if let Some(pos) = nodes
+                                .iter()
+                                .position(|n| n.kind == "database" && n.label == db)
+                            {
+                                for (k, c) in containers.into_iter().enumerate() {
+                                    nodes.insert(
+                                        pos + 1 + k,
+                                        model::VmTreeNode {
+                                            label: c.name,
+                                            kind: "collection".into(),
+                                        },
+                                    );
+                                }
+                            }
+                            schema_display_rows(
+                                &nodes,
+                                &expanded_tables.lock().unwrap(),
+                                &HashSet::new(),
+                                Some(rdbs_connstore::Engine::Mongo),
+                            )
+                        };
+                        let _ = slint::invoke_from_event_loop(move || {
+                            if let Some(w) = weak2.upgrade() {
+                                w.set_schema_tree(ModelRc::from(Rc::new(VecModel::from(rows))));
+                            }
+                        });
+                    });
+                    return;
+                }
+                // No fetch needed (collapse, or already loaded): rebuild now.
+                let nodes = raw_nodes.lock().unwrap();
+                let rows = schema_display_rows(
+                    &nodes,
+                    &expanded_tables.lock().unwrap(),
+                    &HashSet::new(),
+                    engine,
+                );
+                w.set_schema_tree(ModelRc::from(Rc::new(VecModel::from(rows))));
+                return;
+            }
+
+            // SQL/Redis: category headers collapse-toggle (open by default).
             {
                 let mut c = collapsed_categories.borrow_mut();
                 if !c.remove(&label) {
@@ -710,7 +804,7 @@ fn main() -> Result<(), slint::PlatformError> {
             let nodes = raw_nodes.lock().unwrap();
             let rows = schema_display_rows(
                 &nodes,
-                &expanded_tables.borrow(),
+                &expanded_tables.lock().unwrap(),
                 &collapsed_categories.borrow(),
                 engine,
             );

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -126,6 +126,12 @@ fn schema_display_rows(
     collapsed_cats: &HashSet<String>,
     engine: Option<rdbs_connstore::Engine>,
 ) -> Vec<TreeNode> {
+    // Mongo is database→collection: render each database as a collapsible header
+    // and nest only its own collections, so system DBs never mix with the app's.
+    if engine == Some(rdbs_connstore::Engine::Mongo) {
+        return mongo_display_rows(nodes, collapsed_cats);
+    }
+
     let categories = sidebar_categories(engine);
     let primary = categories[0];
     let mut rows: Vec<TreeNode> = Vec::new();
@@ -136,6 +142,7 @@ fn schema_display_rows(
             depth: 0,
             kind: "category".into(),
             expanded: cat_open,
+            db: SharedString::default(),
         });
         if !cat_open || cat != primary {
             continue;
@@ -153,6 +160,7 @@ fn schema_display_rows(
                     depth: 2,
                     kind: "field".into(),
                     expanded: false,
+                    db: SharedString::default(),
                 });
             } else if is_container {
                 show_fields = expanded_tables.contains(&n.label);
@@ -161,11 +169,50 @@ fn schema_display_rows(
                     depth: 1,
                     kind: n.kind.clone().into(),
                     expanded: show_fields,
+                    db: SharedString::default(),
                 });
             } else {
                 // database row: categories replace it; reset field visibility
                 show_fields = false;
             }
+        }
+    }
+    rows
+}
+
+/// Build database→collection rows for Mongo. Each database is a depth-0
+/// collapsible header (collapsed when its name is in `collapsed_cats`); its
+/// collections are depth-1 rows tagged with the owning database.
+fn mongo_display_rows(
+    nodes: &[model::VmTreeNode],
+    collapsed_cats: &HashSet<String>,
+) -> Vec<TreeNode> {
+    let mut rows: Vec<TreeNode> = Vec::new();
+    let mut current_db = String::new();
+    let mut db_open = false;
+    for n in nodes {
+        match n.kind.as_str() {
+            "database" => {
+                current_db = n.label.clone();
+                db_open = !collapsed_cats.contains(&current_db);
+                rows.push(TreeNode {
+                    label: n.label.clone().into(),
+                    depth: 0,
+                    kind: "database".into(),
+                    expanded: db_open,
+                    db: current_db.clone().into(),
+                });
+            }
+            "collection" | "table" | "keyspace" if db_open => {
+                rows.push(TreeNode {
+                    label: n.label.clone().into(),
+                    depth: 1,
+                    kind: "collection".into(),
+                    expanded: false,
+                    db: current_db.clone().into(),
+                });
+            }
+            _ => {}
         }
     }
     rows
@@ -606,11 +653,12 @@ fn main() -> Result<(), slint::PlatformError> {
         let weak = window.as_weak();
         let cur_engine = cur_engine.clone();
         let run_sql = run_sql.clone();
-        window.on_open_table(move |label| {
+        window.on_open_table(move |db, label| {
             let Some(w) = weak.upgrade() else {
                 return;
             };
             let label = label.to_string();
+            let db = db.to_string();
             let text = match *cur_engine.borrow() {
                 Some(rdbs_connstore::Engine::Postgres) => {
                     format!("SELECT * FROM \"{label}\" LIMIT 300")
@@ -619,7 +667,9 @@ fn main() -> Result<(), slint::PlatformError> {
                     format!("SELECT * FROM `{label}` LIMIT 300")
                 }
                 Some(rdbs_connstore::Engine::Mongo) => {
-                    format!("{{\"collection\":\"{label}\",\"op\":\"find\",\"body\":{{}}}}")
+                    format!(
+                        "{{\"collection\":\"{label}\",\"database\":\"{db}\",\"op\":\"find\",\"body\":{{}}}}"
+                    )
                 }
                 Some(rdbs_connstore::Engine::Redis) => {
                     w.set_result_status(SharedString::from(
@@ -649,17 +699,12 @@ fn main() -> Result<(), slint::PlatformError> {
             };
             let engine = *cur_engine.borrow();
             let label = label.to_string();
-            // A category header toggles its collapsed set (open by default); any
-            // other label toggles a table's expanded-fields set.
-            if sidebar_categories(engine).contains(&label.as_str()) {
+            // Only headers (SQL categories and Mongo database names) invoke this;
+            // toggle the collapsed set for the clicked header (open by default).
+            {
                 let mut c = collapsed_categories.borrow_mut();
                 if !c.remove(&label) {
                     c.insert(label);
-                }
-            } else {
-                let mut e = expanded_tables.borrow_mut();
-                if !e.remove(&label) {
-                    e.insert(label);
                 }
             }
             let nodes = raw_nodes.lock().unwrap();

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -98,9 +98,17 @@ fn build_conn_items(
     rows
 }
 
-/// Top-level sidebar categories (TablePlus-style). The label is also the toggle
-/// key, so `on_toggle_schema_node` can tell a category click from a table click.
-const SIDEBAR_CATEGORIES: [&str; 3] = ["Tables", "Views", "Functions"];
+/// Top-level sidebar categories per engine (TablePlus-style). The label is also
+/// the toggle key, so `on_toggle_schema_node` can tell a category click from a
+/// table click. The first entry is the "primary" category that holds the
+/// engine's containers. ponytail: SQL keeps the Views/Functions placeholders.
+fn sidebar_categories(engine: Option<rdbs_connstore::Engine>) -> &'static [&'static str] {
+    match engine {
+        Some(rdbs_connstore::Engine::Mongo) => &["Collections"],
+        Some(rdbs_connstore::Engine::Redis) => &["Keys"],
+        _ => &["Tables", "Views", "Functions"],
+    }
+}
 
 /// Build the collapsible schema sidebar rows from the raw flat node list.
 ///
@@ -116,9 +124,12 @@ fn schema_display_rows(
     nodes: &[model::VmTreeNode],
     expanded_tables: &HashSet<String>,
     collapsed_cats: &HashSet<String>,
+    engine: Option<rdbs_connstore::Engine>,
 ) -> Vec<TreeNode> {
+    let categories = sidebar_categories(engine);
+    let primary = categories[0];
     let mut rows: Vec<TreeNode> = Vec::new();
-    for cat in SIDEBAR_CATEGORIES {
+    for &cat in categories {
         let cat_open = !collapsed_cats.contains(cat);
         rows.push(TreeNode {
             label: cat.into(),
@@ -126,7 +137,7 @@ fn schema_display_rows(
             kind: "category".into(),
             expanded: cat_open,
         });
-        if !cat_open || cat != "Tables" {
+        if !cat_open || cat != primary {
             continue;
         }
         // Walk the flat nodes: containers + (when expanded) their fields.
@@ -172,13 +183,14 @@ fn set_tab_titles(w: &MainWindow, count: usize) {
 
 /// Push a `GridModel` into the window's grid/json/status properties.
 fn apply_grid(w: &MainWindow, g: model::GridModel) {
+    // Documents carry both a flattened grid and the raw JSON; the UI toggles
+    // between them. Fall through to the grid push below so the table view works.
     if g.is_documents {
         w.set_is_documents(true);
-        w.set_doc_json(SharedString::from(g.json));
-        w.set_result_status(SharedString::default());
-        return;
+        w.set_doc_json(SharedString::from(g.json.clone()));
+    } else {
+        w.set_is_documents(false);
     }
-    w.set_is_documents(false);
     if !g.status.is_empty() {
         // Affected: no grid, just a status toast.
         w.set_grid_col_count(0);
@@ -440,17 +452,37 @@ fn main() -> Result<(), slint::PlatformError> {
                         let fields = model::to_structure_model(&schema);
                         // Stash raw nodes for later expand/collapse rebuilds, and
                         // render the initial view (categories open, fields hidden).
-                        let rows = schema_display_rows(&nodes, &HashSet::new(), &HashSet::new());
+                        let rows = schema_display_rows(
+                            &nodes,
+                            &HashSet::new(),
+                            &HashSet::new(),
+                            Some(engine),
+                        );
+                        // Real database/schema names from introspection; fall back
+                        // to "public" only when the driver exposed none.
+                        let mut schema_names: Vec<SharedString> = schema
+                            .databases
+                            .iter()
+                            .map(|d| SharedString::from(d.name.clone()))
+                            .collect();
+                        if schema_names.is_empty() {
+                            schema_names.push(SharedString::from("public"));
+                        }
+                        let schema_current = schema_names[0].clone();
+                        // SQL editor only makes sense for the SQL engines.
+                        let sql_capable = matches!(
+                            engine,
+                            rdbs_connstore::Engine::Postgres | rdbs_connstore::Engine::MySql
+                        );
                         *raw_nodes.lock().unwrap() = nodes;
                         let _ = slint::invoke_from_event_loop(move || {
                             if let Some(w) = weak2.upgrade() {
                                 w.set_schema_tree(ModelRc::from(Rc::new(VecModel::from(rows))));
-                                // Seed the pinned schema selector. TODO: list real
-                                // schemas once introspection exposes them.
-                                w.set_schema_name(SharedString::from("public"));
-                                w.set_schema_list(ModelRc::from(Rc::new(VecModel::from(vec![
-                                    SharedString::from("public"),
-                                ]))));
+                                w.set_sql_capable(sql_capable);
+                                w.set_schema_name(schema_current);
+                                w.set_schema_list(ModelRc::from(Rc::new(VecModel::from(
+                                    schema_names,
+                                ))));
                                 let sfields: Vec<StructField> = fields
                                     .into_iter()
                                     .map(|f| StructField {
@@ -610,14 +642,16 @@ fn main() -> Result<(), slint::PlatformError> {
         let raw_nodes = raw_nodes.clone();
         let expanded_tables = expanded_tables.clone();
         let collapsed_categories = collapsed_categories.clone();
+        let cur_engine = cur_engine.clone();
         window.on_toggle_schema_node(move |label| {
             let Some(w) = weak.upgrade() else {
                 return;
             };
+            let engine = *cur_engine.borrow();
             let label = label.to_string();
             // A category header toggles its collapsed set (open by default); any
             // other label toggles a table's expanded-fields set.
-            if SIDEBAR_CATEGORIES.contains(&label.as_str()) {
+            if sidebar_categories(engine).contains(&label.as_str()) {
                 let mut c = collapsed_categories.borrow_mut();
                 if !c.remove(&label) {
                     c.insert(label);
@@ -633,6 +667,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 &nodes,
                 &expanded_tables.borrow(),
                 &collapsed_categories.borrow(),
+                engine,
             );
             w.set_schema_tree(ModelRc::from(Rc::new(VecModel::from(rows))));
         });

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -969,6 +969,10 @@ fn main() -> Result<(), slint::PlatformError> {
         let weak = window.as_weak();
         window.on_form_cancel(move || {
             if let Some(w) = weak.upgrade() {
+                // Clear any in-flight test state so the form is never stuck on
+                // "Testing connection…" when reopened.
+                w.set_test_busy(false);
+                w.set_test_result(SharedString::default());
                 w.set_form_open(false);
             }
         });
@@ -1035,12 +1039,21 @@ fn main() -> Result<(), slint::PlatformError> {
 
             let weak2 = weak.clone();
             rt.spawn(async move {
-                let result = async {
+                let attempt = async {
                     let driver = AnyDriver::connect(engine, &cfg).await?;
                     driver.ping().await?;
                     Ok::<_, rdbs_core::error::RdbsError>(())
-                }
-                .await;
+                };
+                // ponytail: timeout-bounded, no hard abort; add CancellationToken
+                // if a true cancel button is ever needed. Bounds a hung connect so
+                // "Testing connection…" always resolves.
+                let result =
+                    match tokio::time::timeout(std::time::Duration::from_secs(8), attempt).await {
+                        Ok(r) => r,
+                        Err(_) => Err(rdbs_core::error::RdbsError::Connection(
+                            "connection timed out".into(),
+                        )),
+                    };
                 let _ = slint::invoke_from_event_loop(move || {
                     if let Some(w) = weak2.upgrade() {
                         w.set_test_busy(false);

--- a/app/src/model.rs
+++ b/app/src/model.rs
@@ -86,6 +86,60 @@ fn redis_cell(v: &RedisValue) -> VmCell {
     }
 }
 
+/// Flatten Mongo documents into a tabular grid: columns are the ordered union
+/// of top-level keys (`_id` first), cells are the matching values. A missing key
+/// is a null cell; a nested object/array is rendered as compact JSON so the row
+/// still reads as one line. The raw pretty JSON is kept separately for the
+/// JSON-view toggle. ponytail: top-level keys only, no deep column expansion.
+fn flatten_documents(docs: &[serde_json::Value]) -> (Vec<VmColumn>, Vec<Vec<VmCell>>) {
+    let mut keys: Vec<String> = Vec::new();
+    for doc in docs {
+        if let Some(obj) = doc.as_object() {
+            for k in obj.keys() {
+                if !keys.iter().any(|e| e == k) {
+                    keys.push(k.clone());
+                }
+            }
+        }
+    }
+    // _id reads first, like every Mongo client.
+    if let Some(pos) = keys.iter().position(|k| k == "_id") {
+        keys.swap(0, pos);
+    }
+
+    let columns = keys
+        .iter()
+        .map(|k| VmColumn {
+            name: k.clone(),
+            type_name: String::new(),
+        })
+        .collect();
+
+    let rows = docs
+        .iter()
+        .map(|doc| {
+            keys.iter()
+                .map(|k| match doc.get(k) {
+                    None | Some(serde_json::Value::Null) => VmCell {
+                        text: String::new(),
+                        is_null: true,
+                    },
+                    Some(serde_json::Value::String(s)) => VmCell {
+                        text: s.clone(),
+                        is_null: false,
+                    },
+                    Some(v) => VmCell {
+                        text: v.to_string(),
+                        is_null: false,
+                    },
+                })
+                .collect()
+        })
+        .collect();
+
+    (columns, rows)
+}
+
 /// Convert any ResultSet into the grid view-model.
 pub fn to_grid_model(rs: &ResultSet) -> GridModel {
     match rs {
@@ -137,7 +191,10 @@ pub fn to_grid_model(rs: &ResultSet) -> GridModel {
         },
         ResultSet::Documents(docs) => {
             let json = serde_json::to_string_pretty(docs).unwrap_or_else(|_| "[]".into());
+            let (columns, rows) = flatten_documents(docs);
             GridModel {
+                columns,
+                rows,
                 json,
                 is_documents: true,
                 ..Default::default()
@@ -233,6 +290,25 @@ mod tests {
         let grid = to_grid_model(&rs);
         assert!(grid.json.contains("\"a\""));
         assert!(grid.is_documents);
+    }
+
+    #[test]
+    fn documents_flatten_to_grid_with_id_first() {
+        let rs = ResultSet::Documents(vec![
+            serde_json::json!({"_id": "x", "name": "ada", "tags": [1, 2]}),
+            serde_json::json!({"name": "lin", "age": 30}),
+        ]);
+        let grid = to_grid_model(&rs);
+        // union of keys, _id first
+        let names: Vec<&str> = grid.columns.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names[0], "_id");
+        assert!(names.contains(&"name") && names.contains(&"tags") && names.contains(&"age"));
+        // row 0: _id plain string, nested array as compact JSON
+        assert_eq!(grid.rows[0][0].text, "x");
+        let tags_idx = names.iter().position(|n| *n == "tags").unwrap();
+        assert_eq!(grid.rows[0][tags_idx].text, "[1,2]");
+        // row 1 missing _id -> null cell
+        assert!(grid.rows[1][0].is_null);
     }
 
     #[test]

--- a/app/src/query_parse.rs
+++ b/app/src/query_parse.rs
@@ -40,6 +40,12 @@ fn parse_mongo(text: &str) -> Result<Query, String> {
         .filter(|s| !s.is_empty())
         .ok_or_else(|| "missing \"collection\"".to_string())?
         .to_string();
+    // Optional: target a specific database; omitted falls back to the default.
+    let database = v
+        .get("database")
+        .and_then(|d| d.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
     let op = v
         .get("op")
         .and_then(|o| o.as_str())
@@ -61,7 +67,11 @@ fn parse_mongo(text: &str) -> Result<Query, String> {
             ))
         }
     };
-    Ok(Query::Mongo(MongoOp { collection, kind }))
+    Ok(Query::Mongo(MongoOp {
+        collection,
+        database,
+        kind,
+    }))
 }
 
 #[cfg(test)]
@@ -101,6 +111,20 @@ mod tests {
                 assert_eq!(op.collection, "users");
                 assert!(matches!(op.kind, MongoKind::Find(_)));
             }
+            _ => panic!("expected Mongo"),
+        }
+    }
+
+    #[test]
+    fn mongo_parses_optional_database() {
+        let with = r#"{ "collection": "c", "database": "appdb", "op": "find", "body": {} }"#;
+        match parse_query(Engine::Mongo, with).unwrap() {
+            Query::Mongo(op) => assert_eq!(op.database.as_deref(), Some("appdb")),
+            _ => panic!("expected Mongo"),
+        }
+        let without = r#"{ "collection": "c", "op": "find", "body": {} }"#;
+        match parse_query(Engine::Mongo, without).unwrap() {
+            Query::Mongo(op) => assert_eq!(op.database, None),
             _ => panic!("expected Mongo"),
         }
     }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -54,6 +54,7 @@ export component MainWindow inherits Window {
     in property <int> grid-col-count;
     in property <string> doc-json;
     in property <bool> is-documents;
+    in property <bool> sql-capable: true;
     in property <string> result-status;
     in-out property <int> selected-row: 0;
     in-out property <bool> show-structure: false;
@@ -364,6 +365,7 @@ export component MainWindow inherits Window {
                         col-widths: root.grid-col-widths;
                         doc-json: root.doc-json;
                         is-documents: root.is-documents;
+                        sql-capable: root.sql-capable;
                         result-status: root.result-status;
                         selected-row: root.selected-row;
                         show-structure <=> root.show-structure;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -37,7 +37,7 @@ export component MainWindow inherits Window {
     in-out property <string> schema-name: "public";
     callback connect-clicked(int);
     callback toggle-group(string);
-    callback open-table(string);
+    callback open-table(string, string);   // (database, container)
     callback toggle-schema-node(string);
     callback select-schema(string);
 
@@ -231,8 +231,8 @@ export component MainWindow inherits Window {
                     disconnect() => {
                         root.disconnect();
                     }
-                    open-table(t) => {
-                        root.open-table(t);
+                    open-table(db, t) => {
+                        root.open-table(db, t);
                     }
                     toggle-node(t) => {
                         root.toggle-schema-node(t);

--- a/app/src/ui/conn-form.slint
+++ b/app/src/ui/conn-form.slint
@@ -44,7 +44,9 @@ export component ConnForm inherits Rectangle {
 
     if root.open: Rectangle {
         width: 460px;
-        height: 540px;
+        // No fixed height: the card sizes to its VerticalLayout so rows never
+        // overflow past the card edge (was a fixed 540px that pushed the button
+        // row outside the card).
         x: (parent.width - self.width) / 2;
         y: 60px;
         border-radius: Theme.radius-panel;
@@ -98,7 +100,8 @@ export component ConnForm inherits Rectangle {
                 }
             }
 
-            HorizontalLayout {
+            // Redis has no user/database concept — hide those for it.
+            if root.f-engine != "Redis": HorizontalLayout {
                 spacing: Theme.sp2;
                 VerticalLayout {
                     Text { text: "User"; color: Theme.text-dim; font-size: Theme.font-label; }
@@ -113,8 +116,11 @@ export component ConnForm inherits Rectangle {
             Text { text: "Password"; color: Theme.text-dim; font-size: Theme.font-label; }
             LineEdit { text <=> root.f-password; input-type: password; }
 
-            Text { text: "SSL"; color: Theme.text-dim; font-size: Theme.font-label; }
-            ComboBox {
+            // SSL mode only applies to the SQL engines.
+            if root.f-engine == "PostgreSQL" || root.f-engine == "MySQL": Text {
+                text: "SSL"; color: Theme.text-dim; font-size: Theme.font-label;
+            }
+            if root.f-engine == "PostgreSQL" || root.f-engine == "MySQL": ComboBox {
                 model: ["Disable", "Prefer", "Require"];
                 current-value <=> root.f-sslmode;
             }

--- a/app/src/ui/conn-form.slint
+++ b/app/src/ui/conn-form.slint
@@ -44,9 +44,12 @@ export component ConnForm inherits Rectangle {
 
     if root.open: Rectangle {
         width: 460px;
-        // No fixed height: the card sizes to its VerticalLayout so rows never
-        // overflow past the card edge (was a fixed 540px that pushed the button
-        // row outside the card).
+        // Hug the content height: a bare Rectangle fills its parent (the full
+        // overlay), which stretched every input. Binding to the layout's
+        // preferred height sizes the card to its rows — buttons stay inside and
+        // inputs keep their natural height.
+        // ponytail: wrap vbox in a ScrollView only if content ever exceeds the window.
+        height: vbox.preferred-height;
         x: (parent.width - self.width) / 2;
         y: 60px;
         border-radius: Theme.radius-panel;
@@ -56,7 +59,7 @@ export component ConnForm inherits Rectangle {
         drop-shadow-blur: 24px;
         drop-shadow-color: #00000088;
 
-        VerticalLayout {
+        vbox := VerticalLayout {
             padding: Theme.sp4;
             spacing: Theme.sp2;
 

--- a/app/src/ui/sidebar.slint
+++ b/app/src/ui/sidebar.slint
@@ -75,6 +75,10 @@ export component Sidebar inherits Rectangle {
         ScrollView {
             vertical-stretch: 1;
             VerticalLayout {
+                // Lock content width to the viewport so a bolded active row can't
+                // widen the content and feed a relayout loop (the "jittering"
+                // sidebar). Rows elide instead of growing horizontally.
+                width: parent.visible-width;
                 padding-top: Theme.sp1;
                 spacing: 2px;
                 for node[i] in root.tree: Rectangle {
@@ -109,8 +113,9 @@ export component Sidebar inherits Rectangle {
                         padding-left: Theme.sp2 + node.depth * Theme.sp3;
                         padding-right: Theme.sp1;
                         spacing: Theme.sp1;
-                        // chevron: headers + containers expand (rotates when open)
-                        if is-header || is-container: AppIcon {
+                        // chevron: only headers expand/collapse (rotates when open).
+                        // Containers open data on click — no chevron, cleaner column.
+                        if is-header: AppIcon {
                             name: "chevron";
                             size: Theme.icon-sm;
                             color: Theme.text-faint;

--- a/app/src/ui/sidebar.slint
+++ b/app/src/ui/sidebar.slint
@@ -15,7 +15,7 @@ export component Sidebar inherits Rectangle {
     in property <[string]> schema-list;
     in-out property <string> schema-name;
     callback disconnect();
-    callback open-table(string);
+    callback open-table(string, string);   // (database, container)
     callback toggle-node(string);
     callback select-schema(string);
 
@@ -78,14 +78,17 @@ export component Sidebar inherits Rectangle {
                 padding-top: Theme.sp1;
                 spacing: 2px;
                 for node[i] in root.tree: Rectangle {
+                    // headers = SQL categories + Mongo database names (collapsible)
+                    property <bool> is-header: node.kind == "category" || node.kind == "database";
                     property <bool> is-category: node.kind == "category";
+                    property <bool> is-database: node.kind == "database";
                     property <bool> is-container: node.kind == "table" || node.kind == "collection" || node.kind == "keyspace";
                     property <bool> is-field: node.kind == "field";
                     property <bool> is-active: is-container && node.label == root.active-table;
                     height: is-category ? 28px : Theme.row-height;
                     border-radius: Theme.radius-control;
                     background: is-active ? Theme.accent-soft
-                        : (row-ta.has-hover && (is-container || is-category) ? Theme.surface-2 : transparent);
+                        : (row-ta.has-hover && (is-container || is-header) ? Theme.surface-2 : transparent);
                     // active-row accent bar
                     if is-active: Rectangle {
                         x: 0;
@@ -96,18 +99,18 @@ export component Sidebar inherits Rectangle {
                         background: Theme.accent;
                     }
                     row-ta := TouchArea {
-                        enabled: is-container || is-category;
+                        enabled: is-container || is-header;
                         clicked => {
-                            if (is-category) { root.toggle-node(node.label); }
-                            else { root.open-table(node.label); }
+                            if (is-header) { root.toggle-node(node.label); }
+                            else { root.open-table(node.db, node.label); }
                         }
                     }
                     HorizontalLayout {
                         padding-left: Theme.sp2 + node.depth * Theme.sp3;
                         padding-right: Theme.sp1;
                         spacing: Theme.sp1;
-                        // chevron: categories + containers expand (rotates when open)
-                        if is-category || is-container: AppIcon {
+                        // chevron: headers + containers expand (rotates when open)
+                        if is-header || is-container: AppIcon {
                             name: "chevron";
                             size: Theme.icon-sm;
                             color: Theme.text-faint;
@@ -117,6 +120,11 @@ export component Sidebar inherits Rectangle {
                         if is-category: AppIcon {
                             name: node.label == "Views" ? "view"
                                 : (node.label == "Functions" ? "function" : "rows");
+                            size: Theme.icon-sm;
+                            color: Theme.text-faint;
+                        }
+                        if is-database: AppIcon {
+                            name: "database";
                             size: Theme.icon-sm;
                             color: Theme.text-faint;
                         }
@@ -136,12 +144,12 @@ export component Sidebar inherits Rectangle {
                         Text {
                             vertical-alignment: center;
                             text: node.label;
-                            color: is-category ? Theme.text-faint
+                            color: is-header ? Theme.text-faint
                                 : (is-field ? Theme.text-dim
                                     : (is-active ? Theme.accent : Theme.text));
-                            font-size: is-category ? Theme.font-caption
+                            font-size: is-header ? Theme.font-caption
                                 : (is-field ? Theme.font-label : Theme.font-body);
-                            font-weight: is-category ? 700 : (is-active ? 600 : 400);
+                            font-weight: is-header ? 700 : (is-active ? 600 : 400);
                             font-family: is-field ? Theme.mono-family : "";
                             overflow: elide;
                         }

--- a/app/src/ui/structs.slint
+++ b/app/src/ui/structs.slint
@@ -3,7 +3,9 @@
 // them without an import cycle.
 export struct GridColumn { name: string, type-name: string }
 export struct GridCell { text: string, is-null: bool }
-export struct TreeNode { label: string, depth: int, kind: string, expanded: bool }
+// `db` tags the owning database for container rows (Mongo db→collection tree);
+// empty for SQL/Redis where the category path is used instead.
+export struct TreeNode { label: string, depth: int, kind: string, expanded: bool, db: string }
 // A sidebar row is either a group header (is-header=true, name holds the group
 // label, expanded holds its toggle state) or a connection. `index` is the
 // connection's index in the underlying store (-1 for headers) so connect/edit

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -333,17 +333,19 @@ export component WorkArea inherits Rectangle {
                 }
             }
 
-            // documents raw-JSON view (toggled on); full width, left-aligned
+            // documents raw-JSON view (toggled on); pinned top-left, full width
             if !root.show-structure && root.is-documents && root.doc-as-json: ScrollView {
-                Text {
-                    width: parent.visible-width - 2 * Theme.sp2;
-                    x: Theme.sp2;
-                    text: root.doc-json;
-                    color: Theme.text;
-                    horizontal-alignment: left;
-                    wrap: word-wrap;
-                    font-family: Theme.mono-family;
-                    font-size: Theme.font-mono;
+                VerticalLayout {
+                    alignment: start;
+                    padding: Theme.sp2;
+                    Text {
+                        text: root.doc-json;
+                        color: Theme.text;
+                        horizontal-alignment: left;
+                        wrap: word-wrap;
+                        font-family: Theme.mono-family;
+                        font-size: Theme.font-mono;
+                    }
                 }
             }
 

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -11,6 +11,9 @@ export component WorkArea inherits Rectangle {
     in property <[length]> col-widths;     // per-column pixel widths (drag-resizable)
     in property <string> doc-json;
     in property <bool> is-documents;
+    // SQL editor only for SQL engines; documents can switch grid <-> raw JSON.
+    in property <bool> sql-capable: true;
+    in-out property <bool> doc-as-json: false;
     in property <string> result-status;    // Affected toast / errors
     in property <int> selected-row: 0;
     // ----- Data / Structure toggle (Feature B) -----
@@ -41,8 +44,8 @@ export component WorkArea inherits Rectangle {
         // ----- top toolbar: SQL toggle + active table / status -----
         HorizontalLayout {
             spacing: Theme.sp2;
-            // SQL editor toggle pill
-            Rectangle {
+            // SQL editor toggle pill (SQL engines only)
+            if root.sql-capable: Rectangle {
                 width: 66px;
                 height: Theme.row-height;
                 border-radius: Theme.radius-control;
@@ -219,6 +222,46 @@ export component WorkArea inherits Rectangle {
                 }
             }
             Rectangle { width: Theme.sp2; } // gap
+            // Table | JSON toggle — documents only (Feature: Mongo preview)
+            if root.is-documents && !root.show-structure: Rectangle {
+                width: 132px;
+                height: Theme.row-height;
+                border-radius: Theme.radius-control;
+                background: Theme.surface;
+                border-width: 1px;
+                border-color: Theme.hairline;
+                HorizontalLayout {
+                    padding: 2px;
+                    spacing: 2px;
+                    Rectangle {
+                        border-radius: Theme.radius-control - 1px;
+                        background: !root.doc-as-json ? Theme.accent-soft : transparent;
+                        table-ta := TouchArea { clicked => { root.doc-as-json = false; } }
+                        Text {
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                            text: "Table";
+                            color: !root.doc-as-json ? Theme.accent : Theme.text-dim;
+                            font-size: Theme.font-label;
+                            font-weight: !root.doc-as-json ? 600 : 400;
+                        }
+                    }
+                    Rectangle {
+                        border-radius: Theme.radius-control - 1px;
+                        background: root.doc-as-json ? Theme.accent-soft : transparent;
+                        json-ta := TouchArea { clicked => { root.doc-as-json = true; } }
+                        Text {
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                            text: "JSON";
+                            color: root.doc-as-json ? Theme.accent : Theme.text-dim;
+                            font-size: Theme.font-label;
+                            font-weight: root.doc-as-json ? 600 : 400;
+                        }
+                    }
+                }
+            }
+            if root.is-documents: Rectangle { width: Theme.sp2; } // gap
             // client-side filter (only meaningful for Data view); flexes with width
             AppIcon {
                 name: "filter";
@@ -290,18 +333,22 @@ export component WorkArea inherits Rectangle {
                 }
             }
 
-            // documents (JSON) view
-            if !root.show-structure && root.is-documents: ScrollView {
+            // documents raw-JSON view (toggled on); full width, left-aligned
+            if !root.show-structure && root.is-documents && root.doc-as-json: ScrollView {
                 Text {
+                    width: parent.visible-width - 2 * Theme.sp2;
+                    x: Theme.sp2;
                     text: root.doc-json;
                     color: Theme.text;
+                    horizontal-alignment: left;
+                    wrap: word-wrap;
                     font-family: Theme.mono-family;
                     font-size: Theme.font-mono;
                 }
             }
 
-            // tabular / key-value grid
-            if !root.show-structure && !root.is-documents: ScrollView {
+            // tabular / key-value / flattened-document grid
+            if !root.show-structure && !(root.is-documents && root.doc-as-json): ScrollView {
                 VerticalLayout {
                     // fill ScrollView width when few columns; grow past it (scroll) when many
                     width: max(self.preferred-width, parent.visible-width);

--- a/crates/core/src/driver.rs
+++ b/crates/core/src/driver.rs
@@ -19,8 +19,16 @@ pub trait Driver: Send + Sync {
     /// Cheap liveness check.
     async fn ping(&self) -> Result<()>;
 
-    /// Full schema tree (databases → containers → fields).
+    /// Full schema tree (databases → containers → fields). Engines with many
+    /// databases (e.g. Mongo) may return databases with empty `containers` and
+    /// fill them lazily via [`Driver::containers`] when a database is expanded.
     async fn schema(&self) -> Result<Schema>;
+
+    /// List the containers (tables/collections) of one database, fetched on
+    /// demand. Default is empty for engines that return everything in `schema`.
+    async fn containers(&self, _database: &str) -> Result<Vec<crate::schema::Container>> {
+        Ok(Vec::new())
+    }
 
     /// Run a query. Drivers handle the `Query` variant(s) they support and
     /// return `RdbsError::UnsupportedQuery` for the rest.

--- a/crates/core/src/query.rs
+++ b/crates/core/src/query.rs
@@ -17,6 +17,8 @@ pub enum Query {
 #[derive(Debug, Clone)]
 pub struct MongoOp {
     pub collection: String,
+    /// Target database; `None` falls back to the connection's default database.
+    pub database: Option<String>,
     pub kind: MongoKind,
 }
 
@@ -44,6 +46,7 @@ mod tests {
     fn mongo_find_op_constructs() {
         let op = MongoOp {
             collection: "users".into(),
+            database: None,
             kind: MongoKind::Find(serde_json::json!({ "age": { "$gt": 18 } })),
         };
         assert_eq!(op.collection, "users");

--- a/crates/driver-mongo/src/driver.rs
+++ b/crates/driver-mongo/src/driver.rs
@@ -64,35 +64,45 @@ impl Driver for MongoDriver {
         Ok(())
     }
 
+    /// Lazy: list databases only (cheap), with empty containers. Collections are
+    /// fetched per database via `containers()` when the user expands it, so a
+    /// server with many large databases doesn't stall on connect.
     async fn schema(&self) -> Result<Schema> {
         let db_names = self
             .client
             .list_database_names()
             .await
             .map_err(|e| RdbsError::Schema(e.to_string()))?;
-
-        let mut databases = Vec::new();
-        for db_name in db_names {
-            let db = self.client.database(&db_name);
-            let coll_names = db
-                .list_collection_names()
-                .await
-                .map_err(|e| RdbsError::Schema(e.to_string()))?;
-            let containers = coll_names
-                .into_iter()
-                .map(|name| Container {
-                    name,
-                    kind: ContainerKind::Collection,
-                    // Mongo is schemaless: no static field list to report.
-                    fields: Vec::new(),
-                })
-                .collect();
-            databases.push(Database {
-                name: db_name,
-                containers,
-            });
-        }
+        let databases = db_names
+            .into_iter()
+            .map(|name| Database {
+                name,
+                containers: Vec::new(),
+            })
+            .collect();
         Ok(Schema { databases })
+    }
+
+    /// Collections of one database, capped so a database with thousands of
+    /// collections stays light. ponytail: fixed cap, add paging if it matters.
+    async fn containers(&self, database: &str) -> Result<Vec<Container>> {
+        const MAX_COLLECTIONS: usize = 20;
+        let coll_names = self
+            .client
+            .database(database)
+            .list_collection_names()
+            .await
+            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+        Ok(coll_names
+            .into_iter()
+            .take(MAX_COLLECTIONS)
+            .map(|name| Container {
+                name,
+                kind: ContainerKind::Collection,
+                // Mongo is schemaless: no static field list to report.
+                fields: Vec::new(),
+            })
+            .collect())
     }
 
     async fn query(&self, q: &Query) -> Result<ResultSet> {

--- a/crates/driver-mongo/src/driver.rs
+++ b/crates/driver-mongo/src/driver.rs
@@ -35,10 +35,13 @@ fn build_uri(cfg: &ConnConfig) -> String {
 }
 
 impl MongoDriver {
-    fn collection(&self, name: &str) -> Collection<Document> {
+    /// Resolve a collection in the op's database, falling back to the
+    /// connection's default database when the op names none.
+    fn collection(&self, op: &MongoOp) -> Collection<Document> {
+        let db = op.database.as_deref().unwrap_or(&self.default_db);
         self.client
-            .database(&self.default_db)
-            .collection::<Document>(name)
+            .database(db)
+            .collection::<Document>(&op.collection)
     }
 }
 
@@ -97,7 +100,7 @@ impl Driver for MongoDriver {
             Query::Mongo(op) => op,
             _ => return Err(RdbsError::UnsupportedQuery),
         };
-        let coll = self.collection(&op.collection);
+        let coll = self.collection(op);
 
         match &op.kind {
             MongoKind::Find(filter) => {

--- a/crates/driver-mongo/tests/integration.rs
+++ b/crates/driver-mongo/tests/integration.rs
@@ -33,6 +33,7 @@ async fn connect_insert_find_aggregate_schema_against_real_mongo() {
         let inserted = driver
             .query(&Query::Mongo(MongoOp {
                 collection: "users".into(),
+                database: None,
                 kind: MongoKind::Insert(serde_json::json!({ "name": name, "age": age })),
             }))
             .await
@@ -43,6 +44,7 @@ async fn connect_insert_find_aggregate_schema_against_real_mongo() {
     let found = driver
         .query(&Query::Mongo(MongoOp {
             collection: "users".into(),
+            database: None,
             kind: MongoKind::Find(serde_json::json!({ "age": { "$gte": 18 } })),
         }))
         .await
@@ -58,6 +60,7 @@ async fn connect_insert_find_aggregate_schema_against_real_mongo() {
     let agg = driver
         .query(&Query::Mongo(MongoOp {
             collection: "users".into(),
+            database: None,
             kind: MongoKind::Aggregate(vec![
                 serde_json::json!({ "$group": { "_id": null, "total": { "$sum": 1 } } }),
             ]),

--- a/crates/driver-mongo/tests/integration.rs
+++ b/crates/driver-mongo/tests/integration.rs
@@ -75,13 +75,18 @@ async fn connect_insert_find_aggregate_schema_against_real_mongo() {
         other => panic!("expected Documents, got {other:?}"),
     }
 
+    // schema() is lazy: databases only, no eager collection listing.
     let schema = driver.schema().await.unwrap();
-    let has_users = schema
-        .databases
-        .iter()
-        .flat_map(|d| &d.containers)
-        .any(|c| c.name == "users");
-    assert!(has_users, "schema should contain the users collection");
+    assert!(
+        schema.databases.iter().any(|d| d.name == "appdb"),
+        "schema should list the appdb database"
+    );
+    // Collections are fetched per database on demand.
+    let containers = driver.containers("appdb").await.unwrap();
+    assert!(
+        containers.iter().any(|c| c.name == "users"),
+        "appdb should contain the users collection"
+    );
 
     assert!(driver.query(&Query::Sql("SELECT 1".into())).await.is_err());
 

--- a/crates/driver-postgres/tests/integration.rs
+++ b/crates/driver-postgres/tests/integration.rs
@@ -102,6 +102,7 @@ async fn non_sql_queries_are_unsupported() {
     let mongo = driver
         .query(&Query::Mongo(MongoOp {
             collection: "c".into(),
+            database: None,
             kind: MongoKind::Find(serde_json::json!({})),
         }))
         .await;


### PR DESCRIPTION
## Summary
- Fix the connection dialog (floating buttons, giant inputs, one-size-fits-all fields, hung test) and the post-connect MongoDB experience.
- Make the browser engine-aware: real database names, no SQL chrome for NoSQL, document preview as a grid with a JSON toggle.
- Represent MongoDB as database → collection with lazy, capped collection loading so connecting to a busy server stays fast.

## Changes
### Connection form (`app/src/ui/conn-form.slint`, `app/src/main.rs`)
- Card sizes to its content: buttons stay inside, inputs keep natural height.
- Per-engine fields: Redis hides User/Database; SSL only for PostgreSQL/MySQL.
- Test Connection bounded by an 8s timeout; Cancel clears in-flight test state.

### Engine-aware browser (`app/src/ui/workarea.slint`, `app/src/ui/app-window.slint`, `app/src/main.rs`)
- Real database names in the schema selector (was hardcoded `public`).
- SQL editor pill hidden for non-SQL engines; sidebar labels per engine.
- Documents flatten to a grid (`_id` first) with a Table | JSON toggle; raw JSON pinned top-left.

### MongoDB database → collection (`crates/core`, `crates/driver-mongo`, `app/`)
- `MongoOp.database` so a collection in any database is browsable; driver resolves the op's DB (default fallback).
- Sidebar renders databases as collapsible headers, collections nested and tagged with their DB; clicks carry the DB.
- Lazy load: `schema()` lists databases only; `Driver::containers(db)` fetches a database's collections on demand, capped at 20.
- Sidebar content width locked to the viewport to stop a relayout/jitter loop; chevron removed from container rows.

### Build (`Makefile`)
- `fe-build-run` (build then launch) and `fe-show` (launch, build only if missing).

## Test plan
- [x] `make fmt-check`
- [x] `make lint` (clippy `-D warnings`)
- [x] `make test` (unit, incl. new query/parser tests)
- [x] `make fe-show` — form sized right, fields toggle per engine, Mongo tree lazy-loads collections (≤20), open collection shows grid + JSON toggle, `admin > system.version` targets the right DB
- [x] Spot-check Postgres/MySQL/Redis browse unchanged
- [ ] Mongo integration tests (`make test-it`, needs Docker)
