### PR TITLE
feat: add app settings store (theme, UI state, prefs)

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1172,6 +1172,33 @@ fn main() -> Result<(), slint::PlatformError> {
         },
     ));
 
+    // App preferences (theme, update-check, UI state), persisted alongside the
+    // connection store. Follows the same RDBS_STORE_DIR / mock overrides so
+    // tests and the reference screenshots never touch the user's real file.
+    let settings: Rc<RefCell<rdbs_connstore::SettingsStore>> = Rc::new(RefCell::new(
+        if let Ok(dir) = std::env::var("RDBS_STORE_DIR") {
+            let dir = std::path::PathBuf::from(dir);
+            rdbs_connstore::SettingsStore::load(dir.join("settings.json"))
+                .expect("load RDBS_STORE_DIR settings")
+        } else if mock::mock_mode() {
+            let dir = std::env::temp_dir().join(format!("rdbs-mock-{}", std::process::id()));
+            let _ = std::fs::create_dir_all(&dir);
+            rdbs_connstore::SettingsStore::load(dir.join("settings.json")).expect("mock settings")
+        } else {
+            rdbs_connstore::SettingsStore::open_default().unwrap_or_else(|_| {
+                let dir = std::env::temp_dir().join("dbm");
+                let _ = std::fs::create_dir_all(&dir);
+                rdbs_connstore::SettingsStore::load(dir.join("settings.json"))
+                    .expect("settings fallback")
+            })
+        },
+    ));
+
+    // Apply the saved theme before the first paint.
+    window
+        .global::<Theme>()
+        .set_dark(settings.borrow().get().theme.is_dark());
+
     // Fixed window size for the screenshot loop: RDBS_WIN=WxH (logical px).
     if let Ok(spec) = std::env::var("RDBS_WIN") {
         if let Some((w, h)) = spec.split_once('x') {
@@ -1193,8 +1220,18 @@ fn main() -> Result<(), slint::PlatformError> {
         for g in ["OSS", "LOCAL", "SPMB", UNGROUPED] {
             c.insert(g.to_string());
         }
+    } else {
+        // Restore the groups the user had collapsed last session.
+        let mut c = collapsed.borrow_mut();
+        for g in &settings.borrow().get().ui_state.collapsed_groups {
+            c.insert(g.clone());
+        }
     }
     // Current connection-picker search text.
+    // ponytail: filter text is session-only; restoring it would need the picker
+    // FilterField to expose a settable `text` (it is write-only today), and a
+    // pre-filled box on launch is dubious UX. AppSettings keeps the field for
+    // when that plumbing is worth adding.
     let conn_filter: Rc<RefCell<String>> = Rc::new(RefCell::new(String::new()));
 
     // Schema sidebar state: raw flat nodes from the last connect (Send, so the
@@ -2479,6 +2516,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let store = store.clone();
         let collapsed = collapsed.clone();
         let conn_filter = conn_filter.clone();
+        let settings = settings.clone();
         window.on_toggle_group(move |g| {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -2490,6 +2528,12 @@ fn main() -> Result<(), slint::PlatformError> {
                     c.insert(g);
                 }
             }
+            // Persist the new collapsed set (best-effort; a write failure must
+            // not break the UI).
+            let groups: Vec<String> = collapsed.borrow().iter().cloned().collect();
+            let _ = settings
+                .borrow_mut()
+                .update(|s| s.ui_state.collapsed_groups = groups);
             let items =
                 build_conn_items(&store.borrow(), &collapsed.borrow(), &conn_filter.borrow());
             w.set_connections(ModelRc::from(Rc::new(VecModel::from(items))));
@@ -4585,11 +4629,15 @@ fn main() -> Result<(), slint::PlatformError> {
     // ----- light/dark toggle -----
     {
         let weak = window.as_weak();
+        let settings = settings.clone();
         window.on_toggle_theme(move || {
             if let Some(w) = weak.upgrade() {
                 let t = w.global::<Theme>();
                 let now = t.get_dark();
                 t.set_dark(!now);
+                let _ = settings
+                    .borrow_mut()
+                    .update(|s| s.theme = rdbs_connstore::ThemeMode::from_dark(!now));
             }
         });
     }

--- a/crates/connstore/src/lib.rs
+++ b/crates/connstore/src/lib.rs
@@ -5,10 +5,12 @@ pub mod conn_url;
 pub mod error;
 pub mod model;
 pub mod secret;
+pub mod settings;
 pub mod store;
 
 pub use conn_url::{parse_conn_url, ConnUrlError, ParsedUrl};
 pub use error::{ConnStoreError, Result};
 pub use model::{Engine, SavedConnection};
 pub use secret::{EncryptedFileBackend, KeyringBackend, SecretBackend};
+pub use settings::{AppSettings, EditorPrefs, SettingsStore, ThemeMode, UiState};
 pub use store::ConnStore;

--- a/crates/connstore/src/settings.rs
+++ b/crates/connstore/src/settings.rs
@@ -1,0 +1,205 @@
+//! App-wide preferences (theme, update-check, UI state, editor prefs) persisted
+//! as `settings.json` in the same platform config dir as `connections.json`.
+//!
+//! Nothing here is secret, so unlike [`crate::store::ConnStore`] there is no
+//! secret backend — it is a plain serde round-trip with a full-file flush on
+//! each mutation (the struct is tiny).
+
+use std::path::PathBuf;
+
+use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{ConnStoreError, Result};
+
+/// Which color scheme the UI should start in. Matches the app's single
+/// light/dark toggle (`Theme.dark`); default light mirrors `tokens.slint`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ThemeMode {
+    #[default]
+    Light,
+    Dark,
+}
+
+impl ThemeMode {
+    /// The app renders theme as a single `dark` bool.
+    pub fn is_dark(self) -> bool {
+        matches!(self, ThemeMode::Dark)
+    }
+
+    pub fn from_dark(dark: bool) -> Self {
+        if dark {
+            ThemeMode::Dark
+        } else {
+            ThemeMode::Light
+        }
+    }
+}
+
+/// UI state worth restoring across restarts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct UiState {
+    /// Names of sidebar groups the user has collapsed.
+    pub collapsed_groups: Vec<String>,
+    /// Last connection-picker filter text.
+    pub last_filter: String,
+}
+
+/// Query-editor / results preferences.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct EditorPrefs {
+    pub font_size: u16,
+    pub default_page_size: u32,
+}
+
+impl Default for EditorPrefs {
+    fn default() -> Self {
+        EditorPrefs {
+            font_size: 13,
+            default_page_size: 100,
+        }
+    }
+}
+
+/// All persisted app preferences. Container-level `#[serde(default)]` means an
+/// absent or partial `settings.json` fills every missing field from
+/// [`AppSettings::default`] — including `update_check = true`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AppSettings {
+    pub theme: ThemeMode,
+    /// Whether to check GitHub for a newer release on launch.
+    pub update_check: bool,
+    /// Unix seconds of the last update check, used to throttle to once/day.
+    pub last_update_check: Option<i64>,
+    pub ui_state: UiState,
+    pub editor: EditorPrefs,
+}
+
+impl Default for AppSettings {
+    fn default() -> Self {
+        AppSettings {
+            theme: ThemeMode::default(),
+            update_check: true,
+            last_update_check: None,
+            ui_state: UiState::default(),
+            editor: EditorPrefs::default(),
+        }
+    }
+}
+
+/// Owns `settings.json` and flushes the whole file on each mutation.
+pub struct SettingsStore {
+    path: PathBuf,
+    settings: AppSettings,
+}
+
+impl SettingsStore {
+    /// Construct with an explicit path (used by tests and by callers that pin a
+    /// directory). Loads the file if present, else starts from defaults.
+    pub fn load(path: PathBuf) -> Result<Self> {
+        let settings = if path.exists() {
+            let raw = std::fs::read_to_string(&path)?;
+            serde_json::from_str(&raw)?
+        } else {
+            AppSettings::default()
+        };
+        Ok(SettingsStore { path, settings })
+    }
+
+    /// Default location of `settings.json`: platform config dir for qualifier
+    /// `dev`, org `dbm`, app `dbm` — the same dir as `connections.json`.
+    pub fn default_path() -> Result<PathBuf> {
+        let dirs = ProjectDirs::from("dev", "dbm", "dbm").ok_or(ConnStoreError::NoConfigDir)?;
+        Ok(dirs.config_dir().join("settings.json"))
+    }
+
+    /// Open at the platform default path.
+    pub fn open_default() -> Result<Self> {
+        Self::load(Self::default_path()?)
+    }
+
+    /// Read-only view of the current settings.
+    pub fn get(&self) -> &AppSettings {
+        &self.settings
+    }
+
+    /// Mutate settings via a closure, then flush to disk.
+    pub fn update(&mut self, f: impl FnOnce(&mut AppSettings)) -> Result<()> {
+        f(&mut self.settings);
+        self.flush()
+    }
+
+    fn flush(&self) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let json = serde_json::to_string_pretty(&self.settings)?;
+        std::fs::write(&self.path, json)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "rdbs-settings-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.join("settings.json")
+    }
+
+    #[test]
+    fn defaults_when_file_absent() {
+        let s = SettingsStore::load(tmp()).unwrap();
+        assert_eq!(s.get().theme, ThemeMode::Light);
+        assert!(s.get().update_check);
+        assert_eq!(s.get().last_update_check, None);
+        assert_eq!(s.get().editor.default_page_size, 100);
+    }
+
+    #[test]
+    fn round_trips_through_disk() {
+        let path = tmp();
+        let mut s = SettingsStore::load(path.clone()).unwrap();
+        s.update(|s| {
+            s.theme = ThemeMode::Dark;
+            s.update_check = false;
+            s.last_update_check = Some(1_700_000_000);
+            s.ui_state.collapsed_groups = vec!["Prod".into()];
+            s.ui_state.last_filter = "pg".into();
+            s.editor.font_size = 16;
+        })
+        .unwrap();
+
+        let reloaded = SettingsStore::load(path).unwrap();
+        assert_eq!(reloaded.get().theme, ThemeMode::Dark);
+        assert!(!reloaded.get().update_check);
+        assert_eq!(reloaded.get().last_update_check, Some(1_700_000_000));
+        assert_eq!(reloaded.get().ui_state.collapsed_groups, vec!["Prod"]);
+        assert_eq!(reloaded.get().ui_state.last_filter, "pg");
+        assert_eq!(reloaded.get().editor.font_size, 16);
+    }
+
+    #[test]
+    fn partial_json_fills_missing_with_defaults() {
+        let path = tmp();
+        std::fs::write(&path, r#"{"theme":"dark"}"#).unwrap();
+        let s = SettingsStore::load(path).unwrap();
+        assert_eq!(s.get().theme, ThemeMode::Dark);
+        // update_check missing from JSON -> default true, not false.
+        assert!(s.get().update_check);
+        assert_eq!(s.get().editor.default_page_size, 100);
+    }
+}


### PR DESCRIPTION
## Summary
- Connections were the only persisted state, so app preferences reset every launch (theme, sidebar collapse).
- Adds a settings store and wires theme + collapsed-groups persistence.

## Changes
- `crates/connstore/src/settings.rs`: `SettingsStore` serializing `AppSettings` (theme, update_check, last_update_check, ui_state, editor prefs) to `settings.json` in the same config dir as `connections.json`. Mirrors ConnStore's load/flush; no secret backend (nothing sensitive).
- `app/src/main.rs`: load at startup (same RDBS_STORE_DIR / mock overrides), apply saved theme before first paint, restore collapsed sidebar groups, persist on theme toggle and group collapse.
- Filter text stays session-only (restoring needs the picker FilterField to expose a settable text property; noted in a ponytail comment).

## Test plan
- [x] `cargo test -p rdbs-connstore` (round-trip, defaults-when-absent, partial-json).
- [x] `make lint` / workspace tests green.
- [ ] Manual: set dark theme + collapse a group, quit, relaunch → restored; inspect `settings.json`.