### PR TITLE
docs: add PR template, contributing, code of conduct, security policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!--
+Title: conventional-commits style, ≤ 70 chars, no trailing period.
+e.g. feat(app): cancel an in-flight connection
+Keep the PR focused — one logical change is easier to review and revert.
+-->
+
+## Summary
+
+<!-- 1–3 bullets on the WHY: the problem this solves or the need it fills. -->
+
+-
+
+## Changes
+
+<!-- What actually changed, grouped by area (app / core / driver-* / ci / docs). -->
+
+-
+
+## Test plan
+
+<!-- Check what you ran; leave unchecked what still needs doing. -->
+
+- [ ] `make fmt-check`
+- [ ] `make lint`
+- [ ] `make test` (or `make be-test` for backend-only changes)
+- [ ] `make fe-build` / `make fe-run` for UI changes
+- [ ] Manual verification steps (describe them):
+
+## Notes for reviewers
+
+<!-- Optional: screenshots for UI changes, trade-offs, follow-ups, anything risky. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,134 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement — the project
+maintainers, reachable through a
+[GitHub private vulnerability report](https://github.com/suiflex/rdb/security/advisories/new)
+or by contacting **@suiflex**. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,90 @@
+# Contributing to RDBS
+
+Thanks for your interest in RDBS — a native, cross-platform database manager
+(PostgreSQL, MySQL, Redis, MongoDB, and more) built with Rust and Slint.
+
+This guide covers how to build, test, and submit changes. By participating you
+agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Getting started
+
+RDBS is a Cargo workspace:
+
+- `app/` — the Slint UI binary (`rdbs`), the only crate that names a concrete
+  driver (in `app/src/dispatch.rs`).
+- `crates/core/` — the `Driver` trait, `Query`, `ResultSet`, `Schema`, errors.
+- `crates/connstore/` — saved connections + OS keychain / AES-GCM.
+- `crates/driver-*/` — one crate per engine, each implementing `Driver`.
+
+You need a stable Rust toolchain with `rustfmt` and `clippy`:
+
+```bash
+rustup component add rustfmt clippy
+```
+
+UI builds need the Slint system libraries for your platform — see the
+[Slint prerequisites](https://releases.slint.dev/latest/docs/rust/slint/#prerequisites).
+
+## Build, lint, test
+
+A root `Makefile` wraps the common Cargo invocations and splits the frontend
+(the `rdbs` UI binary) from the backend (the `crates/*` libraries). Run
+`make help` for the full list. The most common targets:
+
+```bash
+make fe-build     # build the rdbs UI
+make fe-run       # run the UI
+make be-build     # build backend crates only
+make be-test      # test backend crates only
+make fmt-check    # format check (make fmt to apply)
+make lint         # clippy, warnings treated as errors
+make test         # test the whole workspace
+make all          # fmt-check + lint + test + build (the CI gate)
+```
+
+Run `make all` before opening a pull request. Integration tests
+(`tests/integration.rs`) need Docker and run locally via `make test-it`; they
+are intentionally kept out of CI.
+
+## Adding a database engine
+
+1. Create a new `crates/driver-<engine>/` crate that implements the `Driver`
+   trait from `rdbs-core`.
+2. Add a variant to the `AnyDriver` enum in `app/src/dispatch.rs` and forward
+   the trait methods.
+
+Keep engine-specific logic (SQL strings, protocol quirks) inside the driver
+crate. The app layer must stay engine-agnostic — the only place it names a
+concrete driver is `AnyDriver`.
+
+## Commit conventions
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/); the
+`release-please` workflow parses them to drive the changelog and version bumps.
+
+- Types: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`, `build`, `ci`.
+- Subject line ≤ 72 chars, imperative mood, no trailing period.
+- Wrap the body at 72 chars and explain **why** the change exists — the diff
+  already shows the what.
+- One logical change per commit. Each commit should leave the tree in a
+  buildable, testable state so `git revert` stays safe.
+- Do **not** hand-edit the `release-please`-managed sections of any changelog.
+
+## Branching & pull requests
+
+- Branch off `develop` using a name that matches the leading commit type:
+  `feat/…`, `fix/…`, `refactor/…`, `chore/…`, `docs/…`.
+- Fill out the pull request template (Summary / Changes / Test plan).
+- Keep PRs focused on one logical change — smaller PRs are easier to review.
+- CI runs a scoped workflow per component (a `core` change also retests its
+  dependents). Make sure `make all` passes locally first.
+
+## Reporting bugs & requesting features
+
+Use the issue forms under **Issues → New issue**. Security vulnerabilities must
+**not** be filed as public issues — see [SECURITY.md](SECURITY.md).
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+[MIT License](LICENSE) that covers this project.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Supported versions
+
+RDBS is pre-1.0 and ships from a single tracked package (`rdbs`). Security
+fixes land on the latest release; there are no long-term support branches yet.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.8.x   | :white_check_mark: |
+| < 0.8   | :x:                |
+
+Please upgrade to the latest release before reporting an issue where possible.
+
+## Reporting a vulnerability
+
+**Do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, use GitHub's private vulnerability reporting:
+
+1. Go to the [Security tab](https://github.com/suiflex/rdb/security/advisories/new).
+2. Click **Report a vulnerability** and fill out the advisory form.
+
+If you cannot use private reporting, contact the maintainers (**@suiflex**) and
+ask for a private channel before sharing any details.
+
+Please include, where you can:
+
+- The affected component (`app`, `core`, `connstore`, or a specific
+  `driver-*` crate) and version.
+- A description of the vulnerability and its impact.
+- Steps to reproduce, a proof of concept, or the relevant configuration.
+- Any suggested remediation.
+
+## What to expect
+
+- **Acknowledgement** within 5 business days.
+- An initial assessment and severity triage shortly after.
+- Progress updates as we work on a fix, and coordination on a disclosure
+  timeline. We aim to release a fix before any public disclosure.
+- Credit for the reporter in the advisory, unless you prefer to remain
+  anonymous.
+
+## Scope
+
+RDBS stores connection secrets in the OS keychain, falling back to AES-GCM
+encryption. Reports touching credential handling, secret storage, or the
+database driver connection paths are especially valued.
+
+Thank you for helping keep RDBS and its users safe.


### PR DESCRIPTION
## Summary

- Add the standard community-health files so the repo has clear contribution, conduct, and security-reporting guidance.

## Changes

- **`.github/PULL_REQUEST_TEMPLATE.md`** — Summary / Changes / Test plan structure that prompts contributors to run the Makefile checks.
- **`CONTRIBUTING.md`** — workspace layout, `make` build/lint/test targets, how to add a new engine, commit/branch/PR conventions.
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant v2.1; reports routed to maintainers via GitHub private reporting.
- **`SECURITY.md`** — private vulnerability reporting, supported versions, response expectations; flags credential storage and driver paths as in scope.

## Test plan

- [x] Docs-only change; no code affected
- [x] Links point at the `suiflex/rdb` repo and existing files (`LICENSE`, cross-references)
- [ ] Confirm GitHub renders the PR template on new PRs after merge

## Notes for reviewers

- Enforcement/security contact uses GitHub private vulnerability reporting + **@suiflex**. Swap in a dedicated security email if you'd prefer one.
- Supported-versions table pins `0.8.x`; update as releases advance.
