### PR TITLE
feat(app): native macOS window frame and rename to RDB

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -767,42 +767,6 @@ fn main() -> Result<(), slint::PlatformError> {
         },
     ));
 
-    // ----- frameless-window chrome: drag + minimize/maximize/close -----
-    {
-        let weak = window.as_weak();
-        window.on_win_drag(move |dx, dy| {
-            if let Some(w) = weak.upgrade() {
-                let win = w.window();
-                let pos = win.position();
-                let sf = win.scale_factor();
-                win.set_position(slint::PhysicalPosition::new(
-                    pos.x + (dx * sf) as i32,
-                    pos.y + (dy * sf) as i32,
-                ));
-            }
-        });
-    }
-    {
-        let weak = window.as_weak();
-        window.on_win_minimize(move || {
-            if let Some(w) = weak.upgrade() {
-                w.window().set_minimized(true);
-            }
-        });
-    }
-    {
-        let weak = window.as_weak();
-        window.on_win_maximize(move || {
-            if let Some(w) = weak.upgrade() {
-                let m = w.window().is_maximized();
-                w.window().set_maximized(!m);
-            }
-        });
-    }
-    window.on_win_close(|| {
-        let _ = slint::quit_event_loop();
-    });
-
     // Fixed window size for the screenshot loop: RDBS_WIN=WxH (logical px).
     if let Ok(spec) = std::env::var("RDBS_WIN") {
         if let Some((w, h)) = spec.split_once('x') {
@@ -1596,9 +1560,9 @@ fn main() -> Result<(), slint::PlatformError> {
             let tags: Vec<SharedString> = s.tags.iter().map(|t| t.as_str().into()).collect();
             w.set_sel_tags(ModelRc::from(Rc::new(VecModel::from(tags))));
             let footer = if mock::mock_mode() {
-                "Terakhir terhubung · 2 menit lalu · Tabula 1.2.0 open source".to_string()
+                "Terakhir terhubung · 2 menit lalu · RDB 1.2.0 open source".to_string()
             } else {
-                format!("Tabula {} open source", env!("CARGO_PKG_VERSION"))
+                format!("RDB {} open source", env!("CARGO_PKG_VERSION"))
             };
             w.set_sel_footer(footer.into());
         }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -3,7 +3,7 @@ export { Theme }
 import { Tokens } from "tokens.slint";
 export { Tokens }
 import {
-    SearchCommandPill, WindowControls, BreadcrumbChip, GlyphButton
+    SearchCommandPill, BreadcrumbChip, GlyphButton
 } from "components.slint";
 import { Sidebar } from "sidebar.slint";
 import { ConnPicker } from "picker.slint";
@@ -25,13 +25,12 @@ import {
 } from "structs.slint";
 
 export component MainWindow inherits Window {
-    title: "Tabula";
+    title: "RDB";
     icon: @image-url("../../assets/icon.png");
     preferred-width: 1102px;
     preferred-height: 702px;
     min-width: 400px;
     min-height: 320px;
-    no-frame: true;
     background: Tokens.chrome;
     default-font-size: 13px;
 
@@ -45,10 +44,6 @@ export component MainWindow inherits Window {
     in property <string> bc-conn;
     in property <string> bc-db;
     in property <string> bc-schema;
-    callback win-minimize();
-    callback win-maximize();
-    callback win-close();
-    callback win-drag(length, length); // (dx, dy) while titlebar is dragged
 
     // ----- sidebar models -----
     in property <[ConnItem]> connections;
@@ -346,17 +341,10 @@ export component MainWindow inherits Window {
     VerticalLayout {
         spacing: 0px;
 
-        // ================= titlebar (44px, frameless chrome) =================
+        // ================= toolbar row (44px, under native titlebar) =================
         Rectangle {
             height: Tokens.titlebar-h;
             background: Tokens.chrome;
-
-            // whole-bar drag surface (buttons/chips sit above it)
-            drag-ta := TouchArea {
-                moved => {
-                    root.win-drag(self.mouse-x - self.pressed-x, self.mouse-y - self.pressed-y);
-                }
-            }
 
             HorizontalLayout {
                 padding-left: Tokens.sp4;
@@ -375,7 +363,7 @@ export component MainWindow inherits Window {
                             border-radius: Tokens.radius;
                             background: Tokens.accent;
                             Text {
-                                text: "T";
+                                text: "R";
                                 color: white;
                                 font-size: 14px;
                                 font-weight: 700;
@@ -383,7 +371,7 @@ export component MainWindow inherits Window {
                         }
                     }
                     Text {
-                        text: "Tabula";
+                        text: "RDB";
                         color: Tokens.text;
                         font-size: 15px;
                         font-weight: 700;
@@ -462,14 +450,6 @@ export component MainWindow inherits Window {
                                 }
                             }
                         }
-                    }
-                }
-                VerticalLayout {
-                    alignment: center;
-                    WindowControls {
-                        minimize => { root.win-minimize(); }
-                        maximize => { root.win-maximize(); }
-                        close-window => { root.win-close(); }
                     }
                 }
             }

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -300,16 +300,6 @@ export component GlyphButton inherits Rectangle {
 }
 
 // macOS-style window controls (– □ ×), right-aligned in the design.
-export component WindowControls inherits HorizontalLayout {
-    callback minimize;
-    callback maximize;
-    callback close-window;
-    spacing: Tokens.sp1;
-    GlyphButton { glyph: "–"; clicked => { root.minimize(); } }
-    GlyphButton { glyph: "□"; glyph-size: 12px; clicked => { root.maximize(); } }
-    GlyphButton { glyph: "×"; danger-hover: true; clicked => { root.close-window(); } }
-}
-
 // Filter/search input used in sidebars (white rounded box + magnifier).
 export component FilterField inherits Rectangle {
     in property <string> placeholder;

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -340,7 +340,7 @@ export component WorkArea inherits Rectangle {
                                 horizontal-alignment: center;
                             }
                             Text {
-                                text: "Tabula";
+                                text: "RDB";
                                 color: Tokens.accent.with-alpha(0.65);
                                 font-size: Tokens.font-md;
                                 font-family: Tokens.mono;


### PR DESCRIPTION
## Summary

- macOS user reported the window looked like Windows (square min/max/close on the right, no rounded corners) and could not corner-drag to resize.
- Root cause: `no-frame: true` made a borderless window forcing hand-drawn chrome. Dropping it returns decoration to the OS — traffic-lights on the left, rounded corners, native edge/corner resize, native min/max — all free.
- Also renamed the display name `Tabula` → `RDB` to match the `rdbs` binary/project.

## Changes

- `app/src/ui/app-window.slint`: remove `no-frame: true`; delete whole-bar drag `TouchArea`, `WindowControls` block, and `win-drag/minimize/maximize/close` callbacks; title + brand `Tabula`→`RDB` (`T`→`R`).
- `app/src/ui/components.slint`: delete now-dead `WindowControls` component.
- `app/src/ui/workarea.slint`: placeholder text `Tabula`→`RDB`.
- `app/src/main.rs`: remove `on_win_drag/minimize/maximize/close` handlers; status footer `Tabula`→`RDB`.

## Test plan

- [x] `make fe-build` — clean
- [x] `make lint` — passes (warnings as errors)
- [x] `make fe-run` on macOS: traffic-lights top-left, rounded corners, corner-drag resizes, title shows RDB