### PR TITLE
feat: add settings modal (theme + update-check)

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1195,10 +1195,12 @@ fn main() -> Result<(), slint::PlatformError> {
         },
     ));
 
-    // Apply the saved theme before the first paint.
+    // Apply the saved theme before the first paint, and seed the settings modal
+    // toggles from the persisted values.
     window
         .global::<Theme>()
         .set_dark(settings.borrow().get().theme.is_dark());
+    window.set_update_check_enabled(settings.borrow().get().update_check);
 
     // Fixed window size for the screenshot loop: RDBS_WIN=WxH (logical px).
     if let Ok(spec) = std::env::var("RDBS_WIN") {
@@ -4639,6 +4641,18 @@ fn main() -> Result<(), slint::PlatformError> {
                 let _ = settings
                     .borrow_mut()
                     .update(|s| s.theme = rdbs_connstore::ThemeMode::from_dark(!now));
+            }
+        });
+    }
+
+    // ----- settings: check-for-updates toggle -----
+    {
+        let weak = window.as_weak();
+        let settings = settings.clone();
+        window.on_set_update_check(move |v| {
+            let _ = settings.borrow_mut().update(|s| s.update_check = v);
+            if let Some(w) = weak.upgrade() {
+                w.set_update_check_enabled(v);
             }
         });
     }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -240,6 +240,11 @@ in-out property <string> rename-text;
     callback update-open();                // open the release page
     callback update-dismiss();             // hide until next launch
 
+    // ----- app settings modal -----
+    in-out property <bool> settings-open: false;
+    in property <bool> update-check-enabled: true;
+    callback set-update-check(bool);
+
     // ----- connection form -----
     in property <bool> form-open;
     in property <bool> form-edit-mode;
@@ -481,6 +486,14 @@ in-out property <string> rename-text;
                     SearchCommandPill {
                         width: 248px;
                         activated => { root.toggle-palette(); }
+                    }
+                }
+                // app settings (always available, in and out of a connection)
+                VerticalLayout {
+                    alignment: center;
+                    GlyphButton {
+                        glyph: "⚙";
+                        clicked => { root.settings-open = true; }
                     }
                 }
                 if root.connected: VerticalLayout {
@@ -1133,6 +1146,122 @@ in-out property <string> rename-text;
                     text: "✕";
                     font-size: 13px;
                     color: parent.has-hover ? Tokens.text : Tokens.text-dim;
+                }
+            }
+        }
+    }
+
+    // ----- app settings modal (veil + centered card) -----
+    if root.settings-open: Rectangle {
+        background: Tokens.veil;
+        TouchArea {
+            clicked => { root.settings-open = false; }
+        }
+
+        Rectangle {
+            width: 420px;
+            x: (parent.width - self.width) / 2;
+            y: 120px;
+            height: settings-card.preferred-height;
+            border-radius: Tokens.modal-radius;
+            background: Tokens.card;
+            border-width: 1px;
+            border-color: Tokens.border;
+            drop-shadow-blur: 42px;
+            drop-shadow-offset-y: 12px;
+            drop-shadow-color: #1C191426;
+
+            // swallow veil clicks under the card
+            TouchArea {}
+
+            settings-card := VerticalLayout {
+                padding: Tokens.sp4;
+                padding-top: 18px;
+                spacing: Tokens.sp3;
+
+                Text {
+                    text: "Settings";
+                    color: Tokens.text;
+                    font-size: 15px;
+                    font-weight: 700;
+                    horizontal-alignment: center;
+                }
+
+                // --- appearance ---
+                HorizontalLayout {
+                    spacing: Tokens.sp3;
+                    VerticalLayout {
+                        alignment: center;
+                        horizontal-stretch: 1;
+                        Text {
+                            text: "Dark mode";
+                            color: Tokens.text;
+                            font-size: 13px;
+                        }
+                    }
+                    VerticalLayout {
+                        alignment: center;
+                        TouchArea {
+                            width: 42px;
+                            height: 24px;
+                            clicked => { root.toggle-theme(); }
+                            Rectangle {
+                                border-radius: 12px;
+                                background: Tokens.dark ? Tokens.accent : Tokens.border-strong;
+                                Rectangle {
+                                    width: 18px;
+                                    height: 18px;
+                                    border-radius: 9px;
+                                    background: #FFFFFF;
+                                    x: Tokens.dark ? parent.width - self.width - 3px : 3px;
+                                    y: (parent.height - self.height) / 2;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // --- updates ---
+                HorizontalLayout {
+                    spacing: Tokens.sp3;
+                    VerticalLayout {
+                        alignment: center;
+                        horizontal-stretch: 1;
+                        Text {
+                            text: "Check for updates on launch";
+                            color: Tokens.text;
+                            font-size: 13px;
+                        }
+                    }
+                    VerticalLayout {
+                        alignment: center;
+                        TouchArea {
+                            width: 42px;
+                            height: 24px;
+                            clicked => { root.set-update-check(!root.update-check-enabled); }
+                            Rectangle {
+                                border-radius: 12px;
+                                background: root.update-check-enabled ? Tokens.accent : Tokens.border-strong;
+                                Rectangle {
+                                    width: 18px;
+                                    height: 18px;
+                                    border-radius: 9px;
+                                    background: #FFFFFF;
+                                    x: root.update-check-enabled ? parent.width - self.width - 3px : 3px;
+                                    y: (parent.height - self.height) / 2;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // --- done ---
+                HorizontalLayout {
+                    alignment: end;
+                    PrimaryButton {
+                        text: "Done";
+                        clicked => { root.settings-open = false; }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Settings persistence landed in #34 but had no UI entry point — the theme toggle only showed while connected and the titlebar gear opened the connection edit form.
- Adds an always-visible settings gear that opens an app Settings modal exposing the settings that exist today.

## Changes
- `app/src/ui/app-window.slint`: always-visible ⚙ gear in the titlebar (works in and out of a connection); Settings modal (veil + centered card) with a dark-mode toggle and a check-for-updates-on-launch toggle.
- `app/src/main.rs`: seed the update-check toggle from the persisted value at startup; persist changes when flipped. Dark-mode toggle reuses the existing on_toggle_theme handler (already persists).

## Test plan
- [x] `make lint` / build green.
- [x] Manual: click the gear (picker and connected) → modal opens; toggle dark mode → theme flips and persists; toggle update-check → persists; relaunch → both reflect saved state.

## Notes
- Independent of the update-reminder PR (#37). If both land, expect a trivial conflict in `app-window.slint` property block / `main.rs` wiring.