### PR TITLE
ci(release): fix macos-13 hang and add arm64 linux/windows builds

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -6,6 +6,13 @@ name: release-build
 on:
   release:
     types: [published]
+  # manual re-run for a tag whose original run hung/was cancelled (e.g. the
+  # macos-13 scarcity that blocked v0.10.0), without cutting a new tag.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to (re)build, e.g. v0.10.0
+        required: true
 
 permissions:
   contents: write
@@ -79,7 +86,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          gh release upload "${{ github.event.release.tag_name }}" \
+          gh release upload "${{ github.event.release.tag_name || inputs.tag }}" \
             "rdbs-${{ matrix.target }}.${{ matrix.ext }}" --clobber
 
   # ---- publish jobs: siblings, both need `build`, neither needs the other ----
@@ -94,7 +101,7 @@ jobs:
       - name: Render formula and push to tap
         env:
           GH_TOKEN: ${{ secrets.TAP_PUBLISH_TOKEN }}
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -135,7 +142,7 @@ jobs:
       - name: Render manifest and push to bucket
         env:
           GH_TOKEN: ${{ secrets.TAP_PUBLISH_TOKEN }}
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -16,19 +16,30 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-14
+          - os: macos-14 # Apple Silicon
             target: aarch64-apple-darwin
             ext: tar.gz
-          - os: macos-13
+          - os: macos-14 # cross-compile Intel on Apple Silicon (no scarce macos-13)
             target: x86_64-apple-darwin
             ext: tar.gz
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             ext: tar.gz
+          - os: ubuntu-24.04-arm # native GitHub arm64 linux runner
+            target: aarch64-unknown-linux-gnu
+            ext: tar.gz
+            experimental: true
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             ext: zip
+          - os: windows-11-arm # native GitHub arm64 windows runner
+            target: aarch64-pc-windows-msvc
+            ext: zip
+            experimental: true
     runs-on: ${{ matrix.os }}
+    # experimental arm legs are best-effort: a failure must not fail the `build`
+    # job (publish-* depend on it) so the release still gets published.
+    continue-on-error: ${{ matrix.experimental || false }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- The v0.10.0 `release-build` run hung on the scarce **macos-13** Intel runner (queued ~16min, then cancelled), which cancelled `publish-homebrew`/`publish-scoop` too — the tap/bucket never updated to 0.10.0.
- Linux/Windows built only x86_64 (1 leg each) while macOS built 2 — no arm64 desktop binaries.

## Changes
- **Drop macos-13**: build both darwin targets on `macos-14`; x86_64 cross-compiles on Apple Silicon. No more Intel-runner queue/hang.
- **Symmetric matrix (2/2/2)**: add native arm64 legs `ubuntu-24.04-arm` (aarch64-linux) and `windows-11-arm` (aarch64-windows).
- **Non-blocking arm**: the two arm legs are `experimental: true` + `continue-on-error`, so a flaky/unavailable arm build can't fail the `build` job or block the publish siblings (`fail-fast: false` already set).
- **Manual re-run**: `workflow_dispatch` with a `tag` input (coalesced with the release event) so a hung/cancelled run can be rebuilt + re-published without cutting a new tag.

## Test plan
- [x] YAML parses (actionlint not installed locally; expression syntax reviewed).
- [ ] After merge: Actions → release-build → Run workflow → tag `v0.10.0`.
  - [ ] 2 mac + linux-x86 + win-x86 legs upload assets; release gains the `x86_64-apple-darwin` asset.
  - [ ] arm64 linux/windows legs run best-effort (failure non-blocking).
  - [ ] `publish-homebrew` + `publish-scoop` push `rdbs 0.10.0`.
- [ ] Next real tag: all assets attach; no macos-13 leg.

## Notes
- Publish jobs unchanged — still consume arm-mac/intel-mac/linux-x86/win-x86 (all non-experimental). Adding arm linux/win to the tap/bucket is out of scope.
