### PR TITLE
fix(mongo): correct sidebar tree and data preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5455,7 +5455,7 @@ dependencies = [
 
 [[package]]
 name = "rdbs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "rdbs-connstore",
  "rdbs-core",

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -707,7 +707,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 }
                 Some(rdbs_connstore::Engine::Mongo) => {
                     format!(
-                        "{{\"collection\":\"{label}\",\"database\":\"{db}\",\"op\":\"find\",\"body\":{{}}}}"
+                        "{{\"collection\":\"{label}\",\"database\":\"{db}\",\"op\":\"find\",\"body\":{{}},\"limit\":50}}"
                     )
                 }
                 Some(rdbs_connstore::Engine::Redis) => {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -124,13 +124,14 @@ fn schema_display_rows(
     nodes: &[model::VmTreeNode],
     expanded_tables: &HashSet<String>,
     collapsed_cats: &HashSet<String>,
+    loaded_dbs: &HashSet<String>,
     engine: Option<rdbs_connstore::Engine>,
 ) -> Vec<TreeNode> {
     // Mongo is database→collection: render each database as a collapsible header
     // and nest only its own collections, so system DBs never mix with the app's.
     // `expanded_tables` is the set of OPEN databases (default closed).
     if engine == Some(rdbs_connstore::Engine::Mongo) {
-        return mongo_display_rows(nodes, expanded_tables);
+        return mongo_display_rows(nodes, expanded_tables, loaded_dbs);
     }
 
     let categories = sidebar_categories(engine);
@@ -183,19 +184,40 @@ fn schema_display_rows(
 
 /// Build database→collection rows for Mongo. Each database is a depth-0
 /// collapsible header (open when its name is in `expanded_dbs`, default closed);
-/// its collections are depth-1 rows tagged with the owning database.
+/// its collections are depth-1 rows tagged with the owning database. An open
+/// database with no collection rows gets a non-clickable hint row so the header
+/// never looks stuck: `(loading…)` until its fetch lands in `loaded_dbs`, then
+/// `(no collections)` if it really is empty.
 fn mongo_display_rows(
     nodes: &[model::VmTreeNode],
     expanded_dbs: &HashSet<String>,
+    loaded_dbs: &HashSet<String>,
 ) -> Vec<TreeNode> {
     let mut rows: Vec<TreeNode> = Vec::new();
     let mut current_db = String::new();
     let mut db_open = false;
+    let mut coll_count = 0usize;
+    // Push the loading/empty hint for an open database that emitted no rows.
+    let hint_row = |db: &str| TreeNode {
+        label: if loaded_dbs.contains(db) {
+            "(no collections)".into()
+        } else {
+            "(loading…)".into()
+        },
+        depth: 1,
+        kind: "hint".into(),
+        expanded: false,
+        db: db.to_string().into(),
+    };
     for n in nodes {
         match n.kind.as_str() {
             "database" => {
+                if db_open && coll_count == 0 {
+                    rows.push(hint_row(&current_db));
+                }
                 current_db = n.label.clone();
                 db_open = expanded_dbs.contains(&current_db);
+                coll_count = 0;
                 rows.push(TreeNode {
                     label: n.label.clone().into(),
                     depth: 0,
@@ -205,6 +227,7 @@ fn mongo_display_rows(
                 });
             }
             "collection" | "table" | "keyspace" if db_open => {
+                coll_count += 1;
                 rows.push(TreeNode {
                     label: n.label.clone().into(),
                     depth: 1,
@@ -215,6 +238,9 @@ fn mongo_display_rows(
             }
             _ => {}
         }
+    }
+    if db_open && coll_count == 0 {
+        rows.push(hint_row(&current_db));
     }
     rows
 }
@@ -515,6 +541,7 @@ fn main() -> Result<(), slint::PlatformError> {
                             &nodes,
                             &HashSet::new(),
                             &HashSet::new(),
+                            &HashSet::new(),
                             Some(engine),
                         );
                         // Real database/schema names from introspection; fall back
@@ -741,6 +768,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     let driver = current.clone();
                     let raw_nodes = raw_nodes.clone();
                     let expanded_tables = expanded_tables.clone();
+                    let loaded_dbs = loaded_dbs.clone();
                     let weak2 = weak.clone();
                     let db = label.clone();
                     rt.spawn(async move {
@@ -771,6 +799,7 @@ fn main() -> Result<(), slint::PlatformError> {
                                 &nodes,
                                 &expanded_tables.lock().unwrap(),
                                 &HashSet::new(),
+                                &loaded_dbs.lock().unwrap(),
                                 Some(rdbs_connstore::Engine::Mongo),
                             )
                         };
@@ -788,6 +817,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     &nodes,
                     &expanded_tables.lock().unwrap(),
                     &HashSet::new(),
+                    &loaded_dbs.lock().unwrap(),
                     engine,
                 );
                 w.set_schema_tree(ModelRc::from(Rc::new(VecModel::from(rows))));
@@ -806,6 +836,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 &nodes,
                 &expanded_tables.lock().unwrap(),
                 &collapsed_categories.borrow(),
+                &loaded_dbs.lock().unwrap(),
                 engine,
             );
             w.set_schema_tree(ModelRc::from(Rc::new(VecModel::from(rows))));

--- a/app/src/query_parse.rs
+++ b/app/src/query_parse.rs
@@ -51,6 +51,8 @@ fn parse_mongo(text: &str) -> Result<Query, String> {
         .and_then(|o| o.as_str())
         .ok_or_else(|| "missing \"op\"".to_string())?;
     let body = v.get("body").cloned().unwrap_or(serde_json::Value::Null);
+    // Optional row cap for `find`; omitted means unbounded.
+    let limit = v.get("limit").and_then(|l| l.as_i64());
 
     let kind = match op {
         "find" => MongoKind::Find(body),
@@ -70,6 +72,7 @@ fn parse_mongo(text: &str) -> Result<Query, String> {
     Ok(Query::Mongo(MongoOp {
         collection,
         database,
+        limit,
         kind,
     }))
 }
@@ -125,6 +128,20 @@ mod tests {
         let without = r#"{ "collection": "c", "op": "find", "body": {} }"#;
         match parse_query(Engine::Mongo, without).unwrap() {
             Query::Mongo(op) => assert_eq!(op.database, None),
+            _ => panic!("expected Mongo"),
+        }
+    }
+
+    #[test]
+    fn mongo_parses_optional_limit() {
+        let with = r#"{ "collection": "c", "op": "find", "body": {}, "limit": 50 }"#;
+        match parse_query(Engine::Mongo, with).unwrap() {
+            Query::Mongo(op) => assert_eq!(op.limit, Some(50)),
+            _ => panic!("expected Mongo"),
+        }
+        let without = r#"{ "collection": "c", "op": "find", "body": {} }"#;
+        match parse_query(Engine::Mongo, without).unwrap() {
+            Query::Mongo(op) => assert_eq!(op.limit, None),
             _ => panic!("expected Mongo"),
         }
     }

--- a/app/src/ui/sidebar.slint
+++ b/app/src/ui/sidebar.slint
@@ -88,6 +88,8 @@ export component Sidebar inherits Rectangle {
                     property <bool> is-database: node.kind == "database";
                     property <bool> is-container: node.kind == "table" || node.kind == "collection" || node.kind == "keyspace";
                     property <bool> is-field: node.kind == "field";
+                    // placeholder row (loading / no collections): dim, non-clickable
+                    property <bool> is-hint: node.kind == "hint";
                     property <bool> is-active: is-container && node.label == root.active-table;
                     height: is-category ? 28px : Theme.row-height;
                     border-radius: Theme.radius-control;
@@ -150,12 +152,13 @@ export component Sidebar inherits Rectangle {
                             vertical-alignment: center;
                             text: node.label;
                             color: is-header ? Theme.text-faint
-                                : (is-field ? Theme.text-dim
+                                : (is-field || is-hint ? Theme.text-dim
                                     : (is-active ? Theme.accent : Theme.text));
                             font-size: is-header ? Theme.font-caption
                                 : (is-field ? Theme.font-label : Theme.font-body);
                             font-weight: is-header ? 700 : (is-active ? 600 : 400);
                             font-family: is-field ? Theme.mono-family : "";
+                            font-italic: is-hint;
                             overflow: elide;
                         }
                     }

--- a/crates/core/src/query.rs
+++ b/crates/core/src/query.rs
@@ -19,6 +19,9 @@ pub struct MongoOp {
     pub collection: String,
     /// Target database; `None` falls back to the connection's default database.
     pub database: Option<String>,
+    /// Max rows for a `find`; `None` is unbounded. Browsing sets a default cap so
+    /// a large collection never freezes the UI.
+    pub limit: Option<i64>,
     pub kind: MongoKind,
 }
 
@@ -47,6 +50,7 @@ mod tests {
         let op = MongoOp {
             collection: "users".into(),
             database: None,
+            limit: None,
             kind: MongoKind::Find(serde_json::json!({ "age": { "$gt": 18 } })),
         };
         assert_eq!(op.collection, "users");

--- a/crates/driver-mongo/src/convert.rs
+++ b/crates/driver-mongo/src/convert.rs
@@ -17,11 +17,63 @@ pub fn json_to_document(value: &serde_json::Value) -> Result<Document> {
     }
 }
 
-/// Convert a BSON `Document` back into a `serde_json::Value`. Uses BSON's
-/// relaxed extended-JSON form so ordinary numbers/strings stay plain and only
-/// exotic types (ObjectId, dates) carry `$`-prefixed wrappers.
+/// Convert a BSON `Document` back into a `serde_json::Value`. Starts from BSON's
+/// relaxed extended-JSON form, then collapses the `$`-prefixed wrappers it emits
+/// (`$oid`, `$date`, `$numberLong`, …) into plain scalars so both the table and
+/// JSON preview read like Compass instead of leaking `{"$oid":"…"}`.
 pub fn document_to_json(doc: Document) -> serde_json::Value {
-    Bson::Document(doc).into_relaxed_extjson()
+    simplify(Bson::Document(doc).into_relaxed_extjson())
+}
+
+/// Recursively collapse single-key extended-JSON wrapper objects into the plain
+/// scalar they represent. Anything that isn't a recognized wrapper is walked
+/// through unchanged.
+fn simplify(v: serde_json::Value) -> serde_json::Value {
+    use serde_json::Value;
+    match v {
+        Value::Array(items) => Value::Array(items.into_iter().map(simplify).collect()),
+        Value::Object(map) => {
+            // Only single-key objects can be wrappers; collapse the ones we know.
+            if map.len() == 1 {
+                let (k, inner) = map.into_iter().next().unwrap();
+                return match k.as_str() {
+                    "$oid" => inner, // already a string
+                    // Relaxed ext-JSON dates are ISO strings; pre-1970/post-9999
+                    // dates fall back to {"$date":{"$numberLong":"ms"}}.
+                    "$date" => simplify(inner),
+                    "$numberLong" | "$numberInt" => str_to_number(inner),
+                    "$numberDouble" | "$numberDecimal" => str_to_number(inner),
+                    _ => {
+                        // Not a wrapper: rebuild the one-key object, simplifying its value.
+                        let mut m = serde_json::Map::new();
+                        m.insert(k, simplify(inner));
+                        Value::Object(m)
+                    }
+                };
+            }
+            Value::Object(map.into_iter().map(|(k, val)| (k, simplify(val))).collect())
+        }
+        other => other,
+    }
+}
+
+/// Parse a numeric ext-JSON string into a JSON number; keep the string if it
+/// isn't finite/parseable (e.g. "Infinity", "NaN", Decimal128 precision).
+fn str_to_number(v: serde_json::Value) -> serde_json::Value {
+    match &v {
+        serde_json::Value::String(s) => {
+            if let Ok(i) = s.parse::<i64>() {
+                serde_json::Value::from(i)
+            } else if let Ok(f) = s.parse::<f64>() {
+                serde_json::Number::from_f64(f)
+                    .map(serde_json::Value::Number)
+                    .unwrap_or(v)
+            } else {
+                v
+            }
+        }
+        _ => v,
+    }
 }
 
 #[cfg(test)]
@@ -61,5 +113,35 @@ mod tests {
         let json = document_to_json(d);
         assert_eq!(json["name"], serde_json::json!("bob"));
         assert_eq!(json["score"], serde_json::json!(1.5));
+    }
+
+    #[test]
+    fn objectid_collapses_to_hex_string() {
+        use mongodb::bson::oid::ObjectId;
+        let oid = ObjectId::new();
+        let d = doc! { "_id": oid };
+        let json = document_to_json(d);
+        assert_eq!(json["_id"], serde_json::json!(oid.to_hex()));
+    }
+
+    #[test]
+    fn date_collapses_to_iso_string() {
+        use mongodb::bson::DateTime;
+        let dt = DateTime::from_millis(1_700_000_000_000);
+        let d = doc! { "at": dt };
+        let json = document_to_json(d);
+        // Plain ISO string, not {"$date": ...}.
+        assert!(json["at"].is_string(), "got {}", json["at"]);
+        assert!(json["at"].as_str().unwrap().starts_with("2023-"));
+    }
+
+    #[test]
+    fn nested_array_and_object_wrappers_collapse() {
+        use mongodb::bson::oid::ObjectId;
+        let oid = ObjectId::new();
+        let d = doc! { "refs": [oid], "child": { "_id": oid } };
+        let json = document_to_json(d);
+        assert_eq!(json["refs"][0], serde_json::json!(oid.to_hex()));
+        assert_eq!(json["child"]["_id"], serde_json::json!(oid.to_hex()));
     }
 }

--- a/crates/driver-mongo/src/driver.rs
+++ b/crates/driver-mongo/src/driver.rs
@@ -122,10 +122,11 @@ impl Driver for MongoDriver {
         match &op.kind {
             MongoKind::Find(filter) => {
                 let filter_doc = json_to_document(filter)?;
-                let cursor = coll
-                    .find(filter_doc)
-                    .await
-                    .map_err(|e| RdbsError::Query(e.to_string()))?;
+                let mut find = coll.find(filter_doc);
+                if let Some(n) = op.limit {
+                    find = find.limit(n);
+                }
+                let cursor = find.await.map_err(|e| RdbsError::Query(e.to_string()))?;
                 let docs: Vec<Document> = cursor
                     .try_collect()
                     .await

--- a/crates/driver-mongo/src/driver.rs
+++ b/crates/driver-mongo/src/driver.rs
@@ -20,6 +20,12 @@ pub struct MongoDriver {
     default_db: String,
 }
 
+/// Mongo's internal databases. Hidden from the sidebar so the user's own
+/// databases aren't buried, matching Compass/TablePlus defaults.
+fn is_system_db(name: &str) -> bool {
+    matches!(name, "admin" | "config" | "local")
+}
+
 fn build_uri(cfg: &ConnConfig) -> String {
     let auth = match &cfg.password {
         Some(pw) if !pw.is_empty() => format!("{}:{}@", cfg.user, pw),
@@ -75,6 +81,7 @@ impl Driver for MongoDriver {
             .map_err(|e| RdbsError::Schema(e.to_string()))?;
         let databases = db_names
             .into_iter()
+            .filter(|n| !is_system_db(n))
             .map(|name| Database {
                 name,
                 containers: Vec::new(),
@@ -158,5 +165,19 @@ impl Driver for MongoDriver {
         // mongodb::Client has no explicit close; dropping it ends background tasks.
         drop(self.client);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_system_db;
+
+    #[test]
+    fn system_dbs_are_hidden() {
+        assert!(is_system_db("admin"));
+        assert!(is_system_db("config"));
+        assert!(is_system_db("local"));
+        assert!(!is_system_db("appdb"));
+        assert!(!is_system_db("local_app"));
     }
 }

--- a/crates/driver-mongo/tests/integration.rs
+++ b/crates/driver-mongo/tests/integration.rs
@@ -34,6 +34,7 @@ async fn connect_insert_find_aggregate_schema_against_real_mongo() {
             .query(&Query::Mongo(MongoOp {
                 collection: "users".into(),
                 database: None,
+                limit: None,
                 kind: MongoKind::Insert(serde_json::json!({ "name": name, "age": age })),
             }))
             .await
@@ -45,6 +46,7 @@ async fn connect_insert_find_aggregate_schema_against_real_mongo() {
         .query(&Query::Mongo(MongoOp {
             collection: "users".into(),
             database: None,
+            limit: None,
             kind: MongoKind::Find(serde_json::json!({ "age": { "$gte": 18 } })),
         }))
         .await
@@ -61,6 +63,7 @@ async fn connect_insert_find_aggregate_schema_against_real_mongo() {
         .query(&Query::Mongo(MongoOp {
             collection: "users".into(),
             database: None,
+            limit: None,
             kind: MongoKind::Aggregate(vec![
                 serde_json::json!({ "$group": { "_id": null, "total": { "$sum": 1 } } }),
             ]),

--- a/crates/driver-postgres/tests/integration.rs
+++ b/crates/driver-postgres/tests/integration.rs
@@ -103,6 +103,7 @@ async fn non_sql_queries_are_unsupported() {
         .query(&Query::Mongo(MongoOp {
             collection: "c".into(),
             database: None,
+            limit: None,
             kind: MongoKind::Find(serde_json::json!({})),
         }))
         .await;


### PR DESCRIPTION
## Summary
- Mongo sidebar showed system DBs and looked stuck on empty/loading databases.
- Mongo preview leaked extended-JSON wrappers in both views and ran `find` unbounded.

## Changes
- **Sidebar:** `schema()` filters `admin`/`config`/`local`. Open database with no collections now shows a dim, non-clickable hint row — `(loading…)` until its fetch lands, then `(no collections)` if empty (`mongo_display_rows` + `loaded_dbs` threaded through `schema_display_rows`; `hint` kind styled in `sidebar.slint`).
- **Preview:** new `simplify()` in `convert.rs` collapses `$oid`/`$date`/`$numberLong|Int|Double|Decimal` wrappers after `into_relaxed_extjson()` → `_id` as hex, dates as ISO, numbers plain. Fixes both the table and JSON views from one place.
- **Browse limit:** added `MongoOp.limit`, applied in the driver via `.limit(n)`; click-to-view defaults to 50 rows (editor can omit `limit` for an unbounded query). Mirrors the SQL `LIMIT 300` browse.

## Test plan
- [x] `make be-test` — unit tests for system-DB filter, BSON simplifier (ObjectId/date/nested), and `limit` parse
- [x] `make fe-build`
- [x] `make fmt-check`
- [x] `make lint`
- [ ] `make test-it` — Docker Mongo integration (run locally; not in CI)
- [ ] Manual: seed app DB (ObjectId `_id`, date, nested) + empty DB; verify system DBs hidden, empty DB shows `(no collections)`, click returns ≤50 rows, table `_id`=hex / date=ISO, JSON toggle matches