### PR TITLE
feat: check for updates with install-aware reminder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,7 +706,7 @@ dependencies = [
  "prost-types",
  "tonic",
  "tonic-prost",
- "ureq",
+ "ureq 3.3.0",
 ]
 
 [[package]]
@@ -3380,6 +3380,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3971,7 +3990,7 @@ dependencies = [
  "tokio-util",
  "typed-builder",
  "uuid",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -4720,6 +4739,16 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "open"
+version = "5.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8d3b65c44123a56e0133d2cd06ce4361bd3ca99d41198b2f25e3c3db9b8b4a"
+dependencies = [
+ "is-wsl",
+ "libc",
+]
 
 [[package]]
 name = "openssl"
@@ -5533,10 +5562,11 @@ dependencies = [
 
 [[package]]
 name = "rdbs"
-version = "0.5.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "copypasta",
+ "open",
  "rdbs-connstore",
  "rdbs-core",
  "rdbs-driver-cassandra",
@@ -5545,10 +5575,12 @@ dependencies = [
  "rdbs-driver-postgres",
  "rdbs-driver-redis",
  "rdbs-driver-sqlite",
+ "semver",
  "serde_json",
  "slint",
  "slint-build",
  "tokio",
+ "ureq 2.12.1",
 ]
 
 [[package]]
@@ -7712,6 +7744,22 @@ checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "ureq"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
@@ -8168,6 +8216,15 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "url",
  "web-sys",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -22,6 +22,11 @@ serde_json = "1"
 async-trait = "0.1"
 # clipboard; already in the tree via Slint's winit backend, so no new builds
 copypasta = "0.10"
+# update check: one blocking GitHub GET (ureq, no async/TLS-stack bloat) +
+# semver compare; `open` opens the release page cross-platform.
+ureq = "2"
+semver = "1"
+open = "5"
 
 [build-dependencies]
 slint-build = "1.8"

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -22,6 +22,7 @@ mod query_parse;
 mod shot;
 mod sql_format;
 mod theme;
+mod update;
 
 use std::cell::RefCell;
 use std::collections::HashSet;
@@ -5080,6 +5081,60 @@ fn main() -> Result<(), slint::PlatformError> {
                 build_conn_items(&store.borrow(), &collapsed.borrow(), &conn_filter.borrow());
             w.set_connections(ModelRc::from(Rc::new(VecModel::from(items))));
         });
+    }
+
+    // ----- update reminder: open the release page / dismiss -----
+    {
+        window.on_update_open(move || {
+            let _ = open::that(update::release_page());
+        });
+    }
+    {
+        let weak = window.as_weak();
+        window.on_update_dismiss(move || {
+            if let Some(w) = weak.upgrade() {
+                w.set_update_available(false);
+            }
+        });
+    }
+
+    // ----- update check: once/day, gated by the setting, off the UI thread -----
+    // Skip in mock mode so the reference screenshots stay deterministic.
+    if !mock::mock_mode() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        let (enabled, last) = {
+            let s = settings.borrow();
+            (s.get().update_check, s.get().last_update_check)
+        };
+        if enabled && update::due_for_check(last, now) {
+            // Persist "checked now" up front on the UI thread — the Rc settings
+            // store cannot cross into the worker thread. Worst case a failed
+            // check simply waits a day, which is the intended throttle.
+            let _ = settings
+                .borrow_mut()
+                .update(|s| s.last_update_check = Some(now));
+            let weak = window.as_weak();
+            std::thread::spawn(move || {
+                let Some(tag) = update::fetch_latest_tag() else {
+                    return;
+                };
+                if !update::is_newer(&tag, env!("CARGO_PKG_VERSION")) {
+                    return;
+                }
+                let version = tag.trim_start_matches('v').to_string();
+                let hint = update::InstallMethod::detect().upgrade_hint().to_string();
+                let _ = slint::invoke_from_event_loop(move || {
+                    if let Some(w) = weak.upgrade() {
+                        w.set_update_version(version.into());
+                        w.set_update_hint(hint.into());
+                        w.set_update_available(true);
+                    }
+                });
+            });
+        }
     }
 
     shot::install(&window);

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -233,6 +233,13 @@ in-out property <string> rename-text;
     callback move-row(int);
     callback toggle-theme();
 
+    // ----- update reminder banner (fed from Rust) -----
+    in property <bool> update-available: false;
+    in property <string> update-version;   // e.g. "1.2.0"
+    in property <string> update-hint;      // install-method upgrade instruction
+    callback update-open();                // open the release page
+    callback update-dismiss();             // hide until next launch
+
     // ----- connection form -----
     in property <bool> form-open;
     in property <bool> form-edit-mode;
@@ -1067,5 +1074,67 @@ in-out property <string> rename-text;
             root.form-cancel();
         }
     }
+    }
+
+    // ----- update reminder banner (floating, bottom-right, drawn on top) -----
+    if root.update-available: Rectangle {
+        x: parent.width - self.width - 16px;
+        y: parent.height - self.height - 16px;
+        width: banner-row.preferred-width + 28px;
+        height: 44px;
+        background: Tokens.card;
+        border-radius: Tokens.radius;
+        border-width: 1px;
+        border-color: Tokens.accent;
+        drop-shadow-blur: 16px;
+        drop-shadow-color: #000000.with-alpha(0.28);
+
+        banner-row := HorizontalLayout {
+            padding-left: 14px;
+            padding-right: 14px;
+            spacing: 12px;
+            alignment: start;
+
+            VerticalLayout {
+                alignment: center;
+                spacing: 1px;
+                Text {
+                    text: "Update available — v" + root.update-version;
+                    font-size: 13px;
+                    font-weight: 600;
+                    color: Tokens.text;
+                }
+                Text {
+                    text: root.update-hint;
+                    font-size: 11px;
+                    color: Tokens.text-dim;
+                }
+            }
+
+            TouchArea {
+                width: 62px;
+                clicked => { root.update-open(); }
+                Rectangle {
+                    background: parent.has-hover ? Tokens.accent-hover : Tokens.accent;
+                    border-radius: Tokens.radius;
+                    Text {
+                        text: "Update";
+                        font-size: 12px;
+                        font-weight: 600;
+                        color: #FFFFFF;
+                    }
+                }
+            }
+
+            TouchArea {
+                width: 20px;
+                clicked => { root.update-dismiss(); }
+                Text {
+                    text: "✕";
+                    font-size: 13px;
+                    color: parent.has-hover ? Tokens.text : Tokens.text-dim;
+                }
+            }
+        }
     }
 }

--- a/app/src/update.rs
+++ b/app/src/update.rs
@@ -1,0 +1,137 @@
+//! Startup "a newer version is out" check.
+//!
+//! Network and version comparison live here as small pure-ish helpers;
+//! `main.rs` orchestrates: it reads the throttle/toggle off the settings store
+//! on the UI thread, does the HTTP GET on a background thread, then hops back
+//! via `invoke_from_event_loop` to show the banner and persist the timestamp.
+
+use std::path::Path;
+
+use semver::Version;
+
+const RELEASES_LATEST: &str = "https://api.github.com/repos/suiflex/rdb/releases/latest";
+const RELEASES_PAGE: &str = "https://github.com/suiflex/rdb/releases/latest";
+const DAY_SECS: i64 = 86_400;
+
+/// How the running binary was installed, which decides the upgrade advice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstallMethod {
+    Homebrew,
+    Scoop,
+    /// curl installer, manual copy, or unknown.
+    Other,
+}
+
+impl InstallMethod {
+    pub fn detect() -> Self {
+        Self::from_exe_path(std::env::current_exe().ok().as_deref())
+    }
+
+    fn from_exe_path(path: Option<&Path>) -> Self {
+        let Some(p) = path else {
+            return InstallMethod::Other;
+        };
+        let s = p.to_string_lossy().to_lowercase();
+        if s.contains("/cellar/") || s.contains("/homebrew/") {
+            InstallMethod::Homebrew
+        } else if s.contains("/scoop/apps/") || s.contains("\\scoop\\apps\\") {
+            InstallMethod::Scoop
+        } else {
+            InstallMethod::Other
+        }
+    }
+
+    /// One-line upgrade instruction to show in the banner.
+    pub fn upgrade_hint(self) -> &'static str {
+        match self {
+            InstallMethod::Homebrew => "Run: brew upgrade rdbs",
+            InstallMethod::Scoop => "Run: scoop update rdbs",
+            InstallMethod::Other => "Open the download page",
+        }
+    }
+}
+
+/// Clicking the banner opens the release page for every install method —
+/// self-updating a brew/scoop install from inside the app would fight the
+/// package manager, and the banner text already shows the exact command.
+/// ponytail: no self-update machinery until asked.
+pub fn release_page() -> &'static str {
+    RELEASES_PAGE
+}
+
+/// True if `latest_tag` (e.g. "v1.2.0") is a strictly newer semver than the
+/// running `current` version. Unparseable input is treated as "not newer" so a
+/// malformed tag never nags the user.
+pub fn is_newer(latest_tag: &str, current: &str) -> bool {
+    let latest = latest_tag.trim_start_matches('v');
+    match (Version::parse(latest), Version::parse(current)) {
+        (Ok(l), Ok(c)) => l > c,
+        _ => false,
+    }
+}
+
+/// Throttle: check at most once per day.
+pub fn due_for_check(last_check: Option<i64>, now: i64) -> bool {
+    match last_check {
+        Some(t) => now.saturating_sub(t) >= DAY_SECS,
+        None => true,
+    }
+}
+
+/// Blocking GitHub API call returning the latest release tag. Returns `None` on
+/// any network/parse error — a failed check is silent, never fatal.
+pub fn fetch_latest_tag() -> Option<String> {
+    let body = ureq::get(RELEASES_LATEST)
+        .set("User-Agent", "rdbs-update-check")
+        .set("Accept", "application/vnd.github+json")
+        .timeout(std::time::Duration::from_secs(8))
+        .call()
+        .ok()?
+        .into_string()
+        .ok()?;
+    let json: serde_json::Value = serde_json::from_str(&body).ok()?;
+    json.get("tag_name")?.as_str().map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn detects_homebrew_and_scoop_from_path() {
+        let brew = PathBuf::from("/opt/homebrew/Cellar/rdbs/1.0.0/bin/rdbs");
+        assert_eq!(
+            InstallMethod::from_exe_path(Some(&brew)),
+            InstallMethod::Homebrew
+        );
+        let scoop = PathBuf::from(r"C:\Users\me\scoop\apps\rdbs\current\rdbs.exe");
+        assert_eq!(
+            InstallMethod::from_exe_path(Some(&scoop)),
+            InstallMethod::Scoop
+        );
+        let other = PathBuf::from("/usr/local/bin/rdbs");
+        assert_eq!(
+            InstallMethod::from_exe_path(Some(&other)),
+            InstallMethod::Other
+        );
+        assert_eq!(InstallMethod::from_exe_path(None), InstallMethod::Other);
+    }
+
+    #[test]
+    fn version_comparison() {
+        assert!(is_newer("v1.2.0", "1.1.0"));
+        assert!(is_newer("1.2.0", "1.1.9"));
+        assert!(!is_newer("v1.0.0", "1.0.0")); // equal is not newer
+        assert!(!is_newer("v0.9.0", "1.0.0")); // older
+        assert!(!is_newer("garbage", "1.0.0")); // unparseable -> no nag
+    }
+
+    #[test]
+    fn throttle_window() {
+        assert!(due_for_check(None, 1_000_000));
+        assert!(due_for_check(Some(0), DAY_SECS));
+        assert!(!due_for_check(Some(1000), 1000 + DAY_SECS - 1));
+        assert!(due_for_check(Some(1000), 1000 + DAY_SECS));
+    }
+}


### PR DESCRIPTION
## Summary
- App had no way to tell the user a newer release exists.
- Adds a once-a-day update check and a reminder banner whose upgrade hint matches how the app was installed.

> **Stacked on #34** (needs `SettingsStore`). Base is `feat/app-settings-store`; rebase onto `develop` after #34 merges.

## Changes
- `app/src/update.rs`: `ureq` GET of the latest GitHub release, `semver` compare vs `CARGO_PKG_VERSION`, 24h throttle, install-method detection (Homebrew / Scoop / curl-manual via `current_exe` path). Unit-tested.
- `app/src/ui/app-window.slint`: floating bottom-right banner (version + upgrade hint + Update + dismiss).
- `app/src/main.rs`: launch check off the UI thread (skipped in mock), gated by `update_check`, persists throttle timestamp up front; banner callbacks (open release page / dismiss).
- `app/Cargo.toml`: `ureq`, `semver`, `open`.

## Test plan
- [x] `cargo test -p rdbs --bin rdbs update` (version compare, throttle, install-method mapping).
- [x] `make lint` / workspace tests green.
- [x] Depends on #33 so real releases exist to compare against.
- [ ] Manual: point at a higher release → banner appears; click Update → correct action per install method.