### PR TITLE
refactor(app): variant-driven per-engine presentation + Redis key browsing

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -255,24 +255,8 @@ fn set_tab_titles(w: &MainWindow, count: usize) {
     w.set_tabs(ModelRc::from(Rc::new(VecModel::from(items))));
 }
 
-/// Push a `GridModel` into the window's grid/json/status properties.
-fn apply_grid(w: &MainWindow, g: model::GridModel) {
-    // Documents carry both a flattened grid and the raw JSON; the UI toggles
-    // between them. Fall through to the grid push below so the table view works.
-    if g.is_documents {
-        w.set_is_documents(true);
-        w.set_doc_json(SharedString::from(g.json.clone()));
-    } else {
-        w.set_is_documents(false);
-    }
-    if !g.status.is_empty() {
-        // Affected: no grid, just a status toast.
-        w.set_grid_col_count(0);
-        w.set_grid_columns(ModelRc::from(Rc::new(VecModel::<GridColumn>::default())));
-        w.set_grid_cells(ModelRc::from(Rc::new(VecModel::<GridCell>::default())));
-        w.set_result_status(SharedString::from(g.status));
-        return;
-    }
+/// Push a flat `GridModel` into the window's grid columns/cells properties.
+fn push_grid(w: &MainWindow, g: &model::GridModel) {
     let cols: Vec<GridColumn> = g
         .columns
         .iter()
@@ -281,7 +265,6 @@ fn apply_grid(w: &MainWindow, g: model::GridModel) {
             type_name: c.type_name.clone().into(),
         })
         .collect();
-    let col_count = cols.len() as i32;
     let mut flat: Vec<GridCell> = Vec::new();
     for row in &g.rows {
         for cell in row {
@@ -291,10 +274,86 @@ fn apply_grid(w: &MainWindow, g: model::GridModel) {
             });
         }
     }
-    w.set_grid_col_count(col_count);
+    w.set_grid_col_count(cols.len() as i32);
     w.set_grid_columns(ModelRc::from(Rc::new(VecModel::from(cols))));
     w.set_grid_cells(ModelRc::from(Rc::new(VecModel::from(flat))));
-    w.set_result_status(SharedString::from(format!("{} rows", g.rows.len())));
+}
+
+/// Clear the tabular grid properties (used by non-tabular result kinds).
+fn clear_grid(w: &MainWindow) {
+    w.set_grid_col_count(0);
+    w.set_grid_columns(ModelRc::from(Rc::new(VecModel::<GridColumn>::default())));
+    w.set_grid_cells(ModelRc::from(Rc::new(VecModel::<GridCell>::default())));
+}
+
+/// Return a copy of `g` keeping only rows where some cell matches `needle`
+/// (already lowercased). An empty needle keeps every row.
+fn filter_grid(g: &model::GridModel, needle: &str) -> model::GridModel {
+    if needle.is_empty() {
+        return g.clone();
+    }
+    model::GridModel {
+        columns: g.columns.clone(),
+        rows: g
+            .rows
+            .iter()
+            .filter(|row| row.iter().any(|c| c.text.to_lowercase().contains(needle)))
+            .cloned()
+            .collect(),
+    }
+}
+
+/// Push a `ResultView` into the window, selecting the per-kind result region
+/// via `result-kind` (0 Table, 1 Documents, 2 KeyValue, 3 Affected).
+fn apply_result(w: &MainWindow, view: model::ResultView) {
+    // Reset the KeyValue rows by default; the KeyValue arm repopulates them.
+    let clear_kv =
+        |w: &MainWindow| w.set_kv_rows(ModelRc::from(Rc::new(VecModel::<KvRow>::default())));
+    match view {
+        model::ResultView::Table(g) => {
+            w.set_result_kind(0);
+            w.set_doc_json(SharedString::default());
+            clear_kv(w);
+            push_grid(w, &g);
+            w.set_result_status(SharedString::from(format!("{} rows", g.rows.len())));
+        }
+        model::ResultView::Documents(d) => {
+            w.set_result_kind(1);
+            w.set_doc_json(SharedString::from(d.json));
+            clear_kv(w);
+            push_grid(w, &d.grid);
+            w.set_result_status(SharedString::from(format!(
+                "{} documents",
+                d.grid.rows.len()
+            )));
+        }
+        model::ResultView::KeyValue(kv) => {
+            w.set_result_kind(2);
+            w.set_doc_json(SharedString::default());
+            clear_grid(w);
+            let n = kv.rows.len();
+            let rows: Vec<KvRow> = kv
+                .rows
+                .iter()
+                .map(|(k, c)| KvRow {
+                    key: k.clone().into(),
+                    value: GridCell {
+                        text: c.text.clone().into(),
+                        is_null: c.is_null,
+                    },
+                })
+                .collect();
+            w.set_kv_rows(ModelRc::from(Rc::new(VecModel::from(rows))));
+            w.set_result_status(SharedString::from(format!("{n} keys")));
+        }
+        model::ResultView::Affected(status) => {
+            w.set_result_kind(3);
+            w.set_doc_json(SharedString::default());
+            clear_grid(w);
+            clear_kv(w);
+            w.set_result_status(SharedString::from(status));
+        }
+    }
 }
 
 fn main() -> Result<(), slint::PlatformError> {
@@ -369,10 +428,10 @@ fn main() -> Result<(), slint::PlatformError> {
         title: "Query 1".into(),
     }]))));
 
-    // Last tabular result kept in memory so the client-side filter (Feature C)
+    // Last result view kept in memory so the client-side filter (Feature C)
     // can re-derive the visible rows without re-querying. Arc<Mutex<>> (not Rc)
     // so it can cross into the Send event-loop closure from the query task.
-    let last_grid: Arc<std::sync::Mutex<Option<model::GridModel>>> =
+    let last_view: Arc<std::sync::Mutex<Option<model::ResultView>>> =
         Arc::new(std::sync::Mutex::new(None));
 
     // ----- toggle a sidebar group's collapsed state (Feature A) -----
@@ -451,31 +510,38 @@ fn main() -> Result<(), slint::PlatformError> {
     // ----- apply client-side row filter to the last result (Feature C) -----
     {
         let weak = window.as_weak();
-        let last_grid = last_grid.clone();
+        let last_view = last_view.clone();
         window.on_apply_filter(move || {
             let Some(w) = weak.upgrade() else {
                 return;
             };
             let needle = w.get_grid_filter().to_string().to_lowercase();
-            let guard = last_grid.lock().unwrap();
-            let Some(g) = guard.as_ref() else {
+            let guard = last_view.lock().unwrap();
+            let Some(v) = guard.as_ref() else {
                 return;
             };
-            // Filtering only applies to tabular results; documents/affected
-            // have no rows to filter.
-            if g.is_documents || g.columns.is_empty() {
-                return;
-            }
-            let mut filtered = g.clone();
-            if !needle.is_empty() {
-                filtered.rows = g
-                    .rows
-                    .iter()
-                    .filter(|row| row.iter().any(|c| c.text.to_lowercase().contains(&needle)))
-                    .cloned()
-                    .collect();
-            }
-            apply_grid(&w, filtered);
+            // Filter the row-bearing views; Affected has nothing to filter.
+            let filtered = match v {
+                model::ResultView::Table(g) => model::ResultView::Table(filter_grid(g, &needle)),
+                model::ResultView::Documents(d) => model::ResultView::Documents(model::DocModel {
+                    json: d.json.clone(),
+                    grid: filter_grid(&d.grid, &needle),
+                }),
+                model::ResultView::KeyValue(kv) => model::ResultView::KeyValue(model::KvModel {
+                    rows: kv
+                        .rows
+                        .iter()
+                        .filter(|(k, c)| {
+                            needle.is_empty()
+                                || k.to_lowercase().contains(&needle)
+                                || c.text.to_lowercase().contains(&needle)
+                        })
+                        .cloned()
+                        .collect(),
+                }),
+                model::ResultView::Affected(_) => return,
+            };
+            apply_result(&w, filtered);
         });
     }
 
@@ -626,11 +692,11 @@ fn main() -> Result<(), slint::PlatformError> {
         let weak = window.as_weak();
         let rt = rt.clone();
         let current = current.clone();
-        let last_grid = last_grid.clone();
+        let last_view = last_view.clone();
         Rc::new(move |sql: String| {
             let weak2 = weak.clone();
             let current = current.clone();
-            let last_grid = last_grid.clone();
+            let last_view = last_view.clone();
             rt.spawn(async move {
                 let guard = current.lock().await;
                 let outcome = match guard.as_ref() {
@@ -644,18 +710,23 @@ fn main() -> Result<(), slint::PlatformError> {
                         "not connected".into(),
                     )),
                 };
-                let grid = outcome.as_ref().ok().map(model::to_grid_model);
+                let view = outcome.as_ref().ok().map(model::to_result_view);
                 let err = outcome.err();
                 let _ = slint::invoke_from_event_loop(move || {
                     if let Some(w) = weak2.upgrade() {
-                        match (grid, err) {
-                            (Some(g), _) => {
+                        match (view, err) {
+                            (Some(v), _) => {
+                                // Only tabular-shaped views have resizable columns.
+                                let ncols = match &v {
+                                    model::ResultView::Table(g) => g.columns.len(),
+                                    model::ResultView::Documents(d) => d.grid.columns.len(),
+                                    _ => 0,
+                                };
                                 // Cache for client-side filtering, then reset the
                                 // filter input so the full result shows first.
-                                let ncols = if g.is_documents { 0 } else { g.columns.len() };
-                                *last_grid.lock().unwrap() = Some(g.clone());
+                                *last_view.lock().unwrap() = Some(v.clone());
                                 w.set_grid_filter(SharedString::default());
-                                apply_grid(&w, g);
+                                apply_result(&w, v);
                                 // Fresh result: reset every column to a default width.
                                 let widths: Vec<f32> = vec![140.0; ncols];
                                 w.set_grid_col_widths(ModelRc::from(Rc::new(VecModel::from(
@@ -663,9 +734,11 @@ fn main() -> Result<(), slint::PlatformError> {
                                 ))));
                             }
                             (None, Some(e)) => {
-                                *last_grid.lock().unwrap() = None;
-                                w.set_is_documents(false);
-                                w.set_result_status(SharedString::from(format!("error: {e}")));
+                                *last_view.lock().unwrap() = None;
+                                apply_result(
+                                    &w,
+                                    model::ResultView::Affected(format!("error: {e}")),
+                                );
                             }
                             _ => {}
                         }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -104,8 +104,8 @@ fn build_conn_items(
 /// engine's containers. ponytail: SQL keeps the Views/Functions placeholders.
 fn sidebar_categories(engine: Option<rdbs_connstore::Engine>) -> &'static [&'static str] {
     match engine {
+        // Mongo/Redis use the nested database→leaf path, not these categories.
         Some(rdbs_connstore::Engine::Mongo) => &["Collections"],
-        Some(rdbs_connstore::Engine::Redis) => &["Keys"],
         _ => &["Tables", "Views", "Functions"],
     }
 }
@@ -127,11 +127,17 @@ fn schema_display_rows(
     loaded_dbs: &HashSet<String>,
     engine: Option<rdbs_connstore::Engine>,
 ) -> Vec<TreeNode> {
-    // Mongo is database→collection: render each database as a collapsible header
-    // and nest only its own collections, so system DBs never mix with the app's.
+    // Mongo (database→collection) and Redis (database→key) both render as a
+    // collapsible database header nesting its own lazily-loaded leaves.
     // `expanded_tables` is the set of OPEN databases (default closed).
-    if engine == Some(rdbs_connstore::Engine::Mongo) {
-        return mongo_display_rows(nodes, expanded_tables, loaded_dbs);
+    match engine {
+        Some(rdbs_connstore::Engine::Mongo) => {
+            return nested_display_rows(nodes, expanded_tables, loaded_dbs, "collection");
+        }
+        Some(rdbs_connstore::Engine::Redis) => {
+            return nested_display_rows(nodes, expanded_tables, loaded_dbs, "key");
+        }
+        _ => {}
     }
 
     let categories = sidebar_categories(engine);
@@ -182,25 +188,27 @@ fn schema_display_rows(
     rows
 }
 
-/// Build database→collection rows for Mongo. Each database is a depth-0
-/// collapsible header (open when its name is in `expanded_dbs`, default closed);
-/// its collections are depth-1 rows tagged with the owning database. An open
-/// database with no collection rows gets a non-clickable hint row so the header
-/// never looks stuck: `(loading…)` until its fetch lands in `loaded_dbs`, then
-/// `(no collections)` if it really is empty.
-fn mongo_display_rows(
+/// Build a database→leaf tree for engines that browse per-database (Mongo
+/// collections, Redis keys). Each database is a depth-0 collapsible header (open
+/// when its name is in `expanded_dbs`, default closed); its leaves are depth-1
+/// rows tagged with the owning database and emitted with `leaf_kind`. An open
+/// database with no leaf rows gets a non-clickable hint row so the header never
+/// looks stuck: `(loading…)` until its fetch lands in `loaded_dbs`, then
+/// `(empty)` if it really is empty.
+fn nested_display_rows(
     nodes: &[model::VmTreeNode],
     expanded_dbs: &HashSet<String>,
     loaded_dbs: &HashSet<String>,
+    leaf_kind: &str,
 ) -> Vec<TreeNode> {
     let mut rows: Vec<TreeNode> = Vec::new();
     let mut current_db = String::new();
     let mut db_open = false;
-    let mut coll_count = 0usize;
+    let mut leaf_count = 0usize;
     // Push the loading/empty hint for an open database that emitted no rows.
     let hint_row = |db: &str| TreeNode {
         label: if loaded_dbs.contains(db) {
-            "(no collections)".into()
+            "(empty)".into()
         } else {
             "(loading…)".into()
         },
@@ -212,12 +220,12 @@ fn mongo_display_rows(
     for n in nodes {
         match n.kind.as_str() {
             "database" => {
-                if db_open && coll_count == 0 {
+                if db_open && leaf_count == 0 {
                     rows.push(hint_row(&current_db));
                 }
                 current_db = n.label.clone();
                 db_open = expanded_dbs.contains(&current_db);
-                coll_count = 0;
+                leaf_count = 0;
                 rows.push(TreeNode {
                     label: n.label.clone().into(),
                     depth: 0,
@@ -226,12 +234,12 @@ fn mongo_display_rows(
                     db: current_db.clone().into(),
                 });
             }
-            "collection" | "table" | "keyspace" if db_open => {
-                coll_count += 1;
+            "collection" | "table" | "keyspace" | "key" if db_open => {
+                leaf_count += 1;
                 rows.push(TreeNode {
                     label: n.label.clone().into(),
                     depth: 1,
-                    kind: "collection".into(),
+                    kind: leaf_kind.into(),
                     expanded: false,
                     db: current_db.clone().into(),
                 });
@@ -239,7 +247,7 @@ fn mongo_display_rows(
             _ => {}
         }
     }
-    if db_open && coll_count == 0 {
+    if db_open && leaf_count == 0 {
         rows.push(hint_row(&current_db));
     }
     rows
@@ -784,10 +792,8 @@ fn main() -> Result<(), slint::PlatformError> {
                     )
                 }
                 Some(rdbs_connstore::Engine::Redis) => {
-                    w.set_result_status(SharedString::from(
-                        "click a key in the SQL panel for Redis",
-                    ));
-                    return;
+                    // BROWSE is resolved by the Redis driver (TYPE + type-aware read).
+                    format!("BROWSE {label}")
                 }
                 None => return,
             };
@@ -815,9 +821,17 @@ fn main() -> Result<(), slint::PlatformError> {
             let engine = *cur_engine.borrow();
             let label = label.to_string();
 
-            // Mongo: database headers open an opt-in set (default closed) and load
-            // their collections lazily the first time they are expanded.
-            if engine == Some(rdbs_connstore::Engine::Mongo) {
+            // Mongo/Redis: database headers open an opt-in set (default closed)
+            // and load their leaves (collections / keys) lazily on first expand.
+            if matches!(
+                engine,
+                Some(rdbs_connstore::Engine::Mongo) | Some(rdbs_connstore::Engine::Redis)
+            ) {
+                let leaf_kind = if engine == Some(rdbs_connstore::Engine::Redis) {
+                    "key"
+                } else {
+                    "collection"
+                };
                 let now_open = {
                     let mut e = expanded_tables.lock().unwrap();
                     if e.remove(&label) {
@@ -863,7 +877,7 @@ fn main() -> Result<(), slint::PlatformError> {
                                         pos + 1 + k,
                                         model::VmTreeNode {
                                             label: c.name,
-                                            kind: "collection".into(),
+                                            kind: leaf_kind.into(),
                                         },
                                     );
                                 }
@@ -873,7 +887,7 @@ fn main() -> Result<(), slint::PlatformError> {
                                 &expanded_tables.lock().unwrap(),
                                 &HashSet::new(),
                                 &loaded_dbs.lock().unwrap(),
-                                Some(rdbs_connstore::Engine::Mongo),
+                                engine,
                             )
                         };
                         let _ = slint::invoke_from_event_loop(move || {
@@ -897,7 +911,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 return;
             }
 
-            // SQL/Redis: category headers collapse-toggle (open by default).
+            // SQL: category headers collapse-toggle (open by default).
             {
                 let mut c = collapsed_categories.borrow_mut();
                 if !c.remove(&label) {

--- a/app/src/model.rs
+++ b/app/src/model.rs
@@ -17,16 +17,37 @@ pub struct VmColumn {
     pub type_name: String,
 }
 
-/// Flat grid model covering all four ResultSet variants.
+/// Tabular grid: real columns + rows. Used directly for SQL results and as the
+/// "Table" rendering of Mongo documents.
 #[derive(Debug, Default, Clone)]
 pub struct GridModel {
     pub columns: Vec<VmColumn>,
     pub rows: Vec<Vec<VmCell>>,
-    /// Pretty JSON for Documents.
+}
+
+/// Mongo documents: the raw pretty JSON plus a flattened grid the UI toggles to.
+#[derive(Debug, Default, Clone)]
+pub struct DocModel {
     pub json: String,
-    pub is_documents: bool,
-    /// Status text for Affected (e.g. "3 rows affected").
-    pub status: String,
+    pub grid: GridModel,
+}
+
+/// Redis key/value rows: each row is a key (or list index / hash field) and its
+/// value cell. Kept separate from the SQL grid so Redis presentation can diverge.
+#[derive(Debug, Default, Clone)]
+pub struct KvModel {
+    pub rows: Vec<(String, VmCell)>,
+}
+
+/// Presentation-ready view of a `ResultSet`, one arm per data shape. Drives the
+/// per-kind result region in the UI instead of collapsing everything to a grid.
+#[derive(Debug, Clone)]
+pub enum ResultView {
+    Table(GridModel),
+    Documents(DocModel),
+    KeyValue(KvModel),
+    /// Status toast for writes, e.g. "3 rows affected".
+    Affected(String),
 }
 
 #[derive(Debug, Default, Clone)]
@@ -140,10 +161,11 @@ fn flatten_documents(docs: &[serde_json::Value]) -> (Vec<VmColumn>, Vec<Vec<VmCe
     (columns, rows)
 }
 
-/// Convert any ResultSet into the grid view-model.
-pub fn to_grid_model(rs: &ResultSet) -> GridModel {
+/// Convert any ResultSet into its presentation-ready view. Each variant keeps
+/// its own shape instead of collapsing to a single grid.
+pub fn to_result_view(rs: &ResultSet) -> ResultView {
     match rs {
-        ResultSet::Tabular { cols, rows } => GridModel {
+        ResultSet::Tabular { cols, rows } => ResultView::Table(GridModel {
             columns: cols
                 .iter()
                 .map(|c| VmColumn {
@@ -162,48 +184,22 @@ pub fn to_grid_model(rs: &ResultSet) -> GridModel {
                         .collect()
                 })
                 .collect(),
-            ..Default::default()
-        },
-        ResultSet::KeyValue(pairs) => GridModel {
-            columns: vec![
-                VmColumn {
-                    name: "key".into(),
-                    type_name: "".into(),
-                },
-                VmColumn {
-                    name: "value".into(),
-                    type_name: "".into(),
-                },
-            ],
+        }),
+        ResultSet::KeyValue(pairs) => ResultView::KeyValue(KvModel {
             rows: pairs
                 .iter()
-                .map(|(k, v)| {
-                    vec![
-                        VmCell {
-                            text: k.clone(),
-                            is_null: false,
-                        },
-                        redis_cell(v),
-                    ]
-                })
+                .map(|(k, v)| (k.clone(), redis_cell(v)))
                 .collect(),
-            ..Default::default()
-        },
+        }),
         ResultSet::Documents(docs) => {
             let json = serde_json::to_string_pretty(docs).unwrap_or_else(|_| "[]".into());
             let (columns, rows) = flatten_documents(docs);
-            GridModel {
-                columns,
-                rows,
+            ResultView::Documents(DocModel {
                 json,
-                is_documents: true,
-                ..Default::default()
-            }
+                grid: GridModel { columns, rows },
+            })
         }
-        ResultSet::Affected(n) => GridModel {
-            status: format!("{} rows affected", n),
-            ..Default::default()
-        },
+        ResultSet::Affected(n) => ResultView::Affected(format!("{} rows affected", n)),
     }
 }
 
@@ -242,6 +238,13 @@ mod tests {
     use rdbs_core::result::{Cell, Column, RedisValue, ResultSet};
     use rdbs_core::schema::{Container, ContainerKind, Database, Field, Schema};
 
+    fn expect_table(rs: &ResultSet) -> GridModel {
+        match to_result_view(rs) {
+            ResultView::Table(g) => g,
+            other => panic!("expected Table, got {other:?}"),
+        }
+    }
+
     #[test]
     fn tabular_maps_cols_and_rows_with_null_flag() {
         let rs = ResultSet::Tabular {
@@ -251,7 +254,7 @@ mod tests {
             }],
             rows: vec![vec![Cell::Int(7)], vec![Cell::Null]],
         };
-        let grid = to_grid_model(&rs);
+        let grid = expect_table(&rs);
         assert_eq!(grid.columns.len(), 1);
         assert_eq!(grid.columns[0].name, "id");
         assert_eq!(grid.rows.len(), 2);
@@ -263,9 +266,10 @@ mod tests {
 
     #[test]
     fn affected_maps_to_status_text() {
-        let grid = to_grid_model(&ResultSet::Affected(3));
-        assert_eq!(grid.columns.len(), 0);
-        assert_eq!(grid.status, "3 rows affected");
+        match to_result_view(&ResultSet::Affected(3)) {
+            ResultView::Affected(s) => assert_eq!(s, "3 rows affected"),
+            other => panic!("expected Affected, got {other:?}"),
+        }
     }
 
     #[test]
@@ -275,21 +279,25 @@ mod tests {
             ("k2".into(), RedisValue::Int(9)),
             ("k3".into(), RedisValue::Nil),
         ]);
-        let grid = to_grid_model(&rs);
-        assert_eq!(grid.columns.len(), 2); // key, value
-        assert_eq!(grid.rows[0][0].text, "k1");
-        assert_eq!(grid.rows[0][1].text, "v1");
-        assert_eq!(grid.rows[1][1].text, "9");
-        assert_eq!(grid.rows[2][1].text, "(nil)");
-        assert!(grid.rows[2][1].is_null);
+        let kv = match to_result_view(&rs) {
+            ResultView::KeyValue(kv) => kv,
+            other => panic!("expected KeyValue, got {other:?}"),
+        };
+        assert_eq!(kv.rows.len(), 3);
+        assert_eq!(kv.rows[0].0, "k1");
+        assert_eq!(kv.rows[0].1.text, "v1");
+        assert_eq!(kv.rows[1].1.text, "9");
+        assert_eq!(kv.rows[2].1.text, "(nil)");
+        assert!(kv.rows[2].1.is_null);
     }
 
     #[test]
     fn documents_render_as_json_text_block() {
         let rs = ResultSet::Documents(vec![serde_json::json!({"a": 1})]);
-        let grid = to_grid_model(&rs);
-        assert!(grid.json.contains("\"a\""));
-        assert!(grid.is_documents);
+        match to_result_view(&rs) {
+            ResultView::Documents(d) => assert!(d.json.contains("\"a\"")),
+            other => panic!("expected Documents, got {other:?}"),
+        }
     }
 
     #[test]
@@ -298,7 +306,10 @@ mod tests {
             serde_json::json!({"_id": "x", "name": "ada", "tags": [1, 2]}),
             serde_json::json!({"name": "lin", "age": 30}),
         ]);
-        let grid = to_grid_model(&rs);
+        let grid = match to_result_view(&rs) {
+            ResultView::Documents(d) => d.grid,
+            other => panic!("expected Documents, got {other:?}"),
+        };
         // union of keys, _id first
         let names: Vec<&str> = grid.columns.iter().map(|c| c.name.as_str()).collect();
         assert_eq!(names[0], "_id");

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -9,6 +9,7 @@ import { AppIcon } from "icons.slint";
 import {
     GridColumn,
     GridCell,
+    KvRow,
     TreeNode,
     ConnItem,
     TabItem,
@@ -53,7 +54,9 @@ export component MainWindow inherits Window {
     in property <[GridCell]> grid-cells;
     in property <int> grid-col-count;
     in property <string> doc-json;
-    in property <bool> is-documents;
+    in property <[KvRow]> kv-rows;
+    // result shape: 0 Table, 1 Documents, 2 KeyValue, 3 Affected
+    in property <int> result-kind: 0;
     in property <bool> sql-capable: true;
     in property <string> result-status;
     in-out property <int> selected-row: 0;
@@ -364,7 +367,8 @@ export component MainWindow inherits Window {
                         col-count: root.grid-col-count;
                         col-widths: root.grid-col-widths;
                         doc-json: root.doc-json;
-                        is-documents: root.is-documents;
+                        kv-rows: root.kv-rows;
+                        result-kind: root.result-kind;
                         sql-capable: root.sql-capable;
                         result-status: root.result-status;
                         selected-row: root.selected-row;

--- a/app/src/ui/sidebar.slint
+++ b/app/src/ui/sidebar.slint
@@ -86,7 +86,7 @@ export component Sidebar inherits Rectangle {
                     property <bool> is-header: node.kind == "category" || node.kind == "database";
                     property <bool> is-category: node.kind == "category";
                     property <bool> is-database: node.kind == "database";
-                    property <bool> is-container: node.kind == "table" || node.kind == "collection" || node.kind == "keyspace";
+                    property <bool> is-container: node.kind == "table" || node.kind == "collection" || node.kind == "keyspace" || node.kind == "key";
                     property <bool> is-field: node.kind == "field";
                     // placeholder row (loading / no collections): dim, non-clickable
                     property <bool> is-hint: node.kind == "hint";

--- a/app/src/ui/structs.slint
+++ b/app/src/ui/structs.slint
@@ -3,6 +3,8 @@
 // them without an import cycle.
 export struct GridColumn { name: string, type-name: string }
 export struct GridCell { text: string, is-null: bool }
+// A Redis key/value row: the key (or list index / hash field) and its value cell.
+export struct KvRow { key: string, value: GridCell }
 // `db` tags the owning database for container rows (Mongo db→collection tree);
 // empty for SQL/Redis where the category path is used instead.
 export struct TreeNode { label: string, depth: int, kind: string, expanded: bool, db: string }

--- a/app/src/ui/tabular-grid.slint
+++ b/app/src/ui/tabular-grid.slint
@@ -1,0 +1,74 @@
+import { Theme } from "theme.slint";
+import { GridColumn, GridCell } from "structs.slint";
+import { ScrollView } from "std-widgets.slint";
+
+// Shared row/column grid used by SQL results and the Mongo "Table" view.
+// Cells are flat row-major: row r, col c at r*col-count + c.
+export component TabularGrid inherits ScrollView {
+    in property <[GridColumn]> columns;
+    in property <[GridCell]> cells;
+    in property <int> col-count;
+    in property <[length]> col-widths;     // per-column pixel widths (drag-resizable)
+    in property <int> selected-row: 0;
+    callback resize-col(int, length);      // (column index, drag delta)
+
+    VerticalLayout {
+        // fill ScrollView width when few columns; grow past it (scroll) when many
+        width: max(self.preferred-width, parent.visible-width);
+        // header
+        HorizontalLayout {
+            height: Theme.row-height;
+            for col[c] in root.columns: Rectangle {
+                width: root.col-widths.length > c ? root.col-widths[c] : 140px;
+                background: Theme.surface;
+                clip: true;
+                Text {
+                    vertical-alignment: center;
+                    x: Theme.sp1;
+                    width: parent.width - 2 * Theme.sp1;
+                    overflow: elide;
+                    text: col.name;
+                    color: Theme.text-dim;
+                    font-size: Theme.font-label;
+                }
+                // right-edge drag handle to resize this column
+                Rectangle {
+                    width: 5px;
+                    x: parent.width - self.width;
+                    background: hdl.has-hover || hdl.pressed ? Theme.accent : transparent;
+                    hdl := TouchArea {
+                        mouse-cursor: col-resize;
+                        moved => { root.resize-col(c, self.mouse-x - self.pressed-x); }
+                    }
+                }
+            }
+            // trailing filler so the header spans the full width
+            Rectangle { horizontal-stretch: 1; background: Theme.surface; }
+        }
+        Rectangle { height: 1px; background: Theme.hairline; }
+        // rows
+        for r in (root.col-count > 0 ? root.cells.length / root.col-count : 0): Rectangle {
+            height: Theme.row-height;
+            background: r == root.selected-row ? Theme.accent.with-alpha(0.14) : transparent;
+            HorizontalLayout {
+                for c in root.col-count: Rectangle {
+                    width: root.col-widths.length > c ? root.col-widths[c] : 140px;
+                    clip: true;
+                    Text {
+                        vertical-alignment: center;
+                        x: Theme.sp1;
+                        width: parent.width - 2 * Theme.sp1;
+                        overflow: elide;
+                        text: root.cells[r * root.col-count + c].text;
+                        color: root.cells[r * root.col-count + c].is-null
+                            ? Theme.text-dim : Theme.text;
+                        font-family: Theme.mono-family;
+                        font-size: Theme.font-mono;
+                    }
+                }
+                // trailing filler so the row spans the full width
+                Rectangle { horizontal-stretch: 1; }
+            }
+        }
+    }
+}

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -1,6 +1,7 @@
 import { Theme } from "theme.slint";
-import { GridColumn, GridCell, StructField } from "structs.slint";
+import { GridColumn, GridCell, KvRow, StructField } from "structs.slint";
 import { AppIcon } from "icons.slint";
+import { TabularGrid } from "tabular-grid.slint";
 import { ScrollView, Button, TextEdit, LineEdit } from "std-widgets.slint";
 
 export component WorkArea inherits Rectangle {
@@ -10,7 +11,10 @@ export component WorkArea inherits Rectangle {
     in property <int> col-count;
     in property <[length]> col-widths;     // per-column pixel widths (drag-resizable)
     in property <string> doc-json;
-    in property <bool> is-documents;
+    in property <[KvRow]> kv-rows;         // Redis key/value rows
+    // result shape: 0 Table (SQL), 1 Documents (Mongo), 2 KeyValue (Redis), 3 Affected
+    in property <int> result-kind: 0;
+    property <bool> is-documents: root.result-kind == 1;
     // SQL editor only for SQL engines; documents can switch grid <-> raw JSON.
     in property <bool> sql-capable: true;
     in-out property <bool> doc-as-json: false;
@@ -35,7 +39,7 @@ export component WorkArea inherits Rectangle {
     property <length> editor-h: 140px;
     // a result is present when a table is open / a query has run
     property <bool> has-content: root.col-count > 0 || root.is-documents
-        || root.result-status != "";
+        || root.kv-rows.length > 0 || root.result-status != "";
 
     VerticalLayout {
         padding: Theme.sp4;
@@ -334,7 +338,7 @@ export component WorkArea inherits Rectangle {
             }
 
             // documents raw-JSON view (toggled on); pinned top-left, full width
-            if !root.show-structure && root.is-documents && root.doc-as-json: ScrollView {
+            if !root.show-structure && root.result-kind == 1 && root.doc-as-json: ScrollView {
                 VerticalLayout {
                     alignment: start;
                     padding: Theme.sp2;
@@ -349,66 +353,80 @@ export component WorkArea inherits Rectangle {
                 }
             }
 
-            // tabular / key-value / flattened-document grid
-            if !root.show-structure && !(root.is-documents && root.doc-as-json): ScrollView {
+            // SQL grid (kind 0) + Mongo flattened-document "Table" view (kind 1)
+            if !root.show-structure
+                && (root.result-kind == 0 || (root.result-kind == 1 && !root.doc-as-json)): TabularGrid {
+                columns: root.columns;
+                cells: root.cells;
+                col-count: root.col-count;
+                col-widths: root.col-widths;
+                selected-row: root.selected-row;
+                resize-col(i, d) => { root.resize-col(i, d); }
+            }
+
+            // Redis key/value view (kind 2): two columns, no drag-resize
+            if !root.show-structure && root.result-kind == 2: ScrollView {
                 VerticalLayout {
-                    // fill ScrollView width when few columns; grow past it (scroll) when many
                     width: max(self.preferred-width, parent.visible-width);
-                    // header
                     HorizontalLayout {
                         height: Theme.row-height;
-                        for col[c] in root.columns: Rectangle {
-                            width: root.col-widths.length > c ? root.col-widths[c] : 140px;
+                        Rectangle {
+                            width: 240px;
                             background: Theme.surface;
-                            clip: true;
-                            Text {
-                                vertical-alignment: center;
-                                x: Theme.sp1;
-                                width: parent.width - 2 * Theme.sp1;
-                                overflow: elide;
-                                text: col.name;
-                                color: Theme.text-dim;
-                                font-size: Theme.font-label;
-                            }
-                            // right-edge drag handle to resize this column
-                            Rectangle {
-                                width: 5px;
-                                x: parent.width - self.width;
-                                background: hdl.has-hover || hdl.pressed ? Theme.accent : transparent;
-                                hdl := TouchArea {
-                                    mouse-cursor: col-resize;
-                                    moved => { root.resize-col(c, self.mouse-x - self.pressed-x); }
-                                }
-                            }
+                            Text { x: Theme.sp1; vertical-alignment: center; text: "Key"; color: Theme.text-dim; font-size: Theme.font-label; }
                         }
-                        // trailing filler so the header spans the full width
-                        Rectangle { horizontal-stretch: 1; background: Theme.surface; }
+                        Rectangle {
+                            horizontal-stretch: 1;
+                            background: Theme.surface;
+                            Text { x: Theme.sp1; vertical-alignment: center; text: "Value"; color: Theme.text-dim; font-size: Theme.font-label; }
+                        }
                     }
                     Rectangle { height: 1px; background: Theme.hairline; }
-                    // rows
-                    for r in (root.col-count > 0 ? root.cells.length / root.col-count : 0): Rectangle {
+                    for row[r] in root.kv-rows: Rectangle {
                         height: Theme.row-height;
                         background: r == root.selected-row ? Theme.accent.with-alpha(0.14) : transparent;
                         HorizontalLayout {
-                            for c in root.col-count: Rectangle {
-                                width: root.col-widths.length > c ? root.col-widths[c] : 140px;
+                            Rectangle {
+                                width: 240px;
                                 clip: true;
                                 Text {
                                     vertical-alignment: center;
                                     x: Theme.sp1;
                                     width: parent.width - 2 * Theme.sp1;
                                     overflow: elide;
-                                    text: root.cells[r * root.col-count + c].text;
-                                    color: root.cells[r * root.col-count + c].is-null
-                                        ? Theme.text-dim : Theme.text;
+                                    text: row.key;
+                                    color: Theme.text-dim;
                                     font-family: Theme.mono-family;
                                     font-size: Theme.font-mono;
                                 }
                             }
-                            // trailing filler so the row spans the full width
-                            Rectangle { horizontal-stretch: 1; }
+                            Rectangle {
+                                horizontal-stretch: 1;
+                                clip: true;
+                                Text {
+                                    vertical-alignment: center;
+                                    x: Theme.sp1;
+                                    width: parent.width - 2 * Theme.sp1;
+                                    overflow: elide;
+                                    text: row.value.text;
+                                    color: row.value.is-null ? Theme.text-dim : Theme.text;
+                                    font-family: Theme.mono-family;
+                                    font-size: Theme.font-mono;
+                                }
+                            }
                         }
                     }
+                }
+            }
+
+            // Affected (kind 3): no grid, just the centered status
+            if !root.show-structure && root.result-kind == 3: VerticalLayout {
+                alignment: center;
+                Text {
+                    horizontal-alignment: center;
+                    text: root.result-status;
+                    color: Theme.text-dim;
+                    font-size: Theme.font-body;
                 }
             }
         }

--- a/crates/driver-redis/src/convert.rs
+++ b/crates/driver-redis/src/convert.rs
@@ -51,6 +51,29 @@ fn value_to_redis(value: Value) -> RedisValue {
     }
 }
 
+/// Rows for a list/set browse: index → member. Presented as key/value where the
+/// key column is the position and the value is the member.
+pub fn pairs_from_members(members: Vec<String>) -> Vec<(String, RedisValue)> {
+    members
+        .into_iter()
+        .enumerate()
+        .map(|(i, m)| (i.to_string(), RedisValue::Str(m)))
+        .collect()
+}
+
+/// Rows for a hash (HGETALL) or sorted-set (ZRANGE WITHSCORES) browse, both of
+/// which reply as a flat `[k, v, k, v, …]` array: field/member → value/score.
+pub fn pairs_from_flat(flat: Vec<String>) -> Vec<(String, RedisValue)> {
+    flat.chunks(2)
+        .map(|c| {
+            (
+                c[0].clone(),
+                RedisValue::Str(c.get(1).cloned().unwrap_or_default()),
+            )
+        })
+        .collect()
+}
+
 /// Flatten one element of a bulk reply to a display string.
 fn scalar_to_string(value: Value) -> String {
     match value {
@@ -126,6 +149,33 @@ mod tests {
             ResultSet::KeyValue(pairs) => assert!(matches!(pairs[0].1, RedisValue::Nil)),
             _ => panic!("wrong variant"),
         }
+    }
+
+    #[test]
+    fn members_map_to_index_keyed_rows() {
+        let rows = pairs_from_members(vec!["x".into(), "y".into()]);
+        assert_eq!(rows[0].0, "0");
+        assert!(matches!(rows[0].1, RedisValue::Str(ref s) if s == "x"));
+        assert_eq!(rows[1].0, "1");
+        assert!(matches!(rows[1].1, RedisValue::Str(ref s) if s == "y"));
+    }
+
+    #[test]
+    fn flat_pairs_zip_field_and_value() {
+        let rows = pairs_from_flat(vec!["f1".into(), "v1".into(), "f2".into(), "v2".into()]);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].0, "f1");
+        assert!(matches!(rows[0].1, RedisValue::Str(ref s) if s == "v1"));
+        assert_eq!(rows[1].0, "f2");
+        assert!(matches!(rows[1].1, RedisValue::Str(ref s) if s == "v2"));
+    }
+
+    #[test]
+    fn flat_pairs_tolerates_odd_trailing_element() {
+        let rows = pairs_from_flat(vec!["only".into()]);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].0, "only");
+        assert!(matches!(rows[0].1, RedisValue::Str(ref s) if s.is_empty()));
     }
 
     #[test]

--- a/crates/driver-redis/src/driver.rs
+++ b/crates/driver-redis/src/driver.rs
@@ -7,10 +7,15 @@ use rdbs_core::conn::ConnConfig;
 use rdbs_core::driver::Driver;
 use rdbs_core::error::{RdbsError, Result};
 use rdbs_core::query::Query;
+use rdbs_core::result::RedisValue;
 use rdbs_core::result::ResultSet;
-use rdbs_core::schema::{Container, ContainerKind, Database, Field, Schema};
+use rdbs_core::schema::{Container, ContainerKind, Database, Schema};
 
-use crate::convert::{connection_url, value_to_resultset};
+use crate::convert::{connection_url, pairs_from_flat, pairs_from_members, value_to_resultset};
+
+/// Upper bound on keys surfaced when a Redis database is expanded.
+/// ponytail: single SCAN pass, wire the returned cursor for paging if needed.
+const MAX_KEYS: usize = 200;
 
 /// Redis driver over a multiplexed async connection. The connection is shared
 /// behind a Mutex because commands take `&mut` and the trait exposes `&self`.
@@ -52,25 +57,34 @@ impl Driver for RedisDriver {
     }
 
     async fn schema(&self) -> Result<Schema> {
-        let mut conn = self.conn.lock().await;
-        let size: i64 = redis::cmd("DBSIZE")
-            .query_async(&mut *conn)
-            .await
-            .map_err(|e| RdbsError::Schema(e.to_string()))?;
-        drop(conn);
-
-        // Redis is schemaless: surface one keyspace container summarizing key count.
-        let container = Container {
-            name: format!("keys ({size})"),
-            kind: ContainerKind::Keyspace,
-            fields: Vec::<Field>::new(),
-        };
+        // One expandable database header; keys load lazily via `containers()` the
+        // first time it is expanded (mirrors Mongo's database→collection tree).
         Ok(Schema {
             databases: vec![Database {
                 name: format!("db{}", self.db),
-                containers: vec![container],
+                containers: Vec::new(),
             }],
         })
+    }
+
+    async fn containers(&self, _database: &str) -> Result<Vec<Container>> {
+        let mut conn = self.conn.lock().await;
+        // SCAN over one bounded pass; COUNT is a hint, not a hard limit.
+        let (_cursor, keys): (String, Vec<String>) = redis::cmd("SCAN")
+            .arg(0)
+            .arg("COUNT")
+            .arg(MAX_KEYS as i64)
+            .query_async(&mut *conn)
+            .await
+            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+        Ok(keys
+            .into_iter()
+            .map(|k| Container {
+                name: k,
+                kind: ContainerKind::Keyspace,
+                fields: Vec::new(),
+            })
+            .collect())
     }
 
     async fn query(&self, q: &Query) -> Result<ResultSet> {
@@ -80,6 +94,15 @@ impl Driver for RedisDriver {
         };
         if tokens.is_empty() {
             return Err(RdbsError::Query("empty command".into()));
+        }
+
+        // `BROWSE <key>` is a UI-only convention (not a real Redis verb): read a
+        // key with the right command for its type and return typed rows.
+        if tokens[0].eq_ignore_ascii_case("BROWSE") {
+            let key = tokens
+                .get(1)
+                .ok_or_else(|| RdbsError::Query("BROWSE needs a key".into()))?;
+            return self.browse_key(key).await;
         }
 
         let mut cmd = redis::cmd(&tokens[0]);
@@ -100,5 +123,76 @@ impl Driver for RedisDriver {
         // MultiplexedConnection closes when dropped; nothing to await.
         drop(self.conn);
         Ok(())
+    }
+}
+
+impl RedisDriver {
+    /// Read one key using the command appropriate to its type, returning typed
+    /// key/value rows: string→value, list/set→index→member, hash→field→value,
+    /// zset→member→score.
+    async fn browse_key(&self, key: &str) -> Result<ResultSet> {
+        let qerr = |e: redis::RedisError| RdbsError::Query(e.to_string());
+        let mut conn = self.conn.lock().await;
+        let kind: String = redis::cmd("TYPE")
+            .arg(key)
+            .query_async(&mut *conn)
+            .await
+            .map_err(qerr)?;
+        let rows = match kind.as_str() {
+            "string" => {
+                let v: Option<String> = redis::cmd("GET")
+                    .arg(key)
+                    .query_async(&mut *conn)
+                    .await
+                    .map_err(qerr)?;
+                vec![(
+                    key.to_string(),
+                    v.map(RedisValue::Str).unwrap_or(RedisValue::Nil),
+                )]
+            }
+            "list" => {
+                let items: Vec<String> = redis::cmd("LRANGE")
+                    .arg(key)
+                    .arg(0)
+                    .arg(-1)
+                    .query_async(&mut *conn)
+                    .await
+                    .map_err(qerr)?;
+                pairs_from_members(items)
+            }
+            "set" => {
+                let items: Vec<String> = redis::cmd("SMEMBERS")
+                    .arg(key)
+                    .query_async(&mut *conn)
+                    .await
+                    .map_err(qerr)?;
+                pairs_from_members(items)
+            }
+            "hash" => {
+                let flat: Vec<String> = redis::cmd("HGETALL")
+                    .arg(key)
+                    .query_async(&mut *conn)
+                    .await
+                    .map_err(qerr)?;
+                pairs_from_flat(flat)
+            }
+            "zset" => {
+                let flat: Vec<String> = redis::cmd("ZRANGE")
+                    .arg(key)
+                    .arg(0)
+                    .arg(-1)
+                    .arg("WITHSCORES")
+                    .query_async(&mut *conn)
+                    .await
+                    .map_err(qerr)?;
+                pairs_from_flat(flat)
+            }
+            "none" => vec![(key.to_string(), RedisValue::Nil)],
+            other => vec![(
+                key.to_string(),
+                RedisValue::Str(format!("unsupported type: {other}")),
+            )],
+        };
+        Ok(ResultSet::KeyValue(rows))
     }
 }


### PR DESCRIPTION
## Summary

- Frontend collapsed all four `ResultSet` variants into one flat grid, erasing the SQL/NoSQL split the core model already draws. Presentation is now driven by the `ResultSet` variant.
- Sidebar is engine-aware, and Redis gains real key browsing (SCAN + type-aware read) instead of a faked key/value grid with no click-to-view.

## Changes

**Result views (`app/model.rs`, `app/ui/`)**
- `to_grid_model` → `to_result_view` returning a `ResultView` enum (`Table` / `Documents` / `KeyValue` / `Affected`); no more lossy flatten-to-grid.
- Workarea gates a per-kind result region on a `result-kind` property. Shared row/column grid extracted into a reusable `TabularGrid` (used by SQL results and the Mongo Table view). Redis renders its own two-column key/value view.
- Bridge `apply_grid` → `apply_result`; client-side filter re-derives per view kind.

**Redis (`crates/driver-redis`)**
- `schema()` returns a single expandable database header (was a `keys (N)` summary).
- `containers()` lists real keys via one bounded `SCAN` pass.
- `query()` handles a UI-only `BROWSE <key>` convention: `TYPE` then the read matching the key type (GET / LRANGE / SMEMBERS / HGETALL / ZRANGE WITHSCORES) → typed key/value rows.

**Sidebar (`app/main.rs`, `app/ui/sidebar.slint`)**
- Mongo's lazy database→leaf tree generalized to also serve Redis (collection leaves for Mongo, key leaves for Redis).
- Clicking a Redis key issues `BROWSE` instead of the previous dead-end status message.

## Test plan

- [x] `make fmt-check`
- [x] `make lint` (clippy, warnings as errors)
- [x] `make test` (app variant-mapping tests, redis pure-mapper tests)
- [x] `make fe-build`
- [ ] `make fe-run` manual: Postgres/MySQL grid unchanged; Mongo Table|JSON toggle; Redis expand db → keys load lazily → key click renders value by type
- [ ] `make test-it` (Docker) for driver integration paths

## Deferred (marked `ponytail:`)

- Redis `SCAN` is a single bounded pass (mirrors Mongo's collection cap); wire the cursor for paging if key counts demand.
- `j/k` row-nav is still keyed off the tabular grid, so it does not move selection in the Redis view.