### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in this repo.
+# See https://docs.github.com/articles/about-code-owners
+* @suiflex


### PR DESCRIPTION
## Summary
- Add a `CODEOWNERS` file so PRs auto-request review from the owner.

## Changes
- `.github/CODEOWNERS`: default owner `* @suiflex`.

## Note
- `@suiflex` resolves only if it is a **user**. If `suiflex` is an **org**, GitHub requires a team handle (e.g. `@suiflex/maintainers`) for auto review-requests to work — swap it if reviewers aren't assigned.