### PR TITLE
feat: per-engine query tab, Cmd+/ comment, disconnect, history persistence

### DIFF
--- a/app/src/editor.rs
+++ b/app/src/editor.rs
@@ -499,6 +499,48 @@ impl EditorState {
         }
     }
 
+    /// Toggle a line comment across the affected lines (the selection's line
+    /// span, or the current line when nothing is selected). If every non-blank
+    /// line already starts with `prefix` after its indent, uncomment them all;
+    /// otherwise comment them all with `prefix + " "` at the first non-space
+    /// column. Blank lines are left untouched. One undo entry.
+    pub fn toggle_comment(&mut self, prefix: &str) {
+        let (start, end, had_sel) = match self.selection() {
+            Some(((sl, _), (el, _))) => (sl, el, true),
+            None => (self.line, self.line, false),
+        };
+        self.push_undo(false);
+        // Leading whitespace is ASCII, so byte offset == char offset here.
+        let all_commented = (start..=end).all(|i| {
+            let t = self.lines[i].trim_start();
+            t.is_empty() || t.starts_with(prefix)
+        });
+        for i in start..=end {
+            let indent = self.lines[i].len() - self.lines[i].trim_start().len();
+            let body = self.lines[i][indent..].to_string();
+            if body.is_empty() {
+                continue;
+            }
+            let head = &self.lines[i][..indent];
+            self.lines[i] = if all_commented {
+                let rest = body.strip_prefix(prefix).unwrap_or(&body);
+                let rest = rest.strip_prefix(' ').unwrap_or(rest);
+                format!("{head}{rest}")
+            } else {
+                format!("{head}{prefix} {body}")
+            };
+        }
+        // Keep the affected lines selected so repeated Cmd+/ toggles them back.
+        if had_sel {
+            self.sel = Some((start, 0));
+            self.line = end;
+            self.col = self.lines[end].chars().count();
+        } else {
+            self.sel = None;
+        }
+        self.clamp();
+    }
+
     /// Place the cursor at (line, col), clamped to the buffer. `extend`
     /// keeps/creates the selection anchor (drag or shift-click); otherwise the
     /// selection is dropped (a plain click).
@@ -781,6 +823,25 @@ mod tests {
         ed.backspace();
         ed.backspace();
         assert_eq!(ed.text(), "SELECT 1;");
+    }
+
+    #[test]
+    fn toggle_comment_is_idempotent() {
+        let mut ed = EditorState::from_text("  SELECT 1");
+        ed.toggle_comment("--");
+        assert_eq!(ed.text(), "  -- SELECT 1");
+        ed.toggle_comment("--");
+        assert_eq!(ed.text(), "  SELECT 1");
+    }
+
+    #[test]
+    fn toggle_comment_spans_selection() {
+        let mut ed = EditorState::from_text("a\nb\nc");
+        ed.set_selection((0, 0), (2, 1)); // all three lines
+        ed.toggle_comment("//");
+        assert_eq!(ed.text(), "// a\n// b\n// c");
+        ed.toggle_comment("//");
+        assert_eq!(ed.text(), "a\nb\nc");
     }
 
     #[test]

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1353,6 +1353,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let weak = window.as_weak();
         let refresh_completion = refresh_completion.clone();
         let accept_completion = accept_completion.clone();
+        let cur_engine = cur_engine.clone();
         window.on_editor_key(move |text, meta, alt, shift| {
             // While the autocomplete popup is open it owns nav / accept / close.
             if let Some(w) = weak.upgrade() {
@@ -1464,6 +1465,15 @@ fn main() -> Result<(), slint::PlatformError> {
                         }
                         "z" => {
                             ed.undo();
+                            true
+                        }
+                        "/" => {
+                            // Comment marker follows the connected engine's query
+                            // language; default to SQL when not yet connected.
+                            let engine = cur_engine
+                                .borrow()
+                                .unwrap_or(rdbs_connstore::Engine::Postgres);
+                            ed.toggle_comment(crate::query_parse::comment_prefix(engine));
                             true
                         }
                         _ => false,

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -411,7 +411,35 @@ fn clip_get() -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
-/// Record an executed query at the head of the live history (dedupe, cap 50).
+/// Max recent queries kept, in memory and on disk.
+const RECENT_CAP: usize = 50;
+
+/// Load persisted recent-query history; empty on a missing/unreadable file.
+fn load_recent() -> Vec<String> {
+    let Ok(path) = rdbs_connstore::ConnStore::recent_queries_path() else {
+        return Vec::new();
+    };
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+/// Persist the recent-query history (best-effort; I/O errors are ignored).
+fn save_recent(list: &[String]) {
+    let Ok(path) = rdbs_connstore::ConnStore::recent_queries_path() else {
+        return;
+    };
+    if let Some(dir) = path.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    if let Ok(json) = serde_json::to_string_pretty(list) {
+        let _ = std::fs::write(path, json);
+    }
+}
+
+/// Record an executed query at the head of the history (dedupe, cap
+/// `RECENT_CAP`) and persist it, except in mock mode.
 fn record_recent(list: &RefCell<Vec<String>>, text: &str) {
     let t = text.trim();
     if t.is_empty() {
@@ -420,7 +448,10 @@ fn record_recent(list: &RefCell<Vec<String>>, text: &str) {
     let mut v = list.borrow_mut();
     v.retain(|s| s != t);
     v.insert(0, t.to_string());
-    v.truncate(50);
+    v.truncate(RECENT_CAP);
+    if !mock::mock_mode() {
+        save_recent(&v);
+    }
 }
 
 fn page_bounds(page: u64, limit: u64, total: Option<u64>, shown: u64) -> (u64, u64, bool, bool) {
@@ -1745,7 +1776,7 @@ fn main() -> Result<(), slint::PlatformError> {
             "UPDATE emiten SET updated_at = now() WHERE code = '93344';".into(),
         ]
     } else {
-        Vec::new()
+        load_recent()
     }));
     let rebuild_query_tree = {
         let weak = window.as_weak();

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2786,11 +2786,14 @@ fn main() -> Result<(), slint::PlatformError> {
                         ""
                     },
                 ));
-                load_editor_text(if mock::mock_mode() {
+                // Start empty; the engine hint shows as a ghost placeholder
+                // (rendered by CodeEditor) instead of seeded buffer text.
+                load_editor_text("");
+                w.set_editor_placeholder(SharedString::from(if mock::mock_mode() {
                     ""
                 } else {
                     crate::query_parse::editor_hint(sc.engine)
-                });
+                }));
                 w.set_active_table(SharedString::default());
             }
             // Fresh connection: nothing browsed, nothing expanded.

--- a/app/src/query_parse.rs
+++ b/app/src/query_parse.rs
@@ -9,6 +9,10 @@ use rdbs_core::query::{MongoKind, MongoOp, Query};
 /// Returns a human-readable error string on malformed input (shown in the
 /// result-status line; no driver call is made).
 pub fn parse_query(engine: Engine, text: &str) -> Result<Query, String> {
+    // Drop whole-line comments (Cmd+/ toggles them) before interpreting, so a
+    // commented-out query stays inert in the buffer for every engine.
+    let cleaned = strip_comment_lines(engine, text);
+    let text = cleaned.as_str();
     match engine {
         Engine::Postgres | Engine::MySql | Engine::Sqlite | Engine::Cassandra => {
             Ok(Query::Sql(text.to_string()))
@@ -32,6 +36,27 @@ pub fn editor_hint(engine: Engine) -> &'static str {
         Engine::Redis => "SET key value",
         Engine::Mongo => r#"Mongo JSON — {"collection":"c","op":"find","body":{}}"#,
     }
+}
+
+/// Line-comment marker for the engine's query language. Used by the editor's
+/// Cmd+/ toggle and to strip commented lines before a query runs.
+pub fn comment_prefix(engine: Engine) -> &'static str {
+    match engine {
+        Engine::Postgres | Engine::MySql | Engine::Sqlite | Engine::Cassandra => "--",
+        Engine::Redis => "#",
+        Engine::Mongo => "//",
+    }
+}
+
+/// Remove whole-line comments (lines whose first non-whitespace run is the
+/// engine's comment marker). Inline trailing comments are left for the engine
+/// itself to handle.
+fn strip_comment_lines(engine: Engine, text: &str) -> String {
+    let prefix = comment_prefix(engine);
+    text.lines()
+        .filter(|l| !l.trim_start().starts_with(prefix))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn parse_mongo(text: &str) -> Result<Query, String> {
@@ -95,6 +120,24 @@ mod tests {
                 Query::Sql(s) => assert_eq!(s, "SELECT 1"),
                 _ => panic!("expected Sql"),
             }
+        }
+    }
+
+    #[test]
+    fn sql_commented_lines_are_stripped() {
+        let text = "-- keep this\nSELECT 1";
+        match parse_query(Engine::Postgres, text).unwrap() {
+            Query::Sql(s) => assert_eq!(s, "SELECT 1"),
+            _ => panic!("expected Sql"),
+        }
+    }
+
+    #[test]
+    fn mongo_ignores_commented_line() {
+        let text = "// old query\n{ \"collection\": \"c\", \"op\": \"find\", \"body\": {} }";
+        match parse_query(Engine::Mongo, text).unwrap() {
+            Query::Mongo(op) => assert_eq!(op.collection, "c"),
+            _ => panic!("expected Mongo"),
         }
     }
 

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -422,6 +422,16 @@ export component MainWindow inherits Window {
                             mono: true;
                         }
                     }
+                    // disconnect: drop the driver and return to the picker
+                    // (which lists every connection = switch to another DB)
+                    VerticalLayout {
+                        alignment: center;
+                        GlyphButton {
+                            glyph: "⏏";
+                            danger-hover: true;
+                            clicked => { root.disconnect(); }
+                        }
+                    }
                     if root.bc-db != "": Text {
                         text: "›";
                         color: Tokens.text-faint;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -131,6 +131,7 @@ export component MainWindow inherits Window {
 
     // ----- SQL editor (lexer-highlighted) -----
     in property <[[Span]]> editor-lines;
+    in property <string> editor-placeholder;
     in property <int> cursor-line;
     in property <int> cursor-col;
     // SQL autocomplete popup
@@ -725,6 +726,7 @@ export component MainWindow inherits Window {
                         grid-col-filters: root.grid-col-filters;
                         set-col-filter(i, t) => { root.set-col-filter(i, t); }
                         editor-lines: root.editor-lines;
+                        editor-placeholder: root.editor-placeholder;
                         cursor-line: root.cursor-line;
                         cursor-col: root.cursor-col;
                         completion-items: root.completion-items;

--- a/app/src/ui/code-editor.slint
+++ b/app/src/ui/code-editor.slint
@@ -8,6 +8,8 @@ import { ScrollView } from "std-widgets.slint";
 
 export component CodeEditor inherits Rectangle {
     in property <[[Span]]> lines;
+    // Ghost hint shown only while the buffer is empty (engine-specific).
+    in property <string> placeholder;
     in property <int> cursor-line: 0;
     in property <int> cursor-col: 0;
     // (key text, meta/ctrl, alt/option, shift) -> true when the editor consumed
@@ -136,6 +138,19 @@ export component CodeEditor inherits Rectangle {
                 }
             }
         }
+    }
+
+    // ghost placeholder: only when the buffer is a single empty line
+    if root.placeholder != "" && root.lines.length <= 1
+        && (root.lines.length == 0 || root.lines[0].length == 0): Text {
+        x: root.gutter-w + Tokens.sp3;
+        y: Tokens.sp2;
+        height: root.line-h;
+        text: root.placeholder;
+        color: Tokens.text-ghost;
+        font-family: Tokens.mono;
+        font-size: Tokens.font-md;
+        vertical-alignment: center;
     }
 
     // ----- autocomplete popup (overlays the editor, under the caret) -----

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -369,14 +369,15 @@ export component WorkArea inherits Rectangle {
                     }
                     VerticalLayout {
                         alignment: center;
+                        visible: root.sql-capable;
                         SecondaryButton { text: "Format"; height: 28px; clicked => { root.format-sql(); } }
                     }
                     VerticalLayout {
                         alignment: center;
+                        visible: root.sql-capable;
                         SecondaryButton {
                             text: "Explain";
                             height: 28px;
-                            enabled: root.sql-capable;
                             clicked => { root.explain-query(); }
                         }
                     }

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -44,6 +44,7 @@ export component WorkArea inherits Rectangle {
     in-out property <bool> sql-open: false;
     // SQL editor model (Rust lexer output) + cursor
     in property <[[Span]]> editor-lines;
+    in property <string> editor-placeholder;
     in property <int> cursor-line;
     in property <int> cursor-col;
     // SQL autocomplete popup (passed down to the SQL CodeEditor)
@@ -504,6 +505,7 @@ export component WorkArea inherits Rectangle {
                 CodeEditor {
                     vertical-stretch: 1;
                     lines: root.editor-lines;
+                    placeholder: root.editor-placeholder;
                     cursor-line: root.cursor-line;
                     cursor-col: root.cursor-col;
                     completion-items: root.completion-items;

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -74,8 +74,6 @@ export component WorkArea inherits Rectangle {
     in property <bool> fn-mode: false;
     in property <string> fn-name;
     in property <[[Span]]> fn-lines;
-    // Fresh SQL tab with nothing typed yet → empty-state hint.
-    property <bool> empty-mode: !root.browse-mode && !root.fn-mode && root.query-text == "";
 
     // ----- pagination + edit footer -----
     in property <int> page-start;
@@ -286,63 +284,8 @@ export component WorkArea inherits Rectangle {
         }
 
         // ================= empty state (nothing open) =================
-        if root.empty-mode: Rectangle {
-            vertical-stretch: 1;
-            background: Tokens.canvas;
-            VerticalLayout {
-                alignment: center;
-                spacing: Tokens.sp4;
-                HorizontalLayout {
-                    alignment: center;
-                    Rectangle {
-                        width: 300px;
-                        height: 190px;
-                        border-radius: Tokens.radius-lg;
-                        border-width: 1px;
-                        border-color: Tokens.accent.with-alpha(0.35);
-                        background: Tokens.accent-tint.with-alpha(0.45);
-                        VerticalLayout {
-                            alignment: center;
-                            spacing: Tokens.sp2;
-                            Text {
-                                text: "▦";
-                                color: Tokens.accent.with-alpha(0.65);
-                                font-size: 44px;
-                                horizontal-alignment: center;
-                            }
-                            Text {
-                                text: "RDB";
-                                color: Tokens.accent.with-alpha(0.65);
-                                font-size: Tokens.font-md;
-                                font-family: Tokens.mono;
-                                font-weight: Tokens.weight-emphasis;
-                                horizontal-alignment: center;
-                            }
-                        }
-                    }
-                }
-                HorizontalLayout {
-                    alignment: center;
-                    spacing: Tokens.sp2;
-                    Text {
-                        text: "Open a table from the sidebar, or press";
-                        color: Tokens.text-dim;
-                        font-size: Tokens.font-md;
-                        vertical-alignment: center;
-                    }
-                    KeyCap { text: "⌘P"; }
-                    Text {
-                        text: "to jump anywhere";
-                        color: Tokens.text-dim;
-                        font-size: Tokens.font-md;
-                        vertical-alignment: center;
-                    }
-                }
-            }
-        }
-
         // ================= SQL editor (non-browse tabs) =================
-        if !root.browse-mode && !root.fn-mode && !root.empty-mode: Rectangle {
+        if !root.browse-mode && !root.fn-mode: Rectangle {
             height: root.editor-h;
             background: Tokens.canvas;
             VerticalLayout {
@@ -586,7 +529,7 @@ export component WorkArea inherits Rectangle {
         }
 
         // draggable splitter: grow/shrink the editor vs the results (SQL tabs)
-        if !root.browse-mode && !root.fn-mode && !root.empty-mode: Rectangle {
+        if !root.browse-mode && !root.fn-mode: Rectangle {
             height: 6px;
             background: split-ta.has-hover || split-ta.pressed ? Tokens.accent : Tokens.chrome;
             split-ta := TouchArea {
@@ -603,7 +546,7 @@ export component WorkArea inherits Rectangle {
         // columns) and are toggled by `filter-open`; see the "Filter" button.
 
         // ================= result body =================
-        if !root.fn-mode && !root.empty-mode: body := Rectangle {
+        if !root.fn-mode: body := Rectangle {
             vertical-stretch: 1;
             background: Tokens.canvas;
 

--- a/crates/connstore/src/store.rs
+++ b/crates/connstore/src/store.rs
@@ -49,6 +49,13 @@ impl ConnStore {
         Ok(dirs.config_dir().join("connections.json"))
     }
 
+    /// Location of `recent_queries.json` in the same config dir as the
+    /// connection store — the on-disk cap-limited query history.
+    pub fn recent_queries_path() -> Result<PathBuf> {
+        let dirs = ProjectDirs::from("dev", "dbm", "dbm").ok_or(ConnStoreError::NoConfigDir)?;
+        Ok(dirs.config_dir().join("recent_queries.json"))
+    }
+
     /// Open the store at the platform default path with the runtime-selected
     /// secret backend (keychain, or encrypted-file fallback). Convenience
     /// wrapper over `default_path` + `secret::select_backend` + `load`.


### PR DESCRIPTION
## Summary

- Fix the query tab so it renders an editable editor per engine instead of a splash, and shows the engine hint as a ghost placeholder rather than seeded line-1 text.
- Add Cmd+/ comment toggle across all engines, and a top-bar disconnect button (returns to the picker = switch DB).
- Persist recent query history to disk (capped), so it survives restarts.

## Changes

**Query editor / per-engine tab**
- Render the engine hint as a ghost placeholder in `CodeEditor` (empty buffer), not seeded buffer text (`app/src/main.rs`, `app/src/ui/code-editor.slint`, `workarea.slint`, `app-window.slint`).
- Keep the editor visible and typeable when the buffer is empty; drop `empty-mode` and its landing splash (`app/src/ui/workarea.slint`).
- Hide SQL-only toolbar buttons (Format/Explain) for non-SQL engines via `sql-capable`.

**Cmd+/ comment toggle**
- `comment_prefix(engine)` + strip whole-line comments before running (`--` SQL, `#` Redis, `//` Mongo) in `app/src/query_parse.rs`.
- `EditorState::toggle_comment` in `app/src/editor.rs` (selection-aware, selection preserved).
- Wired to Cmd+/ in the editor key handler (`app/src/main.rs`).

**Disconnect**
- Top-bar eject button wired to the existing `disconnect` callback (`app/src/ui/app-window.slint`).

**History persistence**
- `ConnStore::recent_queries_path()` (`crates/connstore/src/store.rs`).
- Load on startup, save after each run, deduped and capped at `RECENT_CAP=50`; mock mode stays in-memory (`app/src/main.rs`).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p rdbs` clean
- [x] `cargo test -p rdbs` (editor + query_parse: comment strip, toggle idempotent)
- [x] `cargo test -p rdbs-connstore --lib`
- [x] `cargo build -p rdbs` (Slint compiles)
- [x] Manual: connect to Mongo → empty editor shows ghost JSON hint, typeable; Format/Explain hidden
- [x] Manual: select SQL lines, Cmd+/ toggles comments; run ignores commented lines
- [x] Manual: disconnect button returns to picker
- [x] Manual: run a query, restart, history persists