### PR TITLE
feat(app): data grid and editor UX overhaul

### DIFF
--- a/app/src/completion.rs
+++ b/app/src/completion.rs
@@ -1,0 +1,135 @@
+//! SQL identifier autocomplete: given the text before the cursor and the
+//! in-memory schema tree (`VmTreeNode` list), suggest table or column names.
+//! Deliberately small — context is just "after a dot" (columns) or "after
+//! FROM/JOIN/… or a partial word" (tables). No keyword completion.
+
+use crate::model::VmTreeNode;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Candidate {
+    pub label: String,
+    pub kind: String, // "table" | "field"
+    pub sub: String,  // owning table, for column hints
+}
+
+/// The trailing run of identifier chars at the end of `s` (ASCII identifier).
+pub fn trailing_word(s: &str) -> &str {
+    let b = s.as_bytes();
+    let mut i = b.len();
+    while i > 0 && (b[i - 1].is_ascii_alphanumeric() || b[i - 1] == b'_') {
+        i -= 1;
+    }
+    &s[i..]
+}
+
+fn tables(nodes: &[VmTreeNode]) -> Vec<Candidate> {
+    nodes
+        .iter()
+        .filter(|n| n.kind == "table" || n.kind == "collection")
+        .map(|n| Candidate {
+            label: n.label.clone(),
+            kind: "table".into(),
+            sub: String::new(),
+        })
+        .collect()
+}
+
+/// Columns are the `field` nodes that follow a matching table node in the flat
+/// tree (the sidebar stores parent-then-children order).
+fn columns_of(nodes: &[VmTreeNode], owner: &str) -> Vec<Candidate> {
+    let owner_l = owner.to_lowercase();
+    for (i, n) in nodes.iter().enumerate() {
+        if (n.kind == "table" || n.kind == "collection") && n.label.to_lowercase() == owner_l {
+            return nodes[i + 1..]
+                .iter()
+                .take_while(|f| f.kind == "field")
+                .map(|f| Candidate {
+                    label: f.label.clone(),
+                    kind: "field".into(),
+                    sub: owner.to_string(),
+                })
+                .collect();
+        }
+    }
+    Vec::new()
+}
+
+/// The last SQL keyword token on `line`, uppercased (via the editor lexer).
+fn last_keyword(line: &str) -> Option<String> {
+    crate::editor::lex_line(line)
+        .into_iter()
+        .rev()
+        .find(|s| s.kind == 1)
+        .map(|s| s.text.to_uppercase())
+}
+
+/// Suggest completions for the text before the cursor. Returns the char length
+/// of the partial word to replace on accept, plus the (prefix-filtered, capped)
+/// candidates. An empty list means "no popup".
+pub fn suggest(before_cursor: &str, nodes: &[VmTreeNode]) -> (usize, Vec<Candidate>) {
+    let word = trailing_word(before_cursor);
+    let head = before_cursor.strip_suffix(word).unwrap_or(before_cursor);
+    let mut cands = if let Some(before_dot) = head.strip_suffix('.') {
+        columns_of(nodes, trailing_word(before_dot))
+    } else {
+        match last_keyword(before_cursor).as_deref() {
+            Some("FROM") | Some("JOIN") | Some("INTO") | Some("UPDATE") | Some("TABLE") => {
+                tables(nodes)
+            }
+            _ if !word.is_empty() => tables(nodes),
+            _ => return (word.chars().count(), Vec::new()),
+        }
+    };
+    let wl = word.to_lowercase();
+    if !wl.is_empty() {
+        cands.retain(|c| c.label.to_lowercase().starts_with(&wl));
+    }
+    cands.truncate(20);
+    (word.chars().count(), cands)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn nodes() -> Vec<VmTreeNode> {
+        let mk = |l: &str, k: &str| VmTreeNode {
+            label: l.into(),
+            kind: k.into(),
+        };
+        vec![
+            mk("public", "database"),
+            mk("step_config", "table"),
+            mk("config_id", "field"),
+            mk("name", "field"),
+            mk("users", "table"),
+            mk("id", "field"),
+        ]
+    }
+
+    #[test]
+    fn from_prefix_suggests_matching_table() {
+        let (n, c) = suggest("select * from ste", &nodes());
+        assert_eq!(n, 3);
+        assert_eq!(
+            c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
+            ["step_config"]
+        );
+    }
+
+    #[test]
+    fn dot_suggests_that_tables_columns() {
+        let (n, c) = suggest("select * from step_config where step_config.", &nodes());
+        assert_eq!(n, 0);
+        assert_eq!(
+            c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
+            ["config_id", "name"]
+        );
+    }
+
+    #[test]
+    fn bare_word_without_context_is_empty() {
+        let (_, c) = suggest("sele", &nodes());
+        // "sele" is a partial word → tables filtered by prefix (none match)
+        assert!(c.is_empty());
+    }
+}

--- a/app/src/editor.rs
+++ b/app/src/editor.rs
@@ -289,6 +289,11 @@ impl EditorState {
             .unwrap_or(l.len())
     }
 
+    /// Text on the current line up to the cursor — the autocomplete context.
+    pub fn before_cursor(&self) -> &str {
+        &self.lines[self.line][..self.byte_col()]
+    }
+
     fn byte_at(l: &str, col: usize) -> usize {
         l.char_indices().nth(col).map(|(b, _)| b).unwrap_or(l.len())
     }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -650,6 +650,32 @@ async fn fetch_indexes(
     }
 }
 
+/// Does one cell satisfy `op` against `needle` (already lowercased)? Numeric
+/// comparison when both sides parse as f64, else case-insensitive text.
+/// Shared by the global filter and the per-column filter row.
+fn cell_matches(cell: &model::VmCell, op: &str, needle: &str) -> bool {
+    use std::cmp::Ordering;
+    match op {
+        "is null" => cell.is_null,
+        "not null" => !cell.is_null,
+        "=" => cell.text.to_lowercase() == needle,
+        "≠" | "!=" => cell.text.to_lowercase() != needle,
+        ">" | "<" | ">=" | "<=" => {
+            let ord = match (cell.text.parse::<f64>(), needle.parse::<f64>()) {
+                (Ok(a), Ok(b)) => a.partial_cmp(&b),
+                _ => Some(cell.text.to_lowercase().as_str().cmp(needle)),
+            };
+            match ord {
+                Some(Ordering::Greater) => op == ">" || op == ">=",
+                Some(Ordering::Less) => op == "<" || op == "<=",
+                Some(Ordering::Equal) => op == ">=" || op == "<=",
+                None => false,
+            }
+        }
+        _ => cell.text.to_lowercase().contains(needle),
+    }
+}
+
 /// Row filter with an optional column + operator condition (`needle` already
 /// lowercased). `col: None` falls back to the all-cell contains filter.
 fn filter_grid_cond(
@@ -666,38 +692,14 @@ fn filter_grid_cond(
     if needle.is_empty() && op != "is null" && op != "not null" {
         return g.clone();
     }
-    let keep = |row: &[model::VmCell]| -> bool {
-        let Some(cell) = row.get(c) else {
-            return false;
-        };
-        match op {
-            "is null" => cell.is_null,
-            "not null" => !cell.is_null,
-            "=" => cell.text.to_lowercase() == needle,
-            "≠" => cell.text.to_lowercase() != needle,
-            ">" | "<" => match (cell.text.parse::<f64>(), needle.parse::<f64>()) {
-                (Ok(a), Ok(b)) => {
-                    if op == ">" {
-                        a > b
-                    } else {
-                        a < b
-                    }
-                }
-                _ => {
-                    let t = cell.text.to_lowercase();
-                    if op == ">" {
-                        t.as_str() > needle
-                    } else {
-                        t.as_str() < needle
-                    }
-                }
-            },
-            _ => cell.text.to_lowercase().contains(needle),
-        }
-    };
     model::GridModel {
         columns: g.columns.clone(),
-        rows: g.rows.iter().filter(|r| keep(r)).cloned().collect(),
+        rows: g
+            .rows
+            .iter()
+            .filter(|r| r.get(c).is_some_and(|cell| cell_matches(cell, op, needle)))
+            .cloned()
+            .collect(),
     }
 }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -12,6 +12,7 @@
 
 slint::include_modules!();
 
+mod completion;
 mod dispatch;
 mod editor;
 mod export;
@@ -1130,10 +1131,103 @@ fn main() -> Result<(), slint::PlatformError> {
         })
     };
     load_editor_text("");
+
+    // ----- SQL autocomplete: recompute popup, accept a choice -----
+    // completion_ctx = (word char length to replace, candidate labels).
+    let completion_ctx: Rc<RefCell<(usize, Vec<String>)>> = Rc::new(RefCell::new((0, Vec::new())));
+    let refresh_completion: Rc<dyn Fn()> = {
+        let weak = window.as_weak();
+        let ed_state = ed_state.clone();
+        let raw_nodes = raw_nodes.clone();
+        let completion_ctx = completion_ctx.clone();
+        Rc::new(move || {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let before = ed_state.borrow().before_cursor().to_string();
+            let (word_len, cands) = completion::suggest(&before, &raw_nodes.lock().unwrap());
+            if cands.is_empty() {
+                w.set_completion_visible(false);
+                *completion_ctx.borrow_mut() = (0, Vec::new());
+                return;
+            }
+            let items: Vec<PaletteItem> = cands
+                .iter()
+                .map(|c| PaletteItem {
+                    label: c.label.clone().into(),
+                    kind: c.kind.clone().into(),
+                    sub: c.sub.clone().into(),
+                    local: false,
+                })
+                .collect();
+            *completion_ctx.borrow_mut() =
+                (word_len, cands.iter().map(|c| c.label.clone()).collect());
+            w.set_completion_items(ModelRc::from(Rc::new(VecModel::from(items))));
+            w.set_completion_selected(0);
+            w.set_completion_visible(true);
+        })
+    };
+    let accept_completion: Rc<dyn Fn(i32)> = {
+        let weak = window.as_weak();
+        let ed_state = ed_state.clone();
+        let sync_editor = sync_editor.clone();
+        let completion_ctx = completion_ctx.clone();
+        Rc::new(move |idx: i32| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let (word_len, labels) = completion_ctx.borrow().clone();
+            let Some(label) = labels.get(idx.max(0) as usize).cloned() else {
+                return;
+            };
+            {
+                let mut ed = ed_state.borrow_mut();
+                for _ in 0..word_len {
+                    ed.backspace();
+                }
+                ed.insert(&label);
+            }
+            w.set_completion_visible(false);
+            *completion_ctx.borrow_mut() = (0, Vec::new());
+            sync_editor();
+        })
+    };
+    {
+        let accept = accept_completion.clone();
+        window.on_completion_choose(move |i| accept(i));
+    }
     {
         let ed_state = ed_state.clone();
         let sync_editor = sync_editor.clone();
+        let weak = window.as_weak();
+        let refresh_completion = refresh_completion.clone();
+        let accept_completion = accept_completion.clone();
         window.on_editor_key(move |text, meta, alt, shift| {
+            // While the autocomplete popup is open it owns nav / accept / close.
+            if let Some(w) = weak.upgrade() {
+                if w.get_completion_visible() {
+                    let n = w.get_completion_items().row_count() as i32;
+                    match text.as_str() {
+                        "\u{f700}" if n > 0 => {
+                            w.set_completion_selected((w.get_completion_selected() - 1 + n) % n);
+                            return true;
+                        }
+                        "\u{f701}" if n > 0 => {
+                            w.set_completion_selected((w.get_completion_selected() + 1) % n);
+                            return true;
+                        }
+                        "\t" | "\n" | "\r" => {
+                            accept_completion(w.get_completion_selected());
+                            return true;
+                        }
+                        "\u{1b}" => {
+                            w.set_completion_visible(false);
+                            return true;
+                        }
+                        _ => {}
+                    }
+                }
+            }
             // Cursor motion first: arrows / home / end, with macOS ⌘ (line &
             // document) and ⌥ (word) semantics. shift extends the selection.
             if matches!(
@@ -1302,6 +1396,8 @@ fn main() -> Result<(), slint::PlatformError> {
             };
             if handled {
                 sync_editor();
+                // Typing/deleting shifts the completion context — recompute.
+                refresh_completion();
             }
             handled
         });
@@ -1309,7 +1405,11 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let ed_state = ed_state.clone();
         let sync_editor = sync_editor.clone();
+        let weak = window.as_weak();
         window.on_editor_press(move |line, col| {
+            if let Some(w) = weak.upgrade() {
+                w.set_completion_visible(false);
+            }
             ed_state.borrow_mut().move_to(line, col, false);
             sync_editor();
         });

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2061,6 +2061,63 @@ fn main() -> Result<(), slint::PlatformError> {
         });
     }
 
+    // ----- header click: client-side sort by a column -----
+    {
+        let weak = window.as_weak();
+        let last_view = last_view.clone();
+        let edit_buf = edit_buf.clone();
+        let displayed_grid = displayed_grid.clone();
+        let hidden_cols = hidden_cols.clone();
+        let sort_state = sort_state.clone();
+        let col_order = col_order.clone();
+        window.on_sort_col(move |display_c| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let hidden = hidden_cols.lock().unwrap().clone();
+            let order = col_order.lock().unwrap().clone();
+            // display position → ORIGINAL column index
+            let visible: Vec<usize> = order
+                .iter()
+                .copied()
+                .filter(|i| !hidden.contains(i))
+                .collect();
+            let Some(&orig) = visible.get(display_c.max(0) as usize) else {
+                return;
+            };
+            // toggle direction on the same column, else ascending on a new one
+            {
+                let mut s = sort_state.lock().unwrap();
+                if s.0 == orig as i32 {
+                    s.1 = !s.1;
+                } else {
+                    *s = (orig as i32, true);
+                }
+            }
+            let (scol, sasc) = *sort_state.lock().unwrap();
+            w.set_grid_sort_col(display_c);
+            w.set_grid_sort_asc(sasc);
+            let needle = w.get_grid_filter().to_string().to_lowercase();
+            let fcol = w.get_filter_col().to_string();
+            let fop = w.get_filter_op().to_string();
+            let guard = last_view.lock().unwrap();
+            let Some(v) = guard.as_ref() else {
+                return;
+            };
+            if matches!(v, model::ResultView::Affected(_)) {
+                return;
+            }
+            // Sorting renumbers rows → row-keyed pending edits would misland.
+            edit_buf.lock().unwrap().clear();
+            w.set_pending_count(0);
+            w.set_editing_row(-1);
+            w.set_editing_col(-1);
+            let sorted = compute_view(v, &needle, &fcol, &fop, &hidden, &order, scol, sasc);
+            *displayed_grid.lock().unwrap() = view_grid(&sorted);
+            apply_result(&w, sorted);
+        });
+    }
+
     // ----- Columns popup: toggle a column's visibility -----
     {
         let weak = window.as_weak();
@@ -2449,6 +2506,8 @@ fn main() -> Result<(), slint::PlatformError> {
                                 hidden_cols.lock().unwrap().clear();
                                 *col_order.lock().unwrap() = (0..ncols).collect();
                                 *sort_state.lock().unwrap() = (-1, true);
+                                w.set_grid_sort_col(-1);
+                                w.set_grid_sort_asc(true);
                                 let colnames: Vec<SharedString> = match &v {
                                     model::ResultView::Table(g) => g
                                         .columns

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -545,6 +545,23 @@ fn push_grid(w: &MainWindow, g: &model::GridModel) {
     w.set_grid_cells(ModelRc::from(Rc::new(VecModel::from(flat))));
 }
 
+/// Update only the row cells (not columns/widths), so the per-column filter
+/// inputs keep focus while the user types. Columns are assumed unchanged.
+fn set_grid_cells_only(w: &MainWindow, g: &model::GridModel) {
+    let mut flat: Vec<GridCell> = Vec::new();
+    for row in &g.rows {
+        for cell in row {
+            flat.push(GridCell {
+                text: cell.text.clone().into(),
+                is_null: cell.is_null,
+                state: 0,
+            });
+        }
+    }
+    w.set_grid_cells(ModelRc::from(Rc::new(VecModel::from(flat))));
+    w.set_result_status(SharedString::from(format!("{} rows", g.rows.len())));
+}
+
 /// Push `g` with the buffer's pending edits overlaid: changed cells show the
 /// new text (state 1), delete-marked rows state 2, insert rows appended as
 /// state-3 rows at the bottom.
@@ -2340,7 +2357,13 @@ fn main() -> Result<(), slint::PlatformError> {
                 v, &needle, &fcol, &fop, &cfilters, &hidden, &order, scol, sasc,
             );
             *displayed_grid.lock().unwrap() = view_grid(&filtered);
-            apply_result(&w, filtered);
+            // Columns are unchanged, so update only the cells — replacing the
+            // columns model would rebuild (and unfocus) the filter inputs.
+            if let model::ResultView::Table(g) = &filtered {
+                set_grid_cells_only(&w, g);
+            } else {
+                apply_result(&w, filtered);
+            }
         });
     }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -764,11 +764,75 @@ fn project_cols(
 /// then project columns (hide + reorder). Column index arguments are ORIGINAL
 /// indices into `base`.
 #[allow(clippy::too_many_arguments)]
+/// Parse one per-column filter box into `(op, needle)`. A leading operator
+/// (`>=`,`<=`,`!=`,`>`,`<`,`=`) picks the comparison; anything else is a
+/// case-insensitive `contains`. Blank input means "no filter" (None).
+fn parse_col_filter(raw: &str) -> Option<(&'static str, String)> {
+    let t = raw.trim();
+    if t.is_empty() {
+        return None;
+    }
+    for op in [">=", "<=", "!="] {
+        if let Some(rest) = t.strip_prefix(op) {
+            return Some((op, rest.trim().to_lowercase()));
+        }
+    }
+    for op in [">", "<", "="] {
+        if let Some(rest) = t.strip_prefix(op) {
+            return Some((op, rest.trim().to_lowercase()));
+        }
+    }
+    Some(("contains", t.to_lowercase()))
+}
+
+/// Drop rows failing any non-empty per-column filter (`col_filters` indexed by
+/// ORIGINAL column). Conditions combine with AND.
+fn apply_col_filters(g: &model::GridModel, col_filters: &[String]) -> model::GridModel {
+    let parsed: Vec<(usize, &'static str, String)> = col_filters
+        .iter()
+        .enumerate()
+        .filter_map(|(ci, raw)| parse_col_filter(raw).map(|(op, n)| (ci, op, n)))
+        .collect();
+    if parsed.is_empty() {
+        return g.clone();
+    }
+    model::GridModel {
+        columns: g.columns.clone(),
+        rows: g
+            .rows
+            .iter()
+            .filter(|row| {
+                parsed
+                    .iter()
+                    .all(|(ci, op, n)| row.get(*ci).is_some_and(|cell| cell_matches(cell, op, n)))
+            })
+            .cloned()
+            .collect(),
+    }
+}
+
+/// Per-column filter box values in DISPLAY order (visible columns only), for
+/// feeding the grid's filter-row inputs.
+fn display_col_filters(
+    col_filters: &[String],
+    order: &[usize],
+    hidden: &HashSet<usize>,
+) -> Vec<SharedString> {
+    order
+        .iter()
+        .copied()
+        .filter(|i| !hidden.contains(i))
+        .map(|i| SharedString::from(col_filters.get(i).cloned().unwrap_or_default()))
+        .collect()
+}
+
+#[allow(clippy::too_many_arguments)]
 fn build_grid(
     base: &model::GridModel,
     needle: &str,
     fcol: &str,
     fop: &str,
+    col_filters: &[String],
     hidden: &HashSet<usize>,
     order: &[usize],
     sort_col: i32,
@@ -780,7 +844,8 @@ fn build_grid(
         base.columns.iter().position(|c| c.name == fcol)
     };
     let filtered = filter_grid_cond(base, needle, col, fop);
-    let sorted = sort_grid(&filtered, sort_col, sort_asc);
+    let per_col = apply_col_filters(&filtered, col_filters);
+    let sorted = sort_grid(&per_col, sort_col, sort_asc);
     project_cols(&sorted, order, hidden)
 }
 
@@ -794,12 +859,25 @@ fn compute_view(
     needle: &str,
     fcol: &str,
     fop: &str,
+    col_filters: &[String],
     hidden: &HashSet<usize>,
     order: &[usize],
     sort_col: i32,
     sort_asc: bool,
 ) -> model::ResultView {
-    let g = |grid| build_grid(grid, needle, fcol, fop, hidden, order, sort_col, sort_asc);
+    let g = |grid| {
+        build_grid(
+            grid,
+            needle,
+            fcol,
+            fop,
+            col_filters,
+            hidden,
+            order,
+            sort_col,
+            sort_asc,
+        )
+    };
     match base {
         model::ResultView::Table(grid) => model::ResultView::Table(g(grid)),
         model::ResultView::Documents(d) => model::ResultView::Documents(model::DocModel {
@@ -854,7 +932,19 @@ fn group_thousands(n: u64) -> String {
 
 #[cfg(test)]
 mod fmt_tests {
-    use super::group_thousands;
+    use super::{group_thousands, parse_col_filter};
+    #[test]
+    fn col_filter_prefix_ops() {
+        assert_eq!(parse_col_filter(""), None);
+        assert_eq!(parse_col_filter("   "), None);
+        assert_eq!(parse_col_filter(">100"), Some((">", "100".to_string())));
+        assert_eq!(parse_col_filter(">= 5"), Some((">=", "5".to_string())));
+        assert_eq!(parse_col_filter("!=X"), Some(("!=", "x".to_string())));
+        assert_eq!(
+            parse_col_filter("abc"),
+            Some(("contains", "abc".to_string()))
+        );
+    }
     #[test]
     fn groups_thousands_with_dots() {
         assert_eq!(group_thousands(0), "0");
@@ -962,6 +1052,10 @@ fn main() -> Result<(), slint::PlatformError> {
     // Display order of columns as ORIGINAL indices (drag-to-reorder). Reset to
     // 0..ncols on every fresh result.
     let col_order: Arc<std::sync::Mutex<Vec<usize>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+    // Per-column filter boxes, raw text indexed by ORIGINAL column. Empty =
+    // no filter. Reset to blanks on every fresh result.
+    let col_filters: Arc<std::sync::Mutex<Vec<String>>> =
+        Arc::new(std::sync::Mutex::new(Vec::new()));
     // Engine of the live connection, kept on the UI thread so table clicks can
     // build an engine-appropriate "browse this table" query synchronously.
     let cur_engine: Rc<RefCell<Option<rdbs_connstore::Engine>>> = Rc::new(RefCell::new(None));
@@ -2058,6 +2152,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let hidden_cols = hidden_cols.clone();
         let sort_state = sort_state.clone();
         let col_order = col_order.clone();
+        let col_filters = col_filters.clone();
         window.on_apply_filter(move || {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -2067,6 +2162,7 @@ fn main() -> Result<(), slint::PlatformError> {
             let fop = w.get_filter_op().to_string();
             let hidden = hidden_cols.lock().unwrap().clone();
             let order = col_order.lock().unwrap().clone();
+            let cfilters = col_filters.lock().unwrap().clone();
             let (scol, sasc) = *sort_state.lock().unwrap();
             let guard = last_view.lock().unwrap();
             let Some(v) = guard.as_ref() else {
@@ -2084,7 +2180,65 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_pending_count(0);
             w.set_editing_row(-1);
             w.set_editing_col(-1);
-            let filtered = compute_view(v, &needle, &fcol, &fop, &hidden, &order, scol, sasc);
+            let filtered = compute_view(
+                v, &needle, &fcol, &fop, &cfilters, &hidden, &order, scol, sasc,
+            );
+            *displayed_grid.lock().unwrap() = view_grid(&filtered);
+            apply_result(&w, filtered);
+        });
+    }
+
+    // ----- per-column filter box edited -----
+    {
+        let weak = window.as_weak();
+        let last_view = last_view.clone();
+        let edit_buf = edit_buf.clone();
+        let displayed_grid = displayed_grid.clone();
+        let hidden_cols = hidden_cols.clone();
+        let sort_state = sort_state.clone();
+        let col_order = col_order.clone();
+        let col_filters = col_filters.clone();
+        window.on_set_col_filter(move |display_c, text| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let hidden = hidden_cols.lock().unwrap().clone();
+            let order = col_order.lock().unwrap().clone();
+            let (scol, sasc) = *sort_state.lock().unwrap();
+            // display position → ORIGINAL column index
+            let visible: Vec<usize> = order
+                .iter()
+                .copied()
+                .filter(|i| !hidden.contains(i))
+                .collect();
+            let Some(&orig) = visible.get(display_c.max(0) as usize) else {
+                return;
+            };
+            let cfilters = {
+                let mut cf = col_filters.lock().unwrap();
+                if orig < cf.len() {
+                    cf[orig] = text.to_string();
+                }
+                cf.clone()
+            };
+            let needle = w.get_grid_filter().to_string().to_lowercase();
+            let fcol = w.get_filter_col().to_string();
+            let fop = w.get_filter_op().to_string();
+            let guard = last_view.lock().unwrap();
+            let Some(v) = guard.as_ref() else {
+                return;
+            };
+            if matches!(v, model::ResultView::Affected(_)) {
+                return;
+            }
+            // Filtering renumbers rows → row-keyed pending edits would misland.
+            edit_buf.lock().unwrap().clear();
+            w.set_pending_count(0);
+            w.set_editing_row(-1);
+            w.set_editing_col(-1);
+            let filtered = compute_view(
+                v, &needle, &fcol, &fop, &cfilters, &hidden, &order, scol, sasc,
+            );
             *displayed_grid.lock().unwrap() = view_grid(&filtered);
             apply_result(&w, filtered);
         });
@@ -2099,12 +2253,14 @@ fn main() -> Result<(), slint::PlatformError> {
         let hidden_cols = hidden_cols.clone();
         let sort_state = sort_state.clone();
         let col_order = col_order.clone();
+        let col_filters = col_filters.clone();
         window.on_sort_col(move |display_c| {
             let Some(w) = weak.upgrade() else {
                 return;
             };
             let hidden = hidden_cols.lock().unwrap().clone();
             let order = col_order.lock().unwrap().clone();
+            let cfilters = col_filters.lock().unwrap().clone();
             // display position → ORIGINAL column index
             let visible: Vec<usize> = order
                 .iter()
@@ -2141,7 +2297,9 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_pending_count(0);
             w.set_editing_row(-1);
             w.set_editing_col(-1);
-            let sorted = compute_view(v, &needle, &fcol, &fop, &hidden, &order, scol, sasc);
+            let sorted = compute_view(
+                v, &needle, &fcol, &fop, &cfilters, &hidden, &order, scol, sasc,
+            );
             *displayed_grid.lock().unwrap() = view_grid(&sorted);
             apply_result(&w, sorted);
         });
@@ -2156,6 +2314,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let hidden_cols = hidden_cols.clone();
         let sort_state = sort_state.clone();
         let col_order = col_order.clone();
+        let col_filters = col_filters.clone();
         window.on_reorder_col(move |from, local_x| {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -2233,7 +2392,14 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_pending_count(0);
             w.set_editing_row(-1);
             w.set_editing_col(-1);
-            let transformed = compute_view(v, &needle, &fcol, &fop, &hidden, &order, scol, sasc);
+            let cfilters = col_filters.lock().unwrap().clone();
+            // filter boxes follow their columns into the new order
+            w.set_grid_col_filters(ModelRc::from(Rc::new(VecModel::from(display_col_filters(
+                &cfilters, &order, &hidden,
+            )))));
+            let transformed = compute_view(
+                v, &needle, &fcol, &fop, &cfilters, &hidden, &order, scol, sasc,
+            );
             *displayed_grid.lock().unwrap() = view_grid(&transformed);
             apply_result(&w, transformed);
         });
@@ -2248,6 +2414,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let hidden_cols = hidden_cols.clone();
         let sort_state = sort_state.clone();
         let col_order = col_order.clone();
+        let col_filters = col_filters.clone();
         window.on_toggle_column(move |i| {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -2289,7 +2456,13 @@ fn main() -> Result<(), slint::PlatformError> {
             if !hidden.is_empty() {
                 w.set_grid_read_only(true);
             }
-            let transformed = compute_view(v, &needle, &fcol, &fop, &hidden, &order, scol, sasc);
+            let cfilters = col_filters.lock().unwrap().clone();
+            w.set_grid_col_filters(ModelRc::from(Rc::new(VecModel::from(display_col_filters(
+                &cfilters, &order, &hidden,
+            )))));
+            let transformed = compute_view(
+                v, &needle, &fcol, &fop, &cfilters, &hidden, &order, scol, sasc,
+            );
             // ponytail: hiding is structural, so widths reset to type defaults
             // (manual resize is dropped) — same trade-off reorder makes.
             if let Some(g) = view_grid(&transformed) {
@@ -2539,6 +2712,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let hidden_cols = hidden_cols.clone();
         let sort_state = sort_state.clone();
         let col_order = col_order.clone();
+        let col_filters = col_filters.clone();
         Rc::new(move |sql: String| {
             let weak2 = weak.clone();
             let current = current.clone();
@@ -2549,6 +2723,7 @@ fn main() -> Result<(), slint::PlatformError> {
             let hidden_cols = hidden_cols.clone();
             let sort_state = sort_state.clone();
             let col_order = col_order.clone();
+            let col_filters = col_filters.clone();
             if let Some(w) = weak.upgrade() {
                 w.set_query_running(true);
             }
@@ -2627,8 +2802,12 @@ fn main() -> Result<(), slint::PlatformError> {
                                 hidden_cols.lock().unwrap().clear();
                                 *col_order.lock().unwrap() = (0..ncols).collect();
                                 *sort_state.lock().unwrap() = (-1, true);
+                                *col_filters.lock().unwrap() = vec![String::new(); ncols];
                                 w.set_grid_sort_col(-1);
                                 w.set_grid_sort_asc(true);
+                                w.set_grid_col_filters(ModelRc::from(Rc::new(VecModel::from(
+                                    vec![SharedString::default(); ncols],
+                                ))));
                                 let colnames: Vec<SharedString> = match &v {
                                     model::ResultView::Table(g) => g
                                         .columns

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -701,30 +701,110 @@ fn filter_grid_cond(
     }
 }
 
-/// Return a copy of `g` without the hidden column indices.
-fn hide_cols(g: &model::GridModel, hidden: &HashSet<usize>) -> model::GridModel {
-    if hidden.is_empty() {
+/// Sort rows by column `col` (an ORIGINAL column index). Numeric when both
+/// cells parse as f64, else case-insensitive text. Nulls always sort last,
+/// regardless of direction. `col < 0` or out of range leaves the grid as-is.
+fn sort_grid(g: &model::GridModel, col: i32, asc: bool) -> model::GridModel {
+    if col < 0 || col as usize >= g.columns.len() {
         return g.clone();
     }
+    let c = col as usize;
+    let mut rows = g.rows.clone();
+    rows.sort_by(|a, b| {
+        use std::cmp::Ordering;
+        let (x, y) = (&a[c], &b[c]);
+        match (x.is_null, y.is_null) {
+            (true, true) => return Ordering::Equal,
+            (true, false) => return Ordering::Greater,
+            (false, true) => return Ordering::Less,
+            _ => {}
+        }
+        let ord = match (x.text.parse::<f64>(), y.text.parse::<f64>()) {
+            (Ok(m), Ok(n)) => m.partial_cmp(&n).unwrap_or(Ordering::Equal),
+            _ => x.text.to_lowercase().cmp(&y.text.to_lowercase()),
+        };
+        if asc {
+            ord
+        } else {
+            ord.reverse()
+        }
+    });
     model::GridModel {
-        columns: g
-            .columns
-            .iter()
-            .enumerate()
-            .filter(|(i, _)| !hidden.contains(i))
-            .map(|(_, c)| c.clone())
-            .collect(),
+        columns: g.columns.clone(),
+        rows,
+    }
+}
+
+/// Project `g`'s columns into display order `order` (ORIGINAL column indices),
+/// dropping any index in `hidden`. Both columns and each row are projected the
+/// same way, so this subsumes hide + reorder in one pass.
+fn project_cols(
+    g: &model::GridModel,
+    order: &[usize],
+    hidden: &HashSet<usize>,
+) -> model::GridModel {
+    let idx: Vec<usize> = order
+        .iter()
+        .copied()
+        .filter(|i| *i < g.columns.len() && !hidden.contains(i))
+        .collect();
+    model::GridModel {
+        columns: idx.iter().map(|&i| g.columns[i].clone()).collect(),
         rows: g
             .rows
             .iter()
-            .map(|row| {
-                row.iter()
-                    .enumerate()
-                    .filter(|(i, _)| !hidden.contains(i))
-                    .map(|(_, c)| c.clone())
-                    .collect()
-            })
+            .map(|row| idx.iter().map(|&i| row[i].clone()).collect())
             .collect(),
+    }
+}
+
+/// Build the on-screen grid from a base result grid: filter rows, sort rows,
+/// then project columns (hide + reorder). Column index arguments are ORIGINAL
+/// indices into `base`.
+#[allow(clippy::too_many_arguments)]
+fn build_grid(
+    base: &model::GridModel,
+    needle: &str,
+    fcol: &str,
+    fop: &str,
+    hidden: &HashSet<usize>,
+    order: &[usize],
+    sort_col: i32,
+    sort_asc: bool,
+) -> model::GridModel {
+    let col = if fcol == "any column" {
+        None
+    } else {
+        base.columns.iter().position(|c| c.name == fcol)
+    };
+    let filtered = filter_grid_cond(base, needle, col, fop);
+    let sorted = sort_grid(&filtered, sort_col, sort_asc);
+    project_cols(&sorted, order, hidden)
+}
+
+/// Derive the displayed `ResultView` from a cached base view by applying the
+/// active filter, sort, hidden-column set, and column order. Single source of
+/// truth for the filter / sort / hide / reorder handlers. `Affected` has no
+/// grid, so it passes through unchanged.
+#[allow(clippy::too_many_arguments)]
+fn compute_view(
+    base: &model::ResultView,
+    needle: &str,
+    fcol: &str,
+    fop: &str,
+    hidden: &HashSet<usize>,
+    order: &[usize],
+    sort_col: i32,
+    sort_asc: bool,
+) -> model::ResultView {
+    let g = |grid| build_grid(grid, needle, fcol, fop, hidden, order, sort_col, sort_asc);
+    match base {
+        model::ResultView::Table(grid) => model::ResultView::Table(g(grid)),
+        model::ResultView::Documents(d) => model::ResultView::Documents(model::DocModel {
+            json: d.json.clone(),
+            grid: g(&d.grid),
+        }),
+        model::ResultView::Affected(a) => model::ResultView::Affected(a.clone()),
     }
 }
 
@@ -847,6 +927,12 @@ fn main() -> Result<(), slint::PlatformError> {
     // Column indices (into the last result) hidden via the Columns popup.
     let hidden_cols: Arc<std::sync::Mutex<HashSet<usize>>> =
         Arc::new(std::sync::Mutex::new(HashSet::new()));
+    // Client-side sort: ORIGINAL column index (-1 = none) + ascending flag.
+    let sort_state: Arc<std::sync::Mutex<(i32, bool)>> =
+        Arc::new(std::sync::Mutex::new((-1, true)));
+    // Display order of columns as ORIGINAL indices (drag-to-reorder). Reset to
+    // 0..ncols on every fresh result.
+    let col_order: Arc<std::sync::Mutex<Vec<usize>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
     // Engine of the live connection, kept on the UI thread so table clicks can
     // build an engine-appropriate "browse this table" query synchronously.
     let cur_engine: Rc<RefCell<Option<rdbs_connstore::Engine>>> = Rc::new(RefCell::new(None));
@@ -1941,6 +2027,8 @@ fn main() -> Result<(), slint::PlatformError> {
         let edit_buf = edit_buf.clone();
         let displayed_grid = displayed_grid.clone();
         let hidden_cols = hidden_cols.clone();
+        let sort_state = sort_state.clone();
+        let col_order = col_order.clone();
         window.on_apply_filter(move || {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -1949,10 +2037,15 @@ fn main() -> Result<(), slint::PlatformError> {
             let fcol = w.get_filter_col().to_string();
             let fop = w.get_filter_op().to_string();
             let hidden = hidden_cols.lock().unwrap().clone();
+            let order = col_order.lock().unwrap().clone();
+            let (scol, sasc) = *sort_state.lock().unwrap();
             let guard = last_view.lock().unwrap();
             let Some(v) = guard.as_ref() else {
                 return;
             };
+            if matches!(v, model::ResultView::Affected(_)) {
+                return;
+            }
             // Filtering renumbers the visible rows, so pending edits keyed by
             // row index would land on the wrong rows — drop them.
             {
@@ -1962,28 +2055,7 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_pending_count(0);
             w.set_editing_row(-1);
             w.set_editing_col(-1);
-            // Filter the row-bearing views; Affected has nothing to filter.
-            let col_of = |g: &model::GridModel| {
-                if fcol == "any column" {
-                    None
-                } else {
-                    g.columns.iter().position(|c| c.name == fcol)
-                }
-            };
-            let filtered = match v {
-                model::ResultView::Table(g) => model::ResultView::Table(hide_cols(
-                    &filter_grid_cond(g, &needle, col_of(g), &fop),
-                    &hidden,
-                )),
-                model::ResultView::Documents(d) => model::ResultView::Documents(model::DocModel {
-                    json: d.json.clone(),
-                    grid: hide_cols(
-                        &filter_grid_cond(&d.grid, &needle, col_of(&d.grid), &fop),
-                        &hidden,
-                    ),
-                }),
-                model::ResultView::Affected(_) => return,
-            };
+            let filtered = compute_view(v, &needle, &fcol, &fop, &hidden, &order, scol, sasc);
             *displayed_grid.lock().unwrap() = view_grid(&filtered);
             apply_result(&w, filtered);
         });
@@ -1996,6 +2068,8 @@ fn main() -> Result<(), slint::PlatformError> {
         let edit_buf = edit_buf.clone();
         let displayed_grid = displayed_grid.clone();
         let hidden_cols = hidden_cols.clone();
+        let sort_state = sort_state.clone();
+        let col_order = col_order.clone();
         window.on_toggle_column(move |i| {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -2012,10 +2086,17 @@ fn main() -> Result<(), slint::PlatformError> {
             let flags: Vec<bool> = (0..n).map(|c| hidden.contains(&c)).collect();
             w.set_col_hidden(ModelRc::from(Rc::new(VecModel::from(flags))));
             let needle = w.get_grid_filter().to_string().to_lowercase();
+            let fcol = w.get_filter_col().to_string();
+            let fop = w.get_filter_op().to_string();
+            let order = col_order.lock().unwrap().clone();
+            let (scol, sasc) = *sort_state.lock().unwrap();
             let guard = last_view.lock().unwrap();
             let Some(v) = guard.as_ref() else {
                 return;
             };
+            if matches!(v, model::ResultView::Affected(_)) {
+                return;
+            }
             // Hiding renumbers columns: cell edits would write through the
             // wrong column index, so drop pending edits and lock editing
             // until the next refresh restores the full column set.
@@ -2030,16 +2111,9 @@ fn main() -> Result<(), slint::PlatformError> {
             if !hidden.is_empty() {
                 w.set_grid_read_only(true);
             }
-            let transformed = match v {
-                model::ResultView::Table(g) => {
-                    model::ResultView::Table(hide_cols(&filter_grid(g, &needle), &hidden))
-                }
-                model::ResultView::Documents(d) => model::ResultView::Documents(model::DocModel {
-                    json: d.json.clone(),
-                    grid: hide_cols(&filter_grid(&d.grid, &needle), &hidden),
-                }),
-                model::ResultView::Affected(_) => return,
-            };
+            let transformed = compute_view(v, &needle, &fcol, &fop, &hidden, &order, scol, sasc);
+            // ponytail: hiding is structural, so widths reset to type defaults
+            // (manual resize is dropped) — same trade-off reorder makes.
             if let Some(g) = view_grid(&transformed) {
                 let widths: Vec<f32> = g
                     .columns
@@ -2285,6 +2359,8 @@ fn main() -> Result<(), slint::PlatformError> {
         let edit_buf = edit_buf.clone();
         let displayed_grid = displayed_grid.clone();
         let hidden_cols = hidden_cols.clone();
+        let sort_state = sort_state.clone();
+        let col_order = col_order.clone();
         Rc::new(move |sql: String| {
             let weak2 = weak.clone();
             let current = current.clone();
@@ -2293,6 +2369,8 @@ fn main() -> Result<(), slint::PlatformError> {
             let edit_buf = edit_buf.clone();
             let displayed_grid = displayed_grid.clone();
             let hidden_cols = hidden_cols.clone();
+            let sort_state = sort_state.clone();
+            let col_order = col_order.clone();
             if let Some(w) = weak.upgrade() {
                 w.set_query_running(true);
             }
@@ -2366,8 +2444,11 @@ fn main() -> Result<(), slint::PlatformError> {
                                 } as u64;
                                 *last_view.lock().unwrap() = Some(v.clone());
                                 w.set_grid_filter(SharedString::default());
-                                // Fresh result: all columns visible again.
+                                // Fresh result: all columns visible, natural
+                                // order, no client-side sort.
                                 hidden_cols.lock().unwrap().clear();
+                                *col_order.lock().unwrap() = (0..ncols).collect();
+                                *sort_state.lock().unwrap() = (-1, true);
                                 let colnames: Vec<SharedString> = match &v {
                                     model::ResultView::Table(g) => g
                                         .columns

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -3338,6 +3338,47 @@ fn main() -> Result<(), slint::PlatformError> {
         });
     }
 
+    // ----- ⌘\: run the current statement in a fresh tab -----
+    {
+        let weak = window.as_weak();
+        let tab_texts = tab_texts.clone();
+        let ed_state = ed_state.clone();
+        let run_sql = run_sql.clone();
+        let load_editor_text = load_editor_text.clone();
+        let recent_queries = recent_queries.clone();
+        window.on_run_new_tab(move || {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let stmt = {
+                let ed = ed_state.borrow();
+                ed.selected_text()
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or_else(|| ed.current_statement())
+            };
+            if stmt.is_empty() {
+                return;
+            }
+            // Stash the current tab, open a fresh one holding the statement.
+            let active = w.get_active_tab() as usize;
+            {
+                let mut t = tab_texts.borrow_mut();
+                if let Some(slot) = t.get_mut(active) {
+                    *slot = w.get_query_text().to_string();
+                }
+                t.push(stmt.clone());
+            }
+            let count = tab_texts.borrow().len();
+            set_tab_titles(&w, count);
+            w.set_active_tab((count - 1) as i32);
+            load_editor_text(&stmt);
+            w.set_grid_read_only(true);
+            record_recent(&recent_queries, &stmt);
+            run_sql(stmt);
+        });
+    }
+
     // ----- close tab -----
     {
         let weak = window.as_weak();

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2729,11 +2729,24 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let weak = window.as_weak();
         let run_sql = run_sql.clone();
+        let ed_state = ed_state.clone();
         let recent_queries = recent_queries.clone();
         let rebuild_query_tree = rebuild_query_tree.clone();
         window.on_run_query(move || {
             if let Some(w) = weak.upgrade() {
-                let text = w.get_query_text().to_string();
+                // ⌘⏎ / Run: the highlighted selection, else just the statement
+                // under the cursor — so a buffer with several statements runs
+                // only the one the user is editing (⌘A then Run for all).
+                let text = {
+                    let ed = ed_state.borrow();
+                    ed.selected_text()
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .unwrap_or_else(|| ed.current_statement())
+                };
+                if text.is_empty() {
+                    return;
+                }
                 record_recent(&recent_queries, &text);
                 // A manual query result has no row identity — never editable.
                 // (The browse path re-enables editing after its PK fetch.)

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -349,6 +349,15 @@ struct BrowseState {
     pk_cols: Vec<String>,
 }
 
+/// One cached SQL result, shown as a result tab. ⌘⏎ replaces the active one;
+/// ⌘\ appends a new one.
+#[derive(Clone)]
+struct StoredResult {
+    view: model::ResultView,
+    meta: String,
+    latency: String,
+}
+
 /// 1-based display bounds of the current page window plus prev/next
 /// availability. `shown` is how many rows the page actually returned.
 /// Connect + ping, bounded to 8s so "Testing connection…" always resolves.
@@ -934,6 +943,125 @@ fn apply_result(w: &MainWindow, view: model::ResultView) {
     }
 }
 
+/// Present a fresh result view: reset all client-side view state (filter, sort,
+/// hidden, order, per-column filters, pending edits), rebuild the column
+/// metadata + widths + chart, and push it to the grid. Shared by a new query
+/// run and by switching between result tabs.
+#[allow(clippy::too_many_arguments)]
+fn present_view(
+    w: &MainWindow,
+    v: model::ResultView,
+    meta: &str,
+    latency: &str,
+    last_view: &Arc<std::sync::Mutex<Option<model::ResultView>>>,
+    displayed_grid: &Arc<std::sync::Mutex<Option<model::GridModel>>>,
+    hidden_cols: &Arc<std::sync::Mutex<HashSet<usize>>>,
+    sort_state: &Arc<std::sync::Mutex<(i32, bool)>>,
+    col_order: &Arc<std::sync::Mutex<Vec<usize>>>,
+    col_filters: &Arc<std::sync::Mutex<Vec<String>>>,
+    edit_buf: &Arc<std::sync::Mutex<model::EditBuffer>>,
+    browse: &Arc<std::sync::Mutex<BrowseState>>,
+) {
+    let ncols = match &v {
+        model::ResultView::Table(g) => g.columns.len(),
+        model::ResultView::Documents(d) => d.grid.columns.len(),
+        _ => 0,
+    };
+    let shown = match &v {
+        model::ResultView::Table(g) => g.rows.len(),
+        model::ResultView::Documents(d) => d.grid.rows.len(),
+        model::ResultView::Affected(_) => 0,
+    } as u64;
+    *last_view.lock().unwrap() = Some(v.clone());
+    w.set_grid_filter(SharedString::default());
+    hidden_cols.lock().unwrap().clear();
+    *col_order.lock().unwrap() = (0..ncols).collect();
+    *sort_state.lock().unwrap() = (-1, true);
+    *col_filters.lock().unwrap() = vec![String::new(); ncols];
+    w.set_grid_sort_col(-1);
+    w.set_grid_sort_asc(true);
+    w.set_grid_col_filters(ModelRc::from(Rc::new(VecModel::from(vec![
+            SharedString::default();
+            ncols
+        ]))));
+    let colnames: Vec<SharedString> = match &v {
+        model::ResultView::Table(g) => g
+            .columns
+            .iter()
+            .map(|c| SharedString::from(c.name.clone()))
+            .collect(),
+        model::ResultView::Documents(d) => d
+            .grid
+            .columns
+            .iter()
+            .map(|c| SharedString::from(c.name.clone()))
+            .collect(),
+        _ => Vec::new(),
+    };
+    w.set_col_hidden(ModelRc::from(Rc::new(VecModel::from(vec![
+        false;
+        colnames.len()
+    ]))));
+    let mut fcols: Vec<SharedString> = vec![SharedString::from("any column")];
+    fcols.extend(colnames.iter().cloned());
+    w.set_filter_columns(ModelRc::from(Rc::new(VecModel::from(fcols))));
+    w.set_all_columns(ModelRc::from(Rc::new(VecModel::from(colnames))));
+    *displayed_grid.lock().unwrap() = view_grid(&v);
+    {
+        let st = browse.lock().unwrap();
+        let mut b = edit_buf.lock().unwrap();
+        b.clear();
+        b.table = st.table.clone();
+        b.pk_cols = st.pk_cols.clone();
+    }
+    w.set_pending_count(0);
+    w.set_editing_row(-1);
+    w.set_editing_col(-1);
+    w.set_status_error(false);
+    w.set_status_latency(SharedString::from(latency));
+    w.set_results_meta(SharedString::from(meta));
+    let widths: Vec<f32> = match &v {
+        model::ResultView::Table(g) => g
+            .columns
+            .iter()
+            .map(|c| default_col_width(&c.name, &c.type_name))
+            .collect(),
+        _ => vec![140.0; ncols],
+    };
+    w.set_grid_col_widths(ModelRc::from(Rc::new(VecModel::from(widths))));
+    let bars: Vec<ChartBar> = match &v {
+        model::ResultView::Table(g) => model::chart_data(g)
+            .into_iter()
+            .map(|(label, value, frac)| ChartBar {
+                label: label.into(),
+                value: value.into(),
+                frac,
+            })
+            .collect(),
+        _ => Vec::new(),
+    };
+    w.set_chart_bars(ModelRc::from(Rc::new(VecModel::from(bars))));
+    apply_result(w, v);
+    let st = browse.lock().unwrap().clone();
+    if st.table.is_some() {
+        let (start, end, prev, next) = page_bounds(st.page, st.limit, st.total, shown);
+        w.set_page_start(start as i32);
+        w.set_page_end(end as i32);
+        w.set_total_rows(st.total.map(|t| t as i32).unwrap_or(-1));
+        w.set_can_prev(prev);
+        w.set_can_next(next);
+    }
+}
+
+/// Set the result-tab strip labels ("Result 1", …) and active index.
+fn set_result_tabs(w: &MainWindow, count: usize, active: usize) {
+    let labels: Vec<SharedString> = (1..=count)
+        .map(|n| SharedString::from(format!("Result {n}")))
+        .collect();
+    w.set_result_tabs(ModelRc::from(Rc::new(VecModel::from(labels))));
+    w.set_active_result(active as i32);
+}
+
 /// Format a number with `.` thousands separators (e.g. 1000 → "1.000").
 fn group_thousands(n: u64) -> String {
     let s = n.to_string();
@@ -1074,6 +1202,12 @@ fn main() -> Result<(), slint::PlatformError> {
     // no filter. Reset to blanks on every fresh result.
     let col_filters: Arc<std::sync::Mutex<Vec<String>>> =
         Arc::new(std::sync::Mutex::new(Vec::new()));
+    // Result tabs for the SQL editor: cached results + the active index. ⌘\
+    // sets `result_new_tab` so the next run appends instead of replacing.
+    let results: Arc<std::sync::Mutex<Vec<StoredResult>>> =
+        Arc::new(std::sync::Mutex::new(Vec::new()));
+    let active_result: Arc<std::sync::Mutex<usize>> = Arc::new(std::sync::Mutex::new(0));
+    let result_new_tab = Arc::new(std::sync::atomic::AtomicBool::new(false));
     // Engine of the live connection, kept on the UI thread so table clicks can
     // build an engine-appropriate "browse this table" query synchronously.
     let cur_engine: Rc<RefCell<Option<rdbs_connstore::Engine>>> = Rc::new(RefCell::new(None));
@@ -2836,6 +2970,9 @@ fn main() -> Result<(), slint::PlatformError> {
         let sort_state = sort_state.clone();
         let col_order = col_order.clone();
         let col_filters = col_filters.clone();
+        let results = results.clone();
+        let active_result = active_result.clone();
+        let result_new_tab = result_new_tab.clone();
         Rc::new(move |sql: String| {
             let weak2 = weak.clone();
             let current = current.clone();
@@ -2847,6 +2984,10 @@ fn main() -> Result<(), slint::PlatformError> {
             let sort_state = sort_state.clone();
             let col_order = col_order.clone();
             let col_filters = col_filters.clone();
+            let results = results.clone();
+            let active_result = active_result.clone();
+            // ⌘\ set this; consume it so the next plain run replaces again.
+            let new_tab = result_new_tab.swap(false, std::sync::atomic::Ordering::SeqCst);
             if let Some(w) = weak.upgrade() {
                 w.set_query_running(true);
             }
@@ -2905,114 +3046,55 @@ fn main() -> Result<(), slint::PlatformError> {
                         w.set_query_running(false);
                         match (view, err) {
                             (Some(v), _) => {
-                                // Only tabular-shaped views have resizable columns.
-                                let ncols = match &v {
-                                    model::ResultView::Table(g) => g.columns.len(),
-                                    model::ResultView::Documents(d) => d.grid.columns.len(),
-                                    _ => 0,
-                                };
-                                // Cache for client-side filtering, then reset the
-                                // filter input so the full result shows first.
                                 let shown = match &v {
                                     model::ResultView::Table(g) => g.rows.len(),
                                     model::ResultView::Documents(d) => d.grid.rows.len(),
                                     model::ResultView::Affected(_) => 0,
                                 } as u64;
-                                *last_view.lock().unwrap() = Some(v.clone());
-                                w.set_grid_filter(SharedString::default());
-                                // Fresh result: all columns visible, natural
-                                // order, no client-side sort.
-                                hidden_cols.lock().unwrap().clear();
-                                *col_order.lock().unwrap() = (0..ncols).collect();
-                                *sort_state.lock().unwrap() = (-1, true);
-                                *col_filters.lock().unwrap() = vec![String::new(); ncols];
-                                w.set_grid_sort_col(-1);
-                                w.set_grid_sort_asc(true);
-                                w.set_grid_col_filters(ModelRc::from(Rc::new(VecModel::from(
-                                    vec![SharedString::default(); ncols],
-                                ))));
-                                let colnames: Vec<SharedString> = match &v {
-                                    model::ResultView::Table(g) => g
-                                        .columns
-                                        .iter()
-                                        .map(|c| SharedString::from(c.name.clone()))
-                                        .collect(),
-                                    model::ResultView::Documents(d) => d
-                                        .grid
-                                        .columns
-                                        .iter()
-                                        .map(|c| SharedString::from(c.name.clone()))
-                                        .collect(),
-                                    _ => Vec::new(),
-                                };
-                                w.set_col_hidden(ModelRc::from(Rc::new(VecModel::from(
-                                    vec![false; colnames.len()],
-                                ))));
-                                let mut fcols: Vec<SharedString> =
-                                    vec![SharedString::from("any column")];
-                                fcols.extend(colnames.iter().cloned());
-                                w.set_filter_columns(ModelRc::from(Rc::new(VecModel::from(fcols))));
-                                w.set_all_columns(ModelRc::from(Rc::new(VecModel::from(colnames))));
-                                // Fresh result: pending edits refer to rows that
-                                // no longer exist — drop them and re-anchor the
-                                // buffer to the (possibly new) browse target.
-                                *displayed_grid.lock().unwrap() = view_grid(&v);
-                                {
-                                    let st = browse.lock().unwrap();
-                                    let mut b = edit_buf.lock().unwrap();
-                                    b.clear();
-                                    b.table = st.table.clone();
-                                    b.pk_cols = st.pk_cols.clone();
-                                }
-                                w.set_pending_count(0);
-                                w.set_editing_row(-1);
-                                w.set_editing_col(-1);
-                                w.set_status_error(false);
-                                w.set_status_latency(SharedString::from(format!(
-                                    "{elapsed_ms} ms"
-                                )));
-                                w.set_results_meta(SharedString::from(if n_stmts > 1 {
+                                let meta = if n_stmts > 1 {
                                     format!("{n_stmts} statements · {shown} rows · {elapsed_ms} ms")
                                 } else {
                                     format!("{shown} rows · {elapsed_ms} ms")
-                                }));
-                                // Fresh result: type-aware default column widths.
-                                let widths: Vec<f32> = match &v {
-                                    model::ResultView::Table(g) => g
-                                        .columns
-                                        .iter()
-                                        .map(|c| default_col_width(&c.name, &c.type_name))
-                                        .collect(),
-                                    _ => vec![140.0; ncols],
                                 };
-                                w.set_grid_col_widths(ModelRc::from(Rc::new(VecModel::from(
-                                    widths,
-                                ))));
-                                // Chart segment data (SQL results only).
-                                let bars: Vec<ChartBar> = match &v {
-                                    model::ResultView::Table(g) => model::chart_data(g)
-                                        .into_iter()
-                                        .map(|(label, value, frac)| ChartBar {
-                                            label: label.into(),
-                                            value: value.into(),
-                                            frac,
-                                        })
-                                        .collect(),
-                                    _ => Vec::new(),
-                                };
-                                w.set_chart_bars(ModelRc::from(Rc::new(VecModel::from(bars))));
-                                apply_result(&w, v);
-                                // Browse mode: refresh the pagination footer.
-                                let st = browse.lock().unwrap().clone();
-                                if st.table.is_some() {
-                                    let (start, end, prev, next) =
-                                        page_bounds(st.page, st.limit, st.total, shown);
-                                    w.set_page_start(start as i32);
-                                    w.set_page_end(end as i32);
-                                    w.set_total_rows(st.total.map(|t| t as i32).unwrap_or(-1));
-                                    w.set_can_prev(prev);
-                                    w.set_can_next(next);
+                                let latency = format!("{elapsed_ms} ms");
+                                // Result tabs are for SQL runs; browse stays single.
+                                let is_browse = browse.lock().unwrap().table.is_some();
+                                if is_browse {
+                                    results.lock().unwrap().clear();
+                                    set_result_tabs(&w, 0, 0);
+                                } else {
+                                    let mut rv = results.lock().unwrap();
+                                    let mut ar = active_result.lock().unwrap();
+                                    let sr = StoredResult {
+                                        view: v.clone(),
+                                        meta: meta.clone(),
+                                        latency: latency.clone(),
+                                    };
+                                    if new_tab || rv.is_empty() {
+                                        rv.push(sr);
+                                        *ar = rv.len() - 1;
+                                    } else {
+                                        if *ar >= rv.len() {
+                                            *ar = 0;
+                                        }
+                                        rv[*ar] = sr;
+                                    }
+                                    set_result_tabs(&w, rv.len(), *ar);
                                 }
+                                present_view(
+                                    &w,
+                                    v,
+                                    &meta,
+                                    &latency,
+                                    &last_view,
+                                    &displayed_grid,
+                                    &hidden_cols,
+                                    &sort_state,
+                                    &col_order,
+                                    &col_filters,
+                                    &edit_buf,
+                                    &browse,
+                                );
                             }
                             (None, Some(e)) => {
                                 *last_view.lock().unwrap() = None;
@@ -3622,6 +3704,8 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let weak = window.as_weak();
         let tab_texts = tab_texts.clone();
+        let results = results.clone();
+        let active_result = active_result.clone();
         window.on_new_tab(move || {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -3638,18 +3722,21 @@ fn main() -> Result<(), slint::PlatformError> {
             set_tab_titles(&w, count);
             w.set_active_tab((count - 1) as i32);
             w.set_query_text(SharedString::default());
+            // Fresh query tab starts with no result tabs.
+            results.lock().unwrap().clear();
+            *active_result.lock().unwrap() = 0;
+            set_result_tabs(&w, 0, 0);
             clear_grid(&w);
         });
     }
 
-    // ----- ⌘\: run the current statement in a fresh tab -----
+    // ----- ⌘\: run the current statement into a NEW result tab -----
     {
         let weak = window.as_weak();
-        let tab_texts = tab_texts.clone();
         let ed_state = ed_state.clone();
         let run_sql = run_sql.clone();
-        let load_editor_text = load_editor_text.clone();
         let recent_queries = recent_queries.clone();
+        let result_new_tab = result_new_tab.clone();
         window.on_run_new_tab(move || {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -3664,22 +3751,104 @@ fn main() -> Result<(), slint::PlatformError> {
             if stmt.is_empty() {
                 return;
             }
-            // Stash the current tab, open a fresh one holding the statement.
-            let active = w.get_active_tab() as usize;
-            {
-                let mut t = tab_texts.borrow_mut();
-                if let Some(slot) = t.get_mut(active) {
-                    *slot = w.get_query_text().to_string();
-                }
-                t.push(stmt.clone());
-            }
-            let count = tab_texts.borrow().len();
-            set_tab_titles(&w, count);
-            w.set_active_tab((count - 1) as i32);
-            load_editor_text(&stmt);
+            // Same editor; the run lands in an appended result tab.
+            result_new_tab.store(true, std::sync::atomic::Ordering::SeqCst);
             w.set_grid_read_only(true);
             record_recent(&recent_queries, &stmt);
             run_sql(stmt);
+        });
+    }
+
+    // ----- switch / close result tabs -----
+    {
+        let weak = window.as_weak();
+        let results = results.clone();
+        let active_result = active_result.clone();
+        let last_view = last_view.clone();
+        let displayed_grid = displayed_grid.clone();
+        let hidden_cols = hidden_cols.clone();
+        let sort_state = sort_state.clone();
+        let col_order = col_order.clone();
+        let col_filters = col_filters.clone();
+        let edit_buf = edit_buf.clone();
+        let browse = browse.clone();
+        window.on_select_result_tab(move |i| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let i = i.max(0) as usize;
+            let sr = results.lock().unwrap().get(i).cloned();
+            let Some(sr) = sr else {
+                return;
+            };
+            *active_result.lock().unwrap() = i;
+            w.set_active_result(i as i32);
+            present_view(
+                &w,
+                sr.view,
+                &sr.meta,
+                &sr.latency,
+                &last_view,
+                &displayed_grid,
+                &hidden_cols,
+                &sort_state,
+                &col_order,
+                &col_filters,
+                &edit_buf,
+                &browse,
+            );
+        });
+    }
+    {
+        let weak = window.as_weak();
+        let results = results.clone();
+        let active_result = active_result.clone();
+        let last_view = last_view.clone();
+        let displayed_grid = displayed_grid.clone();
+        let hidden_cols = hidden_cols.clone();
+        let sort_state = sort_state.clone();
+        let col_order = col_order.clone();
+        let col_filters = col_filters.clone();
+        let edit_buf = edit_buf.clone();
+        let browse = browse.clone();
+        window.on_close_result_tab(move |i| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let i = i.max(0) as usize;
+            let (count, active, sr) = {
+                let mut rv = results.lock().unwrap();
+                if i >= rv.len() {
+                    return;
+                }
+                rv.remove(i);
+                let mut ar = active_result.lock().unwrap();
+                if *ar >= rv.len() {
+                    *ar = rv.len().saturating_sub(1);
+                }
+                (rv.len(), *ar, rv.get(*ar).cloned())
+            };
+            set_result_tabs(&w, count, active);
+            match sr {
+                Some(sr) => present_view(
+                    &w,
+                    sr.view,
+                    &sr.meta,
+                    &sr.latency,
+                    &last_view,
+                    &displayed_grid,
+                    &hidden_cols,
+                    &sort_state,
+                    &col_order,
+                    &col_filters,
+                    &edit_buf,
+                    &browse,
+                ),
+                None => {
+                    clear_grid(&w);
+                    *last_view.lock().unwrap() = None;
+                }
+            }
         });
     }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -836,6 +836,33 @@ fn apply_result(w: &MainWindow, view: model::ResultView) {
     }
 }
 
+/// Format a number with `.` thousands separators (e.g. 1000 → "1.000").
+fn group_thousands(n: u64) -> String {
+    let s = n.to_string();
+    let bytes = s.as_bytes();
+    let mut out = String::with_capacity(s.len() + s.len() / 3);
+    for (i, b) in bytes.iter().enumerate() {
+        if i > 0 && (bytes.len() - i).is_multiple_of(3) {
+            out.push('.');
+        }
+        out.push(*b as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod fmt_tests {
+    use super::group_thousands;
+    #[test]
+    fn groups_thousands_with_dots() {
+        assert_eq!(group_thousands(0), "0");
+        assert_eq!(group_thousands(999), "999");
+        assert_eq!(group_thousands(1000), "1.000");
+        assert_eq!(group_thousands(10_000), "10.000");
+        assert_eq!(group_thousands(1_234_567), "1.234.567");
+    }
+}
+
 fn main() -> Result<(), slint::PlatformError> {
     // tokio multi-thread runtime on background threads; the Slint event loop
     // owns the main thread. Async results return via invoke_from_event_loop.
@@ -3067,11 +3094,24 @@ fn main() -> Result<(), slint::PlatformError> {
         let run_browse = run_browse.clone();
         let guard_pending = guard_pending.clone();
         window.on_set_limit(move |text| {
-            if weak.upgrade().is_some_and(|w| guard_pending(&w)) {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            // Echo the current limit into both the raw value (stepper math) and
+            // the dotted display, so the field always shows a clean number.
+            let echo = |w: &MainWindow, l: u64| {
+                w.set_limit_value(l as i32);
+                w.set_limit_text(SharedString::from(l.to_string()));
+                w.set_limit_display(SharedString::from(group_thousands(l)));
+            };
+            if guard_pending(&w) {
+                echo(&w, browse.lock().unwrap().limit);
                 return;
             }
-            let parsed = text.trim().parse::<u64>().ok();
-            let Some(l) = parsed.map(|l| l.clamp(1, 10_000)) else {
+            // The manual field may contain dot separators — keep digits only.
+            let digits: String = text.chars().filter(|c| c.is_ascii_digit()).collect();
+            let Some(l) = digits.parse::<u64>().ok().map(|l| l.clamp(1, 10_000)) else {
+                echo(&w, browse.lock().unwrap().limit);
                 return;
             };
             {
@@ -3079,6 +3119,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 st.limit = l;
                 st.page = 0;
             }
+            echo(&w, l);
             run_browse();
         });
     }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2118,6 +2118,98 @@ fn main() -> Result<(), slint::PlatformError> {
         });
     }
 
+    // ----- header drag: reorder result columns -----
+    {
+        let weak = window.as_weak();
+        let last_view = last_view.clone();
+        let edit_buf = edit_buf.clone();
+        let displayed_grid = displayed_grid.clone();
+        let hidden_cols = hidden_cols.clone();
+        let sort_state = sort_state.clone();
+        let col_order = col_order.clone();
+        window.on_reorder_col(move |from, local_x| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let from = from.max(0) as usize;
+            let widths: Vec<f32> = w.get_grid_col_widths().iter().collect();
+            if from >= widths.len() {
+                return;
+            }
+            // absolute drop position within the columns strip → target display col
+            let start: f32 = widths.iter().take(from).sum();
+            let drop = start + local_x;
+            let mut acc = 0.0f32;
+            let mut target = widths.len() - 1;
+            for (i, wd) in widths.iter().enumerate() {
+                if drop < acc + wd {
+                    target = i;
+                    break;
+                }
+                acc += wd;
+            }
+            if target == from {
+                return;
+            }
+            let hidden = hidden_cols.lock().unwrap().clone();
+            // move the dragged column among the visible entries of col_order
+            {
+                let mut order = col_order.lock().unwrap();
+                let visible: Vec<usize> = order
+                    .iter()
+                    .copied()
+                    .enumerate()
+                    .filter(|(_, i)| !hidden.contains(i))
+                    .map(|(pos, _)| pos)
+                    .collect();
+                if from >= visible.len() || target >= visible.len() {
+                    return;
+                }
+                let (fp, tp) = (visible[from], visible[target]);
+                let val = order.remove(fp);
+                let ins = if tp > fp { tp - 1 } else { tp };
+                order.insert(ins, val);
+            }
+            // move the width the same way so a manual resize follows the column
+            let mut widths = widths;
+            let wv = widths.remove(from);
+            let ins = if target > from { target - 1 } else { target };
+            widths.insert(ins, wv);
+            w.set_grid_col_widths(ModelRc::from(Rc::new(VecModel::from(widths))));
+            let order = col_order.lock().unwrap().clone();
+            let (scol, sasc) = *sort_state.lock().unwrap();
+            // keep the sort arrow on the same column after the shuffle
+            if scol >= 0 {
+                let vis: Vec<usize> = order
+                    .iter()
+                    .copied()
+                    .filter(|i| !hidden.contains(i))
+                    .collect();
+                if let Some(p) = vis.iter().position(|&i| i as i32 == scol) {
+                    w.set_grid_sort_col(p as i32);
+                }
+            }
+            let needle = w.get_grid_filter().to_string().to_lowercase();
+            let fcol = w.get_filter_col().to_string();
+            let fop = w.get_filter_op().to_string();
+            let guard = last_view.lock().unwrap();
+            let Some(v) = guard.as_ref() else {
+                return;
+            };
+            if matches!(v, model::ResultView::Affected(_)) {
+                return;
+            }
+            // Reorder renumbers columns → col-keyed pending edits would misland.
+            edit_buf.lock().unwrap().clear();
+            w.set_pending_count(0);
+            w.set_editing_row(-1);
+            w.set_editing_col(-1);
+            let transformed = compute_view(v, &needle, &fcol, &fop, &hidden, &order, scol, sasc);
+            *displayed_grid.lock().unwrap() = view_grid(&transformed);
+            apply_result(&w, transformed);
+        });
+    }
+
     // ----- Columns popup: toggle a column's visibility -----
     {
         let weak = window.as_weak();

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -52,6 +52,9 @@ export component MainWindow inherits Window {
     in property <string> active-table;
     in property <int> active-count: -1;   // sidebar badge: rows in active table
     in property <string> sort-text;
+    in property <int> grid-sort-col: -1;  // client-side result sort
+    in property <bool> grid-sort-asc: true;
+    callback sort-col(int);
     in property <[TreeNode]> query-tree;  // sidebar Queries/History rows
     in property <[string]> schema-list;
     in-out property <string> schema-name: "public";
@@ -696,6 +699,9 @@ export component MainWindow inherits Window {
                         status-error: root.status-error;
                         status-latency: root.status-latency;
                         sort-text: root.sort-text;
+                        grid-sort-col: root.grid-sort-col;
+                        grid-sort-asc: root.grid-sort-asc;
+                        sort-col(i) => { root.sort-col(i); }
                         editor-lines: root.editor-lines;
                         cursor-line: root.cursor-line;
                         cursor-col: root.cursor-col;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -179,6 +179,8 @@ export component MainWindow inherits Window {
     in property <bool> status-error;
     in property <bool> query-running;
     in-out property <string> limit-text: "300";
+    in-out property <int> limit-value: 300;      // raw limit for stepper math
+    in-out property <string> limit-display: "300"; // dotted, e.g. "1.000"
     callback prev-page();
     callback next-page();
     callback refresh-page();
@@ -751,6 +753,8 @@ export component MainWindow inherits Window {
                         read-only: root.grid-read-only;
                         query-running: root.query-running;
                         limit-text <=> root.limit-text;
+                        limit-value: root.limit-value;
+                        limit-display: root.limit-display;
                         run => {
                             root.run-query();
                         }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -133,6 +133,11 @@ export component MainWindow inherits Window {
     in property <[[Span]]> editor-lines;
     in property <int> cursor-line;
     in property <int> cursor-col;
+    // SQL autocomplete popup
+    in property <[PaletteItem]> completion-items;
+    in property <bool> completion-visible;
+    in property <int> completion-selected;
+    callback completion-choose(int);
     in property <string> query-label;
     in property <string> results-meta;
     in-out property <int> sidebar-mode: 0;
@@ -718,6 +723,10 @@ export component MainWindow inherits Window {
                         editor-lines: root.editor-lines;
                         cursor-line: root.cursor-line;
                         cursor-col: root.cursor-col;
+                        completion-items: root.completion-items;
+                        completion-visible: root.completion-visible;
+                        completion-selected: root.completion-selected;
+                        completion-choose(i) => { root.completion-choose(i); }
                         query-label: root.query-label;
                         results-meta: root.results-meta;
                         fn-mode: root.fn-mode;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -55,6 +55,7 @@ export component MainWindow inherits Window {
     in property <int> grid-sort-col: -1;  // client-side result sort
     in property <bool> grid-sort-asc: true;
     callback sort-col(int);
+    callback reorder-col(int, length);
     in property <[TreeNode]> query-tree;  // sidebar Queries/History rows
     in property <[string]> schema-list;
     in-out property <string> schema-name: "public";
@@ -702,6 +703,7 @@ export component MainWindow inherits Window {
                         grid-sort-col: root.grid-sort-col;
                         grid-sort-asc: root.grid-sort-asc;
                         sort-col(i) => { root.sort-col(i); }
+                        reorder-col(i, x) => { root.reorder-col(i, x); }
                         editor-lines: root.editor-lines;
                         cursor-line: root.cursor-line;
                         cursor-col: root.cursor-col;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -56,6 +56,8 @@ export component MainWindow inherits Window {
     in property <bool> grid-sort-asc: true;
     callback sort-col(int);
     callback reorder-col(int, length);
+    in property <[string]> grid-col-filters;
+    callback set-col-filter(int, string);
     in property <[TreeNode]> query-tree;  // sidebar Queries/History rows
     in property <[string]> schema-list;
     in-out property <string> schema-name: "public";
@@ -711,6 +713,8 @@ export component MainWindow inherits Window {
                         grid-sort-asc: root.grid-sort-asc;
                         sort-col(i) => { root.sort-col(i); }
                         reorder-col(i, x) => { root.reorder-col(i, x); }
+                        grid-col-filters: root.grid-col-filters;
+                        set-col-filter(i, t) => { root.set-col-filter(i, t); }
                         editor-lines: root.editor-lines;
                         cursor-line: root.cursor-line;
                         cursor-col: root.cursor-col;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -207,7 +207,11 @@ export component MainWindow inherits Window {
     in property <bool> palette-open;
     in property <[PaletteItem]> palette-items;
     callback new-tab();
-    callback run-new-tab();   // ⌘\: run current statement in a fresh tab
+    callback run-new-tab();   // ⌘\: run current statement into a new result tab
+    in property <[string]> result-tabs;   // "Result 1", "Result 2", …
+    in property <int> active-result;
+    callback select-result-tab(int);
+    callback close-result-tab(int);
     callback close-tab();
     callback select-tab(int);
     callback toggle-palette();
@@ -727,6 +731,10 @@ export component MainWindow inherits Window {
                         completion-visible: root.completion-visible;
                         completion-selected: root.completion-selected;
                         completion-choose(i) => { root.completion-choose(i); }
+                        result-tabs: root.result-tabs;
+                        active-result: root.active-result;
+                        select-result-tab(i) => { root.select-result-tab(i); }
+                        close-result-tab(i) => { root.close-result-tab(i); }
                         query-label: root.query-label;
                         results-meta: root.results-meta;
                         fn-mode: root.fn-mode;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -200,6 +200,7 @@ export component MainWindow inherits Window {
     in property <bool> palette-open;
     in property <[PaletteItem]> palette-items;
     callback new-tab();
+    callback run-new-tab();   // ⌘\: run current statement in a fresh tab
     callback close-tab();
     callback select-tab(int);
     callback toggle-palette();
@@ -269,6 +270,10 @@ export component MainWindow inherits Window {
                 }
                 if (e.text == Key.Return) {
                     root.run-query();
+                    return accept;
+                }
+                if (e.text == "\\") {
+                    root.run-new-tab();
                     return accept;
                 }
                 if (e.text == "s") {

--- a/app/src/ui/code-editor.slint
+++ b/app/src/ui/code-editor.slint
@@ -3,6 +3,7 @@
 // Reference: design/3-sql-editor.png.
 import { Tokens } from "tokens.slint";
 import { Span } from "structs.slint";
+import { PaletteItem } from "palette.slint";
 import { ScrollView } from "std-widgets.slint";
 
 export component CodeEditor inherits Rectangle {
@@ -17,6 +18,11 @@ export component CodeEditor inherits Rectangle {
     callback press-pos(int, int);
     callback drag-pos(int, int);
     callback select-word(int, int);
+    // SQL autocomplete popup, anchored under the caret
+    in property <[PaletteItem]> completion-items;
+    in property <bool> completion-visible;
+    in property <int> completion-selected;
+    callback completion-choose(int);
 
     property <length> line-h: 21px;
     property <length> gutter-w: 40px;
@@ -128,6 +134,58 @@ export component CodeEditor inherits Rectangle {
                         background: Tokens.accent;
                     }
                 }
+            }
+        }
+    }
+
+    // ----- autocomplete popup (overlays the editor, under the caret) -----
+    if root.completion-visible && root.completion-items.length > 0: Rectangle {
+        x: min(root.gutter-w + Tokens.sp3 + root.cursor-col * root.charw, root.width - self.width - Tokens.sp2);
+        y: (root.cursor-line + 1) * root.line-h + 6px;
+        width: 260px;
+        height: min(root.completion-items.length * 22px + 8px, 200px);
+        border-radius: Tokens.radius;
+        border-width: 1px;
+        border-color: Tokens.border-strong;
+        background: Tokens.card;
+        drop-shadow-blur: 12px;
+        drop-shadow-color: Tokens.text.with-alpha(0.25);
+        clip: true;
+        VerticalLayout {
+            padding: 4px;
+            for it[i] in root.completion-items: Rectangle {
+                height: 22px;
+                border-radius: Tokens.radius;
+                background: i == root.completion-selected ? Tokens.accent-tint
+                    : cta.has-hover ? Tokens.chrome : transparent;
+                HorizontalLayout {
+                    padding-left: Tokens.sp2;
+                    padding-right: Tokens.sp2;
+                    spacing: Tokens.sp2;
+                    Text {
+                        text: it.kind == "field" ? "◇" : "▦";
+                        color: Tokens.text-faint;
+                        font-size: Tokens.font-sm;
+                        vertical-alignment: center;
+                    }
+                    Text {
+                        text: it.label;
+                        color: Tokens.text;
+                        font-family: Tokens.mono;
+                        font-size: Tokens.font-sm;
+                        vertical-alignment: center;
+                        overflow: elide;
+                    }
+                    Rectangle { horizontal-stretch: 1; }
+                    Text {
+                        text: it.sub;
+                        color: Tokens.text-faint;
+                        font-family: Tokens.mono;
+                        font-size: Tokens.font-xs;
+                        vertical-alignment: center;
+                    }
+                }
+                cta := TouchArea { clicked => { root.completion-choose(i); } }
             }
         }
     }

--- a/app/src/ui/tabular-grid.slint
+++ b/app/src/ui/tabular-grid.slint
@@ -13,6 +13,7 @@ export component TabularGrid inherits ScrollView {
     in property <int> sorted-col: -1;       // display col currently sorted, -1 none
     in property <bool> sort-asc: true;
     callback sort-col(int);                 // header click → sort by this column
+    callback reorder-col(int, length);      // header drag → (col, drop x in cell)
     in-out property <int> selected-row: 0;
     in-out property <int> selected-col: -1;
     // inline edit overlay: row/col currently being edited, -1 = none
@@ -72,11 +73,26 @@ export component TabularGrid inherits ScrollView {
                         font-size: Tokens.font-sm;
                     }
                 }
-                // click the header (except the resize handle) to sort by it
+                // header (minus the resize handle): click sorts, drag reorders
                 TouchArea {
                     width: parent.width - 5px;
                     x: 0;
-                    clicked => { root.sort-col(c); }
+                    property <bool> dragging;
+                    moved => {
+                        if (abs(self.mouse-x - self.pressed-x) > 6px) {
+                            self.dragging = true;
+                        }
+                    }
+                    pointer-event(e) => {
+                        if (e.kind == PointerEventKind.down) { self.dragging = false; }
+                        if (e.kind == PointerEventKind.up) {
+                            if (self.dragging) {
+                                root.reorder-col(c, self.mouse-x);
+                            } else {
+                                root.sort-col(c);
+                            }
+                        }
+                    }
                 }
                 Rectangle { width: 1px; x: parent.width - 1px; background: Tokens.border; }
                 // right-edge drag handle to resize this column

--- a/app/src/ui/tabular-grid.slint
+++ b/app/src/ui/tabular-grid.slint
@@ -14,6 +14,9 @@ export component TabularGrid inherits ScrollView {
     in property <bool> sort-asc: true;
     callback sort-col(int);                 // header click → sort by this column
     callback reorder-col(int, length);      // header drag → (col, drop x in cell)
+    in property <bool> filter-open;         // show the per-column filter row
+    in property <[string]> col-filter-values; // current text per display column
+    callback set-col-filter(int, string);   // (display col, raw filter text)
     in-out property <int> selected-row: 0;
     in-out property <int> selected-col: -1;
     // inline edit overlay: row/col currently being edited, -1 = none
@@ -109,6 +112,40 @@ export component TabularGrid inherits ScrollView {
             Rectangle { horizontal-stretch: 1; background: Tokens.canvas; }
         }
         Rectangle { height: 1px; background: Tokens.border-strong; }
+
+        // ----- per-column filter row (type e.g. >100, matches AND) -----
+        if root.filter-open: HorizontalLayout {
+            height: 26px;
+            Rectangle { width: 44px; background: Tokens.chrome; }
+            for col[c] in root.columns: Rectangle {
+                width: root.col-widths.length > c ? root.col-widths[c] : 140px;
+                background: Tokens.chrome;
+                clip: true;
+                Rectangle {
+                    x: 2px;
+                    y: 2px;
+                    width: parent.width - 5px;
+                    height: parent.height - 4px;
+                    border-radius: Tokens.radius;
+                    border-width: 1px;
+                    border-color: fin.has-focus ? Tokens.accent : Tokens.border-strong;
+                    background: Tokens.card;
+                    fin := TextInput {
+                        x: Tokens.sp1;
+                        width: parent.width - 2 * Tokens.sp1;
+                        vertical-alignment: center;
+                        text: root.col-filter-values.length > c ? root.col-filter-values[c] : "";
+                        color: Tokens.text;
+                        font-family: Tokens.mono;
+                        font-size: Tokens.font-xs;
+                        single-line: true;
+                        accepted => { root.set-col-filter(c, self.text); }
+                    }
+                }
+            }
+            Rectangle { horizontal-stretch: 1; background: Tokens.chrome; }
+        }
+        if root.filter-open: Rectangle { height: 1px; background: Tokens.border; }
 
         // ----- rows (24px) -----
         for r in (root.col-count > 0 ? root.cells.length / root.col-count : 0): Rectangle {

--- a/app/src/ui/tabular-grid.slint
+++ b/app/src/ui/tabular-grid.slint
@@ -5,7 +5,7 @@ import { Tokens } from "tokens.slint";
 import { GridColumn, GridCell } from "structs.slint";
 import { ScrollView } from "std-widgets.slint";
 
-export component TabularGrid inherits ScrollView {
+export component TabularGrid inherits Rectangle {
     in property <[GridColumn]> columns;
     in property <[GridCell]> cells;
     in property <int> col-count;
@@ -30,8 +30,14 @@ export component TabularGrid inherits ScrollView {
     callback edit-cancelled();
 
     VerticalLayout {
-        // fill ScrollView width when few columns; grow past it (scroll) when many
-        width: max(self.preferred-width, parent.visible-width);
+        // ----- frozen header band: mirrors the body's horizontal scroll so the
+        // headers stay put while rows scroll vertically -----
+        Rectangle {
+            clip: true;
+            height: Tokens.grid-header-h + 1px + (root.filter-open ? 27px : 0px);
+            VerticalLayout {
+                x: body.viewport-x;
+                width: max(self.preferred-width, body.visible-width);
 
         // ----- header (27px): "name" 600 + type dim, mono -----
         HorizontalLayout {
@@ -139,13 +145,22 @@ export component TabularGrid inherits ScrollView {
                         font-family: Tokens.mono;
                         font-size: Tokens.font-xs;
                         single-line: true;
-                        accepted => { root.set-col-filter(c, self.text); }
+                        // filter live as the user types (no Enter needed)
+                        edited => { root.set-col-filter(c, self.text); }
                     }
                 }
             }
             Rectangle { horizontal-stretch: 1; background: Tokens.chrome; }
         }
         if root.filter-open: Rectangle { height: 1px; background: Tokens.border; }
+            }
+        }
+
+        // ----- rows: the only vertically-scrolling region -----
+        body := ScrollView {
+            vertical-stretch: 1;
+            VerticalLayout {
+                width: max(self.preferred-width, body.visible-width);
 
         // ----- rows (24px) -----
         for r in (root.col-count > 0 ? root.cells.length / root.col-count : 0): Rectangle {
@@ -271,6 +286,8 @@ export component TabularGrid inherits ScrollView {
                 }
                 // trailing filler so the row spans the full width
                 Rectangle { horizontal-stretch: 1; }
+            }
+        }
             }
         }
     }

--- a/app/src/ui/tabular-grid.slint
+++ b/app/src/ui/tabular-grid.slint
@@ -10,6 +10,9 @@ export component TabularGrid inherits ScrollView {
     in property <[GridCell]> cells;
     in property <int> col-count;
     in property <[length]> col-widths;     // per-column pixel widths (drag-resizable)
+    in property <int> sorted-col: -1;       // display col currently sorted, -1 none
+    in property <bool> sort-asc: true;
+    callback sort-col(int);                 // header click → sort by this column
     in-out property <int> selected-row: 0;
     in-out property <int> selected-col: -1;
     // inline edit overlay: row/col currently being edited, -1 = none
@@ -59,6 +62,21 @@ export component TabularGrid inherits ScrollView {
                         font-family: Tokens.mono;
                         font-size: Tokens.font-xs;
                     }
+                    Rectangle { horizontal-stretch: 1; }
+                    // asc/desc arrow when this column drives the sort
+                    Text {
+                        vertical-alignment: center;
+                        text: root.sorted-col == c ? (root.sort-asc ? "↑" : "↓") : "";
+                        color: Tokens.accent;
+                        font-family: Tokens.mono;
+                        font-size: Tokens.font-sm;
+                    }
+                }
+                // click the header (except the resize handle) to sort by it
+                TouchArea {
+                    width: parent.width - 5px;
+                    x: 0;
+                    clicked => { root.sort-col(c); }
                 }
                 Rectangle { width: 1px; x: parent.width - 1px; background: Tokens.border; }
                 // right-edge drag handle to resize this column

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -72,6 +72,8 @@ export component WorkArea inherits Rectangle {
     in property <int> pending-count;
     in property <bool> read-only: true;
     in-out property <string> limit-text;
+    // Draggable height of the SQL editor pane (session-local).
+    in-out property <length> editor-h: 340px;
     in property <int> limit-value;
     in property <string> limit-display;
 
@@ -327,7 +329,7 @@ export component WorkArea inherits Rectangle {
 
         // ================= SQL editor (non-browse tabs) =================
         if !root.browse-mode && !root.fn-mode && !root.empty-mode: Rectangle {
-            height: 340px;
+            height: root.editor-h;
             background: Tokens.canvas;
             VerticalLayout {
                 width: 100%;
@@ -522,6 +524,20 @@ export component WorkArea inherits Rectangle {
                     TextButton { text: "Copy"; clicked => { root.copy-results(); } }
                     TextButton { text: "Export CSV"; clicked => { root.export-csv(); } }
                     TextButton { text: "Chart"; clicked => { root.sql-view-mode = 2; } }
+                }
+            }
+        }
+
+        // draggable splitter: grow/shrink the editor vs the results (SQL tabs)
+        if !root.browse-mode && !root.fn-mode && !root.empty-mode: Rectangle {
+            height: 6px;
+            background: split-ta.has-hover || split-ta.pressed ? Tokens.accent : Tokens.chrome;
+            split-ta := TouchArea {
+                mouse-cursor: row-resize;
+                moved => {
+                    root.editor-h = clamp(
+                        root.editor-h + (self.mouse-y - self.pressed-y),
+                        120px, root.height - 200px);
                 }
             }
         }

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -37,6 +37,7 @@ export component WorkArea inherits Rectangle {
     in property <int> grid-sort-col: -1; // client-side sort: display col + dir
     in property <bool> grid-sort-asc: true;
     callback sort-col(int);
+    callback reorder-col(int, length);
     in-out property <bool> sql-open: false;
     // SQL editor model (Rust lexer output) + cursor
     in property <[[Span]]> editor-lines;
@@ -560,6 +561,7 @@ export component WorkArea inherits Rectangle {
                 sorted-col: root.grid-sort-col;
                 sort-asc: root.grid-sort-asc;
                 sort-col(i) => { root.sort-col(i); }
+                reorder-col(i, x) => { root.reorder-col(i, x); }
                 selected-row <=> root.selected-row;
                 selected-col <=> root.selected-col;
                 editing-row: root.editing-row;

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -5,6 +5,7 @@ import { Tokens } from "tokens.slint";
 import { GridColumn, GridCell, StructField, Span, ChartBar, IndexRow } from "structs.slint";
 import { CodeEditor } from "code-editor.slint";
 import { TabularGrid } from "tabular-grid.slint";
+import { PaletteItem } from "palette.slint";
 import {
     UnderlineSegment, SecondaryButton, PrimaryButton, TextButton, FilterField, KeyCap
 } from "components.slint";
@@ -45,6 +46,11 @@ export component WorkArea inherits Rectangle {
     in property <[[Span]]> editor-lines;
     in property <int> cursor-line;
     in property <int> cursor-col;
+    // SQL autocomplete popup (passed down to the SQL CodeEditor)
+    in property <[PaletteItem]> completion-items;
+    in property <bool> completion-visible;
+    in property <int> completion-selected;
+    callback completion-choose(int);
     in property <string> query-label;    // "emiten-per-sektor.sql · saved"
     in property <string> results-meta;   // "10 rows · 38 ms"
     callback editor-key(string, bool, bool, bool) -> bool;
@@ -495,6 +501,10 @@ export component WorkArea inherits Rectangle {
                     lines: root.editor-lines;
                     cursor-line: root.cursor-line;
                     cursor-col: root.cursor-col;
+                    completion-items: root.completion-items;
+                    completion-visible: root.completion-visible;
+                    completion-selected: root.completion-selected;
+                    completion-choose(i) => { root.completion-choose(i); }
                     edit-key(t, cmd, alt, shift) => { root.editor-key(t, cmd, alt, shift) }
                     press-pos(l, c) => { root.editor-press(l, c); }
                     drag-pos(l, c) => { root.editor-drag(l, c); }

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -53,6 +53,11 @@ export component WorkArea inherits Rectangle {
     callback completion-choose(int);
     in property <string> query-label;    // "emiten-per-sektor.sql · saved"
     in property <string> results-meta;   // "10 rows · 38 ms"
+    // result tabs (SQL): ⌘⏎ replaces the active one, ⌘\ appends
+    in property <[string]> result-tabs;
+    in property <int> active-result;
+    callback select-result-tab(int);
+    callback close-result-tab(int);
     callback editor-key(string, bool, bool, bool) -> bool;
     callback editor-press(int, int);
     callback editor-drag(int, int);
@@ -536,6 +541,43 @@ export component WorkArea inherits Rectangle {
                     TextButton { text: "Copy"; clicked => { root.copy-results(); } }
                     TextButton { text: "Export CSV"; clicked => { root.export-csv(); } }
                     TextButton { text: "Chart"; clicked => { root.sql-view-mode = 2; } }
+                }
+                // result tabs — appear once ⌘\ has spawned a second result
+                if root.result-tabs.length > 1: HorizontalLayout {
+                    height: 30px;
+                    padding-left: Tokens.sp3;
+                    padding-right: Tokens.sp3;
+                    spacing: Tokens.sp1;
+                    alignment: start;
+                    for name[i] in root.result-tabs: Rectangle {
+                        height: 24px;
+                        width: rl.preferred-width + 2 * Tokens.sp2 + 18px;
+                        border-radius: Tokens.radius;
+                        background: i == root.active-result ? Tokens.accent-tint
+                            : rta.has-hover ? Tokens.chrome : transparent;
+                        rta := TouchArea { clicked => { root.select-result-tab(i); } }
+                        HorizontalLayout {
+                            padding-left: Tokens.sp2;
+                            padding-right: Tokens.sp1;
+                            spacing: Tokens.sp1;
+                            rl := Text {
+                                text: name;
+                                color: i == root.active-result ? Tokens.on-tint : Tokens.text-dim;
+                                font-size: Tokens.font-sm;
+                                vertical-alignment: center;
+                            }
+                            Rectangle {
+                                width: 16px;
+                                Text {
+                                    text: "×";
+                                    color: Tokens.text-faint;
+                                    vertical-alignment: center;
+                                    horizontal-alignment: center;
+                                }
+                                TouchArea { clicked => { root.close-result-tab(i); } }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -38,6 +38,8 @@ export component WorkArea inherits Rectangle {
     in property <bool> grid-sort-asc: true;
     callback sort-col(int);
     callback reorder-col(int, length);
+    in property <[string]> grid-col-filters;
+    callback set-col-filter(int, string);
     in-out property <bool> sql-open: false;
     // SQL editor model (Rust lexer output) + cursor
     in property <[[Span]]> editor-lines;
@@ -542,58 +544,8 @@ export component WorkArea inherits Rectangle {
             }
         }
 
-        // ================= expandable filter panel =================
-        // Available in both browse and SQL tabs — sits directly above the grid.
-        if root.filter-open && !root.fn-mode && !root.empty-mode: Rectangle {
-            height: 74px;
-            background: Tokens.chrome.with-alpha(0.5);
-            VerticalLayout {
-                padding: Tokens.sp2;
-                padding-left: Tokens.sp3;
-                padding-right: Tokens.sp3;
-                spacing: Tokens.sp1;
-                HorizontalLayout {
-                    height: 30px;
-                    spacing: Tokens.sp2;
-                    ComboBox {
-                        width: 150px;
-                        model: root.filter-columns;
-                        current-value <=> root.filter-col;
-                    }
-                    ComboBox {
-                        width: 110px;
-                        model: ["contains", "=", "≠", ">", "<", "is null", "not null"];
-                        current-value <=> root.filter-op;
-                    }
-                    FilterField {
-                        horizontal-stretch: 1;
-                        height: 28px;
-                        placeholder: "value";
-                        text <=> root.grid-filter;
-                        submitted => { root.apply-filter(); }
-                    }
-                }
-                HorizontalLayout {
-                    height: 28px;
-                    spacing: Tokens.sp2;
-                    Rectangle { horizontal-stretch: 1; }
-                    SecondaryButton {
-                        text: "Clear";
-                        clicked => {
-                            root.grid-filter = "";
-                            root.filter-col = "any column";
-                            root.filter-op = "contains";
-                            root.apply-filter();
-                        }
-                    }
-                    PrimaryButton {
-                        text: "Apply";
-                        clicked => { root.apply-filter(); }
-                    }
-                }
-            }
-            Rectangle { y: parent.height - 1px; height: 1px; width: parent.width; background: Tokens.border; }
-        }
+        // The per-column filter inputs live inside TabularGrid (aligned to the
+        // columns) and are toggled by `filter-open`; see the "Filter" button.
 
         // ================= result body =================
         if !root.fn-mode && !root.empty-mode: body := Rectangle {
@@ -612,6 +564,9 @@ export component WorkArea inherits Rectangle {
                 sort-asc: root.grid-sort-asc;
                 sort-col(i) => { root.sort-col(i); }
                 reorder-col(i, x) => { root.reorder-col(i, x); }
+                filter-open: root.filter-open;
+                col-filter-values: root.grid-col-filters;
+                set-col-filter(i, t) => { root.set-col-filter(i, t); }
                 selected-row <=> root.selected-row;
                 selected-col <=> root.selected-col;
                 editing-row: root.editing-row;

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -34,6 +34,9 @@ export component WorkArea inherits Rectangle {
     in-out property <string> grid-filter;
     in property <string> active-table;
     in property <string> sort-text;      // e.g. "sort: id ↑"
+    in property <int> grid-sort-col: -1; // client-side sort: display col + dir
+    in property <bool> grid-sort-asc: true;
+    callback sort-col(int);
     in-out property <bool> sql-open: false;
     // SQL editor model (Rust lexer output) + cursor
     in property <[[Span]]> editor-lines;
@@ -552,6 +555,9 @@ export component WorkArea inherits Rectangle {
                 cells: root.cells;
                 col-count: root.col-count;
                 col-widths: root.col-widths;
+                sorted-col: root.grid-sort-col;
+                sort-asc: root.grid-sort-asc;
+                sort-col(i) => { root.sort-col(i); }
                 selected-row <=> root.selected-row;
                 selected-col <=> root.selected-col;
                 editing-row: root.editing-row;

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -217,58 +217,6 @@ export component WorkArea inherits Rectangle {
             }
         }
 
-        // ================= expandable filter panel =================
-        if root.browse-mode && root.filter-open: Rectangle {
-            height: 74px;
-            background: Tokens.chrome.with-alpha(0.5);
-            VerticalLayout {
-                padding: Tokens.sp2;
-                padding-left: Tokens.sp3;
-                padding-right: Tokens.sp3;
-                spacing: Tokens.sp1;
-                HorizontalLayout {
-                    height: 30px;
-                    spacing: Tokens.sp2;
-                    ComboBox {
-                        width: 150px;
-                        model: root.filter-columns;
-                        current-value <=> root.filter-col;
-                    }
-                    ComboBox {
-                        width: 110px;
-                        model: ["contains", "=", "≠", ">", "<", "is null", "not null"];
-                        current-value <=> root.filter-op;
-                    }
-                    FilterField {
-                        horizontal-stretch: 1;
-                        height: 28px;
-                        placeholder: "value";
-                        text <=> root.grid-filter;
-                        submitted => { root.apply-filter(); }
-                    }
-                }
-                HorizontalLayout {
-                    height: 28px;
-                    spacing: Tokens.sp2;
-                    Rectangle { horizontal-stretch: 1; }
-                    SecondaryButton {
-                        text: "Clear";
-                        clicked => {
-                            root.grid-filter = "";
-                            root.filter-col = "any column";
-                            root.filter-op = "contains";
-                            root.apply-filter();
-                        }
-                    }
-                    PrimaryButton {
-                        text: "Apply";
-                        clicked => { root.apply-filter(); }
-                    }
-                }
-            }
-            Rectangle { y: parent.height - 1px; height: 1px; width: parent.width; background: Tokens.border; }
-        }
-
         // ================= function view =================
         if root.fn-mode: Rectangle {
             vertical-stretch: 1;
@@ -535,11 +483,65 @@ export component WorkArea inherits Rectangle {
                         vertical-alignment: center;
                     }
                     Rectangle { horizontal-stretch: 1; }
+                    TextButton { text: root.filter-open ? "Filter ▲" : "Filter ▼"; clicked => { root.filter-open = !root.filter-open; } }
                     TextButton { text: "Copy"; clicked => { root.copy-results(); } }
                     TextButton { text: "Export CSV"; clicked => { root.export-csv(); } }
                     TextButton { text: "Chart"; clicked => { root.sql-view-mode = 2; } }
                 }
             }
+        }
+
+        // ================= expandable filter panel =================
+        // Available in both browse and SQL tabs — sits directly above the grid.
+        if root.filter-open && !root.fn-mode && !root.empty-mode: Rectangle {
+            height: 74px;
+            background: Tokens.chrome.with-alpha(0.5);
+            VerticalLayout {
+                padding: Tokens.sp2;
+                padding-left: Tokens.sp3;
+                padding-right: Tokens.sp3;
+                spacing: Tokens.sp1;
+                HorizontalLayout {
+                    height: 30px;
+                    spacing: Tokens.sp2;
+                    ComboBox {
+                        width: 150px;
+                        model: root.filter-columns;
+                        current-value <=> root.filter-col;
+                    }
+                    ComboBox {
+                        width: 110px;
+                        model: ["contains", "=", "≠", ">", "<", "is null", "not null"];
+                        current-value <=> root.filter-op;
+                    }
+                    FilterField {
+                        horizontal-stretch: 1;
+                        height: 28px;
+                        placeholder: "value";
+                        text <=> root.grid-filter;
+                        submitted => { root.apply-filter(); }
+                    }
+                }
+                HorizontalLayout {
+                    height: 28px;
+                    spacing: Tokens.sp2;
+                    Rectangle { horizontal-stretch: 1; }
+                    SecondaryButton {
+                        text: "Clear";
+                        clicked => {
+                            root.grid-filter = "";
+                            root.filter-col = "any column";
+                            root.filter-op = "contains";
+                            root.apply-filter();
+                        }
+                    }
+                    PrimaryButton {
+                        text: "Apply";
+                        clicked => { root.apply-filter(); }
+                    }
+                }
+            }
+            Rectangle { y: parent.height - 1px; height: 1px; width: parent.width; background: Tokens.border; }
         }
 
         // ================= result body =================

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -72,6 +72,8 @@ export component WorkArea inherits Rectangle {
     in property <int> pending-count;
     in property <bool> read-only: true;
     in-out property <string> limit-text;
+    in property <int> limit-value;
+    in property <string> limit-display;
 
     // Browse chrome shows whenever a table is open in this tab.
     property <bool> browse-mode: root.active-table != "";
@@ -371,15 +373,47 @@ export component WorkArea inherits Rectangle {
                     }
                     VerticalLayout {
                         alignment: center;
-                        SecondaryButton {
-                            text: "Limit " + root.limit-text + "  ⇅";
-                            height: 28px;
-                            clicked => {
-                                // cycle presets: 100 → 300 → 500 → 1000 → 100
-                                root.limit-text = root.limit-text == "100" ? "300"
-                                    : root.limit-text == "300" ? "500"
-                                    : root.limit-text == "500" ? "1000" : "100";
-                                root.set-limit(root.limit-text);
+                        HorizontalLayout {
+                            spacing: Tokens.sp2;
+                            VerticalLayout {
+                                alignment: center;
+                                Text {
+                                    text: "Limit";
+                                    color: Tokens.text-faint;
+                                    font-size: Tokens.font-sm;
+                                    vertical-alignment: center;
+                                }
+                            }
+                            SecondaryButton {
+                                text: "−";
+                                height: 28px;
+                                clicked => { root.set-limit("\{root.limit-value - 100}"); }
+                            }
+                            // editable field; Rust reformats with dot separators
+                            Rectangle {
+                                width: 76px;
+                                height: 28px;
+                                border-radius: Tokens.radius;
+                                border-width: 1px;
+                                border-color: Tokens.border-strong;
+                                background: Tokens.card;
+                                limit-input := TextInput {
+                                    x: Tokens.sp2;
+                                    width: parent.width - 2 * Tokens.sp2;
+                                    vertical-alignment: center;
+                                    horizontal-alignment: right;
+                                    text: root.limit-display;
+                                    color: Tokens.text;
+                                    font-family: Tokens.mono;
+                                    font-size: Tokens.font-sm;
+                                    single-line: true;
+                                    accepted => { root.set-limit(self.text); }
+                                }
+                            }
+                            SecondaryButton {
+                                text: "+";
+                                height: 28px;
+                                clicked => { root.set-limit("\{root.limit-value + 100}"); }
                             }
                         }
                     }


### PR DESCRIPTION
This PR introduces several major UX improvements to the SQL editor and query results grid.

### Features & Fixes

1. **Multiple Result Tabs**
   - Run the current statement into a new result tab using `⌘\` (query editor stays put).
   - Replace the active result tab using `⌘⏎`.
   - Results strip is displayed above the grid once multiple results exist (with tabs that can be clicked to switch or closed).
   - Each tab caches its state (sorting/filtering is reset upon switching).
   - Factored presentation logic into a shared `present_view` helper.

2. **Draggable Editor/Results Split**
   - The boundary between the SQL query editor and the results grid is now draggable, allowing flexible layout resizing.

3. **Query Editor Shortcuts**
   - Run the statement currently under the cursor with `⌘⏎`.
   - Run the current statement in a new tab with `⌘\`.

4. **SQL Editor Autocomplete**
   - Suggests table names after SQL keywords (e.g. `FROM`, `JOIN`) or partial words.
   - Suggests column names after `[table_name].`.
   - Uses the in-memory schema tree (`raw_nodes`).
   - Supports keyboard navigation (↑/↓ to move, Tab/Enter to accept, Esc or click to dismiss).

5. **Per-Column Filters with Operator Prefixes**
   - Replaces the single global filter panel with a row of input fields under the column headers (toggled by the Filter button).
   - Supports substring match or operator prefixes for comparisons (`>`, `>=`, `<`, `<=`, `=`, `!=`).
   - Conditions across columns are combined using `AND`.
   - Filters live in `col_filters` and compose with sort, reorder, and hide actions.

6. **Sticky Headers and Live Filtering**
   - Split the grid into a frozen header band (synchronized horizontally with the body scroll) and scrollable body rows.
   - Live filtering processes on every keystroke, updating only the row cells without losing input focus.

7. **Reordering & Sorting Columns**
   - Support drag-to-reorder for columns in the results grid.
   - Client-side sorting by clicking on column headers (shows indicator arrows).

8. **Misc Improvements**
   - Editable limit stepper with thousands grouping.
   - Centralized grid computation and view generation in `compute_view`.
