### PR TITLE
fix(app): search icon, ⌘⏎ run, Postgres JSON cells, tab close/new

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5119,6 +5119,8 @@ dependencies = [
  "chrono",
  "fallible-iterator 0.2.0",
  "postgres-protocol",
+ "serde_core",
+ "serde_json",
  "uuid",
 ]
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -3135,6 +3135,28 @@ fn main() -> Result<(), slint::PlatformError> {
             if let Some(w) = weak.upgrade() {
                 w.set_selected_row(r);
                 w.set_selected_col(c);
+                // Feed the bottom inspector: full cell value, pretty-printed
+                // when it parses as JSON so json/jsonb columns are readable.
+                let cols = w.get_grid_col_count();
+                let val = if cols > 0 && c >= 0 && r >= 0 {
+                    let idx = (r * cols + c) as usize;
+                    w.get_grid_cells().row_data(idx).map(|cell| {
+                        if cell.is_null {
+                            "NULL".to_string()
+                        } else {
+                            let t = cell.text.to_string();
+                            match serde_json::from_str::<serde_json::Value>(&t) {
+                                Ok(v) if v.is_object() || v.is_array() => {
+                                    serde_json::to_string_pretty(&v).unwrap_or(t)
+                                }
+                                _ => t,
+                            }
+                        }
+                    })
+                } else {
+                    None
+                };
+                w.set_selected_cell_value(SharedString::from(val.unwrap_or_default()));
             }
         });
     }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -3048,6 +3048,7 @@ fn main() -> Result<(), slint::PlatformError> {
             set_tab_titles(&w, count);
             w.set_active_tab((count - 1) as i32);
             w.set_query_text(SharedString::default());
+            clear_grid(&w);
         });
     }
 
@@ -3061,6 +3062,14 @@ fn main() -> Result<(), slint::PlatformError> {
             };
             let mut t = tab_texts.borrow_mut();
             if t.len() <= 1 {
+                // Only tab: nothing to remove, so reset it to a blank slate
+                // instead of silently no-op'ing (which read as "close broken").
+                if let Some(slot) = t.get_mut(0) {
+                    slot.clear();
+                }
+                drop(t);
+                w.set_query_text(SharedString::default());
+                clear_grid(&w);
                 return;
             }
             let active = w.get_active_tab() as usize;

--- a/app/src/query_parse.rs
+++ b/app/src/query_parse.rs
@@ -27,9 +27,9 @@ pub fn parse_query(engine: Engine, text: &str) -> Result<Query, String> {
 /// Editor placeholder/hint per engine (shown in the UI).
 pub fn editor_hint(engine: Engine) -> &'static str {
     match engine {
-        Engine::Postgres | Engine::MySql | Engine::Sqlite => "SQL — e.g. SELECT * FROM table",
-        Engine::Cassandra => "CQL — e.g. SELECT * FROM keyspace.table",
-        Engine::Redis => "Redis command — e.g. SET key value",
+        Engine::Postgres | Engine::MySql | Engine::Sqlite => "SELECT * FROM table",
+        Engine::Cassandra => "SELECT * FROM keyspace.table",
+        Engine::Redis => "SET key value",
         Engine::Mongo => r#"Mongo JSON — {"collection":"c","op":"find","body":{}}"#,
     }
 }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -337,10 +337,11 @@ export component MainWindow inherits Window {
             }
             return reject;
         }
-    }
 
-    VerticalLayout {
-        spacing: 0px;
+        // The whole app UI lives inside this FocusScope so keys the editor and
+        // other inner FocusScopes reject bubble up here to the ⌘ shortcut table.
+        VerticalLayout {
+            spacing: 0px;
 
         // ================= toolbar row (44px, under native titlebar) =================
         Rectangle {
@@ -918,5 +919,6 @@ export component MainWindow inherits Window {
         cancel() => {
             root.form-cancel();
         }
+    }
     }
 }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -95,6 +95,7 @@ export component MainWindow inherits Window {
     in property <string> result-status;
     in-out property <int> selected-row: 0;
     in-out property <int> selected-col: -1;
+    in property <string> selected-cell-value;
     in property <int> editing-row: -1;
     in property <int> editing-col: -1;
     callback select-cell(int, int);
@@ -726,6 +727,7 @@ export component MainWindow inherits Window {
                         find-close() => { root.find-close(); }
                         selected-row: root.selected-row;
                         selected-col: root.selected-col;
+                        selected-cell-value: root.selected-cell-value;
                         editing-row: root.editing-row;
                         editing-col: root.editing-col;
                         show-structure <=> root.show-structure;

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -250,11 +250,9 @@ export component SearchCommandPill inherits Rectangle {
         padding-left: Tokens.sp3;
         padding-right: 5px;
         spacing: Tokens.sp2;
-        Text {
-            text: "⌕";
-            color: Tokens.text-faint;
-            font-size: Tokens.font-md;
-            vertical-alignment: center;
+        VerticalLayout {
+            alignment: center;
+            AppIcon { name: "search"; size: 14px; color: Tokens.text-faint; }
         }
         Text {
             text: root.placeholder;
@@ -409,11 +407,9 @@ export component FilterField inherits Rectangle {
         padding-left: Tokens.sp2;
         padding-right: 6px;
         spacing: Tokens.sp2;
-        Text {
-            text: "⌕";
-            color: Tokens.text-faint;
-            font-size: Tokens.font-md;
-            vertical-alignment: center;
+        VerticalLayout {
+            alignment: center;
+            AppIcon { name: "search"; size: 14px; color: Tokens.text-faint; }
         }
         input := TextInput {
             font-size: Tokens.font-sm;

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -26,6 +26,7 @@ export component WorkArea inherits Rectangle {
     in property <string> status-latency;
     in-out property <int> selected-row: 0;
     in-out property <int> selected-col: -1;
+    in property <string> selected-cell-value;   // full text of the selected cell (pretty JSON when it parses)
     in property <int> editing-row: -1;
     in property <int> editing-col: -1;
     in-out property <bool> show-structure: false;
@@ -561,6 +562,31 @@ export component WorkArea inherits Rectangle {
                 cell-edited(r, c, t) => { root.cell-edited(r, c, t); }
                 cell-advance(r, c, t, fwd) => { root.cell-advance(r, c, t, fwd); }
                 edit-cancelled() => { root.edit-cancelled(); }
+            }
+
+            // Selected-cell inspector: full value of the clicked cell (pretty
+            // JSON when it parses). Overlays the grid's bottom edge, only while
+            // a cell is selected — lets long/JSON cells stay single-line above.
+            if root.result-kind == 0 && root.selected-col >= 0 && root.selected-cell-value != "": Rectangle {
+                y: parent.height - self.height;
+                height: min(140px, parent.height * 0.45);
+                width: 100%;
+                background: Tokens.card;
+                Rectangle { height: 1px; y: 0; background: Tokens.border-strong; }
+                ScrollView {
+                    width: 100%;
+                    height: 100%;
+                    VerticalLayout {
+                        padding: Tokens.sp3;
+                        Text {
+                            text: root.selected-cell-value;
+                            color: Tokens.text;
+                            font-family: Tokens.mono;
+                            font-size: Tokens.font-sm;
+                            wrap: word-wrap;
+                        }
+                    }
+                }
             }
 
             // empty result: distinct from an error, distinct from loading

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -540,7 +540,7 @@ export component WorkArea inherits Rectangle {
         }
 
         // ================= result body =================
-        if !root.fn-mode && !root.empty-mode: Rectangle {
+        if !root.fn-mode && !root.empty-mode: body := Rectangle {
             vertical-stretch: 1;
             background: Tokens.canvas;
 
@@ -567,15 +567,17 @@ export component WorkArea inherits Rectangle {
             // Selected-cell inspector: full value of the clicked cell (pretty
             // JSON when it parses). Overlays the grid's bottom edge, only while
             // a cell is selected — lets long/JSON cells stay single-line above.
-            if root.result-kind == 0 && root.selected-col >= 0 && root.selected-cell-value != "": Rectangle {
+            // Drag the top edge to resize (row-resize like the column handles).
+            if root.result-kind == 0 && root.selected-col >= 0 && root.selected-cell-value != "": panel := Rectangle {
+                property <length> panel-h: 200px;
                 y: parent.height - self.height;
-                height: min(140px, parent.height * 0.45);
+                height: clamp(self.panel-h, 60px, body.height - 60px);
                 width: 100%;
                 background: Tokens.card;
-                Rectangle { height: 1px; y: 0; background: Tokens.border-strong; }
                 ScrollView {
+                    y: 5px;
                     width: 100%;
-                    height: 100%;
+                    height: parent.height - 5px;
                     VerticalLayout {
                         padding: Tokens.sp3;
                         Text {
@@ -584,6 +586,21 @@ export component WorkArea inherits Rectangle {
                             font-family: Tokens.mono;
                             font-size: Tokens.font-sm;
                             wrap: word-wrap;
+                        }
+                    }
+                }
+                // top drag handle: 5px grab strip; dragging up grows the panel.
+                Rectangle {
+                    height: 5px;
+                    y: 0;
+                    width: 100%;
+                    background: grip.has-hover || grip.pressed ? Tokens.accent : Tokens.border-strong;
+                    grip := TouchArea {
+                        mouse-cursor: row-resize;
+                        moved => {
+                            panel.panel-h = clamp(
+                                panel.height - (self.mouse-y - self.pressed-y),
+                                60px, body.height - 60px);
                         }
                     }
                 }

--- a/crates/driver-postgres/Cargo.toml
+++ b/crates/driver-postgres/Cargo.toml
@@ -7,10 +7,11 @@ edition = "2021"
 rdbs-core = { path = "../core" }
 async-trait = "0.1"
 tokio = { version = "1", features = ["full"] }
-tokio-postgres = { version = "0.7", features = ["with-uuid-1", "with-chrono-0_4"] }
+tokio-postgres = { version = "0.7", features = ["with-uuid-1", "with-chrono-0_4", "with-serde_json-1"] }
 uuid = "1"
 chrono = { version = "0.4", default-features = false }
 rust_decimal = { version = "1", features = ["db-tokio-postgres"] }
+serde_json = "1"
 native-tls = "0.2"
 postgres-native-tls = "0.5"
 
@@ -18,4 +19,3 @@ postgres-native-tls = "0.5"
 testcontainers = "0.27"
 testcontainers-modules = { version = "0.15", features = ["postgres"] }
 tokio = { version = "1", features = ["full", "macros", "rt-multi-thread"] }
-serde_json = "1"

--- a/crates/driver-postgres/src/type_map.rs
+++ b/crates/driver-postgres/src/type_map.rs
@@ -15,6 +15,7 @@ pub enum CellKind {
     Timestamp,
     Date,
     Numeric,
+    Json,
 }
 
 /// Classify a pg `Type` into a `CellKind`. Unknown types -> `Text` (string
@@ -30,6 +31,7 @@ pub fn classify(ty: &Type) -> CellKind {
         Type::DATE => CellKind::Date,
         Type::NUMERIC => CellKind::Numeric,
         Type::TEXT | Type::VARCHAR | Type::BPCHAR | Type::NAME => CellKind::Text,
+        Type::JSON | Type::JSONB => CellKind::Json,
         _ => CellKind::Text,
     }
 }
@@ -95,6 +97,12 @@ pub fn extract_cell(row: &Row, idx: usize) -> Cell {
             Ok(None) => Cell::Null,
             Err(_) => string_fallback(row, idx),
         },
+        CellKind::Json => match row.try_get::<_, Option<serde_json::Value>>(idx) {
+            // Compact single-line render; the UI inspector pretty-prints on demand.
+            Ok(Some(v)) => Cell::Text(v.to_string()),
+            Ok(None) => Cell::Null,
+            Err(_) => string_fallback(row, idx),
+        },
         CellKind::Text => string_fallback(row, idx),
     }
 }
@@ -141,6 +149,12 @@ mod tests {
         assert_eq!(classify(&Type::TIMESTAMP), CellKind::Timestamp);
         assert_eq!(classify(&Type::DATE), CellKind::Date);
         assert_eq!(classify(&Type::NUMERIC), CellKind::Numeric);
+    }
+
+    #[test]
+    fn json_types_classify_as_json() {
+        assert_eq!(classify(&Type::JSON), CellKind::Json);
+        assert_eq!(classify(&Type::JSONB), CellKind::Json);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fix four reported UI/driver defects: broken search icon, ⌘⏎ not running queries, Postgres `json`/`jsonb` columns showing NULL, and unusable tab close/new.
- Add a resizable selected-cell inspector so long/JSON values are readable while cells stay single-line in the grid.

## Changes
- **Search icon** (`components.slint`): replace the raw Unicode `⌕` (rendered as an empty box) with the existing `AppIcon{name:"search"}` SVG in the command pill and filter field.
- **⌘⏎ run** (`app-window.slint`): the window shortcut `FocusScope` was empty and a *sibling* of the content, so editor keys never bubbled to it. Wrap the app content inside it — repairs ⌘⏎ plus ⌘S/⌘R/⌘F/⌘W/⌘T/⌘1-9 while the editor is focused.
- **Postgres JSON** (`driver-postgres`): add `CellKind::Json`, map `json`/`jsonb`, read via `serde_json::Value` (compact string) instead of falling through to a failing `String` read that became NULL. Enables `with-serde_json-1`.
- **Cell inspector** (`workarea.slint`, `app-window.slint`, `main.rs`): bottom panel shows the selected cell's full value, pretty-printed when it parses as JSON. Drag its top edge to resize.
- **Tabs** (`main.rs`): closing the only tab resets it (clears text + grid) instead of silent no-op; new tab clears the result grid for a clean slate.
- **Placeholder hints** (`query_parse.rs`): trim `SQL — e.g.` prefixes to bare examples.

## Test plan
- [x] `cargo test -p rdbs-driver-postgres --lib` (json classify test passes)
- [x] `make fe-build`, `make lint`, `make fmt-check`
- [x] `make fe-run`: search icons crisp; focus editor + ⌘⏎ runs; Postgres `varians`/`targets` show JSON not NULL; click JSON cell → inspector, drag top edge to resize; ✕ on lone tab resets; ＋ clears grid.