### PR TITLE
feat(app): schema switch refetch, connect cancel, tab rename, editor folding

### DIFF
--- a/app/src/dispatch.rs
+++ b/app/src/dispatch.rs
@@ -102,6 +102,32 @@ impl AnyDriver {
         }
     }
 
+    #[allow(dead_code)]
+    pub async fn schema_for(&self, schema: &str) -> Result<Schema> {
+        match self {
+            AnyDriver::Postgres(d) => d.schema_for(schema).await,
+            AnyDriver::Mysql(d) => d.schema_for(schema).await,
+            AnyDriver::Redis(d) => d.schema_for(schema).await,
+            AnyDriver::Mongo(d) => d.schema_for(schema).await,
+            AnyDriver::Sqlite(d) => d.schema_for(schema).await,
+            AnyDriver::Cassandra(d) => d.schema_for(schema).await,
+            AnyDriver::Mock(d) => d.schema_for(schema).await,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub async fn list_schemas(&self) -> Result<Vec<String>> {
+        match self {
+            AnyDriver::Postgres(d) => d.list_schemas().await,
+            AnyDriver::Mysql(d) => d.list_schemas().await,
+            AnyDriver::Redis(d) => d.list_schemas().await,
+            AnyDriver::Mongo(d) => d.list_schemas().await,
+            AnyDriver::Sqlite(d) => d.list_schemas().await,
+            AnyDriver::Cassandra(d) => d.list_schemas().await,
+            AnyDriver::Mock(d) => d.list_schemas().await,
+        }
+    }
+
     pub async fn containers(&self, database: &str) -> Result<Vec<Container>> {
         match self {
             AnyDriver::Postgres(d) => d.containers(database).await,

--- a/app/src/editor.rs
+++ b/app/src/editor.rs
@@ -770,6 +770,47 @@ pub fn find_matches(lines: &[String], needle: &str) -> Vec<(usize, usize, usize)
     out
 }
 
+/// Inclusive `(first_line, last_line)` of each SQL statement, for the editor's
+/// gutter fold arrows. Uses the same string/comment rules as
+/// [`split_statements`] (a `;` inside a `'literal'` or after `--` doesn't end a
+/// statement), carrying string state across lines. Blank leading lines are
+/// skipped so a block starts at its first content line. A block is foldable
+/// only when `last_line > first_line`.
+pub fn statement_line_spans(lines: &[String]) -> Vec<(usize, usize)> {
+    let mut out: Vec<(usize, usize)> = Vec::new();
+    let mut in_str = false;
+    let mut start: Option<usize> = None;
+    for (li, line) in lines.iter().enumerate() {
+        if start.is_none() && !line.trim().is_empty() {
+            start = Some(li);
+        }
+        let chars: Vec<char> = line.chars().collect();
+        let mut i = 0;
+        let mut ends = false;
+        while i < chars.len() {
+            let c = chars[i];
+            if c == '\'' {
+                in_str = !in_str;
+            } else if !in_str && c == '-' && chars.get(i + 1) == Some(&'-') {
+                break; // rest of the line is a comment
+            } else if c == ';' && !in_str {
+                ends = true;
+            }
+            i += 1;
+        }
+        if ends {
+            if let Some(s) = start.take() {
+                out.push((s, li));
+            }
+        }
+    }
+    // Trailing statement without a terminating ';'.
+    if let (Some(s), false) = (start, lines.is_empty()) {
+        out.push((s, lines.len() - 1));
+    }
+    out
+}
+
 /// True when a statement segment carries no executable SQL — only whitespace
 /// and `--` line comments.
 fn is_blank_sql(seg: &str) -> bool {
@@ -787,6 +828,24 @@ mod tests {
             .into_iter()
             .map(|s| (s.text, s.kind))
             .collect()
+    }
+
+    fn spans(text: &str) -> Vec<(usize, usize)> {
+        let lines: Vec<String> = text.lines().map(str::to_string).collect();
+        statement_line_spans(&lines)
+    }
+
+    #[test]
+    fn fold_spans_group_multiline_statements() {
+        // Two statements: lines 0-2 (ends with ;) and lines 3-4 (no ;).
+        assert_eq!(
+            spans("select *\nfrom t\nwhere x=1;\nupdate t\nset a=1"),
+            vec![(0, 2), (3, 4)]
+        );
+        // Semicolon inside a literal does not split.
+        assert_eq!(spans("select 'a;b'\nfrom t;"), vec![(0, 1)]);
+        // A semicolon after `--` is a comment, not a terminator.
+        assert_eq!(spans("select 1 -- a;b\nfrom t;"), vec![(0, 1)]);
     }
 
     #[test]

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1270,9 +1270,14 @@ fn main() -> Result<(), slint::PlatformError> {
     // ----- SQL editor: Rust-owned buffer + lexer feeding the span model -----
     let ed_state: Rc<RefCell<editor::EditorState>> =
         Rc::new(RefCell::new(editor::EditorState::from_text("")));
+    // Statement head lines the user has folded closed. Kept by line index and
+    // re-validated against the current statement spans on every render, so an
+    // edit that shifts lines can only unfold — never hide the wrong lines.
+    let folded_heads: Rc<RefCell<HashSet<usize>>> = Rc::new(RefCell::new(HashSet::new()));
     let sync_editor = {
         let weak = window.as_weak();
         let ed_state = ed_state.clone();
+        let folded_heads = folded_heads.clone();
         move || {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -1305,6 +1310,25 @@ fn main() -> Result<(), slint::PlatformError> {
                 })
                 .collect();
             w.set_editor_lines(ModelRc::from(Rc::new(VecModel::from(lines))));
+            // Fold arrows: 1 = open head, 2 = closed head, 0 = plain line.
+            // `hidden` blanks out the body lines of a closed statement.
+            let n = ed.lines.len();
+            let mut hidden = vec![false; n];
+            let mut fold_state = vec![0i32; n];
+            let folded = folded_heads.borrow();
+            for (h, e) in editor::statement_line_spans(&ed.lines) {
+                if e > h {
+                    let closed = folded.contains(&h);
+                    fold_state[h] = if closed { 2 } else { 1 };
+                    if closed {
+                        for hl in hidden.iter_mut().take(e + 1).skip(h + 1) {
+                            *hl = true;
+                        }
+                    }
+                }
+            }
+            w.set_editor_line_hidden(ModelRc::from(Rc::new(VecModel::from(hidden))));
+            w.set_editor_fold_state(ModelRc::from(Rc::new(VecModel::from(fold_state))));
             w.set_cursor_line(ed.line as i32);
             w.set_cursor_col(ed.col as i32);
             w.set_query_text(SharedString::from(ed.text()));
@@ -1319,6 +1343,39 @@ fn main() -> Result<(), slint::PlatformError> {
         })
     };
     load_editor_text("");
+
+    // ----- toggle a statement fold from the gutter arrow -----
+    {
+        let ed_state = ed_state.clone();
+        let folded_heads = folded_heads.clone();
+        let sync_editor = sync_editor.clone();
+        window.on_toggle_fold(move |line| {
+            let head = line.max(0) as usize;
+            let now_closed = {
+                let mut f = folded_heads.borrow_mut();
+                if f.remove(&head) {
+                    false
+                } else {
+                    f.insert(head);
+                    true
+                }
+            };
+            // Folding a block that contains the caret would strand it on a
+            // hidden line; pull the caret up to the visible head.
+            if now_closed {
+                let mut ed = ed_state.borrow_mut();
+                if let Some((_, e)) = editor::statement_line_spans(&ed.lines)
+                    .into_iter()
+                    .find(|(h, _)| *h == head)
+                {
+                    if ed.line > head && ed.line <= e {
+                        ed.move_to(head as i32, 0, false);
+                    }
+                }
+            }
+            sync_editor();
+        });
+    }
 
     // ----- SQL autocomplete: recompute popup, accept a choice -----
     // completion_ctx = (word char length to replace, candidate labels).

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2004,17 +2004,63 @@ fn main() -> Result<(), slint::PlatformError> {
     }
     {
         let weak = window.as_weak();
+        let rt = rt.clone();
+        let current = current.clone();
+        let raw_nodes = raw_nodes.clone();
+        let cur_engine = cur_engine.clone();
+        let expanded_tables = expanded_tables.clone();
+        let collapsed_categories = collapsed_categories.clone();
         window.on_schema_choose(move |idx| {
             let Some(w) = weak.upgrade() else {
                 return;
             };
-            if let Some(it) = w.get_schema_items().row_data(idx.max(0) as usize) {
-                w.set_schema_name(it.label.clone());
-                w.set_bc_schema(it.label);
-                // Anything browsed belonged to the old schema; force a fresh pick.
-                w.set_active_table(SharedString::default());
-            }
             w.set_schema_modal_open(false);
+            let Some(it) = w.get_schema_items().row_data(idx.max(0) as usize) else {
+                return;
+            };
+            let schema_name = it.label.to_string();
+            w.set_schema_name(it.label.clone());
+            w.set_bc_schema(it.label);
+            // Anything browsed belonged to the old schema; force a fresh pick and
+            // drop expand/collapse state that referenced the old schema's tables.
+            w.set_active_table(SharedString::default());
+            expanded_tables.lock().unwrap().clear();
+            collapsed_categories.borrow_mut().clear();
+            let engine = *cur_engine.borrow();
+            let Some(engine) = engine else {
+                return;
+            };
+            // Refetch the table tree for the chosen schema off the event loop.
+            let weak2 = weak.clone();
+            let current = current.clone();
+            let raw_nodes = raw_nodes.clone();
+            rt.spawn(async move {
+                let guard = current.lock_owned().await;
+                let Some((_, driver)) = guard.as_ref() else {
+                    return;
+                };
+                let Ok(schema) = driver.schema_for(&schema_name).await else {
+                    return;
+                };
+                let nodes = model::to_tree_model(&schema);
+                let rows = schema_display_rows(
+                    &nodes,
+                    &HashSet::new(),
+                    &HashSet::new(),
+                    &HashSet::new(),
+                    Some(engine),
+                    "",
+                );
+                drop(guard);
+                *raw_nodes.lock().unwrap() = nodes;
+                let _ = slint::invoke_from_event_loop(move || {
+                    if let Some(w) = weak2.upgrade() {
+                        w.set_schema_tree(ModelRc::from(Rc::new(VecModel::from(rows))));
+                        let empty_cols: Vec<StructField> = Vec::new();
+                        w.set_structure_columns(ModelRc::from(Rc::new(VecModel::from(empty_cols))));
+                    }
+                });
+            });
         });
     }
     {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2822,6 +2822,10 @@ fn main() -> Result<(), slint::PlatformError> {
         });
     }
 
+    // Handle of the in-flight connect task, so the Cancel button can abort it.
+    let connect_handle: Rc<RefCell<Option<tokio::task::JoinHandle<()>>>> =
+        Rc::new(RefCell::new(None));
+
     // ----- connect: spawn driver work on tokio, push schema back to UI -----
     {
         let weak = window.as_weak();
@@ -2835,6 +2839,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let cur_engine = cur_engine.clone();
         let load_editor_text = load_editor_text.clone();
         let fn_defs = fn_defs.clone();
+        let connect_handle = connect_handle.clone();
         window.on_connect_clicked(move |idx| {
             let i = idx as usize;
             let (sc, cfg) = {
@@ -2887,20 +2892,28 @@ fn main() -> Result<(), slint::PlatformError> {
             let engine = sc.engine;
             let raw_nodes = raw_nodes.clone();
             let fn_defs = fn_defs.clone();
-            rt.spawn(async move {
+            let handle = rt.spawn(async move {
                 let mut slot = match claimed {
                     Some(g) => g,
                     None => store_driver.clone().lock_owned().await,
                 };
                 *slot = None;
-                let result = async {
+                // Bound the attempt so an unreachable host can't spin forever;
+                // the Cancel button aborts sooner.
+                let attempt = async {
                     let cfg =
                         cfg.map_err(|e| rdbs_core::error::RdbsError::Connection(e.to_string()))?;
                     let driver = AnyDriver::connect(engine, &cfg).await?;
                     let schema = driver.schema().await?;
                     Ok::<_, rdbs_core::error::RdbsError>((driver, schema))
-                }
-                .await;
+                };
+                let result =
+                    match tokio::time::timeout(std::time::Duration::from_secs(15), attempt).await {
+                        Ok(r) => r,
+                        Err(_) => Err(rdbs_core::error::RdbsError::Connection(
+                            "connection timed out".into(),
+                        )),
+                    };
 
                 match result {
                     Ok((driver, schema)) => {
@@ -3019,6 +3032,23 @@ fn main() -> Result<(), slint::PlatformError> {
                     }
                 }
             });
+            *connect_handle.borrow_mut() = Some(handle);
+        });
+    }
+
+    // ----- cancel an in-flight connect -----
+    {
+        let weak = window.as_weak();
+        let connect_handle = connect_handle.clone();
+        window.on_cancel_connect(move || {
+            if let Some(h) = connect_handle.borrow_mut().take() {
+                h.abort();
+            }
+            if let Some(w) = weak.upgrade() {
+                w.set_connecting(false);
+                w.set_connected(false);
+                w.set_picker_error(SharedString::from("connection cancelled"));
+            }
         });
     }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -549,12 +549,18 @@ fn browse_text(
     }
 }
 
-/// Rebuild the tab model titles "Query 1..N".
-fn set_tab_titles(w: &MainWindow, count: usize) {
-    let items: Vec<TabItem> = (1..=count)
-        .map(|n| TabItem {
+/// Rebuild the tab model. A `Some` title is a user rename; `None` falls back
+/// to the positional "Query N".
+fn set_tab_titles(w: &MainWindow, titles: &[Option<String>]) {
+    let items: Vec<TabItem> = titles
+        .iter()
+        .enumerate()
+        .map(|(i, t)| TabItem {
             kind: "sql".into(),
-            title: format!("Query {n}").into(),
+            title: t
+                .clone()
+                .unwrap_or_else(|| format!("Query {}", i + 1))
+                .into(),
         })
         .collect();
     w.set_tabs(ModelRc::from(Rc::new(VecModel::from(items))));
@@ -2397,6 +2403,8 @@ fn main() -> Result<(), slint::PlatformError> {
 
     // Per-tab query text. MVP: switching tabs swaps the editor text.
     let tab_texts: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(vec![String::new()]));
+    // Parallel to `tab_texts`: Some = user rename, None = default "Query N".
+    let tab_titles: Rc<RefCell<Vec<Option<String>>>> = Rc::new(RefCell::new(vec![None]));
     window.set_tabs(ModelRc::from(Rc::new(VecModel::from(vec![TabItem {
         title: "Query 1".into(),
         kind: "sql".into(),
@@ -3817,6 +3825,7 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let weak = window.as_weak();
         let tab_texts = tab_texts.clone();
+        let tab_titles = tab_titles.clone();
         let results = results.clone();
         let active_result = active_result.clone();
         window.on_new_tab(move || {
@@ -3831,8 +3840,9 @@ fn main() -> Result<(), slint::PlatformError> {
                 }
                 t.push(String::new());
             }
+            tab_titles.borrow_mut().push(None);
             let count = tab_texts.borrow().len();
-            set_tab_titles(&w, count);
+            set_tab_titles(&w, &tab_titles.borrow());
             w.set_active_tab((count - 1) as i32);
             w.set_query_text(SharedString::default());
             // Fresh query tab starts with no result tabs.
@@ -3969,6 +3979,7 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let weak = window.as_weak();
         let tab_texts = tab_texts.clone();
+        let tab_titles = tab_titles.clone();
         window.on_close_tab(move || {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -3981,6 +3992,8 @@ fn main() -> Result<(), slint::PlatformError> {
                     slot.clear();
                 }
                 drop(t);
+                *tab_titles.borrow_mut() = vec![None];
+                set_tab_titles(&w, &tab_titles.borrow());
                 w.set_query_text(SharedString::default());
                 clear_grid(&w);
                 return;
@@ -3990,11 +4003,47 @@ fn main() -> Result<(), slint::PlatformError> {
             t.remove(remove_at);
             let new_active = active.saturating_sub(1).min(t.len() - 1);
             let text = t[new_active].clone();
-            let count = t.len();
             drop(t);
-            set_tab_titles(&w, count);
+            {
+                let mut titles = tab_titles.borrow_mut();
+                if remove_at < titles.len() {
+                    titles.remove(remove_at);
+                }
+            }
+            set_tab_titles(&w, &tab_titles.borrow());
             w.set_active_tab(new_active as i32);
             w.set_query_text(SharedString::from(text));
+        });
+    }
+
+    // ----- rename a query tab (double-click opens a modal) -----
+    {
+        let weak = window.as_weak();
+        window.on_open_rename(move |idx, title| {
+            if let Some(w) = weak.upgrade() {
+                w.set_rename_target(idx);
+                w.set_rename_text(title);
+                w.set_rename_modal_open(true);
+            }
+        });
+    }
+    {
+        let weak = window.as_weak();
+        let tab_titles = tab_titles.clone();
+        window.on_rename_commit(move || {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let i = w.get_rename_target().max(0) as usize;
+            let name = w.get_rename_text().trim().to_string();
+            {
+                let mut titles = tab_titles.borrow_mut();
+                if let Some(slot) = titles.get_mut(i) {
+                    // Empty name reverts to the default "Query N".
+                    *slot = if name.is_empty() { None } else { Some(name) };
+                }
+            }
+            set_tab_titles(&w, &tab_titles.borrow());
         });
     }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2859,27 +2859,20 @@ fn main() -> Result<(), slint::PlatformError> {
                 match result {
                     Ok((driver, schema)) => {
                         // Postgres: list real namespaces so the sidebar schema
-                        // switcher offers more than "public".
-                        let mut pg_schemas: Vec<SharedString> = Vec::new();
-                        if matches!(engine, rdbs_connstore::Engine::Postgres) {
-                            let q = rdbs_core::query::Query::Sql(
-                                "SELECT schema_name FROM information_schema.schemata \
-                                 WHERE schema_name NOT LIKE 'pg_%' \
-                                 AND schema_name <> 'information_schema' ORDER BY 1"
-                                    .into(),
-                            );
-                            if let Ok(rdbs_core::result::ResultSet::Tabular { rows, .. }) =
-                                driver.query(&q).await
-                            {
-                                for r in rows {
-                                    if let Some(rdbs_core::result::Cell::Text(s)) =
-                                        r.into_iter().next()
-                                    {
-                                        pg_schemas.push(SharedString::from(s));
-                                    }
-                                }
-                            }
-                        }
+                        // switcher offers more than "public". Engine-specific SQL
+                        // lives in the driver, not here.
+                        let pg_schemas: Vec<SharedString> =
+                            if matches!(engine, rdbs_connstore::Engine::Postgres) {
+                                driver
+                                    .list_schemas()
+                                    .await
+                                    .unwrap_or_default()
+                                    .into_iter()
+                                    .map(SharedString::from)
+                                    .collect()
+                            } else {
+                                Vec::new()
+                            };
                         *slot = Some((engine, driver));
                         drop(slot);
                         let nodes = model::to_tree_model(&schema);

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -62,6 +62,7 @@ export component MainWindow inherits Window {
     in property <[string]> schema-list;
     in-out property <string> schema-name: "public";
     callback connect-clicked(int);
+callback cancel-connect();
     callback toggle-group(string);
     callback open-table(string, string);   // (database, container)
     callback toggle-schema-node(string);
@@ -519,6 +520,7 @@ export component MainWindow inherits Window {
             sel-footer: root.sel-footer;
             select-conn(i) => { root.select-conn(i); }
             connect-clicked(i) => { root.connect-clicked(i); }
+            cancel-connect() => { root.cancel-connect(); }
             test-clicked(i) => { root.test-conn-quick(i); }
             add-clicked() => { root.open-add-form(); }
             edit-clicked(i) => { root.open-edit-form(i); }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -3,7 +3,7 @@ export { Theme }
 import { Tokens } from "tokens.slint";
 export { Tokens }
 import {
-    SearchCommandPill, BreadcrumbChip, GlyphButton, IconButton
+    SearchCommandPill, BreadcrumbChip, GlyphButton, IconButton, PrimaryButton, SecondaryButton
 } from "components.slint";
 import { Sidebar } from "sidebar.slint";
 import { ConnPicker } from "picker.slint";
@@ -63,6 +63,14 @@ export component MainWindow inherits Window {
     in-out property <string> schema-name: "public";
     callback connect-clicked(int);
 callback cancel-connect();
+// Rename a query tab via a modal (inline edit re-enters Slint's event
+// dispatch and panics). `open-rename` stashes the target + current title,
+// `rename-commit` applies `rename-text` to `rename-target`.
+callback open-rename(int, string);
+callback rename-commit();
+in-out property <bool> rename-modal-open: false;
+in-out property <int> rename-target: -1;
+in-out property <string> rename-text;
     callback toggle-group(string);
     callback open-table(string, string);   // (database, container)
     callback toggle-schema-node(string);
@@ -601,7 +609,7 @@ callback cancel-connect();
                     horizontal-stretch: 1;
                     spacing: 0px;
                     // ----- doc-tab row (36px, tabs h30, active = card + accent top inset) -----
-                    Rectangle {
+                    tabbar := Rectangle {
                         height: Tokens.doc-tab-row-h;
                         background: Tokens.chrome;
                         HorizontalLayout {
@@ -617,6 +625,9 @@ callback cancel-connect();
                                 tab-ta := TouchArea {
                                     clicked => {
                                         root.select-tab(i);
+                                    }
+                                    double-clicked => {
+                                        root.open-rename(i, tab.title);
                                     }
                                 }
 
@@ -916,6 +927,82 @@ callback cancel-connect();
             root.schema-modal-open = false;
         }
         new-item => { }
+    }
+
+    // ----- Rename query tab -----
+    rename-modal := Rectangle {
+        visible: root.rename-modal-open;
+        background: Tokens.veil;
+        TouchArea { clicked => { root.rename-modal-open = false; } }
+        // Focus the field once the modal shows; `changed` runs after the
+        // triggering event settles, so it can't re-enter dispatch (an inline
+        // init-focus does, and panics "Recursion detected").
+        changed visible => {
+            if (self.visible) { ti.focus(); }
+        }
+        Rectangle {
+            width: 360px;
+            x: (parent.width - self.width) / 2;
+            y: 120px;
+            height: box.preferred-height;
+            border-radius: Tokens.modal-radius;
+            background: Tokens.card;
+            border-width: 1px;
+            border-color: Tokens.border;
+            drop-shadow-blur: 42px;
+            drop-shadow-offset-y: 12px;
+            drop-shadow-color: #1C191426;
+            TouchArea {}
+            box := VerticalLayout {
+                padding: Tokens.sp4;
+                spacing: Tokens.sp3;
+                Text {
+                    text: "Rename tab";
+                    color: Tokens.text;
+                    font-size: 15px;
+                    font-weight: 700;
+                    horizontal-alignment: center;
+                }
+                Rectangle {
+                    height: 34px;
+                    border-radius: Tokens.radius;
+                    background: Tokens.canvas;
+                    border-width: 1px;
+                    border-color: Tokens.border;
+                    ti := TextInput {
+                        x: Tokens.sp2;
+                        width: parent.width - 2 * Tokens.sp2;
+                        vertical-alignment: center;
+                        text <=> root.rename-text;
+                        color: Tokens.text;
+                        font-family: Tokens.mono;
+                        font-size: Tokens.font-md;
+                        single-line: true;
+                        accepted => {
+                            root.rename-commit();
+                            root.rename-modal-open = false;
+                        }
+                    }
+                }
+                HorizontalLayout {
+                    spacing: Tokens.sp2;
+                    alignment: end;
+                    SecondaryButton {
+                        text: "Cancel";
+                        height: 30px;
+                        clicked => { root.rename-modal-open = false; }
+                    }
+                    PrimaryButton {
+                        text: "Rename";
+                        height: 30px;
+                        clicked => {
+                            root.rename-commit();
+                            root.rename-modal-open = false;
+                        }
+                    }
+                }
+            }
+        }
     }
 
     // ----- Open Connection (⌘O) -----

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -140,6 +140,9 @@ in-out property <string> rename-text;
 
     // ----- SQL editor (lexer-highlighted) -----
     in property <[[Span]]> editor-lines;
+    in property <[int]> editor-fold-state;
+    in property <[bool]> editor-line-hidden;
+    callback toggle-fold(int);
     in property <string> editor-placeholder;
     in property <int> cursor-line;
     in property <int> cursor-col;
@@ -749,6 +752,9 @@ in-out property <string> rename-text;
                         grid-col-filters: root.grid-col-filters;
                         set-col-filter(i, t) => { root.set-col-filter(i, t); }
                         editor-lines: root.editor-lines;
+                        editor-fold-state: root.editor-fold-state;
+                        editor-line-hidden: root.editor-line-hidden;
+                        toggle-fold(l) => { root.toggle-fold(l); }
                         editor-placeholder: root.editor-placeholder;
                         cursor-line: root.cursor-line;
                         cursor-col: root.cursor-col;

--- a/app/src/ui/code-editor.slint
+++ b/app/src/ui/code-editor.slint
@@ -8,6 +8,12 @@ import { ScrollView } from "std-widgets.slint";
 
 export component CodeEditor inherits Rectangle {
     in property <[[Span]]> lines;
+    // Per-line fold metadata, parallel to `lines`. `fold-state`: 0 plain,
+    // 1 open statement head (▾), 2 closed head (▸). `line-hidden`: body line
+    // of a closed statement, collapsed to zero height.
+    in property <[int]> fold-state;
+    in property <[bool]> line-hidden;
+    callback toggle-fold(int);
     // Ghost hint shown only while the buffer is empty (engine-specific).
     in property <string> placeholder;
     in property <int> cursor-line: 0;
@@ -58,7 +64,9 @@ export component CodeEditor inherits Rectangle {
                 padding-bottom: Tokens.sp2;
 
                 for line[li] in root.lines: Rectangle {
-                    height: root.line-h;
+                    height: root.line-hidden[li] ? 0 : root.line-h;
+                    clip: true;
+                    visible: !root.line-hidden[li];
                     background: li == root.cursor-line ? Tokens.editor-line : transparent;
 
                     // Char column under the pointer, hit-tested from the mono
@@ -88,18 +96,38 @@ export component CodeEditor inherits Rectangle {
 
                     HorizontalLayout {
                         spacing: 0;
-                        // gutter number
+                        // gutter: fold-arrow slot (left) + line number (right)
                         Rectangle {
                             width: root.gutter-w;
-                            Text {
-                                width: parent.width - 12px;
-                                horizontal-alignment: right;
-                                vertical-alignment: center;
-                                text: li + 1;
-                                color: li == root.cursor-line ? Tokens.text : Tokens.text-ghost;
-                                font-family: Tokens.mono;
-                                font-size: Tokens.font-sm;
-                                font-weight: li == root.cursor-line ? 600 : 400;
+                            HorizontalLayout {
+                                padding-right: 6px;
+                                spacing: 2px;
+                                Rectangle {
+                                    width: 14px;
+                                    if root.fold-state[li] != 0: fold-ta := TouchArea {
+                                        mouse-cursor: pointer;
+                                        clicked => {
+                                            root.toggle-fold(li);
+                                        }
+                                        Text {
+                                            text: root.fold-state[li] == 2 ? "▶" : "▼";
+                                            color: fold-ta.has-hover ? Tokens.accent : Tokens.text-dim;
+                                            font-size: 10px;
+                                            horizontal-alignment: center;
+                                            vertical-alignment: center;
+                                        }
+                                    }
+                                }
+                                Text {
+                                    horizontal-stretch: 1;
+                                    horizontal-alignment: right;
+                                    vertical-alignment: center;
+                                    text: li + 1;
+                                    color: li == root.cursor-line ? Tokens.text : Tokens.text-ghost;
+                                    font-family: Tokens.mono;
+                                    font-size: Tokens.font-sm;
+                                    font-weight: li == root.cursor-line ? 600 : 400;
+                                }
                             }
                         }
                         Rectangle { width: Tokens.sp3; }
@@ -123,6 +151,14 @@ export component CodeEditor inherits Rectangle {
                                     font-italic: span.kind == 4;
                                 }
                             }
+                        }
+                        // folded indicator: the collapsed statement's body
+                        if root.fold-state[li] == 2: Text {
+                            text: " ⋯";
+                            color: Tokens.text-faint;
+                            font-family: Tokens.mono;
+                            font-size: Tokens.font-md;
+                            vertical-alignment: center;
                         }
                         Rectangle { horizontal-stretch: 1; }
                     }

--- a/app/src/ui/picker.slint
+++ b/app/src/ui/picker.slint
@@ -27,6 +27,7 @@ export component ConnPicker inherits Rectangle {
 
     callback select-conn(int);
     callback connect-clicked(int);
+    callback cancel-connect();
     callback test-clicked(int);
     callback add-clicked();
     callback edit-clicked(int);
@@ -288,6 +289,11 @@ export component ConnPicker inherits Rectangle {
                                     enabled: !root.connecting;
                                     height: 30px;
                                     clicked => { root.connect-clicked(root.selected-conn); }
+                                }
+                                if root.connecting: SecondaryButton {
+                                    text: "Cancel";
+                                    height: 30px;
+                                    clicked => { root.cancel-connect(); }
                                 }
                                 SecondaryButton {
                                     text: "Test";

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -46,6 +46,9 @@ export component WorkArea inherits Rectangle {
     in-out property <bool> sql-open: false;
     // SQL editor model (Rust lexer output) + cursor
     in property <[[Span]]> editor-lines;
+    in property <[int]> editor-fold-state;
+    in property <[bool]> editor-line-hidden;
+    callback toggle-fold(int);
     in property <string> editor-placeholder;
     in property <int> cursor-line;
     in property <int> cursor-col;
@@ -451,6 +454,9 @@ export component WorkArea inherits Rectangle {
                 if !root.editor-collapsed: CodeEditor {
                     vertical-stretch: 1;
                     lines: root.editor-lines;
+                    fold-state: root.editor-fold-state;
+                    line-hidden: root.editor-line-hidden;
+                    toggle-fold(l) => { root.toggle-fold(l); }
                     placeholder: root.editor-placeholder;
                     cursor-line: root.cursor-line;
                     cursor-col: root.cursor-col;

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -13,6 +13,8 @@ import { ScrollView, ComboBox } from "std-widgets.slint";
 
 export component WorkArea inherits Rectangle {
     // ----- editor / results state (wired 1:1 from MainWindow) -----
+    // Collapse the SQL editor pane to give the results grid more room.
+    property <bool> editor-collapsed: false;
     in-out property <string> query-text;
     in property <[GridColumn]> columns;
     in property <[GridCell]> cells;
@@ -446,7 +448,7 @@ export component WorkArea inherits Rectangle {
                         }
                     }
                 }
-                CodeEditor {
+                if !root.editor-collapsed: CodeEditor {
                     vertical-stretch: 1;
                     lines: root.editor-lines;
                     placeholder: root.editor-placeholder;
@@ -483,6 +485,7 @@ export component WorkArea inherits Rectangle {
                         vertical-alignment: center;
                     }
                     Rectangle { horizontal-stretch: 1; }
+                    TextButton { text: root.editor-collapsed ? "Editor ▸" : "Editor ▾"; clicked => { root.editor-collapsed = !root.editor-collapsed; } }
                     TextButton { text: root.filter-open ? "Filter ▲" : "Filter ▼"; clicked => { root.filter-open = !root.filter-open; } }
                     TextButton { text: "Copy"; clicked => { root.copy-results(); } }
                     TextButton { text: "Export CSV"; clicked => { root.export-csv(); } }

--- a/crates/core/src/driver.rs
+++ b/crates/core/src/driver.rs
@@ -25,6 +25,19 @@ pub trait Driver: Send + Sync {
     /// fill them lazily via [`Driver::containers`] when a database is expanded.
     async fn schema(&self) -> Result<Schema>;
 
+    /// Switchable namespaces/schemas the sidebar can browse (e.g. Postgres
+    /// schemas). Default empty: the engine has nothing to switch and the UI
+    /// keeps its current schema name.
+    async fn list_schemas(&self) -> Result<Vec<String>> {
+        Ok(Vec::new())
+    }
+
+    /// Schema tree scoped to one namespace (e.g. a specific Postgres schema).
+    /// Default delegates to [`Driver::schema`] for engines without namespaces.
+    async fn schema_for(&self, _schema: &str) -> Result<Schema> {
+        self.schema().await
+    }
+
     /// List the containers (tables/collections) of one database, fetched on
     /// demand. Default is empty for engines that return everything in `schema`.
     async fn containers(&self, _database: &str) -> Result<Vec<crate::schema::Container>> {

--- a/crates/driver-postgres/src/driver.rs
+++ b/crates/driver-postgres/src/driver.rs
@@ -70,7 +70,25 @@ impl Driver for PostgresDriver {
     }
 
     async fn schema(&self) -> Result<Schema> {
-        schema_impl(&self.client).await
+        schema_impl(&self.client, "public").await
+    }
+
+    async fn schema_for(&self, schema: &str) -> Result<Schema> {
+        schema_impl(&self.client, schema).await
+    }
+
+    async fn list_schemas(&self) -> Result<Vec<String>> {
+        let rows = self
+            .client
+            .query(
+                "SELECT schema_name FROM information_schema.schemata \
+                 WHERE schema_name NOT LIKE 'pg_%' \
+                 AND schema_name <> 'information_schema' ORDER BY 1",
+                &[],
+            )
+            .await
+            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+        Ok(rows.iter().map(|r| r.get::<_, String>(0)).collect())
     }
 
     async fn query(&self, q: &Query) -> Result<ResultSet> {
@@ -220,7 +238,7 @@ fn column_meta(rows: &[tokio_postgres::Row]) -> Vec<Column> {
     }
 }
 
-async fn schema_impl(client: &Client) -> Result<Schema> {
+async fn schema_impl(client: &Client, schema: &str) -> Result<Schema> {
     // The current database name groups everything under one logical Database.
     let db_row = client
         .query_one("SELECT current_database()", &[])
@@ -230,7 +248,7 @@ async fn schema_impl(client: &Client) -> Result<Schema> {
         .try_get(0)
         .map_err(|e| RdbsError::Schema(e.to_string()))?;
 
-    // User tables + columns from information_schema, public schema only.
+    // User tables + columns from information_schema, scoped to one schema.
     // Ordered so columns of the same table are contiguous for grouping.
     let rows = client
         .query(
@@ -238,9 +256,9 @@ async fn schema_impl(client: &Client) -> Result<Schema> {
              FROM information_schema.columns c \
              JOIN information_schema.tables t \
                ON t.table_schema = c.table_schema AND t.table_name = c.table_name \
-             WHERE c.table_schema = 'public' AND t.table_type = 'BASE TABLE' \
+             WHERE c.table_schema = $1 AND t.table_type = 'BASE TABLE' \
              ORDER BY c.table_name, c.ordinal_position",
-            &[],
+            &[&schema],
         )
         .await
         .map_err(|e| RdbsError::Schema(e.to_string()))?;
@@ -275,9 +293,9 @@ async fn schema_impl(client: &Client) -> Result<Schema> {
             "SELECT p.proname, pg_catalog.pg_get_functiondef(p.oid) \
              FROM pg_catalog.pg_proc p \
              JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace \
-             WHERE n.nspname = 'public' AND p.prokind = 'f' \
+             WHERE n.nspname = $1 AND p.prokind = 'f' \
              ORDER BY p.proname",
-            &[],
+            &[&schema],
         )
         .await
     {


### PR DESCRIPTION
## Summary

- Fix connect/schema/tab UX gaps surfaced while using the app against Postgres.
- Keep every engine-specific query behind the `Driver` trait / `AnyDriver` — the app layer stays engine-agnostic (closes an inline-SQL leak).

## Changes

**Backend (core + driver-postgres)**
- Add `Driver::list_schemas` and `Driver::schema_for(name)` with default impls, so non-namespaced engines are unaffected.
- Postgres: parameterize the schema (was hardcoded `'public'`) and implement `list_schemas`.

**App**
- Forward the two new methods through `AnyDriver`.
- Replace the inline `information_schema.schemata` query in the connect handler with `driver.list_schemas()`.
- Refetch the table sidebar when switching schema (was only relabelling).
- Make an in-flight connection cancellable: store the task handle, add a Cancel button while connecting, and bound the attempt with a 15s timeout.
- Rename query tabs via a modal (prefilled with the current title). An inline TextInput in the tab loop re-entered Slint's event dispatch and panicked "Recursion detected"; a modal avoids it.
- Collapse the SQL editor pane (toggle in the results header).
- Per-statement code folding in the SQL editor: gutter arrows (`▼`/`▶`) collapse a statement's body to zero height with a `⋯` marker. Line indices stay stable, so cursor and hit-testing are unaffected; fold state is re-validated each render.

## Test plan

- [x] `make fmt-check`
- [x] `make lint` (clippy `-D warnings`)
- [x] `make be-test` + editor unit tests (39 pass, incl. `statement_line_spans`)
- [x] App launches clean (no startup panic)
- [x] Manual (Postgres): connect to a dead host → Cancel returns to picker
- [x] Manual: switch schema → sidebar table list updates
- [x] Manual: double-click a tab → rename modal → title changes
- [x] Manual: multi-line query → gutter `▼` folds the statement
- [x] Manual: non-Postgres engine (MySQL/Mongo) still connects + browses
