### PR TITLE
fix: frontend audit — wire dead controls, implement missing features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "rdbs"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "rdbs-connstore",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5467,6 +5467,7 @@ name = "rdbs"
 version = "0.4.0"
 dependencies = [
  "async-trait",
+ "copypasta",
  "rdbs-connstore",
  "rdbs-core",
  "rdbs-driver-mongo",

--- a/README.md
+++ b/README.md
@@ -25,41 +25,7 @@ A native, lightweight, cross-platform database manager built with Rust and Slint
 | Redis | `redis` crate | Key-value / raw |
 | MongoDB | `mongodb` crate | Documents (JSON) |
 
-## Architecture
-
-Cargo workspace (monorepo):
-
-```
-rdbs/
-├── Cargo.toml                  # workspace root
-├── app/                        # binary: Slint UI + event handlers
-│   ├── build.rs                # slint-build codegen
-│   └── src/
-│       ├── main.rs             # Slint event loop + Tokio async bridge
-│       ├── dispatch.rs         # AnyDriver enum (erases concrete driver types)
-│       ├── model.rs            # ResultSet / Schema → Slint view-models
-│       ├── query_parse.rs      # text → Query enum per engine
-│       ├── theme.rs            # color / accent helpers
-│       └── ui/                 # .slint markup files
-│           ├── app-window.slint
-│           ├── conn-form.slint
-│           ├── picker.slint
-│           ├── workarea.slint
-│           ├── sidebar.slint
-│           ├── palette.slint
-│           ├── structs.slint
-│           ├── theme.slint
-│           └── icons.slint
-├── crates/
-│   ├── core/                   # Driver trait + ResultSet + Schema + Error
-│   ├── connstore/              # saved connections (JSON) + secret backend
-│   ├── driver-postgres/
-│   ├── driver-mysql/
-│   ├── driver-redis/
-│   └── driver-mongo/
-└── docs/
-    └── superpowers/            # design specs + implementation plans
-```
+## Design
 
 ### Core design rule
 

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -18,6 +18,8 @@ rdbs-driver-mongo = { path = "../crates/driver-mongo" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "time"] }
 serde_json = "1"
 async-trait = "0.1"
+# clipboard; already in the tree via Slint's winit backend, so no new builds
+copypasta = "0.10"
 
 [build-dependencies]
 slint-build = "1.8"

--- a/app/src/editor.rs
+++ b/app/src/editor.rs
@@ -92,6 +92,11 @@ fn is_ident(c: char) -> bool {
 
 /// Lex one line into colored spans. Whitespace stays attached to plain spans
 /// so concatenating span texts reproduces the line exactly.
+/// True when `word` (already uppercased) is a SQL keyword.
+pub fn is_keyword(word: &str) -> bool {
+    KEYWORDS.contains(&word)
+}
+
 pub fn lex_line(line: &str) -> Vec<Span> {
     let mut spans: Vec<Span> = Vec::new();
     let push = |spans: &mut Vec<Span>, text: &str, kind: i32| {

--- a/app/src/editor.rs
+++ b/app/src/editor.rs
@@ -292,9 +292,54 @@ impl EditorState {
     }
 
     /// Current line text — the "Run Selection" fallback unit.
-    #[allow(dead_code)] // wired up when Run Selection gains a real selection
     pub fn current_line(&self) -> &str {
         &self.lines[self.line]
+    }
+
+    /// Statement under the cursor: the `;`-delimited segment containing the
+    /// cursor, ignoring semicolons inside single-quoted literals. Falls back
+    /// to the current line when the segment is empty.
+    pub fn current_statement(&self) -> String {
+        let text = self.text();
+        let chars: Vec<char> = text.chars().collect();
+        // cursor position as a char offset into the joined text
+        let mut offset = 0;
+        for (i, l) in self.lines.iter().enumerate() {
+            if i == self.line {
+                offset += self.col.min(l.chars().count());
+                break;
+            }
+            offset += l.chars().count() + 1; // +1 for the newline
+        }
+        // split into statements on top-level semicolons
+        let mut segments: Vec<(usize, usize)> = Vec::new();
+        let mut seg_start = 0;
+        let mut in_str = false;
+        for (i, &c) in chars.iter().enumerate() {
+            if c == '\'' {
+                in_str = !in_str;
+            }
+            if c == ';' && !in_str {
+                segments.push((seg_start, i + 1));
+                seg_start = i + 1;
+            }
+        }
+        if seg_start < chars.len() {
+            segments.push((seg_start, chars.len()));
+        }
+        let (s, e) = segments
+            .iter()
+            .copied()
+            .find(|&(s, e)| offset >= s && offset < e)
+            .or_else(|| segments.last().copied())
+            .unwrap_or((0, chars.len()));
+        let stmt: String = chars[s..e].iter().collect();
+        let stmt = stmt.trim();
+        if stmt.is_empty() {
+            self.current_line().trim().to_string()
+        } else {
+            stmt.to_string()
+        }
     }
 }
 
@@ -354,5 +399,30 @@ mod tests {
         assert_eq!((ed.line, ed.col), (1, 0));
         ed.move_cursor(0, -1); // wraps back to previous line end
         assert_eq!((ed.line, ed.col), (0, 2));
+    }
+
+    #[test]
+    fn statement_under_cursor() {
+        let mut ed = EditorState::from_text("SELECT 1;\nSELECT 2;\nSELECT 3");
+        ed.line = 1;
+        ed.col = 3;
+        assert_eq!(ed.current_statement(), "SELECT 2;");
+        ed.line = 2;
+        ed.col = 0;
+        assert_eq!(ed.current_statement(), "SELECT 3");
+    }
+
+    #[test]
+    fn statement_ignores_semicolon_in_literal() {
+        let mut ed = EditorState::from_text("SELECT 'a;b' FROM t; SELECT 2;");
+        ed.line = 0;
+        ed.col = 4;
+        assert_eq!(ed.current_statement(), "SELECT 'a;b' FROM t;");
+    }
+
+    #[test]
+    fn statement_without_semicolons_is_whole_text() {
+        let ed = EditorState::from_text("SELECT *\nFROM t");
+        assert_eq!(ed.current_statement(), "SELECT *\nFROM t");
     }
 }

--- a/app/src/export.rs
+++ b/app/src/export.rs
@@ -1,0 +1,66 @@
+//! File-export helpers: timestamped paths in ~/Downloads (temp-dir fallback).
+//! No chrono/time dependency — the civil-date math is a dozen lines.
+
+use std::path::PathBuf;
+
+/// `~/Downloads/<prefix>-YYYYMMDD-HHMMSS.<ext>`; temp dir when $HOME is unset
+/// or Downloads does not exist.
+pub fn export_path(prefix: &str, ext: &str) -> PathBuf {
+    let dir = std::env::var_os("HOME")
+        .map(|h| PathBuf::from(h).join("Downloads"))
+        .filter(|d| d.is_dir())
+        .unwrap_or_else(std::env::temp_dir);
+    dir.join(format!("{prefix}-{}.{ext}", timestamp()))
+}
+
+/// Current UTC time as "YYYYMMDD-HHMMSS".
+fn timestamp() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    fmt_timestamp(secs)
+}
+
+fn fmt_timestamp(secs: u64) -> String {
+    let (y, m, d) = civil_from_days((secs / 86_400) as i64);
+    let tod = secs % 86_400;
+    format!(
+        "{y:04}{m:02}{d:02}-{:02}{:02}{:02}",
+        tod / 3600,
+        (tod % 3600) / 60,
+        tod % 60
+    )
+}
+
+/// Days since 1970-01-01 → (year, month, day). Howard Hinnant's civil_from_days.
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097);
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn civil_date_epoch_and_leap() {
+        assert_eq!(civil_from_days(0), (1970, 1, 1));
+        // 2024-02-29 is day 19782
+        assert_eq!(civil_from_days(19_782), (2024, 2, 29));
+    }
+
+    #[test]
+    fn timestamp_format() {
+        assert_eq!(fmt_timestamp(0), "19700101-000000");
+        assert_eq!(fmt_timestamp(86_399), "19700101-235959");
+    }
+}

--- a/app/src/export.rs
+++ b/app/src/export.rs
@@ -3,6 +3,48 @@
 
 use std::path::PathBuf;
 
+use crate::model::GridModel;
+
+/// RFC-4180-style CSV: fields quoted when they contain a comma, quote or
+/// newline; quotes doubled.
+pub fn to_csv(g: &GridModel) -> String {
+    fn esc(s: &str) -> String {
+        if s.contains([',', '"', '\n', '\r']) {
+            format!("\"{}\"", s.replace('"', "\"\""))
+        } else {
+            s.to_string()
+        }
+    }
+    let mut out = String::new();
+    let header: Vec<String> = g.columns.iter().map(|c| esc(&c.name)).collect();
+    out.push_str(&header.join(","));
+    out.push('\n');
+    for row in &g.rows {
+        let cells: Vec<String> = row.iter().map(|c| esc(&c.text)).collect();
+        out.push_str(&cells.join(","));
+        out.push('\n');
+    }
+    out
+}
+
+/// TSV for the clipboard (pastes into spreadsheets); tabs/newlines inside
+/// cells become spaces.
+pub fn to_tsv(g: &GridModel) -> String {
+    fn clean(s: &str) -> String {
+        s.replace(['\t', '\n', '\r'], " ")
+    }
+    let mut out = String::new();
+    let header: Vec<String> = g.columns.iter().map(|c| clean(&c.name)).collect();
+    out.push_str(&header.join("\t"));
+    out.push('\n');
+    for row in &g.rows {
+        let cells: Vec<String> = row.iter().map(|c| clean(&c.text)).collect();
+        out.push_str(&cells.join("\t"));
+        out.push('\n');
+    }
+    out
+}
+
 /// `~/Downloads/<prefix>-YYYYMMDD-HHMMSS.<ext>`; temp dir when $HOME is unset
 /// or Downloads does not exist.
 pub fn export_path(prefix: &str, ext: &str) -> PathBuf {
@@ -56,6 +98,30 @@ mod tests {
         assert_eq!(civil_from_days(0), (1970, 1, 1));
         // 2024-02-29 is day 19782
         assert_eq!(civil_from_days(19_782), (2024, 2, 29));
+    }
+
+    fn grid() -> GridModel {
+        use crate::model::{VmCell, VmColumn};
+        GridModel {
+            columns: vec![
+                VmColumn { name: "id".into(), type_name: "int".into() },
+                VmColumn { name: "name".into(), type_name: "text".into() },
+            ],
+            rows: vec![vec![
+                VmCell { text: "1".into(), is_null: false },
+                VmCell { text: "a,\"b\"\n".into(), is_null: false },
+            ]],
+        }
+    }
+
+    #[test]
+    fn csv_quotes_special_chars() {
+        assert_eq!(to_csv(&grid()), "id,name\n1,\"a,\"\"b\"\"\n\"\n");
+    }
+
+    #[test]
+    fn tsv_strips_control_chars() {
+        assert_eq!(to_tsv(&grid()), "id\tname\n1\ta,\"b\" \n");
     }
 
     #[test]

--- a/app/src/export.rs
+++ b/app/src/export.rs
@@ -104,12 +104,24 @@ mod tests {
         use crate::model::{VmCell, VmColumn};
         GridModel {
             columns: vec![
-                VmColumn { name: "id".into(), type_name: "int".into() },
-                VmColumn { name: "name".into(), type_name: "text".into() },
+                VmColumn {
+                    name: "id".into(),
+                    type_name: "int".into(),
+                },
+                VmColumn {
+                    name: "name".into(),
+                    type_name: "text".into(),
+                },
             ],
             rows: vec![vec![
-                VmCell { text: "1".into(), is_null: false },
-                VmCell { text: "a,\"b\"\n".into(), is_null: false },
+                VmCell {
+                    text: "1".into(),
+                    is_null: false,
+                },
+                VmCell {
+                    text: "a,\"b\"\n".into(),
+                    is_null: false,
+                },
             ]],
         }
     }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1814,6 +1814,30 @@ fn main() -> Result<(), slint::PlatformError> {
         });
     }
 
+    // ----- Explain button: run EXPLAIN for the editor SQL -----
+    {
+        let weak = window.as_weak();
+        let run_sql = run_sql.clone();
+        window.on_explain_query(move || {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            if !w.get_sql_capable() {
+                return;
+            }
+            let text = w.get_query_text().to_string();
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                return;
+            }
+            if trimmed.to_uppercase().starts_with("EXPLAIN") {
+                run_sql(trimmed.to_string());
+            } else {
+                run_sql(format!("EXPLAIN {trimmed}"));
+            }
+        });
+    }
+
     // ----- Format button: tidy the editor SQL in place -----
     {
         let weak = window.as_weak();

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -344,6 +344,18 @@ struct BrowseState {
 
 /// 1-based display bounds of the current page window plus prev/next
 /// availability. `shown` is how many rows the page actually returned.
+/// Record an executed query at the head of the live history (dedupe, cap 50).
+fn record_recent(list: &RefCell<Vec<String>>, text: &str) {
+    let t = text.trim();
+    if t.is_empty() {
+        return;
+    }
+    let mut v = list.borrow_mut();
+    v.retain(|s| s != t);
+    v.insert(0, t.to_string());
+    v.truncate(50);
+}
+
 fn page_bounds(page: u64, limit: u64, total: Option<u64>, shown: u64) -> (u64, u64, bool, bool) {
     let start = if shown == 0 { 0 } else { page * limit + 1 };
     let end = page * limit + shown;
@@ -842,11 +854,17 @@ fn main() -> Result<(), slint::PlatformError> {
             "SELECT date_trunc('day', created_at) AS day, sum(amount)\nFROM transactions\nGROUP BY 1\nORDER BY 1 DESC;",
         ),
     ]);
-    let recent_queries: Rc<Vec<&str>> = Rc::new(vec![
-        "SELECT * FROM emiten LIMIT 100;",
-        "INSERT INTO sectors (name) VALUES ('Technology');",
-        "UPDATE emiten SET updated_at = now() WHERE code = '93344';",
-    ]);
+    // Live history: filled as queries run; mock mode seeds a few for the
+    // screenshot harness.
+    let recent_queries: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(if mock::mock_mode() {
+        vec![
+            "SELECT * FROM emiten LIMIT 100;".into(),
+            "INSERT INTO sectors (name) VALUES ('Technology');".into(),
+            "UPDATE emiten SET updated_at = now() WHERE code = '93344';".into(),
+        ]
+    } else {
+        Vec::new()
+    }));
     let rebuild_query_tree = {
         let weak = window.as_weak();
         let saved = saved_queries.clone();
@@ -855,27 +873,33 @@ fn main() -> Result<(), slint::PlatformError> {
             let Some(w) = weak.upgrade() else {
                 return;
             };
+            // Mode 2 (History) shows only the live history; mode 1 (Queries)
+            // shows Saved + Recent.
+            let history_only = w.get_sidebar_mode() == 2;
             let mut rows: Vec<TreeNode> = Vec::new();
-            rows.push(TreeNode {
-                label: "Saved".into(),
-                depth: 0,
-                kind: "qcat".into(),
-                expanded: true,
-                db: SharedString::default(),
-                count: saved.len() as i32,
-            });
-            for (i, (name, _)) in saved.iter().enumerate() {
+            if !history_only {
                 rows.push(TreeNode {
-                    label: (*name).into(),
-                    depth: 1,
-                    kind: "query".into(),
-                    expanded: *name == active,
+                    label: "Saved".into(),
+                    depth: 0,
+                    kind: "qcat".into(),
+                    expanded: true,
                     db: SharedString::default(),
-                    count: i as i32,
+                    count: saved.len() as i32,
                 });
+                for (i, (name, _)) in saved.iter().enumerate() {
+                    rows.push(TreeNode {
+                        label: (*name).into(),
+                        depth: 1,
+                        kind: "query".into(),
+                        expanded: *name == active,
+                        db: SharedString::default(),
+                        count: i as i32,
+                    });
+                }
             }
+            let recent = recent.borrow();
             rows.push(TreeNode {
-                label: "Recent".into(),
+                label: if history_only { "History" } else { "Recent" }.into(),
                 depth: 0,
                 kind: "qcat".into(),
                 expanded: true,
@@ -886,7 +910,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 let label: String = if q.chars().count() > 24 {
                     format!("{}…", q.chars().take(23).collect::<String>())
                 } else {
-                    (*q).to_string()
+                    q.clone()
                 };
                 rows.push(TreeNode {
                     label: label.into(),
@@ -914,8 +938,8 @@ fn main() -> Result<(), slint::PlatformError> {
             let (title, text, is_saved) =
                 if let Some((name, sql)) = saved.iter().find(|(n, _)| *n == label.as_str()) {
                     ((*name).to_string(), (*sql).to_string(), true)
-                } else if let Some(sql) = recent.get(idx.max(0) as usize) {
-                    ("Query".to_string(), (*sql).to_string(), false)
+                } else if let Some(sql) = recent.borrow().get(idx.max(0) as usize) {
+                    ("Query".to_string(), sql.clone(), false)
                 } else {
                     return;
                 };
@@ -1751,10 +1775,25 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let weak = window.as_weak();
         let run_sql = run_sql.clone();
+        let recent_queries = recent_queries.clone();
+        let rebuild_query_tree = rebuild_query_tree.clone();
         window.on_run_query(move || {
             if let Some(w) = weak.upgrade() {
-                run_sql(w.get_query_text().to_string());
+                let text = w.get_query_text().to_string();
+                record_recent(&recent_queries, &text);
+                run_sql(text);
+                if w.get_sidebar_mode() != 0 {
+                    rebuild_query_tree("");
+                }
             }
+        });
+    }
+
+    // ----- sidebar Items / Queries / History tabs -----
+    {
+        let rebuild_query_tree = rebuild_query_tree.clone();
+        window.on_sidebar_mode_changed(move |_mode| {
+            rebuild_query_tree("");
         });
     }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1814,6 +1814,20 @@ fn main() -> Result<(), slint::PlatformError> {
         });
     }
 
+    // ----- Run Selection: run the statement under the cursor -----
+    {
+        let run_sql = run_sql.clone();
+        let ed_state = ed_state.clone();
+        let recent_queries = recent_queries.clone();
+        window.on_run_selection(move || {
+            let stmt = ed_state.borrow().current_statement();
+            if !stmt.is_empty() {
+                record_recent(&recent_queries, &stmt);
+                run_sql(stmt);
+            }
+        });
+    }
+
     // ----- Explain button: run EXPLAIN for the editor SQL -----
     {
         let weak = window.as_weak();

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1958,12 +1958,8 @@ fn main() -> Result<(), slint::PlatformError> {
                                 let mut fcols: Vec<SharedString> =
                                     vec![SharedString::from("any column")];
                                 fcols.extend(colnames.iter().cloned());
-                                w.set_filter_columns(ModelRc::from(Rc::new(VecModel::from(
-                                    fcols,
-                                ))));
-                                w.set_all_columns(ModelRc::from(Rc::new(VecModel::from(
-                                    colnames,
-                                ))));
+                                w.set_filter_columns(ModelRc::from(Rc::new(VecModel::from(fcols))));
+                                w.set_all_columns(ModelRc::from(Rc::new(VecModel::from(colnames))));
                                 // Fresh result: pending edits refer to rows that
                                 // no longer exist — drop them and re-anchor the
                                 // buffer to the (possibly new) browse target.

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -562,6 +562,33 @@ fn filter_grid(g: &model::GridModel, needle: &str) -> model::GridModel {
     }
 }
 
+/// Return a copy of `g` without the hidden column indices.
+fn hide_cols(g: &model::GridModel, hidden: &HashSet<usize>) -> model::GridModel {
+    if hidden.is_empty() {
+        return g.clone();
+    }
+    model::GridModel {
+        columns: g
+            .columns
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| !hidden.contains(i))
+            .map(|(_, c)| c.clone())
+            .collect(),
+        rows: g
+            .rows
+            .iter()
+            .map(|row| {
+                row.iter()
+                    .enumerate()
+                    .filter(|(i, _)| !hidden.contains(i))
+                    .map(|(_, c)| c.clone())
+                    .collect()
+            })
+            .collect(),
+    }
+}
+
 /// Push a `ResultView` into the window, selecting the per-kind result region
 /// via `result-kind` (0 Table, 1 Documents, 3 Affected).
 fn apply_result(w: &MainWindow, view: model::ResultView) {
@@ -714,6 +741,9 @@ fn main() -> Result<(), slint::PlatformError> {
     // indices refer to THIS grid, and its cells carry the pre-edit pk values.
     let displayed_grid: Arc<std::sync::Mutex<Option<model::GridModel>>> =
         Arc::new(std::sync::Mutex::new(None));
+    // Column indices (into the last result) hidden via the Columns popup.
+    let hidden_cols: Arc<std::sync::Mutex<HashSet<usize>>> =
+        Arc::new(std::sync::Mutex::new(HashSet::new()));
     // Engine of the live connection, kept on the UI thread so table clicks can
     // build an engine-appropriate "browse this table" query synchronously.
     let cur_engine: Rc<RefCell<Option<rdbs_connstore::Engine>>> = Rc::new(RefCell::new(None));
@@ -1447,11 +1477,13 @@ fn main() -> Result<(), slint::PlatformError> {
         let last_view = last_view.clone();
         let edit_buf = edit_buf.clone();
         let displayed_grid = displayed_grid.clone();
+        let hidden_cols = hidden_cols.clone();
         window.on_apply_filter(move || {
             let Some(w) = weak.upgrade() else {
                 return;
             };
             let needle = w.get_grid_filter().to_string().to_lowercase();
+            let hidden = hidden_cols.lock().unwrap().clone();
             let guard = last_view.lock().unwrap();
             let Some(v) = guard.as_ref() else {
                 return;
@@ -1467,15 +1499,81 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_editing_col(-1);
             // Filter the row-bearing views; Affected has nothing to filter.
             let filtered = match v {
-                model::ResultView::Table(g) => model::ResultView::Table(filter_grid(g, &needle)),
+                model::ResultView::Table(g) => {
+                    model::ResultView::Table(hide_cols(&filter_grid(g, &needle), &hidden))
+                }
                 model::ResultView::Documents(d) => model::ResultView::Documents(model::DocModel {
                     json: d.json.clone(),
-                    grid: filter_grid(&d.grid, &needle),
+                    grid: hide_cols(&filter_grid(&d.grid, &needle), &hidden),
                 }),
                 model::ResultView::Affected(_) => return,
             };
             *displayed_grid.lock().unwrap() = view_grid(&filtered);
             apply_result(&w, filtered);
+        });
+    }
+
+    // ----- Columns popup: toggle a column's visibility -----
+    {
+        let weak = window.as_weak();
+        let last_view = last_view.clone();
+        let edit_buf = edit_buf.clone();
+        let displayed_grid = displayed_grid.clone();
+        let hidden_cols = hidden_cols.clone();
+        window.on_toggle_column(move |i| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let idx = i.max(0) as usize;
+            let hidden = {
+                let mut h = hidden_cols.lock().unwrap();
+                if !h.insert(idx) {
+                    h.remove(&idx);
+                }
+                h.clone()
+            };
+            let n = w.get_all_columns().row_count();
+            let flags: Vec<bool> = (0..n).map(|c| hidden.contains(&c)).collect();
+            w.set_col_hidden(ModelRc::from(Rc::new(VecModel::from(flags))));
+            let needle = w.get_grid_filter().to_string().to_lowercase();
+            let guard = last_view.lock().unwrap();
+            let Some(v) = guard.as_ref() else {
+                return;
+            };
+            // Hiding renumbers columns: cell edits would write through the
+            // wrong column index, so drop pending edits and lock editing
+            // until the next refresh restores the full column set.
+            // ponytail: remap edit indices instead if editing-with-hidden-
+            // columns ever matters.
+            {
+                edit_buf.lock().unwrap().clear();
+            }
+            w.set_pending_count(0);
+            w.set_editing_row(-1);
+            w.set_editing_col(-1);
+            if !hidden.is_empty() {
+                w.set_grid_read_only(true);
+            }
+            let transformed = match v {
+                model::ResultView::Table(g) => {
+                    model::ResultView::Table(hide_cols(&filter_grid(g, &needle), &hidden))
+                }
+                model::ResultView::Documents(d) => model::ResultView::Documents(model::DocModel {
+                    json: d.json.clone(),
+                    grid: hide_cols(&filter_grid(&d.grid, &needle), &hidden),
+                }),
+                model::ResultView::Affected(_) => return,
+            };
+            if let Some(g) = view_grid(&transformed) {
+                let widths: Vec<f32> = g
+                    .columns
+                    .iter()
+                    .map(|c| default_col_width(&c.name, &c.type_name))
+                    .collect();
+                w.set_grid_col_widths(ModelRc::from(Rc::new(VecModel::from(widths))));
+            }
+            *displayed_grid.lock().unwrap() = view_grid(&transformed);
+            apply_result(&w, transformed);
         });
     }
 
@@ -1692,6 +1790,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let browse = browse.clone();
         let edit_buf = edit_buf.clone();
         let displayed_grid = displayed_grid.clone();
+        let hidden_cols = hidden_cols.clone();
         Rc::new(move |sql: String| {
             let weak2 = weak.clone();
             let current = current.clone();
@@ -1699,6 +1798,7 @@ fn main() -> Result<(), slint::PlatformError> {
             let browse = browse.clone();
             let edit_buf = edit_buf.clone();
             let displayed_grid = displayed_grid.clone();
+            let hidden_cols = hidden_cols.clone();
             rt.spawn(async move {
                 let guard = current.lock().await;
                 let t0 = std::time::Instant::now();
@@ -1735,6 +1835,28 @@ fn main() -> Result<(), slint::PlatformError> {
                                 } as u64;
                                 *last_view.lock().unwrap() = Some(v.clone());
                                 w.set_grid_filter(SharedString::default());
+                                // Fresh result: all columns visible again.
+                                hidden_cols.lock().unwrap().clear();
+                                let colnames: Vec<SharedString> = match &v {
+                                    model::ResultView::Table(g) => g
+                                        .columns
+                                        .iter()
+                                        .map(|c| SharedString::from(c.name.clone()))
+                                        .collect(),
+                                    model::ResultView::Documents(d) => d
+                                        .grid
+                                        .columns
+                                        .iter()
+                                        .map(|c| SharedString::from(c.name.clone()))
+                                        .collect(),
+                                    _ => Vec::new(),
+                                };
+                                w.set_col_hidden(ModelRc::from(Rc::new(VecModel::from(
+                                    vec![false; colnames.len()],
+                                ))));
+                                w.set_all_columns(ModelRc::from(Rc::new(VecModel::from(
+                                    colnames,
+                                ))));
                                 // Fresh result: pending edits refer to rows that
                                 // no longer exist — drop them and re-anchor the
                                 // buffer to the (possibly new) browse target.

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1814,6 +1814,46 @@ fn main() -> Result<(), slint::PlatformError> {
         });
     }
 
+    // ----- Copy results (TSV → clipboard) / Export CSV (~/Downloads) -----
+    {
+        let weak = window.as_weak();
+        let displayed_grid = displayed_grid.clone();
+        window.on_copy_results(move || {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let Some(grid) = displayed_grid.lock().unwrap().clone() else {
+                return;
+            };
+            use copypasta::ClipboardProvider;
+            let msg = match copypasta::ClipboardContext::new()
+                .and_then(|mut cb| cb.set_contents(export::to_tsv(&grid)))
+            {
+                Ok(()) => format!("copied {} rows", grid.rows.len()),
+                Err(e) => format!("copy failed: {e}"),
+            };
+            w.set_results_meta(SharedString::from(msg));
+        });
+    }
+    {
+        let weak = window.as_weak();
+        let displayed_grid = displayed_grid.clone();
+        window.on_export_csv(move || {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let Some(grid) = displayed_grid.lock().unwrap().clone() else {
+                return;
+            };
+            let path = export::export_path("rdbs-export", "csv");
+            let msg = match std::fs::write(&path, export::to_csv(&grid)) {
+                Ok(()) => format!("exported → {}", path.display()),
+                Err(e) => format!("export failed: {e}"),
+            };
+            w.set_results_meta(SharedString::from(msg));
+        });
+    }
+
     // ----- Run Selection: run the statement under the cursor -----
     {
         let run_sql = run_sql.clone();

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -562,6 +562,43 @@ fn filter_grid(g: &model::GridModel, needle: &str) -> model::GridModel {
     }
 }
 
+/// List a table's indexes as (name, definition) via the engine catalog.
+/// Empty for engines without one (Redis, Mongo) and on any query error.
+async fn fetch_indexes(
+    engine: rdbs_connstore::Engine,
+    driver: &AnyDriver,
+    table: &rdbs_core::write::TableRef,
+) -> Vec<(String, String)> {
+    let esc = |s: &str| s.replace('\'', "''");
+    let sql = match engine {
+        rdbs_connstore::Engine::Postgres => format!(
+            "SELECT indexname, indexdef FROM pg_indexes \
+             WHERE tablename = '{}' AND schemaname = '{}' ORDER BY 1",
+            esc(&table.name),
+            esc(table.schema.as_deref().unwrap_or("public")),
+        ),
+        rdbs_connstore::Engine::MySql => format!(
+            "SELECT index_name, GROUP_CONCAT(column_name ORDER BY seq_in_index \
+             SEPARATOR ', ') FROM information_schema.statistics \
+             WHERE table_name = '{}' AND table_schema = \
+             COALESCE(NULLIF('{}', ''), DATABASE()) GROUP BY index_name ORDER BY 1",
+            esc(&table.name),
+            esc(table.database.as_deref().unwrap_or("")),
+        ),
+        _ => return Vec::new(),
+    };
+    match driver.query(&rdbs_core::query::Query::Sql(sql)).await {
+        Ok(rdbs_core::result::ResultSet::Tabular { rows, .. }) => rows
+            .into_iter()
+            .filter_map(|r| {
+                let mut it = r.into_iter();
+                Some((it.next()?.render(), it.next()?.render()))
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
 /// Row filter with an optional column + operator condition (`needle` already
 /// lowercased). `col: None` falls back to the all-cell contains filter.
 fn filter_grid_cond(
@@ -2194,6 +2231,7 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_show_structure(false);
             w.set_total_rows(-1);
             w.set_grid_read_only(true);
+            w.set_index_rows(ModelRc::from(Rc::new(VecModel::<IndexRow>::default())));
             run_browse();
 
             // Fetch total + primary key off-thread; footer updates when done.
@@ -2203,11 +2241,12 @@ fn main() -> Result<(), slint::PlatformError> {
             let edit_buf = edit_buf.clone();
             rt.spawn(async move {
                 let guard = current.lock().await;
-                let Some((_, driver)) = guard.as_ref() else {
+                let Some((engine, driver)) = guard.as_ref() else {
                     return;
                 };
                 let total = driver.count(&table).await.ok();
                 let pk = driver.primary_key(&table).await.unwrap_or_default();
+                let indexes = fetch_indexes(*engine, driver, &table).await;
                 let (page, limit) = {
                     let mut st = browse.lock().unwrap();
                     // Ignore a late reply if the user already opened another table.
@@ -2227,6 +2266,14 @@ fn main() -> Result<(), slint::PlatformError> {
                 }
                 let _ = slint::invoke_from_event_loop(move || {
                     if let Some(w) = weak2.upgrade() {
+                        let rows: Vec<IndexRow> = indexes
+                            .into_iter()
+                            .map(|(name, definition)| IndexRow {
+                                name: name.into(),
+                                definition: definition.into(),
+                            })
+                            .collect();
+                        w.set_index_rows(ModelRc::from(Rc::new(VecModel::from(rows))));
                         w.set_total_rows(total.map(|t| t as i32).unwrap_or(-1));
                         w.set_grid_read_only(pk.is_empty());
                         w.set_sort_text(if pk.is_empty() {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1768,6 +1768,19 @@ fn main() -> Result<(), slint::PlatformError> {
                                 w.set_grid_col_widths(ModelRc::from(Rc::new(VecModel::from(
                                     widths,
                                 ))));
+                                // Chart segment data (SQL results only).
+                                let bars: Vec<ChartBar> = match &v {
+                                    model::ResultView::Table(g) => model::chart_data(g)
+                                        .into_iter()
+                                        .map(|(label, value, frac)| ChartBar {
+                                            label: label.into(),
+                                            value: value.into(),
+                                            frac,
+                                        })
+                                        .collect(),
+                                    _ => Vec::new(),
+                                };
+                                w.set_chart_bars(ModelRc::from(Rc::new(VecModel::from(bars))));
                                 apply_result(&w, v);
                                 // Browse mode: refresh the pagination footer.
                                 let st = browse.lock().unwrap().clone();

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1040,6 +1040,45 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_db_modal_open(false);
         });
     }
+    // ----- schema switcher: sidebar "schema: …" selector -----
+    {
+        let weak = window.as_weak();
+        window.on_select_schema(move |_current| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let items: Vec<PaletteItem> = w
+                .get_schema_list()
+                .iter()
+                .map(|s| PaletteItem {
+                    label: s,
+                    kind: "database".into(),
+                    sub: SharedString::default(),
+                    local: false,
+                })
+                .collect();
+            if items.is_empty() {
+                return;
+            }
+            w.set_schema_items(ModelRc::from(Rc::new(VecModel::from(items))));
+            w.set_schema_modal_open(true);
+        });
+    }
+    {
+        let weak = window.as_weak();
+        window.on_schema_choose(move |idx| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            if let Some(it) = w.get_schema_items().row_data(idx.max(0) as usize) {
+                w.set_schema_name(it.label.clone());
+                w.set_bc_schema(it.label);
+                // Anything browsed belonged to the old schema; force a fresh pick.
+                w.set_active_table(SharedString::default());
+            }
+            w.set_schema_modal_open(false);
+        });
+    }
     {
         let weak = window.as_weak();
         let store = store.clone();
@@ -1458,6 +1497,28 @@ fn main() -> Result<(), slint::PlatformError> {
 
                 match result {
                     Ok((driver, schema)) => {
+                        // Postgres: list real namespaces so the sidebar schema
+                        // switcher offers more than "public".
+                        let mut pg_schemas: Vec<SharedString> = Vec::new();
+                        if matches!(engine, rdbs_connstore::Engine::Postgres) {
+                            let q = rdbs_core::query::Query::Sql(
+                                "SELECT schema_name FROM information_schema.schemata \
+                                 WHERE schema_name NOT LIKE 'pg_%' \
+                                 AND schema_name <> 'information_schema' ORDER BY 1"
+                                    .into(),
+                            );
+                            if let Ok(rdbs_core::result::ResultSet::Tabular { rows, .. }) =
+                                driver.query(&q).await
+                            {
+                                for r in rows {
+                                    if let Some(rdbs_core::result::Cell::Text(s)) =
+                                        r.into_iter().next()
+                                    {
+                                        pg_schemas.push(SharedString::from(s));
+                                    }
+                                }
+                            }
+                        }
                         *store_driver.lock().await = Some((engine, driver));
                         let nodes = model::to_tree_model(&schema);
                         let fields = model::to_structure_model(&schema);
@@ -1476,7 +1537,11 @@ fn main() -> Result<(), slint::PlatformError> {
                         // `"dbname"."table"` query would fail).
                         let mut schema_names: Vec<SharedString> =
                             if matches!(engine, rdbs_connstore::Engine::Postgres) {
-                                vec![SharedString::from("public")]
+                                if pg_schemas.is_empty() {
+                                    vec![SharedString::from("public")]
+                                } else {
+                                    pg_schemas
+                                }
                             } else {
                                 schema
                                     .databases
@@ -1487,7 +1552,12 @@ fn main() -> Result<(), slint::PlatformError> {
                         if schema_names.is_empty() {
                             schema_names.push(SharedString::from("public"));
                         }
-                        let schema_current = schema_names[0].clone();
+                        // Default to "public" when present, else the first name.
+                        let schema_current = schema_names
+                            .iter()
+                            .find(|s| s.as_str() == "public")
+                            .unwrap_or(&schema_names[0])
+                            .clone();
                         // SQL editor only makes sense for the SQL engines.
                         let sql_capable = matches!(
                             engine,

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -14,6 +14,7 @@ slint::include_modules!();
 
 mod dispatch;
 mod editor;
+mod export;
 mod mock;
 mod model;
 mod query_parse;
@@ -2761,6 +2762,30 @@ fn main() -> Result<(), slint::PlatformError> {
                 w.set_test_result(SharedString::default());
                 w.set_form_open(false);
             }
+        });
+    }
+    // backup saved connections to a JSON file. Passwords are not in the
+    // list — they live in the keychain — so the dump is safe to write.
+    {
+        let weak = window.as_weak();
+        let store = store.clone();
+        window.on_backup_conns(move || {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let st = store.borrow();
+            let json = match serde_json::to_string_pretty(st.list()) {
+                Ok(j) => j,
+                Err(e) => {
+                    w.set_sel_footer(SharedString::from(format!("backup failed: {e}")));
+                    return;
+                }
+            };
+            let path = export::export_path("rdbs-connections", "json");
+            w.set_sel_footer(SharedString::from(match std::fs::write(&path, json) {
+                Ok(()) => format!("backup → {}", path.display()),
+                Err(e) => format!("backup failed: {e}"),
+            }));
         });
     }
     // quick test from the picker detail pane: saved config, result in the

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -344,6 +344,29 @@ struct BrowseState {
 
 /// 1-based display bounds of the current page window plus prev/next
 /// availability. `shown` is how many rows the page actually returned.
+/// Connect + ping, bounded to 8s so "Testing connection…" always resolves.
+/// Returns the elapsed milliseconds on success.
+// ponytail: timeout-bounded, no hard abort; add CancellationToken if a true
+// cancel button is ever needed.
+async fn try_connect(
+    engine: rdbs_connstore::Engine,
+    cfg: rdbs_core::conn::ConnConfig,
+) -> Result<u64, rdbs_core::error::RdbsError> {
+    let t0 = std::time::Instant::now();
+    let attempt = async {
+        let driver = AnyDriver::connect(engine, &cfg).await?;
+        driver.ping().await?;
+        Ok::<_, rdbs_core::error::RdbsError>(())
+    };
+    match tokio::time::timeout(std::time::Duration::from_secs(8), attempt).await {
+        Ok(Ok(())) => Ok(t0.elapsed().as_millis().max(1) as u64),
+        Ok(Err(e)) => Err(e),
+        Err(_) => Err(rdbs_core::error::RdbsError::Connection(
+            "connection timed out".into(),
+        )),
+    }
+}
+
 /// Record an executed query at the head of the live history (dedupe, cap 50).
 fn record_recent(list: &RefCell<Vec<String>>, text: &str) {
     let t = text.trim();
@@ -2740,6 +2763,44 @@ fn main() -> Result<(), slint::PlatformError> {
             }
         });
     }
+    // quick test from the picker detail pane: saved config, result in the
+    // detail footer line.
+    {
+        let weak = window.as_weak();
+        let rt = rt.clone();
+        let store = store.clone();
+        window.on_test_conn_quick(move |idx| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let (engine, cfg) = {
+                let st = store.borrow();
+                let Some(sc) = st.list().get(idx.max(0) as usize) else {
+                    return;
+                };
+                match st.conn_config_for(&sc.id) {
+                    Ok(c) => (sc.engine, c),
+                    Err(e) => {
+                        w.set_sel_footer(SharedString::from(format!("connection failed: {e}")));
+                        return;
+                    }
+                }
+            };
+            w.set_sel_footer(SharedString::from("Testing connection…"));
+            let weak2 = weak.clone();
+            rt.spawn(async move {
+                let result = try_connect(engine, cfg).await;
+                let _ = slint::invoke_from_event_loop(move || {
+                    if let Some(w) = weak2.upgrade() {
+                        w.set_sel_footer(SharedString::from(match result {
+                            Ok(ms) => format!("connection ok · {ms}ms"),
+                            Err(e) => format!("connection failed: {e}"),
+                        }));
+                    }
+                });
+            });
+        });
+    }
     // test connection: build a config straight from the form fields (not the
     // store) so unsaved edits are exercised, open a real connection, then drop
     // it. Result reported in the form's test-result line.
@@ -2802,26 +2863,12 @@ fn main() -> Result<(), slint::PlatformError> {
 
             let weak2 = weak.clone();
             rt.spawn(async move {
-                let attempt = async {
-                    let driver = AnyDriver::connect(engine, &cfg).await?;
-                    driver.ping().await?;
-                    Ok::<_, rdbs_core::error::RdbsError>(())
-                };
-                // ponytail: timeout-bounded, no hard abort; add CancellationToken
-                // if a true cancel button is ever needed. Bounds a hung connect so
-                // "Testing connection…" always resolves.
-                let result =
-                    match tokio::time::timeout(std::time::Duration::from_secs(8), attempt).await {
-                        Ok(r) => r,
-                        Err(_) => Err(rdbs_core::error::RdbsError::Connection(
-                            "connection timed out".into(),
-                        )),
-                    };
+                let result = try_connect(engine, cfg).await;
                 let _ = slint::invoke_from_event_loop(move || {
                     if let Some(w) = weak2.upgrade() {
                         w.set_test_busy(false);
                         match result {
-                            Ok(()) => {
+                            Ok(_) => {
                                 w.set_test_ok(true);
                                 w.set_test_result(SharedString::from("connection ok"));
                             }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2512,7 +2512,7 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_f_database(SharedString::default());
             w.set_f_password(SharedString::default());
             w.set_f_sslmode(SharedString::from("Prefer"));
-            w.set_f_color(SharedString::from("#3b82f6"));
+            w.set_f_color(SharedString::from("#2c5fd8"));
             w.set_f_import_url(SharedString::default());
             w.set_form_error(SharedString::default());
             w.set_test_result(SharedString::default());
@@ -2549,7 +2549,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 rdbs_core::conn::SslMode::Require => "Require",
             }));
             w.set_f_color(SharedString::from(
-                sc.color.unwrap_or_else(|| "#3b82f6".into()),
+                sc.color.unwrap_or_else(|| "#2c5fd8".into()),
             ));
             w.set_f_import_url(SharedString::default());
             w.set_form_error(SharedString::default());

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -19,6 +19,7 @@ mod mock;
 mod model;
 mod query_parse;
 mod shot;
+mod sql_format;
 mod theme;
 
 use std::cell::RefCell;
@@ -1808,6 +1809,20 @@ fn main() -> Result<(), slint::PlatformError> {
                 run_sql(text);
                 if w.get_sidebar_mode() != 0 {
                     rebuild_query_tree("");
+                }
+            }
+        });
+    }
+
+    // ----- Format button: tidy the editor SQL in place -----
+    {
+        let weak = window.as_weak();
+        let load_editor_text = load_editor_text.clone();
+        window.on_format_sql(move || {
+            if let Some(w) = weak.upgrade() {
+                let text = w.get_query_text().to_string();
+                if !text.trim().is_empty() {
+                    load_editor_text(&sql_format::format(&text));
                 }
             }
         });

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -562,6 +562,57 @@ fn filter_grid(g: &model::GridModel, needle: &str) -> model::GridModel {
     }
 }
 
+/// Row filter with an optional column + operator condition (`needle` already
+/// lowercased). `col: None` falls back to the all-cell contains filter.
+fn filter_grid_cond(
+    g: &model::GridModel,
+    needle: &str,
+    col: Option<usize>,
+    op: &str,
+) -> model::GridModel {
+    let Some(c) = col else {
+        return filter_grid(g, needle);
+    };
+    // null checks ignore the value box; other operators with an empty value
+    // keep every row (matches the plain filter's behavior)
+    if needle.is_empty() && op != "is null" && op != "not null" {
+        return g.clone();
+    }
+    let keep = |row: &[model::VmCell]| -> bool {
+        let Some(cell) = row.get(c) else {
+            return false;
+        };
+        match op {
+            "is null" => cell.is_null,
+            "not null" => !cell.is_null,
+            "=" => cell.text.to_lowercase() == needle,
+            "≠" => cell.text.to_lowercase() != needle,
+            ">" | "<" => match (cell.text.parse::<f64>(), needle.parse::<f64>()) {
+                (Ok(a), Ok(b)) => {
+                    if op == ">" {
+                        a > b
+                    } else {
+                        a < b
+                    }
+                }
+                _ => {
+                    let t = cell.text.to_lowercase();
+                    if op == ">" {
+                        t.as_str() > needle
+                    } else {
+                        t.as_str() < needle
+                    }
+                }
+            },
+            _ => cell.text.to_lowercase().contains(needle),
+        }
+    };
+    model::GridModel {
+        columns: g.columns.clone(),
+        rows: g.rows.iter().filter(|r| keep(r)).cloned().collect(),
+    }
+}
+
 /// Return a copy of `g` without the hidden column indices.
 fn hide_cols(g: &model::GridModel, hidden: &HashSet<usize>) -> model::GridModel {
     if hidden.is_empty() {
@@ -1483,6 +1534,8 @@ fn main() -> Result<(), slint::PlatformError> {
                 return;
             };
             let needle = w.get_grid_filter().to_string().to_lowercase();
+            let fcol = w.get_filter_col().to_string();
+            let fop = w.get_filter_op().to_string();
             let hidden = hidden_cols.lock().unwrap().clone();
             let guard = last_view.lock().unwrap();
             let Some(v) = guard.as_ref() else {
@@ -1498,13 +1551,24 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_editing_row(-1);
             w.set_editing_col(-1);
             // Filter the row-bearing views; Affected has nothing to filter.
-            let filtered = match v {
-                model::ResultView::Table(g) => {
-                    model::ResultView::Table(hide_cols(&filter_grid(g, &needle), &hidden))
+            let col_of = |g: &model::GridModel| {
+                if fcol == "any column" {
+                    None
+                } else {
+                    g.columns.iter().position(|c| c.name == fcol)
                 }
+            };
+            let filtered = match v {
+                model::ResultView::Table(g) => model::ResultView::Table(hide_cols(
+                    &filter_grid_cond(g, &needle, col_of(g), &fop),
+                    &hidden,
+                )),
                 model::ResultView::Documents(d) => model::ResultView::Documents(model::DocModel {
                     json: d.json.clone(),
-                    grid: hide_cols(&filter_grid(&d.grid, &needle), &hidden),
+                    grid: hide_cols(
+                        &filter_grid_cond(&d.grid, &needle, col_of(&d.grid), &fop),
+                        &hidden,
+                    ),
                 }),
                 model::ResultView::Affected(_) => return,
             };
@@ -1853,6 +1917,12 @@ fn main() -> Result<(), slint::PlatformError> {
                                 };
                                 w.set_col_hidden(ModelRc::from(Rc::new(VecModel::from(
                                     vec![false; colnames.len()],
+                                ))));
+                                let mut fcols: Vec<SharedString> =
+                                    vec![SharedString::from("any column")];
+                                fcols.extend(colnames.iter().cloned());
+                                w.set_filter_columns(ModelRc::from(Rc::new(VecModel::from(
+                                    fcols,
                                 ))));
                                 w.set_all_columns(ModelRc::from(Rc::new(VecModel::from(
                                     colnames,

--- a/app/src/model.rs
+++ b/app/src/model.rs
@@ -154,6 +154,49 @@ fn flatten_documents(docs: &[serde_json::Value]) -> (Vec<VmColumn>, Vec<Vec<VmCe
     (columns, rows)
 }
 
+/// (label, value-text, frac) triples for the results bar chart: first
+/// non-numeric column is the label, first numeric column the value, capped
+/// at 30 rows and normalized by the largest absolute value. Empty when the
+/// grid has no numeric column.
+pub fn chart_data(g: &GridModel) -> Vec<(String, String, f32)> {
+    let ncols = g.columns.len();
+    if ncols == 0 || g.rows.is_empty() {
+        return Vec::new();
+    }
+    let is_numeric = |c: usize| {
+        let mut any = false;
+        for row in &g.rows {
+            match row.get(c) {
+                Some(cell) if cell.is_null || cell.text.is_empty() => {}
+                Some(cell) if cell.text.parse::<f64>().is_ok() => any = true,
+                _ => return false,
+            }
+        }
+        any
+    };
+    let Some(value_col) = (0..ncols).find(|&c| is_numeric(c)) else {
+        return Vec::new();
+    };
+    let label_col = (0..ncols).find(|&c| !is_numeric(c));
+    let mut out: Vec<(String, String, f64)> = Vec::new();
+    for (i, row) in g.rows.iter().take(30).enumerate() {
+        let raw = row.get(value_col).map(|c| c.text.clone()).unwrap_or_default();
+        let value: f64 = raw.parse().unwrap_or(0.0);
+        let label = label_col
+            .and_then(|lc| row.get(lc))
+            .map(|c| c.text.clone())
+            .unwrap_or_else(|| format!("row {}", i + 1));
+        out.push((label, raw, value));
+    }
+    let max = out.iter().fold(0.0_f64, |m, (_, _, v)| m.max(v.abs()));
+    if max <= 0.0 {
+        return Vec::new();
+    }
+    out.into_iter()
+        .map(|(l, s, v)| (l, s, (v.abs() / max) as f32))
+        .collect()
+}
+
 /// Convert any ResultSet into its presentation-ready view. Each variant keeps
 /// its own shape instead of collapsing to a single grid.
 pub fn to_result_view(rs: &ResultSet) -> ResultView {
@@ -257,6 +300,39 @@ mod tests {
     use super::*;
     use rdbs_core::result::{Cell, Column, RedisValue, ResultSet};
     use rdbs_core::schema::{Container, ContainerKind, Database, Field, Schema};
+
+    #[test]
+    fn chart_data_picks_label_and_numeric_columns() {
+        let g = GridModel {
+            columns: vec![
+                VmColumn { name: "sector".into(), type_name: "text".into() },
+                VmColumn { name: "total".into(), type_name: "int".into() },
+            ],
+            rows: vec![
+                vec![
+                    VmCell { text: "energy".into(), is_null: false },
+                    VmCell { text: "10".into(), is_null: false },
+                ],
+                vec![
+                    VmCell { text: "tech".into(), is_null: false },
+                    VmCell { text: "5".into(), is_null: false },
+                ],
+            ],
+        };
+        let bars = chart_data(&g);
+        assert_eq!(bars.len(), 2);
+        assert_eq!(bars[0], ("energy".into(), "10".into(), 1.0));
+        assert_eq!(bars[1].2, 0.5);
+    }
+
+    #[test]
+    fn chart_data_empty_without_numeric_column() {
+        let g = GridModel {
+            columns: vec![VmColumn { name: "name".into(), type_name: "text".into() }],
+            rows: vec![vec![VmCell { text: "a".into(), is_null: false }]],
+        };
+        assert!(chart_data(&g).is_empty());
+    }
 
     fn expect_table(rs: &ResultSet) -> GridModel {
         match to_result_view(rs) {

--- a/app/src/model.rs
+++ b/app/src/model.rs
@@ -180,7 +180,10 @@ pub fn chart_data(g: &GridModel) -> Vec<(String, String, f32)> {
     let label_col = (0..ncols).find(|&c| !is_numeric(c));
     let mut out: Vec<(String, String, f64)> = Vec::new();
     for (i, row) in g.rows.iter().take(30).enumerate() {
-        let raw = row.get(value_col).map(|c| c.text.clone()).unwrap_or_default();
+        let raw = row
+            .get(value_col)
+            .map(|c| c.text.clone())
+            .unwrap_or_default();
         let value: f64 = raw.parse().unwrap_or(0.0);
         let label = label_col
             .and_then(|lc| row.get(lc))
@@ -305,17 +308,35 @@ mod tests {
     fn chart_data_picks_label_and_numeric_columns() {
         let g = GridModel {
             columns: vec![
-                VmColumn { name: "sector".into(), type_name: "text".into() },
-                VmColumn { name: "total".into(), type_name: "int".into() },
+                VmColumn {
+                    name: "sector".into(),
+                    type_name: "text".into(),
+                },
+                VmColumn {
+                    name: "total".into(),
+                    type_name: "int".into(),
+                },
             ],
             rows: vec![
                 vec![
-                    VmCell { text: "energy".into(), is_null: false },
-                    VmCell { text: "10".into(), is_null: false },
+                    VmCell {
+                        text: "energy".into(),
+                        is_null: false,
+                    },
+                    VmCell {
+                        text: "10".into(),
+                        is_null: false,
+                    },
                 ],
                 vec![
-                    VmCell { text: "tech".into(), is_null: false },
-                    VmCell { text: "5".into(), is_null: false },
+                    VmCell {
+                        text: "tech".into(),
+                        is_null: false,
+                    },
+                    VmCell {
+                        text: "5".into(),
+                        is_null: false,
+                    },
                 ],
             ],
         };
@@ -328,8 +349,14 @@ mod tests {
     #[test]
     fn chart_data_empty_without_numeric_column() {
         let g = GridModel {
-            columns: vec![VmColumn { name: "name".into(), type_name: "text".into() }],
-            rows: vec![vec![VmCell { text: "a".into(), is_null: false }]],
+            columns: vec![VmColumn {
+                name: "name".into(),
+                type_name: "text".into(),
+            }],
+            rows: vec![vec![VmCell {
+                text: "a".into(),
+                is_null: false,
+            }]],
         };
         assert!(chart_data(&g).is_empty());
     }

--- a/app/src/sql_format.rs
+++ b/app/src/sql_format.rs
@@ -1,0 +1,129 @@
+//! Minimal SQL formatter: uppercase keywords, one clause per line, collapsed
+//! whitespace. String literals, quoted identifiers and comments pass through
+//! untouched. Not a parser — just enough for an editor tidy-up button.
+
+use crate::editor;
+
+/// Keywords that start a new line. BY/ON etc. stay inline after their opener.
+const CLAUSE_STARTERS: &[&str] = &[
+    "FROM", "WHERE", "GROUP", "HAVING", "ORDER", "LIMIT", "OFFSET", "JOIN", "LEFT", "RIGHT",
+    "INNER", "FULL", "UNION", "VALUES", "SET",
+];
+
+/// Join qualifiers: a following JOIN stays on the same line.
+const JOIN_QUALIFIERS: &[&str] = &["LEFT", "RIGHT", "INNER", "FULL", "OUTER", "CROSS"];
+
+pub fn format(sql: &str) -> String {
+    let chars: Vec<char> = sql.chars().collect();
+    let mut out = String::with_capacity(sql.len());
+    let mut i = 0;
+    let mut prev_word = String::new();
+    while i < chars.len() {
+        let c = chars[i];
+        if c == '-' && chars.get(i + 1) == Some(&'-') {
+            let start = i;
+            while i < chars.len() && chars[i] != '\n' {
+                i += 1;
+            }
+            out.extend(chars[start..i].iter());
+            continue;
+        }
+        if c == '/' && chars.get(i + 1) == Some(&'*') {
+            let start = i;
+            i += 2;
+            while i < chars.len() && !(chars[i] == '*' && chars.get(i + 1) == Some(&'/')) {
+                i += 1;
+            }
+            i = (i + 2).min(chars.len());
+            out.extend(chars[start..i].iter());
+            continue;
+        }
+        if c == '\'' || c == '"' {
+            let start = i;
+            i += 1;
+            while i < chars.len() {
+                if chars[i] == c {
+                    i += 1;
+                    // doubled quote = escaped, keep scanning
+                    if chars.get(i) == Some(&c) {
+                        i += 1;
+                        continue;
+                    }
+                    break;
+                }
+                i += 1;
+            }
+            out.extend(chars[start..i].iter());
+            continue;
+        }
+        if c.is_whitespace() {
+            while i < chars.len() && chars[i].is_whitespace() {
+                i += 1;
+            }
+            if !out.is_empty() && !out.ends_with('\n') {
+                out.push(' ');
+            }
+            continue;
+        }
+        if c.is_alphanumeric() || c == '_' {
+            let start = i;
+            while i < chars.len() && (chars[i].is_alphanumeric() || chars[i] == '_') {
+                i += 1;
+            }
+            let word: String = chars[start..i].iter().collect();
+            let upper = word.to_uppercase();
+            if editor::is_keyword(&upper) {
+                let joins_previous =
+                    upper == "JOIN" && JOIN_QUALIFIERS.contains(&prev_word.as_str());
+                if CLAUSE_STARTERS.contains(&upper.as_str()) && !out.is_empty() && !joins_previous
+                {
+                    while out.ends_with(' ') {
+                        out.pop();
+                    }
+                    if !out.ends_with('\n') {
+                        out.push('\n');
+                    }
+                }
+                out.push_str(&upper);
+                prev_word = upper;
+            } else {
+                out.push_str(&word);
+                prev_word = String::new();
+            }
+            continue;
+        }
+        out.push(c);
+        prev_word = String::new();
+        i += 1;
+    }
+    out.trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uppercases_and_splits_clauses() {
+        assert_eq!(
+            format("select  a, b from t where a = 1 order by b desc limit 10"),
+            "SELECT a, b\nFROM t\nWHERE a = 1\nORDER BY b DESC\nLIMIT 10"
+        );
+    }
+
+    #[test]
+    fn join_qualifier_stays_with_join() {
+        assert_eq!(
+            format("select * from a left join b on a.id = b.id"),
+            "SELECT *\nFROM a\nLEFT JOIN b ON a.id = b.id"
+        );
+    }
+
+    #[test]
+    fn literals_and_comments_untouched() {
+        assert_eq!(
+            format("select 'from x' as \"From\" -- from here\nfrom t"),
+            "SELECT 'from x' AS \"From\" -- from here\nFROM t"
+        );
+    }
+}

--- a/app/src/sql_format.rs
+++ b/app/src/sql_format.rs
@@ -75,8 +75,7 @@ pub fn format(sql: &str) -> String {
             if editor::is_keyword(&upper) {
                 let joins_previous =
                     upper == "JOIN" && JOIN_QUALIFIERS.contains(&prev_word.as_str());
-                if CLAUSE_STARTERS.contains(&upper.as_str()) && !out.is_empty() && !joins_previous
-                {
+                if CLAUSE_STARTERS.contains(&upper.as_str()) && !out.is_empty() && !joins_previous {
                     while out.ends_with(' ') {
                         out.pop();
                     }

--- a/app/src/theme.rs
+++ b/app/src/theme.rs
@@ -16,9 +16,9 @@ pub fn parse_hex(s: &str) -> Option<Color> {
     Some(Color::from_rgb_u8(r, g, b))
 }
 
-/// Parse with a fallback to the spec's default accent (#3b82f6).
+/// Parse with a fallback to the design-system accent (Tokens.accent, #2c5fd8).
 pub fn accent_or_default(s: &str) -> Color {
-    parse_hex(s).unwrap_or_else(|| Color::from_rgb_u8(0x3b, 0x82, 0xf6))
+    parse_hex(s).unwrap_or_else(|| Color::from_rgb_u8(0x2c, 0x5f, 0xd8))
 }
 
 #[cfg(test)]

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -135,6 +135,11 @@ export component MainWindow inherits Window {
     callback open-db-modal();
     callback open-conn-modal();
 
+    // ----- schema switcher modal -----
+    in-out property <bool> schema-modal-open: false;
+    in property <[PaletteItem]> schema-items;
+    callback schema-choose(int);
+
     // ----- pagination + edit footer -----
     in property <int> page-start;
     in property <int> page-end;
@@ -747,6 +752,22 @@ export component MainWindow inherits Window {
         new-item => {
             root.open-add-form();
         }
+    }
+
+    // ----- Switch schema (sidebar selector) -----
+    ListModal {
+        title: "Switch schema";
+        placeholder: "Search for schema...";
+        confirm-label: "Switch";
+        open: root.schema-modal-open;
+        items: root.schema-items;
+        choose(i) => {
+            root.schema-choose(i);
+        }
+        dismiss => {
+            root.schema-modal-open = false;
+        }
+        new-item => { }
     }
 
     // ----- Open Connection (⌘O) -----

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -21,6 +21,7 @@ import {
     StructField,
     Span,
     ChartBar,
+    IndexRow,
 } from "structs.slint";
 
 export component MainWindow inherits Window {
@@ -120,6 +121,7 @@ export component MainWindow inherits Window {
     in property <[string]> filter-columns;
     in-out property <string> filter-col: "any column";
     in-out property <string> filter-op: "contains";
+    in property <[IndexRow]> index-rows;
     callback apply-filter();
     callback resize-grid-col(int, length);
 
@@ -677,6 +679,7 @@ export component MainWindow inherits Window {
                         filter-columns: root.filter-columns;
                         filter-col <=> root.filter-col;
                         filter-op <=> root.filter-op;
+                        index-rows: root.index-rows;
                         editor-key(t, cmd, shift) => { root.editor-key(t, cmd, shift) }
                         editor-click-line(l) => { root.editor-click-line(l); }
                         selected-row: root.selected-row;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -108,6 +108,7 @@ export component MainWindow inherits Window {
     in property <[length]> grid-col-widths;
     callback run-query();
     callback format-sql();
+    callback explain-query();
     callback apply-filter();
     callback resize-grid-col(int, length);
 
@@ -679,6 +680,9 @@ export component MainWindow inherits Window {
                         }
                         format-sql() => {
                             root.format-sql();
+                        }
+                        explain-query() => {
+                            root.explain-query();
                         }
                         apply-filter() => {
                             root.apply-filter();

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -495,6 +495,9 @@ export component MainWindow inherits Window {
                     filter-tree(t) => {
                         root.filter-tree(t);
                     }
+                    add-item() => {
+                        root.new-tab();
+                    }
                 }
 
                 // draggable vertical splitter (sidebar width)

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -114,6 +114,9 @@ export component MainWindow inherits Window {
     callback copy-results();
     callback export-csv();
     in property <[ChartBar]> chart-bars;
+    in property <[string]> all-columns;
+    in property <[bool]> col-hidden;
+    callback toggle-column(int);
     callback apply-filter();
     callback resize-grid-col(int, length);
 
@@ -663,6 +666,11 @@ export component MainWindow inherits Window {
                         fn-name: root.fn-name;
                         fn-lines: root.fn-lines;
                         chart-bars: root.chart-bars;
+                        all-columns: root.all-columns;
+                        col-hidden: root.col-hidden;
+                        toggle-column(i) => {
+                            root.toggle-column(i);
+                        }
                         editor-key(t, cmd, shift) => { root.editor-key(t, cmd, shift) }
                         editor-click-line(l) => { root.editor-click-line(l); }
                         selected-row: root.selected-row;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -412,7 +412,7 @@ export component MainWindow inherits Window {
                 if root.connected: VerticalLayout {
                     alignment: center;
                     HorizontalLayout {
-                        spacing: 2px;
+                        spacing: Tokens.sp1;
                         // history: jump the sidebar to the History tab
                         GlyphButton {
                             glyph: "◷";
@@ -553,7 +553,7 @@ export component MainWindow inherits Window {
                         HorizontalLayout {
                             padding-left: Tokens.sp2;
                             padding-top: Tokens.doc-tab-row-h - Tokens.doc-tab-h;
-                            spacing: 2px;
+                            spacing: Tokens.sp1;
                             for tab[i] in root.tabs: Rectangle {
                                 width: min(170px, tab-content.preferred-width + 2 * Tokens.sp3);
                                 height: Tokens.doc-tab-h;
@@ -577,7 +577,7 @@ export component MainWindow inherits Window {
                                 tab-content := HorizontalLayout {
                                     padding-left: Tokens.sp3;
                                     padding-right: Tokens.sp1;
-                                    spacing: 6px;
+                                    spacing: Tokens.sp2;
                                     if tab.kind == "table": VerticalLayout {
                                         alignment: center;
                                         Rectangle {

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -20,6 +20,7 @@ import {
     TabItem,
     StructField,
     Span,
+    ChartBar,
 } from "structs.slint";
 
 export component MainWindow inherits Window {
@@ -112,6 +113,7 @@ export component MainWindow inherits Window {
     callback explain-query();
     callback copy-results();
     callback export-csv();
+    in property <[ChartBar]> chart-bars;
     callback apply-filter();
     callback resize-grid-col(int, length);
 
@@ -660,6 +662,7 @@ export component MainWindow inherits Window {
                         fn-mode: root.fn-mode;
                         fn-name: root.fn-name;
                         fn-lines: root.fn-lines;
+                        chart-bars: root.chart-bars;
                         editor-key(t, cmd, shift) => { root.editor-key(t, cmd, shift) }
                         editor-click-line(l) => { root.editor-click-line(l); }
                         selected-row: root.selected-row;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -117,6 +117,9 @@ export component MainWindow inherits Window {
     in property <[string]> all-columns;
     in property <[bool]> col-hidden;
     callback toggle-column(int);
+    in property <[string]> filter-columns;
+    in-out property <string> filter-col: "any column";
+    in-out property <string> filter-op: "contains";
     callback apply-filter();
     callback resize-grid-col(int, length);
 
@@ -671,6 +674,9 @@ export component MainWindow inherits Window {
                         toggle-column(i) => {
                             root.toggle-column(i);
                         }
+                        filter-columns: root.filter-columns;
+                        filter-col <=> root.filter-col;
+                        filter-op <=> root.filter-op;
                         editor-key(t, cmd, shift) => { root.editor-key(t, cmd, shift) }
                         editor-click-line(l) => { root.editor-click-line(l); }
                         selected-row: root.selected-row;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -413,9 +413,24 @@ export component MainWindow inherits Window {
                     alignment: center;
                     HorizontalLayout {
                         spacing: 2px;
-                        GlyphButton { glyph: "◷"; clicked => { root.select-tab(root.active-tab); } }
+                        // history: jump the sidebar to the History tab
+                        GlyphButton {
+                            glyph: "◷";
+                            clicked => {
+                                root.sidebar-mode = 2;
+                                root.sidebar-mode-changed(2);
+                            }
+                        }
                         GlyphButton { glyph: "▭"; glyph-size: 11px; clicked => { root.toggle-theme(); } }
-                        GlyphButton { glyph: "⚙"; clicked => { root.open-add-form(); } }
+                        // settings of the current connection (edit form)
+                        GlyphButton {
+                            glyph: "⚙";
+                            clicked => {
+                                if (root.selected-conn >= 0) {
+                                    root.open-edit-form(root.selected-conn);
+                                }
+                            }
+                        }
                     }
                 }
                 VerticalLayout {

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -192,6 +192,7 @@ export component MainWindow inherits Window {
     in property <bool> test-busy;
     callback open-add-form();
     callback open-edit-form(int);
+    callback backup-conns();
     callback form-engine-changed(string);
     callback form-import-url();
     callback form-test-conn();
@@ -441,6 +442,10 @@ export component MainWindow inherits Window {
             edit-clicked(i) => { root.open-edit-form(i); }
             toggle-group(g) => { root.toggle-group(g); }
             filter(t) => { root.conn-filter(t); }
+            // URL import lives in the add form; file-based import would need
+            // a native dialog dependency.
+            import-clicked() => { root.open-add-form(); }
+            backup-clicked() => { root.backup-conns(); }
         }
 
         // ===== workspace (shown once connected) =====

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -107,6 +107,7 @@ export component MainWindow inherits Window {
     in-out property <string> grid-filter;
     in property <[length]> grid-col-widths;
     callback run-query();
+    callback run-selection();
     callback format-sql();
     callback explain-query();
     callback apply-filter();
@@ -677,6 +678,9 @@ export component MainWindow inherits Window {
                         limit-text <=> root.limit-text;
                         run => {
                             root.run-query();
+                        }
+                        run-selection() => {
+                            root.run-selection();
                         }
                         format-sql() => {
                             root.format-sql();

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -110,6 +110,8 @@ export component MainWindow inherits Window {
     callback run-selection();
     callback format-sql();
     callback explain-query();
+    callback copy-results();
+    callback export-csv();
     callback apply-filter();
     callback resize-grid-col(int, length);
 
@@ -687,6 +689,12 @@ export component MainWindow inherits Window {
                         }
                         explain-query() => {
                             root.explain-query();
+                        }
+                        copy-results() => {
+                            root.copy-results();
+                        }
+                        export-csv() => {
+                            root.export-csv();
                         }
                         apply-filter() => {
                             root.apply-filter();

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -107,6 +107,7 @@ export component MainWindow inherits Window {
     in-out property <string> grid-filter;
     in property <[length]> grid-col-widths;
     callback run-query();
+    callback format-sql();
     callback apply-filter();
     callback resize-grid-col(int, length);
 
@@ -675,6 +676,9 @@ export component MainWindow inherits Window {
                         limit-text <=> root.limit-text;
                         run => {
                             root.run-query();
+                        }
+                        format-sql() => {
+                            root.format-sql();
                         }
                         apply-filter() => {
                             root.apply-filter();

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -215,7 +215,7 @@ export component BreadcrumbChip inherits Rectangle {
     animate background { duration: Tokens.fade; }
     content := HorizontalLayout {
         alignment: center;
-        spacing: 6px;
+        spacing: Tokens.sp2;
         if root.show-dot: VerticalLayout {
             alignment: center;
             Rectangle {
@@ -325,7 +325,7 @@ export component FilterField inherits Rectangle {
     HorizontalLayout {
         padding-left: Tokens.sp2;
         padding-right: 6px;
-        spacing: 6px;
+        spacing: Tokens.sp2;
         Text {
             text: "⌕";
             color: Tokens.text-faint;

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -76,13 +76,13 @@ export component SecondaryButton inherits Rectangle {
     width: label.preferred-width + 2 * Tokens.sp4;
     border-radius: Tokens.radius;
     border-width: 1px;
-    border-color: Tokens.border-strong;
-    background: !enabled ? Tokens.chrome
+    border-color: enabled ? Tokens.border-strong : Tokens.border;
+    background: !enabled ? transparent
         : ta.has-hover ? Tokens.chrome : Tokens.card;
     animate background { duration: Tokens.fade; }
     label := Text {
         text: root.text;
-        color: enabled ? Tokens.text : Tokens.text-faint;
+        color: enabled ? Tokens.text : Tokens.text-ghost;
         font-size: Tokens.font-sm;
         font-weight: 500;
     }

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -111,6 +111,42 @@ export component TextButton inherits Rectangle {
     ta := TouchArea { clicked => { root.clicked(); } }
 }
 
+// Form text input (conn form): Tokens-styled card box, optional password mode.
+export component FormField inherits Rectangle {
+    in property <string> placeholder;
+    in-out property <string> text <=> input.text;
+    in property <InputType> input-type: InputType.text;
+    callback accepted;
+    height: 30px;
+    border-radius: Tokens.radius;
+    border-width: 1px;
+    border-color: input.has-focus ? Tokens.accent : Tokens.border;
+    background: Tokens.card;
+    HorizontalLayout {
+        padding-left: Tokens.sp2;
+        padding-right: Tokens.sp2;
+        input := TextInput {
+            font-size: Tokens.font-sm;
+            color: Tokens.text;
+            vertical-alignment: center;
+            single-line: true;
+            input-type: root.input-type;
+            horizontal-stretch: 1;
+            accepted => { root.accepted(); }
+        }
+    }
+    if input.text == "": Text {
+        x: Tokens.sp2;
+        width: parent.width - 2 * Tokens.sp2;
+        text: root.placeholder;
+        color: Tokens.text-faint;
+        font-size: Tokens.font-sm;
+        vertical-alignment: center;
+        overflow: elide;
+        height: 100%;
+    }
+}
+
 // Small bordered key cap (⌘K, ⌘P, ⌘↵).
 export component KeyCap inherits Rectangle {
     in property <string> text;

--- a/app/src/ui/conn-form.slint
+++ b/app/src/ui/conn-form.slint
@@ -1,15 +1,18 @@
 import { Theme } from "theme.slint";
-import { LineEdit, ComboBox, Button } from "std-widgets.slint";
+import { Tokens } from "tokens.slint";
+import { PrimaryButton, SecondaryButton, FormField } from "components.slint";
+import { ComboBox } from "std-widgets.slint";
 
 // 8 preset accent swatches — colors for UI rendering, hex strings for the Rust-side color field.
+// First entry is the app accent (Tokens.accent) so the default matches the design system.
 export global Swatches {
     out property <[color]> colors: [
-        #3b82f6, #ef4444, #22c55e, #f59e0b,
+        #2c5fd8, #e05a4e, #239d5c, #d9962f,
         #a855f7, #ec4899, #14b8a6, #64748b,
     ];
     // Matching hex strings passed to Rust (same order as `colors`).
     out property <[string]> hexes: [
-        "#3b82f6", "#ef4444", "#22c55e", "#f59e0b",
+        "#2c5fd8", "#e05a4e", "#239d5c", "#d9962f",
         "#a855f7", "#ec4899", "#14b8a6", "#64748b",
     ];
 }
@@ -40,7 +43,7 @@ export component ConnForm inherits Rectangle {
     callback cancel();
 
     visible: root.open;
-    background: #00000066;
+    background: Tokens.veil;
 
     if root.open: Rectangle {
         width: 460px;
@@ -57,7 +60,7 @@ export component ConnForm inherits Rectangle {
         border-width: 1px;
         border-color: Theme.hairline;
         drop-shadow-blur: 24px;
-        drop-shadow-color: #00000088;
+        drop-shadow-color: Tokens.text.with-alpha(0.35);
 
         vbox := VerticalLayout {
             padding: Theme.sp4;
@@ -72,16 +75,16 @@ export component ConnForm inherits Rectangle {
             Text { text: "Import URL"; color: Theme.text-dim; font-size: Theme.font-label; }
             HorizontalLayout {
                 spacing: Theme.sp2;
-                LineEdit {
+                FormField {
                     text <=> root.f-import-url;
-                    placeholder-text: "postgresql://user:pass@host:5432/db?sslmode=require";
+                    placeholder: "postgresql://user:pass@host:5432/db?sslmode=require";
                     accepted => { root.import-url(); }
                 }
-                Button { text: "Import"; clicked => { root.import-url(); } }
+                SecondaryButton { text: "Import"; height: 30px; clicked => { root.import-url(); } }
             }
 
             Text { text: "Name"; color: Theme.text-dim; font-size: Theme.font-label; }
-            LineEdit { text <=> root.f-name; }
+            FormField { text <=> root.f-name; }
 
             Text { text: "Engine"; color: Theme.text-dim; font-size: Theme.font-label; }
             ComboBox {
@@ -94,12 +97,12 @@ export component ConnForm inherits Rectangle {
                 spacing: Theme.sp2;
                 VerticalLayout {
                     Text { text: "Host"; color: Theme.text-dim; font-size: Theme.font-label; }
-                    LineEdit { text <=> root.f-host; }
+                    FormField { text <=> root.f-host; }
                 }
                 VerticalLayout {
                     width: 110px;
                     Text { text: "Port"; color: Theme.text-dim; font-size: Theme.font-label; }
-                    LineEdit { text <=> root.f-port; }
+                    FormField { text <=> root.f-port; }
                 }
             }
 
@@ -108,16 +111,16 @@ export component ConnForm inherits Rectangle {
                 spacing: Theme.sp2;
                 VerticalLayout {
                     Text { text: "User"; color: Theme.text-dim; font-size: Theme.font-label; }
-                    LineEdit { text <=> root.f-user; }
+                    FormField { text <=> root.f-user; }
                 }
                 VerticalLayout {
                     Text { text: "Database"; color: Theme.text-dim; font-size: Theme.font-label; }
-                    LineEdit { text <=> root.f-database; }
+                    FormField { text <=> root.f-database; }
                 }
             }
 
             Text { text: "Password"; color: Theme.text-dim; font-size: Theme.font-label; }
-            LineEdit { text <=> root.f-password; input-type: password; }
+            FormField { text <=> root.f-password; input-type: InputType.password; }
 
             // SSL mode only applies to the SQL engines.
             if root.f-engine == "PostgreSQL" || root.f-engine == "MySQL": Text {
@@ -144,27 +147,28 @@ export component ConnForm inherits Rectangle {
 
             Text {
                 text: root.form-error;
-                color: #ef4444;
+                color: Tokens.error;
                 font-size: Theme.font-label;
             }
 
             Text {
                 text: root.test-busy ? "Testing connection…" : root.test-result;
-                color: root.test-ok ? #22c55e : Theme.text-dim;
+                color: root.test-ok ? Tokens.ok : Theme.text-dim;
                 font-size: Theme.font-label;
             }
 
             HorizontalLayout {
                 spacing: Theme.sp2;
-                Button {
+                SecondaryButton {
                     text: "Test Connection";
+                    height: 30px;
                     enabled: !root.test-busy;
                     clicked => { root.test-conn(); }
                 }
-                Button { text: "Save"; clicked => { root.save(); } }
-                Button { text: "Cancel"; clicked => { root.cancel(); } }
+                PrimaryButton { text: "Save"; height: 30px; clicked => { root.save(); } }
+                SecondaryButton { text: "Cancel"; height: 30px; clicked => { root.cancel(); } }
                 Rectangle {}
-                if root.edit-mode: Button { text: "Delete"; clicked => { root.delete-conn(); } }
+                if root.edit-mode: SecondaryButton { text: "Delete"; height: 30px; clicked => { root.delete-conn(); } }
             }
         }
     }

--- a/app/src/ui/conn-form.slint
+++ b/app/src/ui/conn-form.slint
@@ -1,4 +1,3 @@
-import { Theme } from "theme.slint";
 import { Tokens } from "tokens.slint";
 import { PrimaryButton, SecondaryButton, FormField } from "components.slint";
 import { ComboBox } from "std-widgets.slint";
@@ -55,26 +54,26 @@ export component ConnForm inherits Rectangle {
         height: vbox.preferred-height;
         x: (parent.width - self.width) / 2;
         y: 60px;
-        border-radius: Theme.radius-panel;
-        background: Theme.surface;
+        border-radius: Tokens.radius-lg;
+        background: Tokens.card;
         border-width: 1px;
-        border-color: Theme.hairline;
+        border-color: Tokens.border;
         drop-shadow-blur: 24px;
         drop-shadow-color: Tokens.text.with-alpha(0.35);
 
         vbox := VerticalLayout {
-            padding: Theme.sp4;
-            spacing: Theme.sp2;
+            padding: Tokens.sp4;
+            spacing: Tokens.sp2;
 
             Text {
                 text: root.edit-mode ? "Edit Connection" : "New Connection";
-                color: Theme.text;
-                font-size: Theme.font-body;
+                color: Tokens.text;
+                font-size: Tokens.font-md;
             }
 
-            Text { text: "Import URL"; color: Theme.text-dim; font-size: Theme.font-label; }
+            Text { text: "Import URL"; color: Tokens.text-dim; font-size: Tokens.font-sm; }
             HorizontalLayout {
-                spacing: Theme.sp2;
+                spacing: Tokens.sp2;
                 FormField {
                     text <=> root.f-import-url;
                     placeholder: "postgresql://user:pass@host:5432/db?sslmode=require";
@@ -83,10 +82,10 @@ export component ConnForm inherits Rectangle {
                 SecondaryButton { text: "Import"; height: 30px; clicked => { root.import-url(); } }
             }
 
-            Text { text: "Name"; color: Theme.text-dim; font-size: Theme.font-label; }
+            Text { text: "Name"; color: Tokens.text-dim; font-size: Tokens.font-sm; }
             FormField { text <=> root.f-name; }
 
-            Text { text: "Engine"; color: Theme.text-dim; font-size: Theme.font-label; }
+            Text { text: "Engine"; color: Tokens.text-dim; font-size: Tokens.font-sm; }
             ComboBox {
                 model: ["PostgreSQL", "MySQL", "Redis", "MongoDB"];
                 current-value <=> root.f-engine;
@@ -94,53 +93,53 @@ export component ConnForm inherits Rectangle {
             }
 
             HorizontalLayout {
-                spacing: Theme.sp2;
+                spacing: Tokens.sp2;
                 VerticalLayout {
-                    Text { text: "Host"; color: Theme.text-dim; font-size: Theme.font-label; }
+                    Text { text: "Host"; color: Tokens.text-dim; font-size: Tokens.font-sm; }
                     FormField { text <=> root.f-host; }
                 }
                 VerticalLayout {
                     width: 110px;
-                    Text { text: "Port"; color: Theme.text-dim; font-size: Theme.font-label; }
+                    Text { text: "Port"; color: Tokens.text-dim; font-size: Tokens.font-sm; }
                     FormField { text <=> root.f-port; }
                 }
             }
 
             // Redis has no user/database concept — hide those for it.
             if root.f-engine != "Redis": HorizontalLayout {
-                spacing: Theme.sp2;
+                spacing: Tokens.sp2;
                 VerticalLayout {
-                    Text { text: "User"; color: Theme.text-dim; font-size: Theme.font-label; }
+                    Text { text: "User"; color: Tokens.text-dim; font-size: Tokens.font-sm; }
                     FormField { text <=> root.f-user; }
                 }
                 VerticalLayout {
-                    Text { text: "Database"; color: Theme.text-dim; font-size: Theme.font-label; }
+                    Text { text: "Database"; color: Tokens.text-dim; font-size: Tokens.font-sm; }
                     FormField { text <=> root.f-database; }
                 }
             }
 
-            Text { text: "Password"; color: Theme.text-dim; font-size: Theme.font-label; }
+            Text { text: "Password"; color: Tokens.text-dim; font-size: Tokens.font-sm; }
             FormField { text <=> root.f-password; input-type: InputType.password; }
 
             // SSL mode only applies to the SQL engines.
             if root.f-engine == "PostgreSQL" || root.f-engine == "MySQL": Text {
-                text: "SSL"; color: Theme.text-dim; font-size: Theme.font-label;
+                text: "SSL"; color: Tokens.text-dim; font-size: Tokens.font-sm;
             }
             if root.f-engine == "PostgreSQL" || root.f-engine == "MySQL": ComboBox {
                 model: ["Disable", "Prefer", "Require"];
                 current-value <=> root.f-sslmode;
             }
 
-            Text { text: "Color"; color: Theme.text-dim; font-size: Theme.font-label; }
+            Text { text: "Color"; color: Tokens.text-dim; font-size: Tokens.font-sm; }
             HorizontalLayout {
-                spacing: Theme.sp2;
+                spacing: Tokens.sp2;
                 for col[i] in Swatches.colors: Rectangle {
                     width: 22px;
                     height: 22px;
                     border-radius: 11px;
                     background: col;
                     border-width: Swatches.hexes[i] == root.f-color ? 2px : 0px;
-                    border-color: Theme.text;
+                    border-color: Tokens.text;
                     TouchArea { clicked => { root.f-color = Swatches.hexes[i]; } }
                 }
             }
@@ -148,17 +147,17 @@ export component ConnForm inherits Rectangle {
             Text {
                 text: root.form-error;
                 color: Tokens.error;
-                font-size: Theme.font-label;
+                font-size: Tokens.font-sm;
             }
 
             Text {
                 text: root.test-busy ? "Testing connection…" : root.test-result;
-                color: root.test-ok ? Tokens.ok : Theme.text-dim;
-                font-size: Theme.font-label;
+                color: root.test-ok ? Tokens.ok : Tokens.text-dim;
+                font-size: Tokens.font-sm;
             }
 
             HorizontalLayout {
-                spacing: Theme.sp2;
+                spacing: Tokens.sp2;
                 SecondaryButton {
                     text: "Test Connection";
                     height: 30px;

--- a/app/src/ui/icons.slint
+++ b/app/src/ui/icons.slint
@@ -1,12 +1,12 @@
-import { Theme } from "theme.slint";
+import { Tokens } from "tokens.slint";
 
 // Single tintable icon. `name` selects an embedded SVG; `color` recolors it via
 // Slint's `colorize` (the SVGs are black-stroke so any tint reads cleanly).
 // Keeping every glyph here means call sites stay declarative: AppIcon { name: "table"; }
 export component AppIcon inherits Image {
     in property <string> name;
-    in property <length> size: Theme.icon-md;
-    in property <color> color: Theme.text;
+    in property <length> size: Tokens.icon-md;
+    in property <color> color: Tokens.text;
 
     width: size;
     height: size;

--- a/app/src/ui/palette.slint
+++ b/app/src/ui/palette.slint
@@ -142,7 +142,7 @@ export component ListModal inherits Rectangle {
                                     spacing: 1px;
                                     horizontal-stretch: 1;
                                     HorizontalLayout {
-                                        spacing: 6px;
+                                        spacing: Tokens.sp2;
                                         alignment: start;
                                         Text {
                                             text: it.label;

--- a/app/src/ui/picker.slint
+++ b/app/src/ui/picker.slint
@@ -80,7 +80,7 @@ export component ConnPicker inherits Rectangle {
                     VerticalLayout {
                         padding-left: Tokens.sp3;
                         padding-right: Tokens.sp3;
-                        spacing: 2px;
+                        spacing: Tokens.sp1;
                         alignment: start;
 
                         for item[i] in root.connections: Rectangle {
@@ -188,7 +188,7 @@ export component ConnPicker inherits Rectangle {
                         Rectangle {
                             width: new-row.preferred-width;
                             new-row := HorizontalLayout {
-                                spacing: 6px;
+                                spacing: Tokens.sp2;
                                 Text {
                                     text: "+";
                                     color: Tokens.text;
@@ -254,7 +254,7 @@ export component ConnPicker inherits Rectangle {
                         DbBadge { engine: root.sel-engine; size: 44px; }
                         VerticalLayout {
                             alignment: center;
-                            spacing: 3px;
+                            spacing: Tokens.sp1;
                             HorizontalLayout {
                                 spacing: Tokens.sp3;
                                 alignment: start;

--- a/app/src/ui/sidebar.slint
+++ b/app/src/ui/sidebar.slint
@@ -131,11 +131,11 @@ export component Sidebar inherits Rectangle {
                     HorizontalLayout {
                         padding-left: is-category ? Tokens.sp2 : Tokens.sp2 + (node.depth - 1) * Tokens.sp3;
                         padding-right: Tokens.sp2;
-                        spacing: 7px;
+                        spacing: Tokens.sp2;
 
                         // category: "FUNCTIONS · 10"
                         if is-category: HorizontalLayout {
-                            spacing: 5px;
+                            spacing: Tokens.sp2;
                             alignment: start;
                             Text {
                                 text: node.label.to-uppercase();

--- a/app/src/ui/structs.slint
+++ b/app/src/ui/structs.slint
@@ -40,3 +40,5 @@ export struct TabItem { title: string, kind: string }
 export struct Span { text: string, kind: int }
 // One horizontal bar of the results chart; `frac` is value/max in [0,1].
 export struct ChartBar { label: string, value: string, frac: float }
+// One row of the Indexes view: index name + definition/columns.
+export struct IndexRow { name: string, definition: string }

--- a/app/src/ui/structs.slint
+++ b/app/src/ui/structs.slint
@@ -38,3 +38,5 @@ export struct TabItem { title: string, kind: string }
 // One lexed editor token; `kind`: 0 plain · 1 keyword · 2 string ·
 // 3 function · 4 comment · 5 number (mirrors app/src/editor.rs).
 export struct Span { text: string, kind: int }
+// One horizontal bar of the results chart; `frac` is value/max in [0,1].
+export struct ChartBar { label: string, value: string, frac: float }

--- a/app/src/ui/tabular-grid.slint
+++ b/app/src/ui/tabular-grid.slint
@@ -40,7 +40,7 @@ export component TabularGrid inherits ScrollView {
                 HorizontalLayout {
                     padding-left: Tokens.sp2;
                     padding-right: Tokens.sp2;
-                    spacing: 6px;
+                    spacing: Tokens.sp2;
                     alignment: start;
                     Text {
                         vertical-alignment: center;

--- a/app/src/ui/theme.slint
+++ b/app/src/ui/theme.slint
@@ -4,9 +4,7 @@
 import { Tokens } from "tokens.slint";
 
 export global Theme {
-    // dark mode is not part of the Tabula design yet; the flag remains for
-    // the toggle callback but resolves to the light palette.
-    in-out property <bool> dark: false;
+    in-out property <bool> dark <=> Tokens.dark;
 
     out property <color> bg: Tokens.canvas;
     out property <color> surface: Tokens.card;

--- a/app/src/ui/theme.slint
+++ b/app/src/ui/theme.slint
@@ -1,55 +1,10 @@
-// Legacy alias layer: older components (conn-form, icons) still read the
-// `Theme` global. Every value resolves to a `Tokens` entry — no color or
-// metric may be defined here.
+// Rust-facing state global. All design values live in `Tokens`; this only
+// carries the two properties main.rs drives at runtime.
 import { Tokens } from "tokens.slint";
 
 export global Theme {
     in-out property <bool> dark <=> Tokens.dark;
 
-    out property <color> bg: Tokens.canvas;
-    out property <color> surface: Tokens.card;
-    out property <color> surface-2: Tokens.chrome;
-    out property <color> hairline: Tokens.border;
-    out property <color> hairline-strong: Tokens.border-strong;
-    out property <color> text: Tokens.text;
-    out property <color> text-dim: Tokens.text-dim;
-    out property <color> text-faint: Tokens.text-faint;
-
     // per-connection accent, fed from Rust at connect time
     in-out property <color> accent: Tokens.accent;
-    out property <color> accent-soft: Tokens.accent-tint;
-    out property <color> accent-softer: Tokens.accent-tint.with-alpha(0.6);
-
-    out property <length> sp1: Tokens.sp1;
-    out property <length> sp2: Tokens.sp2;
-    out property <length> sp3: Tokens.sp3;
-    out property <length> sp4: Tokens.sp4;
-    out property <length> sp6: Tokens.sp6;
-
-    out property <length> row-height: 28px;
-    out property <length> tree-row-height: 32px;
-    out property <length> gutter-width: 44px;
-    out property <length> radius-panel: Tokens.radius-lg;
-    out property <length> radius-control: Tokens.radius;
-    out property <length> radius-pill: 999px;
-
-    out property <length> icon-sm: Tokens.icon-sm;
-    out property <length> icon-md: Tokens.icon-md;
-    out property <length> icon-lg: 18px;
-
-    out property <length> font-h: 14px;
-    out property <length> font-body: Tokens.font-md;
-    out property <length> font-label: Tokens.font-sm;
-    out property <length> font-caption: Tokens.font-xs;
-    out property <length> font-mono: Tokens.font-md;
-    out property <string> mono-family: Tokens.mono;
-
-    out property <color> edit-pending: Tokens.warn;
-    out property <color> edit-delete: Tokens.error;
-    out property <color> edit-insert: Tokens.ok;
-    out property <color> edit-pending-soft: Tokens.warn-tint;
-    out property <color> edit-delete-soft: Tokens.error-tint;
-    out property <color> edit-insert-soft: Tokens.ok-tint;
-
-    out property <duration> fade: Tokens.fade;
 }

--- a/app/src/ui/tokens.slint
+++ b/app/src/ui/tokens.slint
@@ -1,31 +1,34 @@
 // Design tokens — single source of truth for the Tabula design.
 // Every color/metric in the UI resolves here; no magic hex outside this file.
+// Each color carries a light and a dark value, switched by `dark`.
 import "../../assets/fonts/IBMPlexMono-Regular.ttf";
 import "../../assets/fonts/IBMPlexMono-Medium.ttf";
 import "../../assets/fonts/IBMPlexMono-SemiBold.ttf";
 
 export global Tokens {
+    in-out property <bool> dark: false;
+
     // ----- surfaces -----
-    out property <color> chrome:  #F5F4F1;   // titlebar / toolbars / doc-tab row
-    out property <color> sidebar: #F0EFEC;
-    out property <color> canvas:  #FBFAF8;   // main content background
-    out property <color> card:    #FFFFFF;
+    out property <color> chrome:  dark ? #1E1F24 : #F5F4F1;   // titlebar / toolbars / doc-tab row
+    out property <color> sidebar: dark ? #191A1F : #F0EFEC;
+    out property <color> canvas:  dark ? #141519 : #FBFAF8;   // main content background
+    out property <color> card:    dark ? #232429 : #FFFFFF;
 
     // ----- hairline -----
-    out property <color> border:        #1C1914.with-alpha(0.09);
-    out property <color> border-strong: #1C1914.with-alpha(0.16);
+    out property <color> border:        dark ? #FFFFFF.with-alpha(0.08) : #1C1914.with-alpha(0.09);
+    out property <color> border-strong: dark ? #FFFFFF.with-alpha(0.14) : #1C1914.with-alpha(0.16);
 
     // ----- text -----
-    out property <color> text:        #23242A;
-    out property <color> text-dim:    #71747C;
-    out property <color> text-faint:  #A6A9B0;
-    out property <color> text-ghost:  #C2C4C9;   // NULL cells (italic), disabled
+    out property <color> text:        dark ? #E8E9EC : #23242A;
+    out property <color> text-dim:    dark ? #9DA0A8 : #71747C;
+    out property <color> text-faint:  dark ? #6A6D75 : #A6A9B0;
+    out property <color> text-ghost:  dark ? #4B4E55 : #C2C4C9;   // NULL cells (italic), disabled
 
     // ----- accent -----
     out property <color> accent:         #2C5FD8;
-    out property <color> accent-hover:   #2451BA;
-    out property <color> accent-tint:    #E9EFFC;
-    out property <color> on-tint:        #1D3F8F; // text on accent-tint
+    out property <color> accent-hover:   dark ? #4A7BE8 : #2451BA;
+    out property <color> accent-tint:    dark ? #2C5FD8.with-alpha(0.18) : #E9EFFC;
+    out property <color> on-tint:        dark ? #A9C2F5 : #1D3F8F; // text on accent-tint
 
     // ----- status -----
     out property <color> ok:    #239D5C;
@@ -43,20 +46,20 @@ export global Tokens {
     out property <color> db-mo: #58B98A;
 
     // ----- special cell colors -----
-    out property <color> fk-text: #4A6BB0;   // foreign-key cells, with ↗
+    out property <color> fk-text: dark ? #7FA0DE : #4A6BB0;   // foreign-key cells, with ↗
 
     // ----- syntax highlight (SQL editor) -----
-    out property <color> syn-keyword:  #2C5FD8; // weight 600
-    out property <color> syn-string:   #C14953;
-    out property <color> syn-function: #8250C4;
-    out property <color> syn-comment:  #A6A9B0; // italic
-    out property <color> editor-line:  #F3F1EC; // current-line highlight
+    out property <color> syn-keyword:  dark ? #6C93EE : #2C5FD8; // weight 600
+    out property <color> syn-string:   dark ? #E08087 : #C14953;
+    out property <color> syn-function: dark ? #B48AE8 : #8250C4;
+    out property <color> syn-comment:  dark ? #6A6D75 : #A6A9B0; // italic
+    out property <color> editor-line:  dark ? #1D1E24 : #F3F1EC; // current-line highlight
 
     // ----- edit-pending states -----
     out property <color> edit-outline: #E05A4E; // 2px pending-cell outline
 
     // ----- modal / palette -----
-    out property <color> veil: #FAFAF9.with-alpha(0.55);
+    out property <color> veil: dark ? #101114.with-alpha(0.55) : #FAFAF9.with-alpha(0.55);
     out property <length> modal-radius: 12px;
     out property <length> palette-width: 400px;
 

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -62,9 +62,11 @@ export component WorkArea inherits Rectangle {
     property <bool> browse-mode: root.active-table != "";
     // Footer view segments: 0 Data · 1 Structure · 2 Indexes
     property <int> view-mode: root.show-structure ? 1 : 0;
-    // Expandable filter panel (up to 3 condition rows).
+    // Expandable filter panel: one real condition row.
     in-out property <bool> filter-open: false;
-    in-out property <int> filter-rows: 1;
+    in property <[string]> filter-columns;   // "any column" + real columns
+    in-out property <string> filter-col: "any column";
+    in-out property <string> filter-op: "contains";
 
     callback run();
     callback run-selection();
@@ -186,23 +188,25 @@ export component WorkArea inherits Rectangle {
 
         // ================= expandable filter panel =================
         if root.browse-mode && root.filter-open: Rectangle {
-            height: root.filter-rows * 34px + 40px;
+            height: 74px;
             background: Tokens.chrome.with-alpha(0.5);
             VerticalLayout {
                 padding: Tokens.sp2;
                 padding-left: Tokens.sp3;
                 padding-right: Tokens.sp3;
                 spacing: 4px;
-                for fr in root.filter-rows: HorizontalLayout {
+                HorizontalLayout {
                     height: 30px;
                     spacing: Tokens.sp2;
                     ComboBox {
                         width: 150px;
-                        model: ["id", "code", "name", "short_name", "country", "ccy", "exch", "id_sector", "created_at", "updated_at"];
+                        model: root.filter-columns;
+                        current-value <=> root.filter-col;
                     }
                     ComboBox {
                         width: 110px;
                         model: ["contains", "=", "≠", ">", "<", "is null", "not null"];
+                        current-value <=> root.filter-op;
                     }
                     FilterField {
                         horizontal-stretch: 1;
@@ -215,18 +219,13 @@ export component WorkArea inherits Rectangle {
                 HorizontalLayout {
                     height: 28px;
                     spacing: Tokens.sp2;
-                    TextButton {
-                        text: "+ Add condition";
-                        clicked => {
-                            if (root.filter-rows < 3) { root.filter-rows += 1; }
-                        }
-                    }
                     Rectangle { horizontal-stretch: 1; }
                     SecondaryButton {
                         text: "Clear";
                         clicked => {
                             root.grid-filter = "";
-                            root.filter-rows = 1;
+                            root.filter-col = "any column";
+                            root.filter-op = "contains";
                             root.apply-filter();
                         }
                     }

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -196,7 +196,7 @@ export component WorkArea inherits Rectangle {
                 padding: Tokens.sp2;
                 padding-left: Tokens.sp3;
                 padding-right: Tokens.sp3;
-                spacing: 4px;
+                spacing: Tokens.sp1;
                 HorizontalLayout {
                     height: 30px;
                     spacing: Tokens.sp2;
@@ -327,7 +327,7 @@ export component WorkArea inherits Rectangle {
                 }
                 HorizontalLayout {
                     alignment: center;
-                    spacing: 6px;
+                    spacing: Tokens.sp2;
                     Text {
                         text: "Open a table from the sidebar, or press";
                         color: Tokens.text-dim;
@@ -762,7 +762,7 @@ export component WorkArea inherits Rectangle {
                 }
                 // ● 12 ms
                 HorizontalLayout {
-                    spacing: 5px;
+                    spacing: Tokens.sp2;
                     alignment: end;
                     Rectangle {
                         width: 7px;

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -67,6 +67,7 @@ export component WorkArea inherits Rectangle {
     in-out property <int> filter-rows: 1;
 
     callback run();
+    callback run-selection();
     callback format-sql();
     callback explain-query();
     callback apply-filter();
@@ -342,7 +343,7 @@ export component WorkArea inherits Rectangle {
                     }
                     VerticalLayout {
                         alignment: center;
-                        SecondaryButton { text: "Run Selection"; height: 28px; clicked => { root.run(); } }
+                        SecondaryButton { text: "Run Selection"; height: 28px; clicked => { root.run-selection(); } }
                     }
                     VerticalLayout {
                         alignment: center;

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -2,7 +2,7 @@
 // editor + results split. References: design/2-workspace.png,
 // design/3-sql-editor.png, design/11-filter-edit-t2.png.
 import { Tokens } from "tokens.slint";
-import { GridColumn, GridCell, StructField, Span } from "structs.slint";
+import { GridColumn, GridCell, StructField, Span, ChartBar } from "structs.slint";
 import { CodeEditor } from "code-editor.slint";
 import { TabularGrid } from "tabular-grid.slint";
 import {
@@ -72,6 +72,10 @@ export component WorkArea inherits Rectangle {
     callback explain-query();
     callback copy-results();
     callback export-csv();
+
+    // SQL result footer segments: 0 Data · 1 Message · 2 Chart.
+    in-out property <int> sql-view-mode: 0;
+    in property <[ChartBar]> chart-bars;
     callback apply-filter();
     callback toggle-sql();
     callback resize-col(int, length);
@@ -414,7 +418,7 @@ export component WorkArea inherits Rectangle {
                     Rectangle { horizontal-stretch: 1; }
                     TextButton { text: "Copy"; clicked => { root.copy-results(); } }
                     TextButton { text: "Export CSV"; clicked => { root.export-csv(); } }
-                    TextButton { text: "Chart"; }
+                    TextButton { text: "Chart"; clicked => { root.sql-view-mode = 2; } }
                 }
             }
         }
@@ -425,7 +429,7 @@ export component WorkArea inherits Rectangle {
             background: Tokens.canvas;
 
             // Data grid
-            if root.view-mode == 0 && (root.result-kind == 0 || root.result-kind == 2): TabularGrid {
+            if root.view-mode == 0 && (root.browse-mode || root.sql-view-mode == 0) && (root.result-kind == 0 || root.result-kind == 2): TabularGrid {
                 width: 100%;
                 height: 100%;
                 columns: root.columns;
@@ -444,7 +448,7 @@ export component WorkArea inherits Rectangle {
             }
 
             // Documents (Mongo)
-            if root.view-mode == 0 && root.result-kind == 1: ScrollView {
+            if root.view-mode == 0 && (root.browse-mode || root.sql-view-mode == 0) && root.result-kind == 1: ScrollView {
                 width: 100%;
                 height: 100%;
                 VerticalLayout {
@@ -460,7 +464,7 @@ export component WorkArea inherits Rectangle {
             }
 
             // Affected-rows toast
-            if root.view-mode == 0 && root.result-kind == 3: Text {
+            if root.view-mode == 0 && (root.browse-mode || root.sql-view-mode == 0) && root.result-kind == 3: Text {
                 text: root.result-status;
                 color: root.status-error ? Tokens.error : Tokens.text-dim;
                 font-size: Tokens.font-md;
@@ -496,6 +500,67 @@ export component WorkArea inherits Rectangle {
                 text: "No indexes to show";
                 color: Tokens.text-faint;
                 font-size: Tokens.font-md;
+            }
+
+            // Message view (SQL footer segment)
+            if !root.browse-mode && root.view-mode == 0 && root.sql-view-mode == 1: VerticalLayout {
+                padding: Tokens.sp3;
+                alignment: start;
+                Text {
+                    text: root.result-status == "" ? "No messages" : root.result-status;
+                    color: root.status-error ? Tokens.error : Tokens.text-dim;
+                    font-size: Tokens.font-md;
+                }
+            }
+
+            // Chart view: horizontal bars, first text column vs first numeric column
+            if !root.browse-mode && root.view-mode == 0 && root.sql-view-mode == 2: ScrollView {
+                width: 100%;
+                height: 100%;
+                VerticalLayout {
+                    width: parent.visible-width;
+                    padding: Tokens.sp3;
+                    spacing: Tokens.sp1;
+                    alignment: start;
+                    if root.chart-bars.length == 0: Text {
+                        text: "Nothing to chart — the result needs a numeric column";
+                        color: Tokens.text-faint;
+                        font-size: Tokens.font-md;
+                    }
+                    for bar in root.chart-bars: HorizontalLayout {
+                        height: 20px;
+                        spacing: Tokens.sp2;
+                        Text {
+                            width: 160px;
+                            text: bar.label;
+                            color: Tokens.text-dim;
+                            font-size: Tokens.font-sm;
+                            font-family: Tokens.mono;
+                            overflow: elide;
+                            vertical-alignment: center;
+                        }
+                        Rectangle {
+                            horizontal-stretch: 1;
+                            Rectangle {
+                                x: 0;
+                                width: parent.width * bar.frac;
+                                height: 14px;
+                                y: (parent.height - self.height) / 2;
+                                border-radius: 3px;
+                                background: Tokens.accent;
+                            }
+                        }
+                        Text {
+                            width: 100px;
+                            text: bar.value;
+                            color: Tokens.text;
+                            font-size: Tokens.font-sm;
+                            font-family: Tokens.mono;
+                            horizontal-alignment: right;
+                            vertical-alignment: center;
+                        }
+                    }
+                }
             }
         }
 
@@ -556,9 +621,21 @@ export component WorkArea inherits Rectangle {
                 if !root.browse-mode: HorizontalLayout {
                     spacing: Tokens.sp4;
                     alignment: start;
-                    UnderlineSegment { text: "Data"; active: true; }
-                    UnderlineSegment { text: "Message"; }
-                    UnderlineSegment { text: "Chart"; }
+                    UnderlineSegment {
+                        text: "Data";
+                        active: root.sql-view-mode == 0;
+                        clicked => { root.sql-view-mode = 0; }
+                    }
+                    UnderlineSegment {
+                        text: "Message";
+                        active: root.sql-view-mode == 1;
+                        clicked => { root.sql-view-mode = 1; }
+                    }
+                    UnderlineSegment {
+                        text: "Chart";
+                        active: root.sql-view-mode == 2;
+                        clicked => { root.sql-view-mode = 2; }
+                    }
                 }
 
                 Rectangle { horizontal-stretch: 1; }

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -70,6 +70,8 @@ export component WorkArea inherits Rectangle {
     callback run-selection();
     callback format-sql();
     callback explain-query();
+    callback copy-results();
+    callback export-csv();
     callback apply-filter();
     callback toggle-sql();
     callback resize-col(int, length);
@@ -410,8 +412,8 @@ export component WorkArea inherits Rectangle {
                         vertical-alignment: center;
                     }
                     Rectangle { horizontal-stretch: 1; }
-                    TextButton { text: "Copy"; }
-                    TextButton { text: "Export CSV"; }
+                    TextButton { text: "Copy"; clicked => { root.copy-results(); } }
+                    TextButton { text: "Export CSV"; clicked => { root.export-csv(); } }
                     TextButton { text: "Chart"; }
                 }
             }
@@ -630,7 +632,7 @@ export component WorkArea inherits Rectangle {
                     }
                     VerticalLayout {
                         alignment: center;
-                        SecondaryButton { text: "Export"; height: 24px; }
+                        SecondaryButton { text: "Export"; height: 24px; clicked => { root.export-csv(); } }
                     }
                 }
                 if !root.browse-mode: HorizontalLayout {
@@ -638,7 +640,7 @@ export component WorkArea inherits Rectangle {
                     alignment: end;
                     VerticalLayout {
                         alignment: center;
-                        SecondaryButton { text: "Export"; height: 24px; }
+                        SecondaryButton { text: "Export"; height: 24px; clicked => { root.export-csv(); } }
                     }
                 }
                 // ● 12 ms

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -367,7 +367,17 @@ export component WorkArea inherits Rectangle {
                     }
                     VerticalLayout {
                         alignment: center;
-                        SecondaryButton { text: "Limit 500  ⇅"; height: 28px; }
+                        SecondaryButton {
+                            text: "Limit " + root.limit-text + "  ⇅";
+                            height: 28px;
+                            clicked => {
+                                // cycle presets: 100 → 300 → 500 → 1000 → 100
+                                root.limit-text = root.limit-text == "100" ? "300"
+                                    : root.limit-text == "300" ? "500"
+                                    : root.limit-text == "500" ? "1000" : "100";
+                                root.set-limit(root.limit-text);
+                            }
+                        }
                     }
                 }
                 CodeEditor {

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -76,6 +76,12 @@ export component WorkArea inherits Rectangle {
     // SQL result footer segments: 0 Data · 1 Message · 2 Chart.
     in-out property <int> sql-view-mode: 0;
     in property <[ChartBar]> chart-bars;
+
+    // column-visibility popup (Columns footer button)
+    in property <[string]> all-columns;
+    in property <[bool]> col-hidden;
+    callback toggle-column(int);
+    property <bool> columns-open: false;
     callback apply-filter();
     callback toggle-sql();
     callback resize-col(int, length);
@@ -705,7 +711,7 @@ export component WorkArea inherits Rectangle {
                     }
                     VerticalLayout {
                         alignment: center;
-                        SecondaryButton { text: "Columns"; height: 24px; }
+                        SecondaryButton { text: "Columns"; height: 24px; clicked => { root.columns-open = !root.columns-open; } }
                     }
                     VerticalLayout {
                         alignment: center;
@@ -738,6 +744,53 @@ export component WorkArea inherits Rectangle {
                         font-family: Tokens.mono;
                         vertical-alignment: center;
                     }
+                }
+            }
+        }
+    }
+
+    // ----- column-visibility popup (anchored above the footer) -----
+    if root.columns-open: Rectangle {
+        x: parent.width - self.width - Tokens.sp3;
+        y: parent.height - self.height - Tokens.status-bar-h - Tokens.sp2;
+        width: 240px;
+        height: min(320px, cols-list.preferred-height + 2 * Tokens.sp2);
+        border-radius: Tokens.radius-lg;
+        border-width: 1px;
+        border-color: Tokens.border-strong;
+        background: Tokens.card;
+        drop-shadow-blur: 16px;
+        drop-shadow-color: Tokens.text.with-alpha(0.25);
+        ScrollView {
+            width: 100%;
+            height: 100%;
+            cols-list := VerticalLayout {
+                padding: Tokens.sp2;
+                spacing: 0;
+                for name[i] in root.all-columns: Rectangle {
+                    height: 24px;
+                    border-radius: Tokens.radius;
+                    background: col-ta.has-hover ? Tokens.chrome : transparent;
+                    HorizontalLayout {
+                        padding-left: Tokens.sp2;
+                        padding-right: Tokens.sp2;
+                        spacing: Tokens.sp2;
+                        Text {
+                            text: root.col-hidden[i] ? "○" : "●";
+                            color: root.col-hidden[i] ? Tokens.text-faint : Tokens.accent;
+                            font-size: Tokens.font-sm;
+                            vertical-alignment: center;
+                        }
+                        Text {
+                            text: name;
+                            color: Tokens.text;
+                            font-size: Tokens.font-sm;
+                            font-family: Tokens.mono;
+                            vertical-alignment: center;
+                            overflow: elide;
+                        }
+                    }
+                    col-ta := TouchArea { clicked => { root.toggle-column(i); } }
                 }
             }
         }

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -67,6 +67,7 @@ export component WorkArea inherits Rectangle {
     in-out property <int> filter-rows: 1;
 
     callback run();
+    callback format-sql();
     callback apply-filter();
     callback toggle-sql();
     callback resize-col(int, length);
@@ -344,7 +345,7 @@ export component WorkArea inherits Rectangle {
                     }
                     VerticalLayout {
                         alignment: center;
-                        SecondaryButton { text: "Format"; height: 28px; }
+                        SecondaryButton { text: "Format"; height: 28px; clicked => { root.format-sql(); } }
                     }
                     VerticalLayout {
                         alignment: center;

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -68,6 +68,7 @@ export component WorkArea inherits Rectangle {
 
     callback run();
     callback format-sql();
+    callback explain-query();
     callback apply-filter();
     callback toggle-sql();
     callback resize-col(int, length);
@@ -349,7 +350,12 @@ export component WorkArea inherits Rectangle {
                     }
                     VerticalLayout {
                         alignment: center;
-                        SecondaryButton { text: "Explain"; height: 28px; }
+                        SecondaryButton {
+                            text: "Explain";
+                            height: 28px;
+                            enabled: root.sql-capable;
+                            clicked => { root.explain-query(); }
+                        }
                     }
                     Rectangle { horizontal-stretch: 1; }
                     Text {

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -2,7 +2,7 @@
 // editor + results split. References: design/2-workspace.png,
 // design/3-sql-editor.png, design/11-filter-edit-t2.png.
 import { Tokens } from "tokens.slint";
-import { GridColumn, GridCell, StructField, Span, ChartBar } from "structs.slint";
+import { GridColumn, GridCell, StructField, Span, ChartBar, IndexRow } from "structs.slint";
 import { CodeEditor } from "code-editor.slint";
 import { TabularGrid } from "tabular-grid.slint";
 import {
@@ -78,6 +78,8 @@ export component WorkArea inherits Rectangle {
     // SQL result footer segments: 0 Data · 1 Message · 2 Chart.
     in-out property <int> sql-view-mode: 0;
     in property <[ChartBar]> chart-bars;
+
+    in property <[IndexRow]> index-rows;
 
     // column-visibility popup (Columns footer button)
     in property <[string]> all-columns;
@@ -303,11 +305,23 @@ export component WorkArea inherits Rectangle {
                         border-width: 1px;
                         border-color: Tokens.accent.with-alpha(0.35);
                         background: Tokens.accent-tint.with-alpha(0.45);
-                        Text {
-                            text: "empty-state illustration";
-                            color: Tokens.accent.with-alpha(0.65);
-                            font-size: Tokens.font-sm;
-                            font-family: Tokens.mono;
+                        VerticalLayout {
+                            alignment: center;
+                            spacing: Tokens.sp2;
+                            Text {
+                                text: "▦";
+                                color: Tokens.accent.with-alpha(0.65);
+                                font-size: 44px;
+                                horizontal-alignment: center;
+                            }
+                            Text {
+                                text: "Tabula";
+                                color: Tokens.accent.with-alpha(0.65);
+                                font-size: Tokens.font-md;
+                                font-family: Tokens.mono;
+                                font-weight: Tokens.weight-emphasis;
+                                horizontal-alignment: center;
+                            }
                         }
                     }
                 }
@@ -500,11 +514,32 @@ export component WorkArea inherits Rectangle {
                 }
             }
 
-            // Indexes placeholder
-            if root.view-mode == 2: Text {
+            // Indexes view (from engine catalogs; empty for engines without them)
+            if root.view-mode == 2 && root.index-rows.length == 0: Text {
                 text: "No indexes to show";
                 color: Tokens.text-faint;
                 font-size: Tokens.font-md;
+            }
+            if root.view-mode == 2 && root.index-rows.length > 0: ScrollView {
+                width: 100%;
+                height: 100%;
+                VerticalLayout {
+                    width: parent.visible-width;
+                    padding: Tokens.sp3;
+                    spacing: 0;
+                    alignment: start;
+                    HorizontalLayout {
+                        height: Tokens.grid-header-h;
+                        Text { width: 220px; text: "index"; color: Tokens.text; font-family: Tokens.mono; font-size: Tokens.font-sm; font-weight: 600; vertical-alignment: center; }
+                        Text { text: "definition"; color: Tokens.text; font-family: Tokens.mono; font-size: Tokens.font-sm; font-weight: 600; vertical-alignment: center; }
+                    }
+                    Rectangle { height: 1px; background: Tokens.border-strong; }
+                    for ix in root.index-rows: HorizontalLayout {
+                        height: Tokens.grid-row-h;
+                        Text { width: 220px; text: ix.name; color: Tokens.text; font-family: Tokens.mono; font-size: Tokens.font-sm; vertical-alignment: center; overflow: elide; }
+                        Text { text: ix.definition; color: Tokens.text-dim; font-family: Tokens.mono; font-size: Tokens.font-sm; vertical-alignment: center; overflow: elide; }
+                    }
+                }
             }
 
             // Message view (SQL footer segment)


### PR DESCRIPTION
## Summary
- FE audit found ~20 dead/mislabeled controls, a theme toggle that did nothing, and a connection form that bypassed the design-token system entirely — everything is now wired to a real implementation.
- Includes two pre-work commits (Cargo.lock sync after the 0.4.0 release, README architecture-tree removal) since develop is push-protected.

## Changes
- **Theme**: real dark palette behind `Theme.dark` (Tokens carry light/dark pairs); `Theme` shrinks to the two runtime properties Rust drives; spacing literals normalized to the 4px grid.
- **Conn form**: migrated to Tokens + shared controls (`FormField`, Primary/SecondaryButton); veil/error/ok colors match the system; default swatch = app accent `#2c5fd8` (Rust defaults follow).
- **Wired callbacks**: schema switcher modal (real Postgres namespaces from `information_schema`), sidebar Queries/History tabs with live query history (deduped, cap 50), picker quick-Test (shared `try_connect`, latency in footer), picker Import (routes to URL-import form) and Backup (connection list as JSON to `~/Downloads`, passwords stay in keychain), sidebar `+` opens a new tab.
- **SQL toolbar**: Format (dependency-free formatter), Explain (renders in the results grid, disabled for non-SQL engines), Run Selection (statement under cursor, literal-aware), Limit control cycles 100/300/500/1000 and shows the real value.
- **Results**: Copy (TSV clipboard via `copypasta`, already in the lockfile), Export CSV (RFC-4180, timestamped in `~/Downloads`), Chart view (horizontal bars, first non-numeric column × first numeric), live Data/Message/Chart segments, Columns visibility popup (grid goes read-only while columns are hidden), filter panel with real columns + operators (`contains/=/≠/>/</is null/not null`), Indexes tab populated from `pg_indexes` / `information_schema.statistics`.
- **Titlebar**: ◷ jumps to History, ⚙ opens the current connection's edit form; disabled SecondaryButton no longer looks hovered; empty-state placeholder text replaced.

## Test plan
- [x] `make fmt-check`
- [x] `make lint` (clippy, `-D warnings`)
- [x] `cargo test --workspace` — all unit tests pass (only `driver-postgres/tests/integration.rs` fails locally: needs Docker, excluded from CI by design)
- [x] `make fe-build`
- [x] `RDBS_MOCK=1` screenshot harness renders the picker correctly
- [ ] Manual pass against a real PostgreSQL: schema switcher, Indexes tab, Explain, exports