### PR TITLE
fix(app): connection-form + editor UX (dropdowns, connect feedback, motions, icons)

### DIFF
--- a/app/src/editor.rs
+++ b/app/src/editor.rs
@@ -552,6 +552,59 @@ impl EditorState {
         self.col = self.lines[self.line].chars().count();
     }
 
+    /// Word-wise horizontal motion (macOS Option+Arrow). `dir < 0` jumps to the
+    /// start of the word on the left, `dir > 0` to the end of the word on the
+    /// right, crossing a line boundary when already at the edge. Selection is
+    /// anchored/dropped by the caller via `set_selecting`.
+    pub fn move_word(&mut self, dir: i32) {
+        let chars: Vec<char> = self.lines[self.line].chars().collect();
+        if dir < 0 {
+            if self.col == 0 {
+                if self.line > 0 {
+                    self.line -= 1;
+                    self.col = self.lines[self.line].chars().count();
+                }
+                return;
+            }
+            let mut i = self.col;
+            while i > 0 && !is_ident(chars[i - 1]) {
+                i -= 1;
+            }
+            while i > 0 && is_ident(chars[i - 1]) {
+                i -= 1;
+            }
+            self.col = i;
+        } else {
+            let n = chars.len();
+            if self.col >= n {
+                if self.line + 1 < self.lines.len() {
+                    self.line += 1;
+                    self.col = 0;
+                }
+                return;
+            }
+            let mut i = self.col;
+            while i < n && !is_ident(chars[i]) {
+                i += 1;
+            }
+            while i < n && is_ident(chars[i]) {
+                i += 1;
+            }
+            self.col = i;
+        }
+    }
+
+    /// Cursor to the very start / end of the buffer (macOS Cmd+Up / Cmd+Down).
+    pub fn move_doc_start(&mut self) {
+        self.line = 0;
+        self.col = 0;
+    }
+
+    pub fn move_doc_end(&mut self) {
+        self.line = self.lines.len() - 1;
+        self.col = self.lines[self.line].chars().count();
+    }
+
     /// Current line text — the "Run Selection" fallback unit.
     pub fn current_line(&self) -> &str {
         &self.lines[self.line]
@@ -990,5 +1043,39 @@ mod tests {
         let (l, s, e) = m[0];
         ed.set_selection((l, s), (l, e));
         assert_eq!(ed.selected_text().as_deref(), Some("FROM"));
+    }
+
+    #[test]
+    fn word_motion_jumps_over_whole_words() {
+        let mut ed = EditorState::from_text("SELECT id FROM t");
+        ed.move_doc_start();
+        assert_eq!((ed.line, ed.col), (0, 0));
+        ed.move_word(1); // over "SELECT"
+        assert_eq!(ed.col, 6);
+        ed.move_word(1); // skip space, over "id"
+        assert_eq!(ed.col, 9);
+        ed.move_word(-1); // back to start of "id"
+        assert_eq!(ed.col, 7);
+    }
+
+    #[test]
+    fn word_motion_and_doc_end_cross_lines() {
+        let mut ed = EditorState::from_text("ab\ncd");
+        ed.move_doc_start();
+        ed.move_word(1); // to end of "ab"
+        assert_eq!((ed.line, ed.col), (0, 2));
+        ed.move_word(1); // at line end -> jump to next line start
+        assert_eq!((ed.line, ed.col), (1, 0));
+        ed.move_doc_end();
+        assert_eq!((ed.line, ed.col), (1, 2));
+    }
+
+    #[test]
+    fn shift_word_motion_builds_a_selection() {
+        let mut ed = EditorState::from_text("hello world");
+        ed.move_doc_start();
+        ed.set_selecting(true);
+        ed.move_word(1);
+        assert_eq!(ed.selected_text().as_deref(), Some("hello"));
     }
 }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2079,6 +2079,9 @@ fn main() -> Result<(), slint::PlatformError> {
             // Reflect selection + accent immediately.
             if let Some(w) = weak.upgrade() {
                 w.set_selected_conn(idx);
+                // Show progress + clear any prior failure immediately.
+                w.set_connecting(true);
+                w.set_picker_error(SharedString::default());
                 w.global::<Theme>()
                     .set_accent(theme::accent_or_default(sc.color.as_deref().unwrap_or("")));
                 w.set_status_conn(SharedString::from(sc.name.clone()));
@@ -2230,6 +2233,7 @@ fn main() -> Result<(), slint::PlatformError> {
                                 ))));
                                 w.set_status_latency(SharedString::from("connected"));
                                 w.set_picker_error(SharedString::default());
+                                w.set_connecting(false);
                                 // Swap the picker for the workspace.
                                 w.set_connected(true);
                             }
@@ -2241,6 +2245,7 @@ fn main() -> Result<(), slint::PlatformError> {
                             if let Some(w) = weak2.upgrade() {
                                 // Stay on the picker; surface the failure there.
                                 w.set_connected(false);
+                                w.set_connecting(false);
                                 w.set_picker_error(SharedString::from(format!(
                                     "connection failed: {e}"
                                 )));

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -924,8 +924,58 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let ed_state = ed_state.clone();
         let sync_editor = sync_editor.clone();
-        window.on_editor_key(move |text, cmd, shift| {
-            if cmd {
+        window.on_editor_key(move |text, meta, alt, shift| {
+            // Cursor motion first: arrows / home / end, with macOS ⌘ (line &
+            // document) and ⌥ (word) semantics. shift extends the selection.
+            if matches!(
+                text.as_str(),
+                "\u{f700}" | "\u{f701}" | "\u{f702}" | "\u{f703}" | "\u{f729}" | "\u{f72b}"
+            ) {
+                {
+                    let mut ed = ed_state.borrow_mut();
+                    ed.set_selecting(shift);
+                    match text.as_str() {
+                        "\u{f702}" => {
+                            if alt {
+                                ed.move_word(-1)
+                            } else if meta {
+                                ed.home()
+                            } else {
+                                ed.move_cursor(0, -1)
+                            }
+                        }
+                        "\u{f703}" => {
+                            if alt {
+                                ed.move_word(1)
+                            } else if meta {
+                                ed.end()
+                            } else {
+                                ed.move_cursor(0, 1)
+                            }
+                        }
+                        "\u{f700}" => {
+                            if meta {
+                                ed.move_doc_start()
+                            } else {
+                                ed.move_cursor(-1, 0)
+                            }
+                        }
+                        "\u{f701}" => {
+                            if meta {
+                                ed.move_doc_end()
+                            } else {
+                                ed.move_cursor(1, 0)
+                            }
+                        }
+                        "\u{f729}" => ed.home(),
+                        "\u{f72b}" => ed.end(),
+                        _ => {}
+                    }
+                }
+                sync_editor();
+                return true;
+            }
+            if meta {
                 // Editor-owned cmd combos; everything else bubbles up to the
                 // window shortcut scope (⌘⏎ run, ⌘S commit, ⌘R refresh, …).
                 let handled = {
@@ -1759,7 +1809,7 @@ fn main() -> Result<(), slint::PlatformError> {
             when(
                 Rc::new(|w| !w.get_query_text().trim().is_empty()),
                 Rc::new(|w| {
-                    w.invoke_editor_key("a".into(), true, false);
+                    w.invoke_editor_key("a".into(), true, false, false);
                 }),
             );
         }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -3,7 +3,7 @@ export { Theme }
 import { Tokens } from "tokens.slint";
 export { Tokens }
 import {
-    SearchCommandPill, BreadcrumbChip, GlyphButton
+    SearchCommandPill, BreadcrumbChip, GlyphButton, IconButton
 } from "components.slint";
 import { Sidebar } from "sidebar.slint";
 import { ConnPicker } from "picker.slint";
@@ -434,14 +434,18 @@ export component MainWindow inherits Window {
                     HorizontalLayout {
                         spacing: Tokens.sp1;
                         // history: jump the sidebar to the History tab
-                        GlyphButton {
-                            glyph: "◷";
+                        IconButton {
+                            icon: "clock";
                             clicked => {
                                 root.sidebar-mode = 2;
                                 root.sidebar-mode-changed(2);
                             }
                         }
-                        GlyphButton { glyph: "▭"; glyph-size: 11px; clicked => { root.toggle-theme(); } }
+                        // theme toggle: sun in dark mode, moon in light
+                        IconButton {
+                            icon: Tokens.dark ? "sun" : "moon";
+                            clicked => { root.toggle-theme(); }
+                        }
                         // settings of the current connection (edit form)
                         GlyphButton {
                             glyph: "⚙";

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -79,6 +79,7 @@ export component MainWindow inherits Window {
     // ----- view state: false = connection picker, true = workspace -----
     in property <bool> connected: false;
     in property <string> picker-error;
+    in property <bool> connecting;
     callback disconnect();
     callback conn-filter(string);
 
@@ -469,6 +470,7 @@ export component MainWindow inherits Window {
             connections: root.connections;
             selected-conn: root.selected-conn;
             error: root.picker-error;
+            connecting: root.connecting;
             sel-name: root.sel-name;
             sel-engine: root.sel-engine;
             sel-sub: root.sel-sub;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -128,7 +128,7 @@ export component MainWindow inherits Window {
     in property <string> query-label;
     in property <string> results-meta;
     in-out property <int> sidebar-mode: 0;
-    callback editor-key(string, bool, bool) -> bool;
+    callback editor-key(string, bool, bool, bool) -> bool;
     callback editor-press(int, int);
     callback editor-drag(int, int);
     callback editor-select-word(int, int);
@@ -706,7 +706,7 @@ export component MainWindow inherits Window {
                         filter-col <=> root.filter-col;
                         filter-op <=> root.filter-op;
                         index-rows: root.index-rows;
-                        editor-key(t, cmd, shift) => { root.editor-key(t, cmd, shift) }
+                        editor-key(t, cmd, alt, shift) => { root.editor-key(t, cmd, alt, shift) }
                         editor-press(l, c) => { root.editor-press(l, c); }
                         editor-drag(l, c) => { root.editor-drag(l, c); }
                         editor-select-word(l, c) => { root.editor-select-word(l, c); }

--- a/app/src/ui/code-editor.slint
+++ b/app/src/ui/code-editor.slint
@@ -9,8 +9,9 @@ export component CodeEditor inherits Rectangle {
     in property <[[Span]]> lines;
     in property <int> cursor-line: 0;
     in property <int> cursor-col: 0;
-    // (key text, meta/ctrl, shift) -> true when the editor consumed the key.
-    callback edit-key(string, bool, bool) -> bool;
+    // (key text, meta/ctrl, alt/option, shift) -> true when the editor consumed
+    // the key. meta = ⌘ line/doc motions, alt = ⌥ word motions.
+    callback edit-key(string, bool, bool, bool) -> bool;
     // Mouse: press places the caret, drag extends the selection, double-click
     // selects the word. All carry (line, col) hit-tested from the pointer.
     callback press-pos(int, int);
@@ -33,7 +34,7 @@ export component CodeEditor inherits Rectangle {
 
     focus-scope := FocusScope {
         key-pressed(e) => {
-            if (root.edit-key(e.text, e.modifiers.meta || e.modifiers.control, e.modifiers.shift)) {
+            if (root.edit-key(e.text, e.modifiers.meta || e.modifiers.control, e.modifiers.alt, e.modifiers.shift)) {
                 return accept;
             }
             return reject;

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -1,5 +1,6 @@
 // Shared Tabula components. All colors/metrics come from Tokens.
 import { Tokens } from "tokens.slint";
+import { AppIcon } from "icons.slint";
 
 // Dropdown select: shows the current value + a ▾ caret so it reads as a
 // picker even when closed, then a click opens a themed option list. Replaces
@@ -28,11 +29,9 @@ export component SelectBox inherits Rectangle {
             horizontal-stretch: 1;
             overflow: elide;
         }
-        Text {
-            text: "⌄";
-            color: Tokens.text-faint;
-            font-size: Tokens.font-md;
-            vertical-alignment: center;
+        VerticalLayout {
+            alignment: center;
+            AppIcon { name: "caret"; size: 14px; color: Tokens.text-faint; }
         }
     }
     popup := PopupWindow {
@@ -370,6 +369,25 @@ export component GlyphButton inherits Rectangle {
         text: root.glyph;
         color: ta.has-hover && root.danger-hover ? white : Tokens.text-dim;
         font-size: root.glyph-size;
+    }
+    ta := TouchArea { clicked => { root.clicked(); } }
+}
+
+// Like GlyphButton but draws a crisp SVG (AppIcon) instead of a font glyph —
+// used for header actions whose symbols aren't in the mono font.
+export component IconButton inherits Rectangle {
+    in property <string> icon;
+    in property <length> icon-size: Tokens.icon-sm;
+    callback clicked;
+    width: 28px;
+    height: 28px;
+    border-radius: Tokens.radius;
+    background: ta.has-hover ? Tokens.border : transparent;
+    animate background { duration: Tokens.fade; }
+    AppIcon {
+        name: root.icon;
+        size: root.icon-size;
+        color: Tokens.text-dim;
     }
     ta := TouchArea { clicked => { root.clicked(); } }
 }

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -1,6 +1,79 @@
 // Shared Tabula components. All colors/metrics come from Tokens.
 import { Tokens } from "tokens.slint";
 
+// Dropdown select: shows the current value + a ▾ caret so it reads as a
+// picker even when closed, then a click opens a themed option list. Replaces
+// std-widgets ComboBox, which rendered as a blank borderless box in this theme.
+export component SelectBox inherits Rectangle {
+    in property <[string]> model;
+    in-out property <string> current-value;
+    callback selected(string);
+    height: 30px;
+    border-radius: Tokens.radius;
+    border-width: 1px;
+    border-color: ta.has-hover ? Tokens.border-strong : Tokens.border;
+    background: Tokens.card;
+    ta := TouchArea {
+        clicked => { popup.show(); }
+    }
+    HorizontalLayout {
+        padding-left: Tokens.sp2;
+        padding-right: Tokens.sp2;
+        spacing: Tokens.sp2;
+        Text {
+            text: root.current-value;
+            color: Tokens.text;
+            font-size: Tokens.font-sm;
+            vertical-alignment: center;
+            horizontal-stretch: 1;
+            overflow: elide;
+        }
+        Text {
+            text: "⌄";
+            color: Tokens.text-faint;
+            font-size: Tokens.font-md;
+            vertical-alignment: center;
+        }
+    }
+    popup := PopupWindow {
+        x: 0;
+        y: root.height + 4px;
+        width: root.width;
+        Rectangle {
+            background: Tokens.card;
+            border-radius: Tokens.radius;
+            border-width: 1px;
+            border-color: Tokens.border-strong;
+            drop-shadow-blur: 12px;
+            drop-shadow-color: #00000022;
+            VerticalLayout {
+                padding: 4px;
+                for opt in root.model: Rectangle {
+                    height: 28px;
+                    border-radius: 6px;
+                    background: opt-ta.has-hover ? Tokens.accent-tint : transparent;
+                    opt-ta := TouchArea {
+                        clicked => {
+                            root.current-value = opt;
+                            root.selected(opt);
+                            popup.close();
+                        }
+                    }
+                    HorizontalLayout {
+                        padding-left: Tokens.sp2;
+                        Text {
+                            text: opt;
+                            color: Tokens.text;
+                            font-size: Tokens.font-sm;
+                            vertical-alignment: center;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 // Engine badge: rounded square with 2-letter code, engine color fill.
 export component DbBadge inherits Rectangle {
     in property <string> engine; // "postgres" | "mysql" | "redis" | "sqlite" | "mongo" | "cassandra"

--- a/app/src/ui/conn-form.slint
+++ b/app/src/ui/conn-form.slint
@@ -1,6 +1,5 @@
 import { Tokens } from "tokens.slint";
-import { PrimaryButton, SecondaryButton, FormField } from "components.slint";
-import { ComboBox } from "std-widgets.slint";
+import { PrimaryButton, SecondaryButton, FormField, SelectBox } from "components.slint";
 
 // 8 preset accent swatches — colors for UI rendering, hex strings for the Rust-side color field.
 // First entry is the app accent (Tokens.accent) so the default matches the design system.
@@ -86,7 +85,7 @@ export component ConnForm inherits Rectangle {
             FormField { text <=> root.f-name; }
 
             Text { text: "Engine"; color: Tokens.text-dim; font-size: Tokens.font-sm; }
-            ComboBox {
+            SelectBox {
                 model: ["PostgreSQL", "MySQL", "Redis", "MongoDB", "SQLite", "Cassandra"];
                 current-value <=> root.f-engine;
                 selected(v) => { root.engine-changed(v); }
@@ -138,7 +137,7 @@ export component ConnForm inherits Rectangle {
             if root.f-engine == "PostgreSQL" || root.f-engine == "MySQL": Text {
                 text: "SSL"; color: Tokens.text-dim; font-size: Tokens.font-sm;
             }
-            if root.f-engine == "PostgreSQL" || root.f-engine == "MySQL": ComboBox {
+            if root.f-engine == "PostgreSQL" || root.f-engine == "MySQL": SelectBox {
                 model: ["Disable", "Prefer", "Require"];
                 current-value <=> root.f-sslmode;
             }

--- a/app/src/ui/icons.slint
+++ b/app/src/ui/icons.slint
@@ -29,5 +29,7 @@ export component AppIcon inherits Image {
         name == "layers"    ? @image-url("icons/layers.svg")   :
         name == "sun"       ? @image-url("icons/sun.svg")      :
         name == "moon"      ? @image-url("icons/moon.svg")     :
+        name == "clock"     ? @image-url("icons/clock.svg")    :
+        name == "caret"     ? @image-url("icons/caret.svg")    :
         @image-url("icons/table.svg");
 }

--- a/app/src/ui/icons/caret.svg
+++ b/app/src/ui/icons/caret.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"/></svg>

--- a/app/src/ui/icons/clock.svg
+++ b/app/src/ui/icons/clock.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>

--- a/app/src/ui/picker.slint
+++ b/app/src/ui/picker.slint
@@ -13,6 +13,8 @@ export component ConnPicker inherits Rectangle {
     in property <[ConnItem]> connections;
     in property <int> selected-conn: -1;
     in property <string> error;
+    // True while a connect attempt is in flight (button shows a spinner label).
+    in property <bool> connecting;
 
     // Detail panel (filled by Rust when a row is selected).
     in property <string> sel-name;
@@ -282,7 +284,8 @@ export component ConnPicker inherits Rectangle {
                             HorizontalLayout {
                                 spacing: Tokens.sp2;
                                 PrimaryButton {
-                                    text: "Connect";
+                                    text: root.connecting ? "Connecting…" : "Connect";
+                                    enabled: !root.connecting;
                                     height: 30px;
                                     clicked => { root.connect-clicked(root.selected-conn); }
                                 }
@@ -298,6 +301,14 @@ export component ConnPicker inherits Rectangle {
                                 }
                             }
                         }
+                    }
+
+                    // Connection error surfaced next to the Connect button.
+                    if root.error != "": Text {
+                        text: root.error;
+                        color: Tokens.error;
+                        font-size: Tokens.font-sm;
+                        wrap: word-wrap;
                     }
 
                     // ----- key/value card -----

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -40,7 +40,7 @@ export component WorkArea inherits Rectangle {
     in property <int> cursor-col;
     in property <string> query-label;    // "emiten-per-sektor.sql · saved"
     in property <string> results-meta;   // "10 rows · 38 ms"
-    callback editor-key(string, bool, bool) -> bool;
+    callback editor-key(string, bool, bool, bool) -> bool;
     callback editor-press(int, int);
     callback editor-drag(int, int);
     callback editor-select-word(int, int);
@@ -504,7 +504,7 @@ export component WorkArea inherits Rectangle {
                     lines: root.editor-lines;
                     cursor-line: root.cursor-line;
                     cursor-col: root.cursor-col;
-                    edit-key(t, cmd, shift) => { root.editor-key(t, cmd, shift) }
+                    edit-key(t, cmd, alt, shift) => { root.editor-key(t, cmd, alt, shift) }
                     press-pos(l, c) => { root.editor-press(l, c); }
                     drag-pos(l, c) => { root.editor-drag(l, c); }
                     select-word(l, c) => { root.editor-select-word(l, c); }


### PR DESCRIPTION
## Summary

Five UX fixes to the connection form and query editor, all reported from the macOS build.

- The Engine/SSL dropdowns rendered as blank boxes and the Connect flow gave no feedback.
- The query editor ignored macOS word/line navigation.
- Several toolbar/dropdown symbols showed as tofu boxes (font gaps).

## Changes

- **Editor motions** (`editor.rs`, `code-editor.slint`, `workarea.slint`, `app-window.slint`, `main.rs`): forward the ⌥ (Option) modifier separately from ⌘/Ctrl and route arrows — ⌥←/→ = word, ⌘←/→ = line start/end, ⌘↑/↓ = document ends — each extending the selection under Shift. Adds `move_word`/`move_doc_start`/`move_doc_end` with unit tests.
- **SelectBox** (`components.slint`, `conn-form.slint`): custom dropdown showing the current value + a caret and a themed option list, replacing the std-widgets ComboBox that rendered blank. Used for Engine and SSL.
- **Connect feedback** (`picker.slint`, `app-window.slint`, `main.rs`): a `connecting` flag drives a "Connecting…" disabled button and surfaces the failure message next to it.
- **Icons** (`icons.slint`, `components.slint`, `app-window.slint`, new `clock.svg`/`caret.svg`): new `IconButton` drawing an `AppIcon` (SVG) instead of a font glyph. Header history → clock, theme toggle → sun/moon, dropdown caret → SVG — all previously tofu boxes in IBM Plex Mono.

## Test plan

- [x] `cargo test -p rdbs --bins` — 80 passed (incl. new word-motion tests)
- [x] `cargo clippy --workspace --all-targets -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `make fe-run` on macOS: Engine/SSL dropdowns show value + caret; Connect shows progress + errors; ⌥/⌘ + arrows navigate word/line and Shift-select; header + dropdown icons render (no boxes)