### PR TITLE
ci: publish release binaries to Homebrew tap and Scoop bucket

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,150 @@
+name: release-build
+
+# Fires when release-please publishes the GitHub Release for a new tag.
+# Builds per-platform binaries, attaches them to the Release, then updates the
+# Homebrew tap and Scoop bucket in two independent sibling jobs.
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            target: aarch64-apple-darwin
+            ext: tar.gz
+          - os: macos-13
+            target: x86_64-apple-darwin
+            ext: tar.gz
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            ext: tar.gz
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            ext: zip
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-${{ matrix.target }}
+      # ponytail: same minimal Slint deps as the CI workflow; extend if the
+      # build errors demanding another lib.
+      - name: Install Slint system deps (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libfontconfig1-dev \
+            libxcb-render0-dev \
+            libxcb-shape0-dev \
+            libxcb-xfixes0-dev \
+            libxkbcommon-dev
+      - name: Build release binary
+        run: cargo build --release -p rdbs --target ${{ matrix.target }}
+      - name: Package (unix)
+        if: runner.os != 'Windows'
+        run: |
+          tar -czf "rdbs-${{ matrix.target }}.tar.gz" \
+            -C "target/${{ matrix.target }}/release" rdbs
+      - name: Package (windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Compress-Archive `
+            -Path "target/${{ matrix.target }}/release/rdbs.exe" `
+            -DestinationPath "rdbs-${{ matrix.target }}.zip"
+      - name: Upload asset to Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "rdbs-${{ matrix.target }}.${{ matrix.ext }}" --clobber
+
+  # ---- publish jobs: siblings, both need `build`, neither needs the other ----
+  # A failure in one does NOT cancel the other (GitHub only cancels a job's own
+  # dependents). Single shared PAT: secrets.TAP_PUBLISH_TOKEN.
+
+  publish-homebrew:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Render formula and push to tap
+        env:
+          GH_TOKEN: ${{ secrets.TAP_PUBLISH_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          base="https://github.com/${REPO}/releases/download/${TAG}"
+
+          dl() { gh release download "$TAG" -R "$REPO" -p "$1" -O "$1" --clobber; }
+          sha() { shasum -a 256 "$1" | cut -d' ' -f1; }
+
+          dl "rdbs-aarch64-apple-darwin.tar.gz"
+          dl "rdbs-x86_64-apple-darwin.tar.gz"
+          dl "rdbs-x86_64-unknown-linux-gnu.tar.gz"
+          arm_sha="$(sha rdbs-aarch64-apple-darwin.tar.gz)"
+          intel_sha="$(sha rdbs-x86_64-apple-darwin.tar.gz)"
+          linux_sha="$(sha rdbs-x86_64-unknown-linux-gnu.tar.gz)"
+
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/suiflex/homebrew-tap.git" tap
+          mkdir -p tap/Formula
+          sed -e "s|@VERSION@|${VERSION}|g" \
+              -e "s|@BASE@|${base}|g" \
+              -e "s|@ARM_SHA@|${arm_sha}|g" \
+              -e "s|@INTEL_SHA@|${intel_sha}|g" \
+              -e "s|@LINUX_SHA@|${linux_sha}|g" \
+              packaging/rdbs.rb.tmpl > tap/Formula/rdbs.rb
+
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/rdbs.rb
+          git commit -m "rdbs ${VERSION}" || { echo "no change"; exit 0; }
+          git push
+
+  publish-scoop:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Render manifest and push to bucket
+        env:
+          GH_TOKEN: ${{ secrets.TAP_PUBLISH_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          base="https://github.com/${REPO}/releases/download/${TAG}"
+          asset="rdbs-x86_64-pc-windows-msvc.zip"
+
+          gh release download "$TAG" -R "$REPO" -p "$asset" -O "$asset" --clobber
+          win_sha="$(shasum -a 256 "$asset" | cut -d' ' -f1)"
+
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/suiflex/scoop-bucket.git" bucket
+          mkdir -p bucket/bucket
+          sed -e "s|@VERSION@|${VERSION}|g" \
+              -e "s|@BASE@|${base}|g" \
+              -e "s|@WIN_SHA@|${win_sha}|g" \
+              packaging/rdbs.json.tmpl > bucket/bucket/rdbs.json
+
+          cd bucket
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add bucket/rdbs.json
+          git commit -m "rdbs ${VERSION}" || { echo "no change"; exit 0; }
+          git push

--- a/README.md
+++ b/README.md
@@ -89,6 +89,23 @@ curl -fsSL https://raw.githubusercontent.com/suiflex/rdb/develop/scripts/install
 
 The script installs `rdbs` into `/usr/local/bin` when writable, otherwise it falls back to `~/.local/bin`.
 
+### Homebrew (macOS / Linux)
+
+```bash
+brew install suiflex/tap/rdbs
+```
+
+Upgrade later with `brew upgrade rdbs`.
+
+### Scoop (Windows)
+
+```powershell
+scoop bucket add suiflex https://github.com/suiflex/scoop-bucket
+scoop install rdbs
+```
+
+Upgrade later with `scoop update rdbs`.
+
 ## Build from source
 
 | Tool | Version |

--- a/packaging/rdbs.json.tmpl
+++ b/packaging/rdbs.json.tmpl
@@ -1,0 +1,21 @@
+{
+  "version": "@VERSION@",
+  "description": "Native cross-platform database manager (PostgreSQL, MySQL, Redis, MongoDB)",
+  "homepage": "https://github.com/suiflex/rdb",
+  "license": "MIT",
+  "architecture": {
+    "64bit": {
+      "url": "@BASE@/rdbs-x86_64-pc-windows-msvc.zip",
+      "hash": "@WIN_SHA@"
+    }
+  },
+  "bin": "rdbs.exe",
+  "checkver": "github",
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/suiflex/rdb/releases/download/v$version/rdbs-x86_64-pc-windows-msvc.zip"
+      }
+    }
+  }
+}

--- a/packaging/rdbs.rb.tmpl
+++ b/packaging/rdbs.rb.tmpl
@@ -1,0 +1,33 @@
+# Rendered by .github/workflows/release-build.yml into suiflex/homebrew-tap.
+# Placeholders (@VERSION@, @BASE@, @ARM_SHA@, @INTEL_SHA@, @LINUX_SHA@) are
+# filled in via sed on each release. Edit the template, not the generated file.
+class Rdbs < Formula
+  desc "Native cross-platform database manager (PostgreSQL, MySQL, Redis, MongoDB)"
+  homepage "https://github.com/suiflex/rdb"
+  version "@VERSION@"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "@BASE@/rdbs-aarch64-apple-darwin.tar.gz"
+      sha256 "@ARM_SHA@"
+    end
+    on_intel do
+      url "@BASE@/rdbs-x86_64-apple-darwin.tar.gz"
+      sha256 "@INTEL_SHA@"
+    end
+  end
+
+  on_linux do
+    url "@BASE@/rdbs-x86_64-unknown-linux-gnu.tar.gz"
+    sha256 "@LINUX_SHA@"
+  end
+
+  def install
+    bin.install "rdbs"
+  end
+
+  test do
+    assert_match "rdbs", shell_output("#{bin}/rdbs --version")
+  end
+end


### PR DESCRIPTION
## Summary
- release-please tags releases but nothing built or shipped binaries, so `scripts/install.sh` had no assets to fetch.
- Adds a release-build pipeline that produces per-platform binaries and publishes to Homebrew + Scoop.

## Changes
- `.github/workflows/release-build.yml`: on release `published`, matrix build (macOS arm64/x86_64, Windows, Linux) → assets named by target triple (match install.sh) → attach to the Release.
- `publish-homebrew` and `publish-scoop`: independent sibling jobs (both `needs: [build]`, neither needs the other) so one failing does not cancel the other. Single shared PAT `TAP_PUBLISH_TOKEN`.
- `packaging/rdbs.rb.tmpl`, `packaging/rdbs.json.tmpl`: formula/manifest templates rendered per release.
- README: Homebrew + Scoop install/upgrade docs.

## Test plan
- [x] Requires repo secret `TAP_PUBLISH_TOKEN` and seeded `suiflex/homebrew-tap` + `suiflex/scoop-bucket`.
- [x] Cut a pre-release tag on a fork: confirm matrix builds and uploads assets whose names satisfy `scripts/install.sh`.
- [x] `RDBS_VERSION=<tag> bash scripts/install.sh` installs the built binary.
- [x] Break one publish job temporarily → confirm the other still runs.
- [ ] `brew install suiflex/tap/rdbs` / `scoop install rdbs` install and run.