### PR TITLE
feat(app): add SQLite driver and wire into UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1791,6 +1791,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,6 +2442,9 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash 0.8.12",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2458,6 +2473,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -3552,6 +3576,17 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.8.1",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -5042,7 +5077,7 @@ dependencies = [
  "base64 0.22.1",
  "byteorder",
  "bytes",
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "hmac 0.13.0",
  "md-5 0.11.0",
  "memchr",
@@ -5059,7 +5094,7 @@ checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
 dependencies = [
  "bytes",
  "chrono",
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "postgres-protocol",
  "uuid",
 ]
@@ -5474,6 +5509,7 @@ dependencies = [
  "rdbs-driver-mysql",
  "rdbs-driver-postgres",
  "rdbs-driver-redis",
+ "rdbs-driver-sqlite",
  "serde_json",
  "slint",
  "slint-build",
@@ -5560,6 +5596,16 @@ dependencies = [
  "redis",
  "testcontainers",
  "testcontainers-modules",
+ "tokio",
+]
+
+[[package]]
+name = "rdbs-driver-sqlite"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "rdbs-core",
+ "rusqlite",
  "tokio",
 ]
 
@@ -5813,6 +5859,20 @@ dependencies = [
  "snafu",
  "unicode-linebreak",
  "unicode-width",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.13.0",
+ "fallible-iterator 0.3.0",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -7115,7 +7175,7 @@ dependencies = [
  "async-trait",
  "byteorder",
  "bytes",
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "futures-channel",
  "futures-util",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/driver-mysql",
     "crates/driver-redis",
     "crates/driver-mongo",
+    "crates/driver-sqlite",
     "app",
 ]
 

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -15,6 +15,7 @@ rdbs-driver-postgres = { path = "../crates/driver-postgres" }
 rdbs-driver-mysql = { path = "../crates/driver-mysql" }
 rdbs-driver-redis = { path = "../crates/driver-redis" }
 rdbs-driver-mongo = { path = "../crates/driver-mongo" }
+rdbs-driver-sqlite = { path = "../crates/driver-sqlite" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "time"] }
 serde_json = "1"
 async-trait = "0.1"

--- a/app/src/dispatch.rs
+++ b/app/src/dispatch.rs
@@ -16,12 +16,14 @@ use rdbs_driver_mongo::MongoDriver;
 use rdbs_driver_mysql::MysqlDriver;
 use rdbs_driver_postgres::PostgresDriver;
 use rdbs_driver_redis::RedisDriver;
+use rdbs_driver_sqlite::SqliteDriver;
 
 pub enum AnyDriver {
     Postgres(PostgresDriver),
     Mysql(MysqlDriver),
     Redis(RedisDriver),
     Mongo(MongoDriver),
+    Sqlite(SqliteDriver),
     /// In-process demo driver (RDBS_MOCK=1); no network, seeded data.
     Mock(crate::mock::MockDriver),
 }
@@ -34,6 +36,7 @@ impl AnyDriver {
             Engine::MySql => "MySQL",
             Engine::Redis => "Redis",
             Engine::Mongo => "MongoDB",
+            Engine::Sqlite => "SQLite",
         }
     }
 
@@ -44,6 +47,7 @@ impl AnyDriver {
             Engine::MySql => "mysql",
             Engine::Redis => "redis",
             Engine::Mongo => "mongo",
+            Engine::Sqlite => "sqlite",
         }
     }
 
@@ -59,6 +63,7 @@ impl AnyDriver {
             Engine::MySql => AnyDriver::Mysql(MysqlDriver::connect(cfg).await?),
             Engine::Redis => AnyDriver::Redis(RedisDriver::connect(cfg).await?),
             Engine::Mongo => AnyDriver::Mongo(MongoDriver::connect(cfg).await?),
+            Engine::Sqlite => AnyDriver::Sqlite(SqliteDriver::connect(cfg).await?),
         })
     }
 
@@ -70,6 +75,7 @@ impl AnyDriver {
             AnyDriver::Mysql(d) => d.ping().await,
             AnyDriver::Redis(d) => d.ping().await,
             AnyDriver::Mongo(d) => d.ping().await,
+            AnyDriver::Sqlite(d) => d.ping().await,
             AnyDriver::Mock(d) => d.ping().await,
         }
     }
@@ -80,6 +86,7 @@ impl AnyDriver {
             AnyDriver::Mysql(d) => d.schema().await,
             AnyDriver::Redis(d) => d.schema().await,
             AnyDriver::Mongo(d) => d.schema().await,
+            AnyDriver::Sqlite(d) => d.schema().await,
             AnyDriver::Mock(d) => d.schema().await,
         }
     }
@@ -90,6 +97,7 @@ impl AnyDriver {
             AnyDriver::Mysql(d) => d.containers(database).await,
             AnyDriver::Redis(d) => d.containers(database).await,
             AnyDriver::Mongo(d) => d.containers(database).await,
+            AnyDriver::Sqlite(d) => d.containers(database).await,
             AnyDriver::Mock(d) => d.containers(database).await,
         }
     }
@@ -100,6 +108,7 @@ impl AnyDriver {
             AnyDriver::Mysql(d) => d.query(q).await,
             AnyDriver::Redis(d) => d.query(q).await,
             AnyDriver::Mongo(d) => d.query(q).await,
+            AnyDriver::Sqlite(d) => d.query(q).await,
             AnyDriver::Mock(d) => d.query(q).await,
         }
     }
@@ -110,6 +119,7 @@ impl AnyDriver {
             AnyDriver::Mysql(d) => d.primary_key(table).await,
             AnyDriver::Redis(d) => d.primary_key(table).await,
             AnyDriver::Mongo(d) => d.primary_key(table).await,
+            AnyDriver::Sqlite(d) => d.primary_key(table).await,
             AnyDriver::Mock(d) => d.primary_key(table).await,
         }
     }
@@ -120,6 +130,7 @@ impl AnyDriver {
             AnyDriver::Mysql(d) => d.count(table).await,
             AnyDriver::Redis(d) => d.count(table).await,
             AnyDriver::Mongo(d) => d.count(table).await,
+            AnyDriver::Sqlite(d) => d.count(table).await,
             AnyDriver::Mock(d) => d.count(table).await,
         }
     }
@@ -130,6 +141,7 @@ impl AnyDriver {
             AnyDriver::Mysql(d) => d.commit(ops).await,
             AnyDriver::Redis(d) => d.commit(ops).await,
             AnyDriver::Mongo(d) => d.commit(ops).await,
+            AnyDriver::Sqlite(d) => d.commit(ops).await,
             AnyDriver::Mock(d) => d.commit(ops).await,
         }
     }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -468,6 +468,12 @@ fn browse_text(
                 table.name.replace('`', "``")
             )
         }
+        rdbs_connstore::Engine::Sqlite => {
+            format!(
+                "SELECT * FROM \"{}\" LIMIT {limit} OFFSET {offset}",
+                table.name.replace('"', "\"\"")
+            )
+        }
         rdbs_connstore::Engine::Mongo => {
             let db = table
                 .database
@@ -2121,7 +2127,9 @@ fn main() -> Result<(), slint::PlatformError> {
                         // SQL editor only makes sense for the SQL engines.
                         let sql_capable = matches!(
                             engine,
-                            rdbs_connstore::Engine::Postgres | rdbs_connstore::Engine::MySql
+                            rdbs_connstore::Engine::Postgres
+                                | rdbs_connstore::Engine::MySql
+                                | rdbs_connstore::Engine::Sqlite
                         );
                         *raw_nodes.lock().unwrap() = nodes;
                         {
@@ -2226,7 +2234,9 @@ fn main() -> Result<(), slint::PlatformError> {
                     Some((engine, driver)) => {
                         let stmts = if matches!(
                             engine,
-                            rdbs_connstore::Engine::Postgres | rdbs_connstore::Engine::MySql
+                            rdbs_connstore::Engine::Postgres
+                                | rdbs_connstore::Engine::MySql
+                                | rdbs_connstore::Engine::Sqlite
                         ) {
                             editor::split_statements(&sql)
                         } else {
@@ -3463,6 +3473,7 @@ fn main() -> Result<(), slint::PlatformError> {
             "MySQL" => "3306",
             "Redis" => "6379",
             "MongoDB" => "27017",
+            "SQLite" => "0", // file-based: port unused
             _ => "5432",
         }
     }
@@ -3471,6 +3482,7 @@ fn main() -> Result<(), slint::PlatformError> {
             "MySQL" => rdbs_connstore::Engine::MySql,
             "Redis" => rdbs_connstore::Engine::Redis,
             "MongoDB" => rdbs_connstore::Engine::Mongo,
+            "SQLite" => rdbs_connstore::Engine::Sqlite,
             _ => rdbs_connstore::Engine::Postgres,
         }
     }

--- a/app/src/query_parse.rs
+++ b/app/src/query_parse.rs
@@ -10,7 +10,7 @@ use rdbs_core::query::{MongoKind, MongoOp, Query};
 /// result-status line; no driver call is made).
 pub fn parse_query(engine: Engine, text: &str) -> Result<Query, String> {
     match engine {
-        Engine::Postgres | Engine::MySql => Ok(Query::Sql(text.to_string())),
+        Engine::Postgres | Engine::MySql | Engine::Sqlite => Ok(Query::Sql(text.to_string())),
         Engine::Redis => {
             let tokens: Vec<String> = text.split_whitespace().map(|s| s.to_string()).collect();
             if tokens.is_empty() {
@@ -25,7 +25,7 @@ pub fn parse_query(engine: Engine, text: &str) -> Result<Query, String> {
 /// Editor placeholder/hint per engine (shown in the UI).
 pub fn editor_hint(engine: Engine) -> &'static str {
     match engine {
-        Engine::Postgres | Engine::MySql => "SQL — e.g. SELECT * FROM table",
+        Engine::Postgres | Engine::MySql | Engine::Sqlite => "SQL — e.g. SELECT * FROM table",
         Engine::Redis => "Redis command — e.g. SET key value",
         Engine::Mongo => r#"Mongo JSON — {"collection":"c","op":"find","body":{}}"#,
     }

--- a/app/src/ui/conn-form.slint
+++ b/app/src/ui/conn-form.slint
@@ -87,12 +87,21 @@ export component ConnForm inherits Rectangle {
 
             Text { text: "Engine"; color: Tokens.text-dim; font-size: Tokens.font-sm; }
             ComboBox {
-                model: ["PostgreSQL", "MySQL", "Redis", "MongoDB"];
+                model: ["PostgreSQL", "MySQL", "Redis", "MongoDB", "SQLite"];
                 current-value <=> root.f-engine;
                 selected(v) => { root.engine-changed(v); }
             }
 
-            HorizontalLayout {
+            // SQLite is a local file: one path field, no host/port/user/ssl.
+            if root.f-engine == "SQLite": Text {
+                text: "File"; color: Tokens.text-dim; font-size: Tokens.font-sm;
+            }
+            if root.f-engine == "SQLite": FormField {
+                text <=> root.f-database;
+                placeholder: "/path/to/database.db";
+            }
+
+            if root.f-engine != "SQLite": HorizontalLayout {
                 spacing: Tokens.sp2;
                 VerticalLayout {
                     Text { text: "Host"; color: Tokens.text-dim; font-size: Tokens.font-sm; }
@@ -105,8 +114,8 @@ export component ConnForm inherits Rectangle {
                 }
             }
 
-            // Redis has no user/database concept — hide those for it.
-            if root.f-engine != "Redis": HorizontalLayout {
+            // Redis has no user/database concept — hide those for it (and SQLite).
+            if root.f-engine != "Redis" && root.f-engine != "SQLite": HorizontalLayout {
                 spacing: Tokens.sp2;
                 VerticalLayout {
                     Text { text: "User"; color: Tokens.text-dim; font-size: Tokens.font-sm; }
@@ -118,8 +127,12 @@ export component ConnForm inherits Rectangle {
                 }
             }
 
-            Text { text: "Password"; color: Tokens.text-dim; font-size: Tokens.font-sm; }
-            FormField { text <=> root.f-password; input-type: InputType.password; }
+            if root.f-engine != "SQLite": Text {
+                text: "Password"; color: Tokens.text-dim; font-size: Tokens.font-sm;
+            }
+            if root.f-engine != "SQLite": FormField {
+                text <=> root.f-password; input-type: InputType.password;
+            }
 
             // SSL mode only applies to the SQL engines.
             if root.f-engine == "PostgreSQL" || root.f-engine == "MySQL": Text {

--- a/crates/connstore/src/conn_url.rs
+++ b/crates/connstore/src/conn_url.rs
@@ -49,6 +49,7 @@ fn scheme_to_engine(scheme: &str) -> Option<Engine> {
         "mysql" | "mariadb" => Some(Engine::MySql),
         "redis" | "rediss" => Some(Engine::Redis),
         "mongodb" | "mongodb+srv" => Some(Engine::Mongo),
+        "sqlite" | "file" => Some(Engine::Sqlite),
         _ => None,
     }
 }

--- a/crates/connstore/src/model.rs
+++ b/crates/connstore/src/model.rs
@@ -9,6 +9,8 @@ pub enum Engine {
     MySql,
     Redis,
     Mongo,
+    /// Local file-based engine: no host/port/user; `database` holds the path.
+    Sqlite,
 }
 
 /// A persisted connection. Only non-secret fields are stored. The password is

--- a/crates/driver-sqlite/Cargo.toml
+++ b/crates/driver-sqlite/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rdbs-driver-sqlite"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rdbs-core = { path = "../core" }
+async-trait = "0.1"
+tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
+# `bundled` compiles SQLite in-tree: no system libsqlite, no network.
+rusqlite = { version = "0.32", features = ["bundled"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full", "macros", "rt-multi-thread"] }

--- a/crates/driver-sqlite/src/driver.rs
+++ b/crates/driver-sqlite/src/driver.rs
@@ -1,0 +1,292 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use rusqlite::types::ValueRef;
+use rusqlite::Connection;
+
+use rdbs_core::conn::ConnConfig;
+use rdbs_core::driver::Driver;
+use rdbs_core::error::{RdbsError, Result};
+use rdbs_core::query::Query;
+use rdbs_core::result::{Cell, Column, ResultSet, Row};
+use rdbs_core::schema::{Container, ContainerKind, Database, Field, Schema};
+use rdbs_core::write::{TableRef, WriteOp};
+
+use crate::write_sql;
+
+/// A `Driver` backed by a single rusqlite connection.
+///
+/// ponytail: one global connection mutex. SQLite is a single local file with
+/// no concurrency to exploit; a pool (r2d2) is the upgrade path only if
+/// concurrent tabs ever contend.
+pub struct SqliteDriver {
+    conn: Arc<Mutex<Connection>>,
+    /// Logical database name shown in the schema tree (the file stem).
+    db_name: String,
+}
+
+impl SqliteDriver {
+    /// Run a closure with the locked connection on a blocking thread.
+    async fn with_conn<T, F>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&Connection) -> Result<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.lock().expect("sqlite mutex poisoned");
+            f(&guard)
+        })
+        .await
+        .map_err(|e| RdbsError::Query(e.to_string()))?
+    }
+}
+
+#[async_trait]
+impl Driver for SqliteDriver {
+    async fn connect(cfg: &ConnConfig) -> Result<Self> {
+        // The file path travels in `database` (host/port/user are unused for a
+        // local file). Empty or ":memory:" opens an in-memory database.
+        let path = cfg.database.clone().unwrap_or_default();
+        let db_name = db_name_from_path(&path);
+        let conn = tokio::task::spawn_blocking(move || {
+            if path.is_empty() || path == ":memory:" {
+                Connection::open_in_memory()
+            } else {
+                Connection::open(&path)
+            }
+        })
+        .await
+        .map_err(|e| RdbsError::Connection(e.to_string()))?
+        .map_err(|e| RdbsError::Connection(e.to_string()))?;
+        Ok(SqliteDriver {
+            conn: Arc::new(Mutex::new(conn)),
+            db_name,
+        })
+    }
+
+    async fn ping(&self) -> Result<()> {
+        self.with_conn(|c| {
+            c.query_row("SELECT 1", [], |_| Ok(()))
+                .map_err(|e| RdbsError::Connection(e.to_string()))
+        })
+        .await
+    }
+
+    async fn schema(&self) -> Result<Schema> {
+        let db_name = self.db_name.clone();
+        self.with_conn(move |c| schema_impl(c, &db_name)).await
+    }
+
+    async fn query(&self, q: &Query) -> Result<ResultSet> {
+        let sql = match q {
+            Query::Sql(s) => s.clone(),
+            Query::Command(_) | Query::Mongo(_) => return Err(RdbsError::UnsupportedQuery),
+        };
+        self.with_conn(move |c| run_sql(c, &sql)).await
+    }
+
+    async fn primary_key(&self, table: &TableRef) -> Result<Vec<String>> {
+        let name = table.name.clone();
+        self.with_conn(move |c| primary_key_impl(c, &name)).await
+    }
+
+    async fn count(&self, table: &TableRef) -> Result<u64> {
+        let sql = format!("SELECT count(*) FROM {}", write_sql::table_name(table));
+        self.with_conn(move |c| {
+            let n: i64 = c
+                .query_row(&sql, [], |r| r.get(0))
+                .map_err(|e| RdbsError::Query(e.to_string()))?;
+            Ok(n as u64)
+        })
+        .await
+    }
+
+    async fn commit(&self, ops: &[WriteOp]) -> Result<u64> {
+        if ops.is_empty() {
+            return Ok(0);
+        }
+        let stmts: Vec<String> = ops
+            .iter()
+            .map(|op| match op {
+                WriteOp::Update { table, pk, changes } => write_sql::update_sql(table, pk, changes),
+                WriteOp::Insert { table, values } => write_sql::insert_sql(table, values),
+                WriteOp::Delete { table, pk } => write_sql::delete_sql(table, pk),
+            })
+            .collect();
+        self.with_conn(move |c| {
+            c.execute_batch("BEGIN")
+                .map_err(|e| RdbsError::Query(e.to_string()))?;
+            let mut affected = 0u64;
+            for sql in &stmts {
+                match c.execute(sql, []) {
+                    Ok(n) => affected += n as u64,
+                    Err(e) => {
+                        let _ = c.execute_batch("ROLLBACK");
+                        return Err(RdbsError::Query(e.to_string()));
+                    }
+                }
+            }
+            c.execute_batch("COMMIT")
+                .map_err(|e| RdbsError::Query(e.to_string()))?;
+            Ok(affected)
+        })
+        .await
+    }
+
+    async fn close(self) -> Result<()> {
+        // Dropping the Arc drops the Connection when the last ref goes away.
+        Ok(())
+    }
+}
+
+/// File stem for the schema-tree label; in-memory / empty -> "memory".
+fn db_name_from_path(path: &str) -> String {
+    if path.is_empty() || path == ":memory:" {
+        return "memory".to_string();
+    }
+    std::path::Path::new(path)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("database")
+        .to_string()
+}
+
+/// Map a rusqlite value to the unified `Cell`.
+fn value_to_cell(v: ValueRef) -> Cell {
+    match v {
+        ValueRef::Null => Cell::Null,
+        ValueRef::Integer(i) => Cell::Int(i),
+        ValueRef::Real(f) => Cell::Float(f),
+        ValueRef::Text(t) => Cell::Text(String::from_utf8_lossy(t).into_owned()),
+        ValueRef::Blob(b) => Cell::Bytes(b.to_vec()),
+    }
+}
+
+/// Row-returning heuristic (leading keyword after comment/blank lines).
+fn is_row_returning(sql: &str) -> bool {
+    let head = sql
+        .lines()
+        .map(str::trim_start)
+        .find(|l| !l.is_empty() && !l.starts_with("--"))
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    head.starts_with("select")
+        || head.starts_with("with")
+        || head.starts_with("values")
+        || head.starts_with("explain")
+        || head.starts_with("pragma")
+}
+
+fn run_sql(c: &Connection, sql: &str) -> Result<ResultSet> {
+    if is_row_returning(sql) {
+        let mut stmt = c
+            .prepare(sql)
+            .map_err(|e| RdbsError::Query(e.to_string()))?;
+        let cols: Vec<Column> = stmt
+            .column_names()
+            .into_iter()
+            .map(|name| Column {
+                name: name.to_string(),
+                type_name: String::new(),
+            })
+            .collect();
+        let ncol = cols.len();
+        let mut rows = stmt
+            .query([])
+            .map_err(|e| RdbsError::Query(e.to_string()))?;
+        let mut out: Vec<Row> = Vec::new();
+        while let Some(r) = rows.next().map_err(|e| RdbsError::Query(e.to_string()))? {
+            let mut cells: Row = Vec::with_capacity(ncol);
+            for i in 0..ncol {
+                let v = r.get_ref(i).map_err(|e| RdbsError::Query(e.to_string()))?;
+                cells.push(value_to_cell(v));
+            }
+            out.push(cells);
+        }
+        Ok(ResultSet::Tabular { cols, rows: out })
+    } else {
+        let n = c
+            .execute(sql, [])
+            .map_err(|e| RdbsError::Query(e.to_string()))?;
+        Ok(ResultSet::Affected(n as u64))
+    }
+}
+
+fn schema_impl(c: &Connection, db_name: &str) -> Result<Schema> {
+    let tables: Vec<String> = {
+        let mut stmt = c
+            .prepare(
+                "SELECT name FROM sqlite_master \
+                 WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+            )
+            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+        let rows = stmt
+            .query_map([], |r| r.get::<_, String>(0))
+            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|e| RdbsError::Schema(e.to_string()))?
+    };
+
+    let mut containers: Vec<Container> = Vec::with_capacity(tables.len());
+    for table in tables {
+        let pragma = format!("PRAGMA table_info({})", write_sql::quote_ident(&table));
+        let mut stmt = c
+            .prepare(&pragma)
+            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+        // table_info columns: cid, name, type, notnull, dflt_value, pk
+        let rows = stmt
+            .query_map([], |r| {
+                Ok((
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, i64>(3)?,
+                ))
+            })
+            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+        let mut fields = Vec::new();
+        for row in rows {
+            let (name, type_name, notnull) = row.map_err(|e| RdbsError::Schema(e.to_string()))?;
+            fields.push(Field {
+                name,
+                type_name,
+                nullable: notnull == 0,
+            });
+        }
+        containers.push(Container {
+            name: table,
+            kind: ContainerKind::Table,
+            fields,
+        });
+    }
+
+    Ok(Schema {
+        databases: vec![Database {
+            name: db_name.to_string(),
+            containers,
+            functions: Vec::new(),
+        }],
+    })
+}
+
+/// Primary-key columns in key order. Empty => not editable (rowid-only tables
+/// have no PK column in `SELECT *`, so inline edits can't key on them).
+fn primary_key_impl(c: &Connection, table: &str) -> Result<Vec<String>> {
+    let pragma = format!("PRAGMA table_info({})", write_sql::quote_ident(table));
+    let mut stmt = c
+        .prepare(&pragma)
+        .map_err(|e| RdbsError::Schema(e.to_string()))?;
+    // (name, pk-ordinal); pk == 0 means not part of the primary key.
+    let rows = stmt
+        .query_map([], |r| Ok((r.get::<_, String>(1)?, r.get::<_, i64>(5)?)))
+        .map_err(|e| RdbsError::Schema(e.to_string()))?;
+    let mut pk: Vec<(String, i64)> = Vec::new();
+    for row in rows {
+        let (name, ord) = row.map_err(|e| RdbsError::Schema(e.to_string()))?;
+        if ord > 0 {
+            pk.push((name, ord));
+        }
+    }
+    pk.sort_by_key(|(_, ord)| *ord);
+    Ok(pk.into_iter().map(|(name, _)| name).collect())
+}

--- a/crates/driver-sqlite/src/lib.rs
+++ b/crates/driver-sqlite/src/lib.rs
@@ -1,0 +1,10 @@
+//! rdbs-driver-sqlite: a `rdbs_core::driver::Driver` backed by rusqlite.
+//!
+//! SQLite is a single local file, so `ConnConfig.database` carries the file
+//! path (host/port/user are unused). rusqlite is synchronous; every call runs
+//! inside `spawn_blocking` over an `Arc<Mutex<Connection>>`.
+
+mod driver;
+mod write_sql;
+
+pub use driver::SqliteDriver;

--- a/crates/driver-sqlite/src/write_sql.rs
+++ b/crates/driver-sqlite/src/write_sql.rs
@@ -1,0 +1,117 @@
+//! CQL-free SQL text builders for the buffered write path. Same shape as the
+//! Postgres builder, minus schema qualification (SQLite has no schema
+//! namespace) and with SQLite literal spellings (`X'..'` blobs, 0/1 bools).
+
+use rdbs_core::result::Cell;
+use rdbs_core::write::TableRef;
+
+/// `"ident"` with embedded double quotes doubled.
+pub fn quote_ident(ident: &str) -> String {
+    format!("\"{}\"", ident.replace('"', "\"\""))
+}
+
+/// Bare quoted table name — SQLite has no schema namespace.
+pub fn table_name(t: &TableRef) -> String {
+    quote_ident(&t.name)
+}
+
+/// A cell as a safe SQLite literal.
+pub fn literal(c: &Cell) -> String {
+    match c {
+        Cell::Null => "NULL".into(),
+        Cell::Int(i) => i.to_string(),
+        Cell::Float(f) => f.to_string(),
+        // SQLite has no boolean type; it stores 1/0.
+        Cell::Bool(b) => if *b { "1" } else { "0" }.into(),
+        Cell::Text(s) => format!("'{}'", s.replace('\0', "").replace('\'', "''")),
+        Cell::Bytes(b) => {
+            let hex: String = b.iter().map(|x| format!("{x:02x}")).collect();
+            format!("X'{hex}'")
+        }
+    }
+}
+
+/// `WHERE` clause from (column, value) identity pairs; NULL uses `IS NULL`.
+fn where_clause(pk: &[(String, Cell)]) -> String {
+    let parts: Vec<String> = pk
+        .iter()
+        .map(|(col, val)| match val {
+            Cell::Null => format!("{} IS NULL", quote_ident(col)),
+            v => format!("{} = {}", quote_ident(col), literal(v)),
+        })
+        .collect();
+    parts.join(" AND ")
+}
+
+pub fn update_sql(t: &TableRef, pk: &[(String, Cell)], changes: &[(String, Cell)]) -> String {
+    let sets: Vec<String> = changes
+        .iter()
+        .map(|(col, val)| format!("{} = {}", quote_ident(col), literal(val)))
+        .collect();
+    format!(
+        "UPDATE {} SET {} WHERE {}",
+        table_name(t),
+        sets.join(", "),
+        where_clause(pk)
+    )
+}
+
+pub fn insert_sql(t: &TableRef, values: &[(String, Cell)]) -> String {
+    let cols: Vec<String> = values.iter().map(|(c, _)| quote_ident(c)).collect();
+    let vals: Vec<String> = values.iter().map(|(_, v)| literal(v)).collect();
+    format!(
+        "INSERT INTO {} ({}) VALUES ({})",
+        table_name(t),
+        cols.join(", "),
+        vals.join(", ")
+    )
+}
+
+pub fn delete_sql(t: &TableRef, pk: &[(String, Cell)]) -> String {
+    format!("DELETE FROM {} WHERE {}", table_name(t), where_clause(pk))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t() -> TableRef {
+        TableRef::named("users")
+    }
+
+    #[test]
+    fn update_single_pk() {
+        let sql = update_sql(
+            &t(),
+            &[("id".into(), Cell::Int(7))],
+            &[("name".into(), Cell::Text("bob".into()))],
+        );
+        assert_eq!(
+            sql,
+            "UPDATE \"users\" SET \"name\" = 'bob' WHERE \"id\" = 7"
+        );
+    }
+
+    #[test]
+    fn insert_bool_and_blob_use_sqlite_spelling() {
+        let sql = insert_sql(
+            &t(),
+            &[
+                ("ok".into(), Cell::Bool(true)),
+                ("bin".into(), Cell::Bytes(vec![0xde, 0xad])),
+            ],
+        );
+        assert_eq!(
+            sql,
+            "INSERT INTO \"users\" (\"ok\", \"bin\") VALUES (1, X'dead')"
+        );
+    }
+
+    #[test]
+    fn quotes_escaped_and_null_pk_is_null() {
+        let sql = delete_sql(&t(), &[("k".into(), Cell::Null)]);
+        assert_eq!(sql, "DELETE FROM \"users\" WHERE \"k\" IS NULL");
+        let sql = delete_sql(&t(), &[("k".into(), Cell::Text("o'brien".into()))]);
+        assert_eq!(sql, "DELETE FROM \"users\" WHERE \"k\" = 'o''brien'");
+    }
+}

--- a/crates/driver-sqlite/tests/integration.rs
+++ b/crates/driver-sqlite/tests/integration.rs
@@ -1,0 +1,106 @@
+//! SQLite driver end-to-end. No Docker: uses a temp file, so this runs in
+//! normal `cargo test` (unlike the network-engine drivers).
+
+use rdbs_core::conn::{ConnConfig, SslMode};
+use rdbs_core::driver::Driver;
+use rdbs_core::query::Query;
+use rdbs_core::result::{Cell, ResultSet};
+use rdbs_core::write::{TableRef, WriteOp};
+use rdbs_driver_sqlite::SqliteDriver;
+
+fn cfg(path: &str) -> ConnConfig {
+    ConnConfig {
+        host: String::new(),
+        port: 0,
+        user: String::new(),
+        database: Some(path.to_string()),
+        password: None,
+        sslmode: SslMode::Disable,
+    }
+}
+
+fn temp_db() -> String {
+    let mut p = std::env::temp_dir();
+    p.push(format!("rdbs-sqlite-test-{}.db", std::process::id()));
+    let _ = std::fs::remove_file(&p);
+    p.to_string_lossy().into_owned()
+}
+
+#[tokio::test]
+async fn connect_query_schema_count_commit() {
+    let path = temp_db();
+    let driver = SqliteDriver::connect(&cfg(&path)).await.expect("connect");
+    driver.ping().await.expect("ping");
+
+    driver
+        .query(&Query::Sql(
+            "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, ok BOOLEAN)".into(),
+        ))
+        .await
+        .expect("create");
+
+    match driver
+        .query(&Query::Sql(
+            "INSERT INTO users (id, name, ok) VALUES (1, 'ada', 1)".into(),
+        ))
+        .await
+        .expect("insert")
+    {
+        ResultSet::Affected(n) => assert_eq!(n, 1),
+        other => panic!("expected Affected, got {other:?}"),
+    }
+
+    // schema exposes the table + its PK column
+    let schema = driver.schema().await.expect("schema");
+    let db = &schema.databases[0];
+    let users = db
+        .containers
+        .iter()
+        .find(|c| c.name == "users")
+        .expect("users table");
+    assert!(users.fields.iter().any(|f| f.name == "id"));
+    assert_eq!(
+        driver
+            .primary_key(&TableRef::named("users"))
+            .await
+            .expect("pk"),
+        vec!["id".to_string()]
+    );
+
+    // count
+    assert_eq!(driver.count(&TableRef::named("users")).await.unwrap(), 1);
+
+    // buffered write path: update the row, then read it back
+    let applied = driver
+        .commit(&[WriteOp::Update {
+            table: TableRef::named("users"),
+            pk: vec![("id".into(), Cell::Int(1))],
+            changes: vec![("name".into(), Cell::Text("grace".into()))],
+        }])
+        .await
+        .expect("commit");
+    assert_eq!(applied, 1);
+
+    match driver
+        .query(&Query::Sql("SELECT name FROM users WHERE id = 1".into()))
+        .await
+        .unwrap()
+    {
+        ResultSet::Tabular { rows, .. } => assert_eq!(rows[0][0].render(), "grace"),
+        other => panic!("expected Tabular, got {other:?}"),
+    }
+
+    driver.close().await.expect("close");
+    let _ = std::fs::remove_file(&path);
+}
+
+#[tokio::test]
+async fn rejects_non_sql_query() {
+    let driver = SqliteDriver::connect(&cfg(":memory:"))
+        .await
+        .expect("connect");
+    assert!(driver
+        .query(&Query::Command(vec!["GET".into()]))
+        .await
+        .is_err());
+}


### PR DESCRIPTION
## Summary

- Adds a fifth engine — **SQLite** — as a new `rdbs-driver-sqlite` crate.
- SQLite is a local file, so the connection form is engine-aware: it drops the host/port/user/password/SSL grid for a single **File** path field.
- Reuses all existing SQL machinery (tabular results, SQL editor, browsing, inline CRUD) — no core-type changes.

## Changes

- **`crates/driver-sqlite/`** (new): `Driver` impl backed by rusqlite (`bundled` — no system libsqlite, no network). Sync API wrapped in `spawn_blocking` over `Arc<Mutex<Connection>>` (one global conn mutex; a single local file has no concurrency to exploit). Full CRUD via a transactional `commit`; schema from `sqlite_master` + `PRAGMA table_info`; PK from `table_info.pk`.
- **`crates/connstore`**: `Engine::Sqlite` variant + `sqlite`/`file` URL schemes. Path travels in `ConnConfig.database`.
- **`app/src/dispatch.rs`**: `AnyDriver::Sqlite` + all dispatch arms, `label`/`badge`.
- **`app/src/query_parse.rs`**: SQLite → `Query::Sql`, editor hint.
- **`app/src/main.rs`**: `default_port` (0), `label_to_engine`, `browse_text` (LIMIT/OFFSET), `sql_capable`, statement-split.
- **`app/src/ui/conn-form.slint`**: SQLite engine option + conditional File field; hide host/port/user/password for it.
- Workspace member + app dependency.

## Test plan

- [x] `cargo test -p rdbs-driver-sqlite` — connect/query/schema/count/commit against a temp file + `:memory:` (no Docker)
- [x] `cargo build -p rdbs` — all engine match arms exhaustive
- [x] `cargo clippy --all-targets -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p rdbs-connstore -p rdbs --lib` — 30 passed
- [x] `make fe-run`: pick SQLite in the form, select a `.db` file, connect, browse a table, edit a cell + save