### PR TITLE
fix(app): remove useless borrows in formatting call

### DIFF
--- a/app/src/mock.rs
+++ b/app/src/mock.rs
@@ -317,9 +317,9 @@ fn gen_emiten() -> Vec<Row> {
         let short: String = format!(
             "{}{}{}{}",
             &a[0..1],
-            &a[1..2].to_uppercase(),
+            a[1..2].to_uppercase(),
             &b[0..1],
-            &b[1..2].to_uppercase()
+            b[1..2].to_uppercase()
         )
         .to_uppercase();
         // Weighted sector pick keeps the per-sector totals plausible.


### PR DESCRIPTION
### Summary
* Fixes clippy failures on CI caused by the new `clippy::useless_borrows_in_formatting` lint in newer Rust/clippy toolchains.

### Changes
* `app/src/mock.rs`: Removed leading ampersands from the string-to-uppercase formatting arguments.

### Test plan
- [x] Ran `make fmt-check` to verify formatting
- [x] Ran `cargo clippy -p rdbs --all-targets -- -D warnings` to verify clippy
- [x] Ran `make test` to verify all tests pass
