### PR TITLE
feat(ui): sidebar column expand, dedicated icons, palette & toolbar fixes

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2156,7 +2156,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 let rows = schema_display_rows(
                     &nodes,
                     &HashSet::new(),
-                    &HashSet::new(),
+                    &default_collapsed_cats(),
                     &HashSet::new(),
                     Some(engine),
                     "",
@@ -3056,11 +3056,13 @@ fn main() -> Result<(), slint::PlatformError> {
                         let nodes = model::to_tree_model(&schema);
                         let fields = model::to_structure_model(&schema);
                         // Stash raw nodes for later expand/collapse rebuilds, and
-                        // render the initial view (categories open, fields hidden).
+                        // render the initial view (Functions collapsed, Tables open,
+                        // fields hidden). Matches the reseed done on connect above;
+                        // collapsed_categories itself is !Send so can't cross here.
                         let rows = schema_display_rows(
                             &nodes,
                             &HashSet::new(),
-                            &HashSet::new(),
+                            &default_collapsed_cats(),
                             &HashSet::new(),
                             Some(engine),
                             "",

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -3905,6 +3905,52 @@ fn main() -> Result<(), slint::PlatformError> {
         });
     }
 
+    // ----- expand a table's columns inline (single-click) -----
+    {
+        let weak = window.as_weak();
+        let raw_nodes = raw_nodes.clone();
+        let expanded_tables = expanded_tables.clone();
+        let loaded_dbs = loaded_dbs.clone();
+        let collapsed_categories = collapsed_categories.clone();
+        let cur_engine = cur_engine.clone();
+        let sidebar_filter = sidebar_filter.clone();
+        window.on_toggle_fields(move |db, label| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let engine = *cur_engine.borrow();
+            // ponytail: only SQL tables carry inline fields. Mongo/Redis/Cassandra
+            // leaves have none, so single-click keeps opening them — delegate to the
+            // existing open-table handler instead of duplicating its browse setup.
+            if !matches!(
+                engine,
+                Some(rdbs_connstore::Engine::Postgres)
+                    | Some(rdbs_connstore::Engine::MySql)
+                    | Some(rdbs_connstore::Engine::Sqlite)
+            ) {
+                w.invoke_open_table(db, label);
+                return;
+            }
+            let label = label.to_string();
+            {
+                let mut e = expanded_tables.lock().unwrap();
+                if !e.remove(&label) {
+                    e.insert(label);
+                }
+            }
+            let nodes = raw_nodes.lock().unwrap();
+            let rows = schema_display_rows(
+                &nodes,
+                &expanded_tables.lock().unwrap(),
+                &collapsed_categories.borrow(),
+                &loaded_dbs.lock().unwrap(),
+                engine,
+                &sidebar_filter.lock().unwrap(),
+            );
+            w.set_schema_tree(ModelRc::from(Rc::new(VecModel::from(rows))));
+        });
+    }
+
     // ----- sidebar tree filter -----
     {
         let weak = window.as_weak();

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -137,6 +137,12 @@ fn sidebar_categories(engine: Option<rdbs_connstore::Engine>) -> &'static [&'sta
 /// The current schema model only produces table-like containers, so every
 /// container lands under "Tables"; "Views"/"Functions" render as empty
 /// collapsible headers until schema introspection grows those kinds.
+/// Sidebar categories collapsed on a fresh connection / schema switch.
+/// Functions start closed so the tables list is what you land on.
+fn default_collapsed_cats() -> HashSet<String> {
+    HashSet::from(["Functions".to_string()])
+}
+
 fn schema_display_rows(
     nodes: &[model::VmTreeNode],
     expanded_tables: &HashSet<String>,
@@ -1250,7 +1256,8 @@ fn main() -> Result<(), slint::PlatformError> {
     let loaded_dbs: Arc<std::sync::Mutex<HashSet<String>>> =
         Arc::new(std::sync::Mutex::new(HashSet::new()));
     // Sidebar category headers the user has collapsed (Tables/Views/Functions).
-    let collapsed_categories: Rc<RefCell<HashSet<String>>> = Rc::new(RefCell::new(HashSet::new()));
+    let collapsed_categories: Rc<RefCell<HashSet<String>>> =
+        Rc::new(RefCell::new(default_collapsed_cats()));
     // Sidebar tree filter text. Arc<Mutex> so lazy-load tasks can read it.
     let sidebar_filter: Arc<std::sync::Mutex<String>> =
         Arc::new(std::sync::Mutex::new(String::new()));
@@ -2128,7 +2135,7 @@ fn main() -> Result<(), slint::PlatformError> {
             // drop expand/collapse state that referenced the old schema's tables.
             w.set_active_table(SharedString::default());
             expanded_tables.lock().unwrap().clear();
-            collapsed_categories.borrow_mut().clear();
+            *collapsed_categories.borrow_mut() = default_collapsed_cats();
             let engine = *cur_engine.borrow();
             let Some(engine) = engine else {
                 return;
@@ -2584,7 +2591,7 @@ fn main() -> Result<(), slint::PlatformError> {
             *cur_engine.borrow_mut() = None;
             expanded_tables.lock().unwrap().clear();
             loaded_dbs.lock().unwrap().clear();
-            collapsed_categories.borrow_mut().clear();
+            *collapsed_categories.borrow_mut() = default_collapsed_cats();
             raw_nodes.lock().unwrap().clear();
             let current = current.clone();
             rt.spawn(async move {
@@ -2994,7 +3001,7 @@ fn main() -> Result<(), slint::PlatformError> {
             *cur_engine.borrow_mut() = Some(sc.engine);
             expanded_tables.lock().unwrap().clear();
             loaded_dbs.lock().unwrap().clear();
-            collapsed_categories.borrow_mut().clear();
+            *collapsed_categories.borrow_mut() = default_collapsed_cats();
             let weak2 = weak.clone();
             let store_driver = current.clone();
             // Claim the driver slot synchronously, before any query/browse

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -73,6 +73,7 @@ in-out property <int> rename-target: -1;
 in-out property <string> rename-text;
     callback toggle-group(string);
     callback open-table(string, string);   // (database, container)
+    callback toggle-fields(string, string); // (database, table) — expand columns inline
     callback toggle-schema-node(string);
     callback select-schema(string);
     callback filter-tree(string);
@@ -600,6 +601,9 @@ in-out property <string> rename-text;
                     }
                     open-table(db, t) => {
                         root.open-table(db, t);
+                    }
+                    toggle-fields(db, t) => {
+                        root.toggle-fields(db, t);
                     }
                     toggle-node(t) => {
                         root.toggle-schema-node(t);

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -277,6 +277,9 @@ in-out property <string> rename-text;
     property <length> sidebar-w: Tokens.sidebar-w;
 
     // ----- keyboard shortcuts -----
+    // bumped by ⌘P to ask the sidebar (which lives under `if connected`) to focus
+    // its filter field; Sidebar watches this via a `changed` handler.
+    in-out property <int> focus-filter-tick: 0;
     FocusScope {
         key-pressed(e) => {
             if (e.text == Key.Escape) {
@@ -302,7 +305,12 @@ in-out property <string> rename-text;
                     return accept;
                 }
                 if (e.text == "p") {
-                    root.toggle-palette();
+                    // focus the sidebar filter (the ⌘P hint lives in Items mode).
+                    // sb is inside `if root.connected`, so nudge it via a tick the
+                    // Sidebar watches rather than referencing its id from here.
+                    root.sidebar-mode = 0;
+                    root.sidebar-mode-changed(0);
+                    root.focus-filter-tick += 1;
                     return accept;
                 }
                 if (e.text == Key.Return) {
@@ -572,7 +580,8 @@ in-out property <string> rename-text;
             HorizontalLayout {
                 spacing: 0px;
 
-                Sidebar {
+                sb := Sidebar {
+                    focus-tick: root.focus-filter-tick;
                     // preferred (not fixed) width so the window can auto-shrink the
                     // sidebar instead of treating sidebar-w as a hard min floor
                     horizontal-stretch: 0;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -522,9 +522,9 @@ in-out property <string> rename-text;
                             icon: Tokens.dark ? "sun" : "moon";
                             clicked => { root.toggle-theme(); }
                         }
-                        // settings of the current connection (edit form)
-                        GlyphButton {
-                            glyph: "⚙";
+                        // edit the current connection (distinct from the app ⚙)
+                        IconButton {
+                            icon: "pencil";
                             clicked => {
                                 if (root.selected-conn >= 0) {
                                     root.open-edit-form(root.selected-conn);

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -497,19 +497,20 @@ in-out property <string> rename-text;
                         activated => { root.toggle-palette(); }
                     }
                 }
-                // app settings (always available, in and out of a connection)
-                VerticalLayout {
-                    alignment: center;
-                    GlyphButton {
-                        glyph: "⚙";
-                        clicked => { root.settings-open = true; }
+                // aux icon cluster: app settings (always) + connection tools
+                // (when connected). One row so all four icons share even spacing.
+                HorizontalLayout {
+                    spacing: Tokens.sp1;
+                    VerticalLayout {
+                        alignment: center;
+                        GlyphButton {
+                            glyph: "⚙";
+                            clicked => { root.settings-open = true; }
+                        }
                     }
-                }
-                if root.connected: VerticalLayout {
-                    alignment: center;
-                    HorizontalLayout {
-                        spacing: Tokens.sp1;
-                        // history: jump the sidebar to the History tab
+                    // history: jump the sidebar to the History tab
+                    if root.connected: VerticalLayout {
+                        alignment: center;
                         IconButton {
                             icon: "clock";
                             clicked => {
@@ -517,12 +518,18 @@ in-out property <string> rename-text;
                                 root.sidebar-mode-changed(2);
                             }
                         }
-                        // theme toggle: sun in dark mode, moon in light
+                    }
+                    // theme toggle: sun in dark mode, moon in light
+                    if root.connected: VerticalLayout {
+                        alignment: center;
                         IconButton {
                             icon: Tokens.dark ? "sun" : "moon";
                             clicked => { root.toggle-theme(); }
                         }
-                        // edit the current connection (distinct from the app ⚙)
+                    }
+                    // edit the current connection (distinct from the app ⚙)
+                    if root.connected: VerticalLayout {
+                        alignment: center;
                         IconButton {
                             icon: "pencil";
                             clicked => {

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -398,6 +398,7 @@ export component FilterField inherits Rectangle {
     in property <string> trailing-cap: "";
     callback edited(string);
     callback submitted;
+    public function focus-input() { input.focus(); }
     height: 30px;
     border-radius: Tokens.radius;
     border-width: 1px;

--- a/app/src/ui/icons.slint
+++ b/app/src/ui/icons.slint
@@ -31,5 +31,6 @@ export component AppIcon inherits Image {
         name == "moon"      ? @image-url("icons/moon.svg")     :
         name == "clock"     ? @image-url("icons/clock.svg")    :
         name == "caret"     ? @image-url("icons/caret.svg")    :
+        name == "star"      ? @image-url("icons/star.svg")     :
         @image-url("icons/table.svg");
 }

--- a/app/src/ui/icons.slint
+++ b/app/src/ui/icons.slint
@@ -32,5 +32,6 @@ export component AppIcon inherits Image {
         name == "clock"     ? @image-url("icons/clock.svg")    :
         name == "caret"     ? @image-url("icons/caret.svg")    :
         name == "star"      ? @image-url("icons/star.svg")     :
+        name == "pencil"    ? @image-url("icons/pencil.svg")   :
         @image-url("icons/table.svg");
 }

--- a/app/src/ui/icons/pencil.svg
+++ b/app/src/ui/icons/pencil.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 20h4L18.5 9.5a2.1 2.1 0 0 0-3-3L5 17v3z"/><path d="M13.5 6.5l3 3"/></svg>

--- a/app/src/ui/icons/star.svg
+++ b/app/src/ui/icons/star.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l2.7 5.5 6 .9-4.3 4.2 1 6-5.4-2.8-5.4 2.8 1-6L5.3 9.4l6-.9z"/></svg>

--- a/app/src/ui/palette.slint
+++ b/app/src/ui/palette.slint
@@ -38,7 +38,8 @@ export component ListModal inherits Rectangle {
         width: root.card-width;
         x: (parent.width - self.width) / 2;
         y: 96px;
-        height: card.preferred-height;
+        // cap to the window so the footer buttons never fall off-screen
+        height: min(card.preferred-height, parent.height - self.y - 24px);
         border-radius: Tokens.modal-radius;
         background: Tokens.card;
         border-width: 1px;
@@ -74,7 +75,10 @@ export component ListModal inherits Rectangle {
             }
 
             Rectangle {
-                height: min(list.preferred-height, 500px);
+                // flex: absorb the space left between the search row and footer
+                // (capped) so the footer stays put when the modal is height-limited
+                vertical-stretch: 1;
+                max-height: min(list.preferred-height, 500px);
                 clip: true;
                 Flickable {
                     viewport-height: list.preferred-height;

--- a/app/src/ui/sidebar.slint
+++ b/app/src/ui/sidebar.slint
@@ -19,6 +19,7 @@ export component Sidebar inherits Rectangle {
     in property <[TreeNode]> query-tree;
     callback disconnect();
     callback open-table(string, string);   // (database, container)
+    callback toggle-fields(string, string); // (database, table) — expand columns inline
     callback open-function(string);
     callback open-query(string, int);      // (label, index in its section)
     callback toggle-node(string);
@@ -115,15 +116,22 @@ export component Sidebar inherits Rectangle {
 
                     row-ta := TouchArea {
                         enabled: !is-hint && !is-field;
+                        // single-click a table = expand its columns inline;
+                        // double-click = open the table's data (see below).
                         clicked => {
                             if (is-category || is-database) {
                                 root.toggle-node(node.label);
                             } else if (is-container) {
-                                root.open-table(node.db, node.label);
+                                root.toggle-fields(node.db, node.label);
                             } else if (is-function) {
                                 root.open-function(node.label);
                             } else if (is-query) {
                                 root.open-query(node.label, node.count);
+                            }
+                        }
+                        double-clicked => {
+                            if (is-container) {
+                                root.open-table(node.db, node.label);
                             }
                         }
                     }

--- a/app/src/ui/sidebar.slint
+++ b/app/src/ui/sidebar.slint
@@ -28,6 +28,9 @@ export component Sidebar inherits Rectangle {
     callback filter-tree(string);
     callback mode-changed(int);
     callback add-item();
+    // bumped by ⌘P (app-window) to focus the filter field
+    in property <int> focus-tick;
+    changed focus-tick => { fld.focus-input(); }
 
     background: Tokens.sidebar;
 
@@ -72,7 +75,7 @@ export component Sidebar inherits Rectangle {
             padding-left: Tokens.sp3;
             padding-right: Tokens.sp3;
             padding-bottom: Tokens.sp3;
-            FilterField {
+            fld := FilterField {
                 height: 28px;
                 placeholder: root.mode == 1 ? "Filter queries..." : "Filter items...";
                 trailing-cap: root.mode == 0 ? "⌘P" : "";

--- a/app/src/ui/sidebar.slint
+++ b/app/src/ui/sidebar.slint
@@ -4,6 +4,7 @@
 import { Tokens } from "tokens.slint";
 import { TreeNode } from "structs.slint";
 import { FilterField, KeyCap } from "components.slint";
+import { AppIcon } from "icons.slint";
 import { ScrollView } from "std-widgets.slint";
 
 export component Sidebar inherits Rectangle {
@@ -145,6 +146,19 @@ export component Sidebar inherits Rectangle {
                         if is-category: HorizontalLayout {
                             spacing: Tokens.sp2;
                             alignment: start;
+                            Rectangle {
+                                width: 13px;
+                                VerticalLayout {
+                                    alignment: center;
+                                    AppIcon {
+                                        name: "caret";
+                                        size: 12px;
+                                        color: Tokens.text-dim;
+                                        // down when expanded, right when collapsed
+                                        transform-rotation: node.expanded ? 0deg : -90deg;
+                                    }
+                                }
+                            }
                             Text {
                                 text: node.label.to-uppercase();
                                 color: Tokens.text-dim;
@@ -171,6 +185,20 @@ export component Sidebar inherits Rectangle {
                             vertical-alignment: center;
                             horizontal-alignment: center;
                         }
+                        // expandable SQL tables get a caret hinting single-click
+                        // reveals their columns (Mongo/Redis leaves don't).
+                        if node.kind == "table": Rectangle {
+                            width: 13px;
+                            VerticalLayout {
+                                alignment: center;
+                                AppIcon {
+                                    name: "caret";
+                                    size: 11px;
+                                    color: is-active ? Tokens.on-tint : Tokens.text-faint;
+                                    transform-rotation: node.expanded ? 0deg : -90deg;
+                                }
+                            }
+                        }
                         if is-container || is-database: Rectangle {
                             width: 13px;
                             VerticalLayout {
@@ -183,13 +211,16 @@ export component Sidebar inherits Rectangle {
                                 }
                             }
                         }
-                        if is-query: Text {
-                            text: node.kind == "recent" ? "◷" : ">_";
-                            color: is-active ? Tokens.on-tint : Tokens.text-faint;
-                            font-size: node.kind == "recent" ? 12px : 9px;
+                        if is-query: Rectangle {
                             width: 16px;
-                            font-family: node.kind == "recent" ? "" : Tokens.mono;
-                            vertical-alignment: center;
+                            VerticalLayout {
+                                alignment: center;
+                                AppIcon {
+                                    name: node.kind == "recent" ? "clock" : "star";
+                                    size: 13px;
+                                    color: is-active ? Tokens.on-tint : Tokens.text-faint;
+                                }
+                            }
                         }
 
                         // label

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -340,14 +340,14 @@ export component WorkArea inherits Rectangle {
                         alignment: center;
                         HorizontalLayout {
                             spacing: Tokens.sp2;
-                            VerticalLayout {
-                                alignment: center;
-                                Text {
-                                    text: "Limit";
-                                    color: Tokens.text-faint;
-                                    font-size: Tokens.font-sm;
-                                    vertical-alignment: center;
-                                }
+                            Text {
+                                // no VerticalLayout wrapper: a nested layout defaults
+                                // to horizontal-stretch and would shove the buttons
+                                // away from the label.
+                                text: "Limit";
+                                color: Tokens.text-faint;
+                                font-size: Tokens.font-sm;
+                                vertical-alignment: center;
                             }
                             SecondaryButton {
                                 text: "−";


### PR DESCRIPTION
## Summary
- Sidebar UX polish for the SQL (Postgres) view: Functions collapse by default, tables expand their columns inline, clearer collapse/expand affordance.
- Dedicated, themed icons replace ad-hoc glyphs for saved/recent queries and the connection-settings button.
- Fixes for the command palette sizing, the ⌘P shortcut, and toolbar/Limit spacing found while testing.

## Changes
**Sidebar (Items)**
- Functions category starts collapsed (Tables open) on connect and on schema switch.
- Caret indicator on category and expandable-table rows (down = open, right = collapsed).
- Single-click a table expands its columns (`name: type`) inline; double-click opens the table. Non-SQL leaves (Mongo/Redis) keep opening on single-click.

**Icons / Queries**
- New `star.svg` and `pencil.svg` assets, registered in `AppIcon`.
- Saved queries → star, Recent → clock (replacing `>_` / `◷` glyphs).
- Connection-settings toolbar button → pencil, distinct from the app-settings gear.

**Fixes**
- Command palette height capped to the window so the Cancel/New…/Open footer stays visible with long lists; only the list scrolls.
- ⌘P now focuses the sidebar filter (was a duplicate of ⌘K).
- Even spacing across the four toolbar action icons.
- "Limit" label sits flush with its −/+ stepper (dropped a stretching layout wrapper).

## Test plan
- [x] `make fe-build`
- [x] `make lint`
- [x] Connect Postgres: Functions collapsed, Tables open; caret direction correct.
- [x] Single-click table expands columns; double-click opens it.
- [x] Queries tab shows star (saved) / clock (recent).
- [x] ⌘K palette footer reachable with a long list; shrink window and re-check.
- [x] ⌘P focuses the filter field.
- [ ] Toolbar icons evenly spaced; Limit label next to the stepper.
- [ ] Mongo/Redis connection still opens collections/keys on single-click.
