### PR TITLE
feat(app): add Cassandra (CQL) driver and wire into UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5537,6 +5537,7 @@ dependencies = [
  "copypasta",
  "rdbs-connstore",
  "rdbs-core",
+ "rdbs-driver-cassandra",
  "rdbs-driver-mongo",
  "rdbs-driver-mysql",
  "rdbs-driver-postgres",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,6 +1422,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3730,6 +3744,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+dependencies = [
+ "twox-hash 2.1.2",
+]
+
+[[package]]
 name = "macro_magic"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4037,7 +4060,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-util",
- "twox-hash",
+ "twox-hash 1.6.3",
  "url",
 ]
 
@@ -5410,6 +5433,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_pcg"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b48ac3f7ffaab7fac4d2376632268aa5f89abdb55f7ebf8f4d11fffccb2320f7"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5540,6 +5572,16 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "rdbs-driver-cassandra"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "rdbs-core",
+ "scylla",
  "tokio",
 ]
 
@@ -6107,6 +6149,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "scylla"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4febc4a3c0b2b6a6ab0b25670a28015a7b87f6998b01ad324be19bb583237ad9"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "dashmap",
+ "futures",
+ "hashbrown 0.15.5",
+ "itertools 0.14.0",
+ "rand 0.9.4",
+ "rand_pcg",
+ "scylla-cql",
+ "scylla-cql-core",
+ "smallvec",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "scylla-cql"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7898c851387b20e0996b33d6d98426c432cc0b45ed9af3cb4bd8b4d540ad7ade"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "chrono",
+ "itertools 0.14.0",
+ "lz4_flex",
+ "scylla-cql-core",
+ "snap",
+ "stable_deref_trait",
+ "thiserror 2.0.18",
+ "tokio",
+ "uuid",
+ "yoke",
+]
+
+[[package]]
+name = "scylla-cql-core"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e609d59933b27489fb329e0e290469f0a027fd75a598f8d219b1479ed6213d0"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "chrono",
+ "itertools 0.14.0",
+ "scylla-macros",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
+name = "scylla-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "275a0290cc00fc50a46b302ad09490ccce2eff1203d648addab1bd8ae833b96e"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6583,6 +6698,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
@@ -7417,6 +7538,12 @@ dependencies = [
  "rand 0.8.6",
  "static_assertions",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typed-builder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/driver-redis",
     "crates/driver-mongo",
     "crates/driver-sqlite",
+    "crates/driver-cassandra",
     "app",
 ]
 

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -16,6 +16,7 @@ rdbs-driver-mysql = { path = "../crates/driver-mysql" }
 rdbs-driver-redis = { path = "../crates/driver-redis" }
 rdbs-driver-mongo = { path = "../crates/driver-mongo" }
 rdbs-driver-sqlite = { path = "../crates/driver-sqlite" }
+rdbs-driver-cassandra = { path = "../crates/driver-cassandra" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "time"] }
 serde_json = "1"
 async-trait = "0.1"

--- a/app/src/dispatch.rs
+++ b/app/src/dispatch.rs
@@ -12,12 +12,12 @@ use rdbs_core::query::Query;
 use rdbs_core::result::ResultSet;
 use rdbs_core::schema::{Container, Schema};
 use rdbs_core::write::{TableRef, WriteOp};
+use rdbs_driver_cassandra::CassandraDriver;
 use rdbs_driver_mongo::MongoDriver;
 use rdbs_driver_mysql::MysqlDriver;
 use rdbs_driver_postgres::PostgresDriver;
 use rdbs_driver_redis::RedisDriver;
 use rdbs_driver_sqlite::SqliteDriver;
-use rdbs_driver_cassandra::CassandraDriver;
 
 pub enum AnyDriver {
     Postgres(PostgresDriver),
@@ -25,7 +25,9 @@ pub enum AnyDriver {
     Redis(RedisDriver),
     Mongo(MongoDriver),
     Sqlite(SqliteDriver),
-    Cassandra(CassandraDriver),
+    // Boxed: a scylla Session is far larger than the other drivers, so keep it
+    // off the enum's inline footprint (clippy::large_enum_variant).
+    Cassandra(Box<CassandraDriver>),
     /// In-process demo driver (RDBS_MOCK=1); no network, seeded data.
     Mock(crate::mock::MockDriver),
 }
@@ -68,7 +70,9 @@ impl AnyDriver {
             Engine::Redis => AnyDriver::Redis(RedisDriver::connect(cfg).await?),
             Engine::Mongo => AnyDriver::Mongo(MongoDriver::connect(cfg).await?),
             Engine::Sqlite => AnyDriver::Sqlite(SqliteDriver::connect(cfg).await?),
-            Engine::Cassandra => AnyDriver::Cassandra(CassandraDriver::connect(cfg).await?),
+            Engine::Cassandra => {
+                AnyDriver::Cassandra(Box::new(CassandraDriver::connect(cfg).await?))
+            }
         })
     }
 

--- a/app/src/dispatch.rs
+++ b/app/src/dispatch.rs
@@ -17,6 +17,7 @@ use rdbs_driver_mysql::MysqlDriver;
 use rdbs_driver_postgres::PostgresDriver;
 use rdbs_driver_redis::RedisDriver;
 use rdbs_driver_sqlite::SqliteDriver;
+use rdbs_driver_cassandra::CassandraDriver;
 
 pub enum AnyDriver {
     Postgres(PostgresDriver),
@@ -24,6 +25,7 @@ pub enum AnyDriver {
     Redis(RedisDriver),
     Mongo(MongoDriver),
     Sqlite(SqliteDriver),
+    Cassandra(CassandraDriver),
     /// In-process demo driver (RDBS_MOCK=1); no network, seeded data.
     Mock(crate::mock::MockDriver),
 }
@@ -37,6 +39,7 @@ impl AnyDriver {
             Engine::Redis => "Redis",
             Engine::Mongo => "MongoDB",
             Engine::Sqlite => "SQLite",
+            Engine::Cassandra => "Cassandra",
         }
     }
 
@@ -48,6 +51,7 @@ impl AnyDriver {
             Engine::Redis => "redis",
             Engine::Mongo => "mongo",
             Engine::Sqlite => "sqlite",
+            Engine::Cassandra => "cassandra",
         }
     }
 
@@ -64,6 +68,7 @@ impl AnyDriver {
             Engine::Redis => AnyDriver::Redis(RedisDriver::connect(cfg).await?),
             Engine::Mongo => AnyDriver::Mongo(MongoDriver::connect(cfg).await?),
             Engine::Sqlite => AnyDriver::Sqlite(SqliteDriver::connect(cfg).await?),
+            Engine::Cassandra => AnyDriver::Cassandra(CassandraDriver::connect(cfg).await?),
         })
     }
 
@@ -76,6 +81,7 @@ impl AnyDriver {
             AnyDriver::Redis(d) => d.ping().await,
             AnyDriver::Mongo(d) => d.ping().await,
             AnyDriver::Sqlite(d) => d.ping().await,
+            AnyDriver::Cassandra(d) => d.ping().await,
             AnyDriver::Mock(d) => d.ping().await,
         }
     }
@@ -87,6 +93,7 @@ impl AnyDriver {
             AnyDriver::Redis(d) => d.schema().await,
             AnyDriver::Mongo(d) => d.schema().await,
             AnyDriver::Sqlite(d) => d.schema().await,
+            AnyDriver::Cassandra(d) => d.schema().await,
             AnyDriver::Mock(d) => d.schema().await,
         }
     }
@@ -98,6 +105,7 @@ impl AnyDriver {
             AnyDriver::Redis(d) => d.containers(database).await,
             AnyDriver::Mongo(d) => d.containers(database).await,
             AnyDriver::Sqlite(d) => d.containers(database).await,
+            AnyDriver::Cassandra(d) => d.containers(database).await,
             AnyDriver::Mock(d) => d.containers(database).await,
         }
     }
@@ -109,6 +117,7 @@ impl AnyDriver {
             AnyDriver::Redis(d) => d.query(q).await,
             AnyDriver::Mongo(d) => d.query(q).await,
             AnyDriver::Sqlite(d) => d.query(q).await,
+            AnyDriver::Cassandra(d) => d.query(q).await,
             AnyDriver::Mock(d) => d.query(q).await,
         }
     }
@@ -120,6 +129,7 @@ impl AnyDriver {
             AnyDriver::Redis(d) => d.primary_key(table).await,
             AnyDriver::Mongo(d) => d.primary_key(table).await,
             AnyDriver::Sqlite(d) => d.primary_key(table).await,
+            AnyDriver::Cassandra(d) => d.primary_key(table).await,
             AnyDriver::Mock(d) => d.primary_key(table).await,
         }
     }
@@ -131,6 +141,7 @@ impl AnyDriver {
             AnyDriver::Redis(d) => d.count(table).await,
             AnyDriver::Mongo(d) => d.count(table).await,
             AnyDriver::Sqlite(d) => d.count(table).await,
+            AnyDriver::Cassandra(d) => d.count(table).await,
             AnyDriver::Mock(d) => d.count(table).await,
         }
     }
@@ -142,6 +153,7 @@ impl AnyDriver {
             AnyDriver::Redis(d) => d.commit(ops).await,
             AnyDriver::Mongo(d) => d.commit(ops).await,
             AnyDriver::Sqlite(d) => d.commit(ops).await,
+            AnyDriver::Cassandra(d) => d.commit(ops).await,
             AnyDriver::Mock(d) => d.commit(ops).await,
         }
     }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -153,6 +153,10 @@ fn schema_display_rows(
         Some(rdbs_connstore::Engine::Redis) => {
             return nested_display_rows(nodes, expanded_tables, loaded_dbs, "key", filter);
         }
+        // Cassandra nests keyspace→table like Mongo nests database→collection.
+        Some(rdbs_connstore::Engine::Cassandra) => {
+            return nested_display_rows(nodes, expanded_tables, loaded_dbs, "table", filter);
+        }
         _ => {}
     }
 
@@ -473,6 +477,19 @@ fn browse_text(
                 "SELECT * FROM \"{}\" LIMIT {limit} OFFSET {offset}",
                 table.name.replace('"', "\"\"")
             )
+        }
+        rdbs_connstore::Engine::Cassandra => {
+            // ponytail: CQL is LIMIT-only (no OFFSET); real paging state is a
+            // follow-up. Keyspace travels in `database`.
+            let q = |s: &str| s.replace('"', "\"\"");
+            match table.database.as_deref() {
+                Some(ks) if !ks.is_empty() => format!(
+                    "SELECT * FROM \"{}\".\"{}\" LIMIT {limit}",
+                    q(ks),
+                    q(&table.name)
+                ),
+                _ => format!("SELECT * FROM \"{}\" LIMIT {limit}", q(&table.name)),
+            }
         }
         rdbs_connstore::Engine::Mongo => {
             let db = table
@@ -2130,6 +2147,7 @@ fn main() -> Result<(), slint::PlatformError> {
                             rdbs_connstore::Engine::Postgres
                                 | rdbs_connstore::Engine::MySql
                                 | rdbs_connstore::Engine::Sqlite
+                                | rdbs_connstore::Engine::Cassandra
                         );
                         *raw_nodes.lock().unwrap() = nodes;
                         {
@@ -2237,6 +2255,7 @@ fn main() -> Result<(), slint::PlatformError> {
                             rdbs_connstore::Engine::Postgres
                                 | rdbs_connstore::Engine::MySql
                                 | rdbs_connstore::Engine::Sqlite
+                                | rdbs_connstore::Engine::Cassandra
                         ) {
                             editor::split_statements(&sql)
                         } else {
@@ -2811,16 +2830,19 @@ fn main() -> Result<(), slint::PlatformError> {
             let engine = *cur_engine.borrow();
             let label = label.to_string();
 
-            // Mongo/Redis: database headers open an opt-in set (default closed)
-            // and load their leaves (collections / keys) lazily on first expand.
+            // Mongo/Redis/Cassandra: database (or keyspace) headers open an
+            // opt-in set (default closed) and load their leaves (collections /
+            // keys / tables) lazily on first expand.
             if matches!(
                 engine,
-                Some(rdbs_connstore::Engine::Mongo) | Some(rdbs_connstore::Engine::Redis)
+                Some(rdbs_connstore::Engine::Mongo)
+                    | Some(rdbs_connstore::Engine::Redis)
+                    | Some(rdbs_connstore::Engine::Cassandra)
             ) {
-                let leaf_kind = if engine == Some(rdbs_connstore::Engine::Redis) {
-                    "key"
-                } else {
-                    "collection"
+                let leaf_kind = match engine {
+                    Some(rdbs_connstore::Engine::Redis) => "key",
+                    Some(rdbs_connstore::Engine::Cassandra) => "table",
+                    _ => "collection",
                 };
                 let now_open = {
                     let mut e = expanded_tables.lock().unwrap();
@@ -3474,6 +3496,7 @@ fn main() -> Result<(), slint::PlatformError> {
             "Redis" => "6379",
             "MongoDB" => "27017",
             "SQLite" => "0", // file-based: port unused
+            "Cassandra" => "9042",
             _ => "5432",
         }
     }
@@ -3483,6 +3506,7 @@ fn main() -> Result<(), slint::PlatformError> {
             "Redis" => rdbs_connstore::Engine::Redis,
             "MongoDB" => rdbs_connstore::Engine::Mongo,
             "SQLite" => rdbs_connstore::Engine::Sqlite,
+            "Cassandra" => rdbs_connstore::Engine::Cassandra,
             _ => rdbs_connstore::Engine::Postgres,
         }
     }

--- a/app/src/query_parse.rs
+++ b/app/src/query_parse.rs
@@ -10,7 +10,9 @@ use rdbs_core::query::{MongoKind, MongoOp, Query};
 /// result-status line; no driver call is made).
 pub fn parse_query(engine: Engine, text: &str) -> Result<Query, String> {
     match engine {
-        Engine::Postgres | Engine::MySql | Engine::Sqlite => Ok(Query::Sql(text.to_string())),
+        Engine::Postgres | Engine::MySql | Engine::Sqlite | Engine::Cassandra => {
+            Ok(Query::Sql(text.to_string()))
+        }
         Engine::Redis => {
             let tokens: Vec<String> = text.split_whitespace().map(|s| s.to_string()).collect();
             if tokens.is_empty() {
@@ -26,6 +28,7 @@ pub fn parse_query(engine: Engine, text: &str) -> Result<Query, String> {
 pub fn editor_hint(engine: Engine) -> &'static str {
     match engine {
         Engine::Postgres | Engine::MySql | Engine::Sqlite => "SQL — e.g. SELECT * FROM table",
+        Engine::Cassandra => "CQL — e.g. SELECT * FROM keyspace.table",
         Engine::Redis => "Redis command — e.g. SET key value",
         Engine::Mongo => r#"Mongo JSON — {"collection":"c","op":"find","body":{}}"#,
     }

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -3,7 +3,7 @@ import { Tokens } from "tokens.slint";
 
 // Engine badge: rounded square with 2-letter code, engine color fill.
 export component DbBadge inherits Rectangle {
-    in property <string> engine; // "postgres" | "mysql" | "redis" | "sqlite" | "mongo"
+    in property <string> engine; // "postgres" | "mysql" | "redis" | "sqlite" | "mongo" | "cassandra"
     in property <length> size: 24px;
     width: self.size;
     height: self.size;
@@ -13,6 +13,7 @@ export component DbBadge inherits Rectangle {
         : engine == "redis" ? Tokens.db-re
         : engine == "sqlite" ? Tokens.db-sl
         : engine == "mongo" ? Tokens.db-mo
+        : engine == "cassandra" ? Tokens.db-ca
         : Tokens.text-faint;
     Text {
         text: engine == "postgres" ? "Pg"
@@ -20,6 +21,7 @@ export component DbBadge inherits Rectangle {
             : engine == "redis" ? "Re"
             : engine == "sqlite" ? "Sl"
             : engine == "mongo" ? "Mo"
+            : engine == "cassandra" ? "Ca"
             : "?";
         color: white;
         font-size: root.size * 0.42;

--- a/app/src/ui/conn-form.slint
+++ b/app/src/ui/conn-form.slint
@@ -87,7 +87,7 @@ export component ConnForm inherits Rectangle {
 
             Text { text: "Engine"; color: Tokens.text-dim; font-size: Tokens.font-sm; }
             ComboBox {
-                model: ["PostgreSQL", "MySQL", "Redis", "MongoDB", "SQLite"];
+                model: ["PostgreSQL", "MySQL", "Redis", "MongoDB", "SQLite", "Cassandra"];
                 current-value <=> root.f-engine;
                 selected(v) => { root.engine-changed(v); }
             }

--- a/app/src/ui/palette.slint
+++ b/app/src/ui/palette.slint
@@ -130,7 +130,7 @@ export component ListModal inherits Rectangle {
                                         font-size: 10px;
                                         font-family: Tokens.mono;
                                     }
-                                    if it.kind == "postgres" || it.kind == "mysql" || it.kind == "redis" || it.kind == "mongo" || it.kind == "sqlite": DbBadge {
+                                    if it.kind == "postgres" || it.kind == "mysql" || it.kind == "redis" || it.kind == "mongo" || it.kind == "sqlite" || it.kind == "cassandra": DbBadge {
                                         engine: it.kind;
                                         size: 24px;
                                     }

--- a/app/src/ui/tokens.slint
+++ b/app/src/ui/tokens.slint
@@ -44,6 +44,7 @@ export global Tokens {
     out property <color> db-re: #B93C2E;
     out property <color> db-sl: #8E44AD;
     out property <color> db-mo: #58B98A;
+    out property <color> db-ca: #1287A8;
 
     // ----- special cell colors -----
     out property <color> fk-text: dark ? #7FA0DE : #4A6BB0;   // foreign-key cells, with ↗

--- a/crates/connstore/src/conn_url.rs
+++ b/crates/connstore/src/conn_url.rs
@@ -50,6 +50,7 @@ fn scheme_to_engine(scheme: &str) -> Option<Engine> {
         "redis" | "rediss" => Some(Engine::Redis),
         "mongodb" | "mongodb+srv" => Some(Engine::Mongo),
         "sqlite" | "file" => Some(Engine::Sqlite),
+        "cassandra" | "cql" | "scylla" => Some(Engine::Cassandra),
         _ => None,
     }
 }

--- a/crates/connstore/src/model.rs
+++ b/crates/connstore/src/model.rs
@@ -11,6 +11,8 @@ pub enum Engine {
     Mongo,
     /// Local file-based engine: no host/port/user; `database` holds the path.
     Sqlite,
+    /// CQL engine (Cassandra / ScyllaDB); `database` holds the default keyspace.
+    Cassandra,
 }
 
 /// A persisted connection. Only non-secret fields are stored. The password is

--- a/crates/driver-cassandra/Cargo.toml
+++ b/crates/driver-cassandra/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rdbs-driver-cassandra"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rdbs-core = { path = "../core" }
+async-trait = "0.1"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+scylla = "1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full", "macros", "rt-multi-thread"] }

--- a/crates/driver-cassandra/src/driver.rs
+++ b/crates/driver-cassandra/src/driver.rs
@@ -1,0 +1,263 @@
+use async_trait::async_trait;
+use scylla::client::session::Session;
+use scylla::client::session_builder::SessionBuilder;
+use scylla::value::Row;
+
+use rdbs_core::conn::ConnConfig;
+use rdbs_core::driver::Driver;
+use rdbs_core::error::{RdbsError, Result};
+use rdbs_core::query::Query;
+use rdbs_core::result::{Column, ResultSet};
+use rdbs_core::schema::{Container, ContainerKind, Database, Field, Schema};
+use rdbs_core::write::{TableRef, WriteOp};
+
+use crate::type_map;
+use crate::write_cql;
+
+/// System keyspaces hidden from the schema tree.
+const SYSTEM_KEYSPACES: &[&str] = &[
+    "system",
+    "system_schema",
+    "system_auth",
+    "system_distributed",
+    "system_traces",
+    "system_distributed_everywhere",
+    "system_views",
+    "system_virtual_schema",
+];
+
+/// A `Driver` backed by a scylla `Session` (works against Cassandra + Scylla).
+pub struct CassandraDriver {
+    session: Session,
+}
+
+#[async_trait]
+impl Driver for CassandraDriver {
+    async fn connect(cfg: &ConnConfig) -> Result<Self> {
+        let node = format!("{}:{}", cfg.host, cfg.port);
+        let mut builder = SessionBuilder::new().known_node(node);
+        if !cfg.user.is_empty() {
+            builder = builder.user(cfg.user.clone(), cfg.password.clone().unwrap_or_default());
+        }
+        if let Some(ks) = cfg.database.as_deref().filter(|s| !s.is_empty()) {
+            builder = builder.use_keyspace(ks.to_string(), false);
+        }
+        let session = builder
+            .build()
+            .await
+            .map_err(|e| RdbsError::Connection(e.to_string()))?;
+        Ok(CassandraDriver { session })
+    }
+
+    async fn ping(&self) -> Result<()> {
+        self.session
+            .query_unpaged("SELECT now() FROM system.local", ())
+            .await
+            .map_err(|e| RdbsError::Connection(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn schema(&self) -> Result<Schema> {
+        // Lazy: list keyspaces only; tables/columns load per keyspace in
+        // `containers()` when the sidebar expands it (mirrors Mongo).
+        let res = self
+            .session
+            .query_unpaged("SELECT keyspace_name FROM system_schema.keyspaces", ())
+            .await
+            .map_err(|e| RdbsError::Schema(e.to_string()))?
+            .into_rows_result()
+            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+        let mut databases = Vec::new();
+        for row in res
+            .rows::<(String,)>()
+            .map_err(|e| RdbsError::Schema(e.to_string()))?
+        {
+            let (name,) = row.map_err(|e| RdbsError::Schema(e.to_string()))?;
+            if SYSTEM_KEYSPACES.contains(&name.as_str()) {
+                continue;
+            }
+            databases.push(Database {
+                name,
+                containers: Vec::new(),
+                functions: Vec::new(),
+            });
+        }
+        Ok(Schema { databases })
+    }
+
+    async fn containers(&self, database: &str) -> Result<Vec<Container>> {
+        // Tables of one keyspace, with their columns.
+        let tables_res = self
+            .session
+            .query_unpaged(
+                "SELECT table_name FROM system_schema.tables WHERE keyspace_name = ?",
+                (database,),
+            )
+            .await
+            .map_err(|e| RdbsError::Schema(e.to_string()))?
+            .into_rows_result()
+            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+
+        let mut containers = Vec::new();
+        for row in tables_res
+            .rows::<(String,)>()
+            .map_err(|e| RdbsError::Schema(e.to_string()))?
+        {
+            let (table,) = row.map_err(|e| RdbsError::Schema(e.to_string()))?;
+            let fields = self.columns_of(database, &table).await?;
+            containers.push(Container {
+                name: table,
+                kind: ContainerKind::Table,
+                fields,
+            });
+        }
+        Ok(containers)
+    }
+
+    async fn query(&self, q: &Query) -> Result<ResultSet> {
+        let cql = match q {
+            Query::Sql(s) => s,
+            Query::Command(_) | Query::Mongo(_) => return Err(RdbsError::UnsupportedQuery),
+        };
+        let res = self
+            .session
+            .query_unpaged(cql.as_str(), ())
+            .await
+            .map_err(|e| RdbsError::Query(e.to_string()))?;
+        if !res.is_rows() {
+            // ponytail: CQL DML returns no affected-row count.
+            return Ok(ResultSet::Affected(0));
+        }
+        let rows_res = res
+            .into_rows_result()
+            .map_err(|e| RdbsError::Query(e.to_string()))?;
+        let cols: Vec<Column> = rows_res
+            .column_specs()
+            .iter()
+            .map(|c| Column {
+                name: c.name().to_string(),
+                type_name: String::new(),
+            })
+            .collect();
+        let mut out = Vec::new();
+        for row in rows_res
+            .rows::<Row>()
+            .map_err(|e| RdbsError::Query(e.to_string()))?
+        {
+            let row = row.map_err(|e| RdbsError::Query(e.to_string()))?;
+            out.push(row.columns.iter().map(type_map::cell).collect());
+        }
+        Ok(ResultSet::Tabular { cols, rows: out })
+    }
+
+    async fn primary_key(&self, table: &TableRef) -> Result<Vec<String>> {
+        let keyspace = table.database.as_deref().unwrap_or_default();
+        let res = self
+            .session
+            .query_unpaged(
+                "SELECT column_name, kind, position FROM system_schema.columns \
+                 WHERE keyspace_name = ? AND table_name = ?",
+                (keyspace, table.name.as_str()),
+            )
+            .await
+            .map_err(|e| RdbsError::Schema(e.to_string()))?
+            .into_rows_result()
+            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+        // Partition keys first (by position), then clustering keys (by position).
+        let mut partition: Vec<(i32, String)> = Vec::new();
+        let mut clustering: Vec<(i32, String)> = Vec::new();
+        for row in res
+            .rows::<(String, String, i32)>()
+            .map_err(|e| RdbsError::Schema(e.to_string()))?
+        {
+            let (name, kind, position) = row.map_err(|e| RdbsError::Schema(e.to_string()))?;
+            match kind.as_str() {
+                "partition_key" => partition.push((position, name)),
+                "clustering" => clustering.push((position, name)),
+                _ => {}
+            }
+        }
+        partition.sort_by_key(|(p, _)| *p);
+        clustering.sort_by_key(|(p, _)| *p);
+        Ok(partition
+            .into_iter()
+            .chain(clustering)
+            .map(|(_, name)| name)
+            .collect())
+    }
+
+    async fn count(&self, table: &TableRef) -> Result<u64> {
+        let cql = format!("SELECT count(*) FROM {}", write_cql::table_name(table));
+        let res = self
+            .session
+            .query_unpaged(cql, ())
+            .await
+            .map_err(|e| RdbsError::Query(e.to_string()))?
+            .into_rows_result()
+            .map_err(|e| RdbsError::Query(e.to_string()))?;
+        let (n,): (i64,) = res
+            .first_row()
+            .map_err(|e| RdbsError::Query(e.to_string()))?;
+        Ok(n as u64)
+    }
+
+    async fn commit(&self, ops: &[WriteOp]) -> Result<u64> {
+        // No CQL transaction: apply sequentially, stop at the first failure
+        // (mirrors the Mongo driver's contract).
+        let mut applied = 0u64;
+        for op in ops {
+            let cql = match op {
+                WriteOp::Update { table, pk, changes } => write_cql::update_sql(table, pk, changes),
+                WriteOp::Insert { table, values } => write_cql::insert_sql(table, values),
+                WriteOp::Delete { table, pk } => write_cql::delete_sql(table, pk),
+            };
+            match self.session.query_unpaged(cql, ()).await {
+                Ok(_) => applied += 1,
+                Err(e) => {
+                    return Err(RdbsError::Query(format!(
+                        "{e} (applied {applied} of {} ops)",
+                        ops.len()
+                    )))
+                }
+            }
+        }
+        Ok(applied)
+    }
+
+    async fn close(self) -> Result<()> {
+        // Dropping the session closes its connection pool.
+        Ok(())
+    }
+}
+
+impl CassandraDriver {
+    /// Column definitions of one table.
+    async fn columns_of(&self, keyspace: &str, table: &str) -> Result<Vec<Field>> {
+        let res = self
+            .session
+            .query_unpaged(
+                "SELECT column_name, type FROM system_schema.columns \
+                 WHERE keyspace_name = ? AND table_name = ?",
+                (keyspace, table),
+            )
+            .await
+            .map_err(|e| RdbsError::Schema(e.to_string()))?
+            .into_rows_result()
+            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+        let mut fields = Vec::new();
+        for row in res
+            .rows::<(String, String)>()
+            .map_err(|e| RdbsError::Schema(e.to_string()))?
+        {
+            let (name, type_name) = row.map_err(|e| RdbsError::Schema(e.to_string()))?;
+            // CQL columns are nullable except primary-key parts; the schema
+            // table doesn't flag that cheaply, so report nullable.
+            fields.push(Field {
+                name,
+                type_name,
+                nullable: true,
+            });
+        }
+        Ok(fields)
+    }
+}

--- a/crates/driver-cassandra/src/lib.rs
+++ b/crates/driver-cassandra/src/lib.rs
@@ -1,0 +1,12 @@
+//! rdbs-driver-cassandra: a `rdbs_core::driver::Driver` backed by scylla.
+//!
+//! Cassandra speaks CQL: results are tabular, but the namespace is
+//! keyspace→table (a keyspace maps to a `Database`, its tables to `Container`s).
+//! Schema is loaded lazily like Mongo — `schema()` lists keyspaces, and
+//! `containers()` fills a keyspace's tables when the sidebar expands it.
+
+mod driver;
+mod type_map;
+mod write_cql;
+
+pub use driver::CassandraDriver;

--- a/crates/driver-cassandra/src/type_map.rs
+++ b/crates/driver-cassandra/src/type_map.rs
@@ -1,0 +1,54 @@
+//! CQL value → unified `Cell`. Pragmatic, not exhaustive: collections, UDTs
+//! and the temporal/decimal types fall back to their debug string, which is
+//! always safe to display in the grid.
+
+use rdbs_core::result::Cell;
+use scylla::value::CqlValue;
+
+/// One column of a row (`None` = NULL) into a `Cell`.
+pub fn cell(value: &Option<CqlValue>) -> Cell {
+    match value {
+        None => Cell::Null,
+        Some(v) => cql_to_cell(v),
+    }
+}
+
+fn cql_to_cell(v: &CqlValue) -> Cell {
+    match v {
+        CqlValue::Boolean(b) => Cell::Bool(*b),
+        CqlValue::Int(i) => Cell::Int(*i as i64),
+        CqlValue::BigInt(i) => Cell::Int(*i),
+        CqlValue::SmallInt(i) => Cell::Int(*i as i64),
+        CqlValue::TinyInt(i) => Cell::Int(*i as i64),
+        CqlValue::Counter(c) => Cell::Int(c.0),
+        CqlValue::Float(f) => Cell::Float(*f as f64),
+        CqlValue::Double(f) => Cell::Float(*f),
+        CqlValue::Text(s) | CqlValue::Ascii(s) => Cell::Text(s.clone()),
+        CqlValue::Blob(b) => Cell::Bytes(b.clone()),
+        CqlValue::Uuid(u) => Cell::Text(u.to_string()),
+        CqlValue::Timeuuid(u) => Cell::Text(u.to_string()),
+        CqlValue::Inet(a) => Cell::Text(a.to_string()),
+        CqlValue::Empty => Cell::Null,
+        other => Cell::Text(format!("{other:?}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn null_and_scalars_map() {
+        assert!(matches!(cell(&None), Cell::Null));
+        assert!(matches!(cell(&Some(CqlValue::Int(7))), Cell::Int(7)));
+        assert!(matches!(cell(&Some(CqlValue::BigInt(9))), Cell::Int(9)));
+        assert!(matches!(
+            cell(&Some(CqlValue::Boolean(true))),
+            Cell::Bool(true)
+        ));
+        match cell(&Some(CqlValue::Text("hi".into()))) {
+            Cell::Text(s) => assert_eq!(s, "hi"),
+            _ => panic!("wrong"),
+        }
+    }
+}

--- a/crates/driver-cassandra/src/write_cql.rs
+++ b/crates/driver-cassandra/src/write_cql.rs
@@ -1,0 +1,113 @@
+//! CQL text builders for the buffered write path. Like the SQL builders but
+//! keyspace-qualified (`"ks"."tbl"`) and with CQL literal spellings
+//! (`0x..` blobs, lowercase `null`). No `IS NULL` — a CQL primary key is never
+//! null, so identity comparisons are always `=`.
+
+use rdbs_core::result::Cell;
+use rdbs_core::write::TableRef;
+
+/// `"ident"` with embedded double quotes doubled.
+pub fn quote_ident(ident: &str) -> String {
+    format!("\"{}\"", ident.replace('"', "\"\""))
+}
+
+/// Keyspace-qualified table name; `database` carries the keyspace.
+pub fn table_name(t: &TableRef) -> String {
+    match &t.database {
+        Some(ks) if !ks.is_empty() => {
+            format!("{}.{}", quote_ident(ks), quote_ident(&t.name))
+        }
+        _ => quote_ident(&t.name),
+    }
+}
+
+/// A cell as a CQL literal.
+pub fn literal(c: &Cell) -> String {
+    match c {
+        Cell::Null => "null".into(),
+        Cell::Int(i) => i.to_string(),
+        Cell::Float(f) => f.to_string(),
+        Cell::Bool(b) => b.to_string(),
+        Cell::Text(s) => format!("'{}'", s.replace('\'', "''")),
+        Cell::Bytes(b) => {
+            let hex: String = b.iter().map(|x| format!("{x:02x}")).collect();
+            format!("0x{hex}")
+        }
+    }
+}
+
+fn where_clause(pk: &[(String, Cell)]) -> String {
+    pk.iter()
+        .map(|(col, val)| format!("{} = {}", quote_ident(col), literal(val)))
+        .collect::<Vec<_>>()
+        .join(" AND ")
+}
+
+pub fn update_sql(t: &TableRef, pk: &[(String, Cell)], changes: &[(String, Cell)]) -> String {
+    let sets: Vec<String> = changes
+        .iter()
+        .map(|(col, val)| format!("{} = {}", quote_ident(col), literal(val)))
+        .collect();
+    format!(
+        "UPDATE {} SET {} WHERE {}",
+        table_name(t),
+        sets.join(", "),
+        where_clause(pk)
+    )
+}
+
+pub fn insert_sql(t: &TableRef, values: &[(String, Cell)]) -> String {
+    let cols: Vec<String> = values.iter().map(|(c, _)| quote_ident(c)).collect();
+    let vals: Vec<String> = values.iter().map(|(_, v)| literal(v)).collect();
+    format!(
+        "INSERT INTO {} ({}) VALUES ({})",
+        table_name(t),
+        cols.join(", "),
+        vals.join(", ")
+    )
+}
+
+pub fn delete_sql(t: &TableRef, pk: &[(String, Cell)]) -> String {
+    format!("DELETE FROM {} WHERE {}", table_name(t), where_clause(pk))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t() -> TableRef {
+        TableRef {
+            database: Some("app".into()),
+            schema: None,
+            name: "users".into(),
+        }
+    }
+
+    #[test]
+    fn update_is_keyspace_qualified() {
+        let sql = update_sql(
+            &t(),
+            &[("id".into(), Cell::Int(7))],
+            &[("name".into(), Cell::Text("bob".into()))],
+        );
+        assert_eq!(
+            sql,
+            "UPDATE \"app\".\"users\" SET \"name\" = 'bob' WHERE \"id\" = 7"
+        );
+    }
+
+    #[test]
+    fn blob_and_quote_escaping() {
+        let sql = insert_sql(
+            &t(),
+            &[
+                ("k".into(), Cell::Text("o'brien".into())),
+                ("bin".into(), Cell::Bytes(vec![0xde, 0xad])),
+            ],
+        );
+        assert_eq!(
+            sql,
+            "INSERT INTO \"app\".\"users\" (\"k\", \"bin\") VALUES ('o''brien', 0xdead)"
+        );
+    }
+}

--- a/crates/driver-cassandra/tests/integration.rs
+++ b/crates/driver-cassandra/tests/integration.rs
@@ -1,0 +1,104 @@
+//! Cassandra driver end-to-end. Needs a running cluster (like the Mongo
+//! driver's tests), so it is `#[ignore]` by default. Run with:
+//!
+//!   docker run --rm -d -p 9042:9042 cassandra:5
+//!   cargo test -p rdbs-driver-cassandra -- --ignored
+
+use rdbs_core::conn::{ConnConfig, SslMode};
+use rdbs_core::driver::Driver;
+use rdbs_core::query::Query;
+use rdbs_core::result::{Cell, ResultSet};
+use rdbs_core::write::{TableRef, WriteOp};
+use rdbs_driver_cassandra::CassandraDriver;
+
+fn cfg() -> ConnConfig {
+    ConnConfig {
+        host: "127.0.0.1".into(),
+        port: 9042,
+        user: String::new(),
+        database: None,
+        password: None,
+        sslmode: SslMode::Disable,
+    }
+}
+
+fn table() -> TableRef {
+    TableRef {
+        database: Some("rdbs_it".into()),
+        schema: None,
+        name: "users".into(),
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a running Cassandra on 127.0.0.1:9042"]
+async fn connect_schema_query_count_commit() {
+    let driver = CassandraDriver::connect(&cfg()).await.expect("connect");
+    driver.ping().await.expect("ping");
+
+    driver
+        .query(&Query::Sql(
+            "CREATE KEYSPACE IF NOT EXISTS rdbs_it WITH replication = \
+             {'class':'SimpleStrategy','replication_factor':1}"
+                .into(),
+        ))
+        .await
+        .expect("create keyspace");
+    driver
+        .query(&Query::Sql(
+            "CREATE TABLE IF NOT EXISTS rdbs_it.users (id int PRIMARY KEY, name text)".into(),
+        ))
+        .await
+        .expect("create table");
+    driver
+        .query(&Query::Sql(
+            "INSERT INTO rdbs_it.users (id, name) VALUES (1, 'ada')".into(),
+        ))
+        .await
+        .expect("insert");
+
+    // keyspace shows up + its table lists via lazy containers()
+    assert!(driver
+        .schema()
+        .await
+        .unwrap()
+        .databases
+        .iter()
+        .any(|d| d.name == "rdbs_it"));
+    assert!(driver
+        .containers("rdbs_it")
+        .await
+        .unwrap()
+        .iter()
+        .any(|c| c.name == "users"));
+
+    assert_eq!(driver.primary_key(&table()).await.unwrap(), vec!["id"]);
+    assert_eq!(driver.count(&table()).await.unwrap(), 1);
+
+    // buffered write path
+    driver
+        .commit(&[WriteOp::Update {
+            table: table(),
+            pk: vec![("id".into(), Cell::Int(1))],
+            changes: vec![("name".into(), Cell::Text("grace".into()))],
+        }])
+        .await
+        .expect("commit");
+
+    match driver
+        .query(&Query::Sql(
+            "SELECT name FROM rdbs_it.users WHERE id = 1".into(),
+        ))
+        .await
+        .unwrap()
+    {
+        ResultSet::Tabular { rows, .. } => assert_eq!(rows[0][0].render(), "grace"),
+        other => panic!("expected Tabular, got {other:?}"),
+    }
+
+    driver
+        .query(&Query::Sql("DROP KEYSPACE rdbs_it".into()))
+        .await
+        .expect("drop keyspace");
+    driver.close().await.expect("close");
+}


### PR DESCRIPTION
## Summary

- Adds a sixth engine — **Cassandra / ScyllaDB** — as a new `rdbs-driver-cassandra` crate backed by the `scylla` session.
- CQL results are tabular, but the namespace is keyspace→table: keyspaces render as nested sidebar groups (like Mongo databases nest collections) and load their tables lazily.
- Full inline CRUD, keyed on the partition + clustering primary key.

## Changes

- **`crates/driver-cassandra/`** (new): `Driver` impl over `scylla::Session`. Schema is lazy — `schema()` lists keyspaces (system keyspaces filtered), `containers(keyspace)` fills tables + columns from `system_schema`. `query()` maps CQL rows → `ResultSet::Tabular` via a `CqlValue → Cell` type map; non-row statements return `Affected(0)` (CQL has no rowcount). `commit()` builds keyspace-qualified CQL keyed on the full primary key, applied sequentially (CQL has no transaction).
- **`crates/connstore`**: `Engine::Cassandra` + `cassandra`/`cql`/`scylla` URL schemes. `database` holds the default keyspace.
- **`app/src/dispatch.rs`**: `AnyDriver::Cassandra` (boxed — a scylla Session dwarfs the other drivers) + all dispatch arms, `label`/`badge`.
- **`app/src/query_parse.rs`**: Cassandra → `Query::Sql` (CQL text) + CQL editor hint.
- **`app/src/main.rs`**: `default_port` (9042), `label_to_engine`, `browse_text` (LIMIT-only, keyspace-qualified), `sql_capable` + statement splitting, and the keyspace-nested schema tree (render + lazy expand).
- **UI**: `Cassandra` engine option in the form; `Ca` badge + `db-ca` color (tokens, `DbBadge`, palette).

## Notes

- Cassandra paging is LIMIT-only for now; token/paging-state paging is a follow-up.
- The integration test needs a running Cassandra, so it is `#[ignore]` (same as the Mongo driver).

## Test plan

- [x] `cargo test -p rdbs-driver-cassandra` — unit tests (type map + CQL builders); integration `#[ignore]`
- [x] `cargo clippy -p rdbs -p rdbs-driver-cassandra --all-targets -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p rdbs-connstore -p rdbs --lib` — 30 passed
- [x] `cargo test -p rdbs-driver-cassandra -- --ignored` against `docker run -p 9042:9042 cassandra:5`
- [x] `make fe-run`: add a Cassandra connection, connect, sidebar nests keyspace→table, browse a table, edit a row keyed on its primary key