### PR TITLE
feat: mongosh query UX for Mongo + autocomplete/schema fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3502,6 +3502,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4953,6 +4964,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
+dependencies = [
+ "pest",
+]
+
+[[package]]
 name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5566,6 +5619,7 @@ version = "0.11.0"
 dependencies = [
  "async-trait",
  "copypasta",
+ "json5",
  "open",
  "rdbs-connstore",
  "rdbs-core",
@@ -7615,6 +7669,12 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "udev"

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -19,6 +19,9 @@ rdbs-driver-sqlite = { path = "../crates/driver-sqlite" }
 rdbs-driver-cassandra = { path = "../crates/driver-cassandra" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "time"] }
 serde_json = "1"
+# permissive JSON for the Mongo editor: mongosh uses bare keys / single quotes
+# (`{_id:-1}`), which strict serde_json rejects.
+json5 = "0.4"
 async-trait = "0.1"
 # clipboard; already in the tree via Slint's winit backend, so no new builds
 copypasta = "0.10"

--- a/app/src/completion.rs
+++ b/app/src/completion.rs
@@ -99,6 +99,15 @@ pub fn trailing_word(s: &str) -> &str {
     &s[i..]
 }
 
+/// Does `name` match a schema/database node in the tree? Used to treat
+/// `schema.` as "list that schema's tables" rather than a table's columns.
+fn is_database(nodes: &[VmTreeNode], name: &str) -> bool {
+    let nl = name.to_lowercase();
+    nodes
+        .iter()
+        .any(|n| n.kind == "database" && n.label.to_lowercase() == nl)
+}
+
 fn tables(nodes: &[VmTreeNode]) -> Vec<Candidate> {
     nodes
         .iter()
@@ -147,20 +156,29 @@ pub fn suggest(before_cursor: &str, nodes: &[VmTreeNode]) -> (usize, Vec<Candida
     let word = trailing_word(before_cursor);
     let head = before_cursor.strip_suffix(word).unwrap_or(before_cursor);
     let mut cands = if let Some(before_dot) = head.strip_suffix('.') {
-        // `table.` / `alias.` → that table's columns.
-        let owner = resolve_alias(before_cursor, trailing_word(before_dot));
-        columns_of(nodes, &owner)
+        // `table.` / `alias.` → that table's columns. When the name before the
+        // dot is a schema/database, offer that schema's tables instead.
+        let owner_word = trailing_word(before_dot);
+        let owner = resolve_alias(before_cursor, owner_word);
+        let cols = columns_of(nodes, &owner);
+        if cols.is_empty() && is_database(nodes, owner_word) {
+            tables(nodes)
+        } else {
+            cols
+        }
     } else {
         match last_keyword(before_cursor).as_deref() {
             // table position
             Some("FROM") | Some("JOIN") | Some("INTO") | Some("UPDATE") | Some("TABLE") => {
                 tables(nodes)
             }
-            // column position: offer columns (and tables, for `table.col`)
+            // column position: offer columns and tables, plus keywords so the
+            // next clause (FROM/WHERE/…) is always reachable, e.g. after `*`.
             Some("SELECT") | Some("WHERE") | Some("AND") | Some("OR") | Some("ON")
             | Some("HAVING") | Some("SET") | Some("BY") | Some("VALUES") => {
                 let mut c = all_columns(nodes);
                 c.extend(tables(nodes));
+                c.extend(keywords());
                 c
             }
             // statement start / no useful context: keywords + tables
@@ -245,6 +263,23 @@ mod tests {
         assert_eq!(
             c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
             ["config_id", "name"]
+        );
+    }
+
+    #[test]
+    fn star_context_offers_from_keyword() {
+        let (_, c) = suggest("select * f", &nodes());
+        let labels: Vec<&str> = c.iter().map(|x| x.label.as_str()).collect();
+        assert!(labels.contains(&"FROM"));
+    }
+
+    #[test]
+    fn schema_dot_suggests_its_tables() {
+        let (n, c) = suggest("select * from public.", &nodes());
+        assert_eq!(n, 0);
+        assert_eq!(
+            c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
+            ["step_config", "users"]
         );
     }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -4114,6 +4114,8 @@ fn main() -> Result<(), slint::PlatformError> {
         let tab_titles = tab_titles.clone();
         let results = results.clone();
         let active_result = active_result.clone();
+        let ed_state = ed_state.clone();
+        let load_editor_text = load_editor_text.clone();
         window.on_new_tab(move || {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -4122,7 +4124,7 @@ fn main() -> Result<(), slint::PlatformError> {
             {
                 let mut t = tab_texts.borrow_mut();
                 if let Some(slot) = t.get_mut(active) {
-                    *slot = w.get_query_text().to_string();
+                    *slot = ed_state.borrow().text();
                 }
                 t.push(String::new());
             }
@@ -4130,7 +4132,7 @@ fn main() -> Result<(), slint::PlatformError> {
             let count = tab_texts.borrow().len();
             set_tab_titles(&w, &tab_titles.borrow());
             w.set_active_tab((count - 1) as i32);
-            w.set_query_text(SharedString::default());
+            load_editor_text("");
             // Fresh query tab starts with no result tabs.
             results.lock().unwrap().clear();
             *active_result.lock().unwrap() = 0;
@@ -4266,6 +4268,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let weak = window.as_weak();
         let tab_texts = tab_texts.clone();
         let tab_titles = tab_titles.clone();
+        let load_editor_text = load_editor_text.clone();
         window.on_close_tab(move || {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -4280,7 +4283,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 drop(t);
                 *tab_titles.borrow_mut() = vec![None];
                 set_tab_titles(&w, &tab_titles.borrow());
-                w.set_query_text(SharedString::default());
+                load_editor_text("");
                 clear_grid(&w);
                 return;
             }
@@ -4298,7 +4301,7 @@ fn main() -> Result<(), slint::PlatformError> {
             }
             set_tab_titles(&w, &tab_titles.borrow());
             w.set_active_tab(new_active as i32);
-            w.set_query_text(SharedString::from(text));
+            load_editor_text(&text);
         });
     }
 
@@ -4337,6 +4340,8 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let weak = window.as_weak();
         let tab_texts = tab_texts.clone();
+        let ed_state = ed_state.clone();
+        let load_editor_text = load_editor_text.clone();
         window.on_select_tab(move |idx| {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -4348,12 +4353,12 @@ fn main() -> Result<(), slint::PlatformError> {
             }
             let active = w.get_active_tab() as usize;
             if let Some(slot) = t.get_mut(active) {
-                *slot = w.get_query_text().to_string();
+                *slot = ed_state.borrow().text();
             }
             let text = t[i].clone();
             drop(t);
             w.set_active_tab(idx);
-            w.set_query_text(SharedString::from(text));
+            load_editor_text(&text);
         });
     }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -354,6 +354,9 @@ struct BrowseState {
     limit: u64,
     total: Option<u64>,
     pk_cols: Vec<String>,
+    /// Compass-style Mongo filter document (raw JSON, already validated). Empty
+    /// = browse all. Ignored for non-Mongo engines.
+    mongo_filter: String,
 }
 
 /// Default browse page size per engine. Mongo documents are fat, so a Mongo
@@ -512,6 +515,8 @@ fn browse_text(
     table: &rdbs_core::write::TableRef,
     page: u64,
     limit: u64,
+    // Mongo-only filter document (raw JSON, empty = all). Unused by SQL engines.
+    filter: &str,
 ) -> String {
     let offset = page * limit;
     match engine {
@@ -555,8 +560,12 @@ fn browse_text(
                 .as_deref()
                 .map(|d| format!("\"database\":\"{d}\","))
                 .unwrap_or_default();
+            let body = match filter.trim() {
+                "" => "{}",
+                f => f,
+            };
             format!(
-                "{{\"collection\":\"{}\",{db}\"op\":\"find\",\"body\":{{}},\"limit\":{limit},\"skip\":{offset}}}",
+                "{{\"collection\":\"{}\",{db}\"op\":\"find\",\"body\":{body},\"limit\":{limit},\"skip\":{offset}}}",
                 table.name
             )
         }
@@ -3598,7 +3607,7 @@ fn main() -> Result<(), slint::PlatformError> {
             let Some(table) = st.table else {
                 return;
             };
-            let text = browse_text(engine, &table, st.page, st.limit);
+            let text = browse_text(engine, &table, st.page, st.limit, &st.mongo_filter);
             w.set_query_text(SharedString::from(text.clone()));
             run_sql(text);
         })
@@ -3638,7 +3647,9 @@ fn main() -> Result<(), slint::PlatformError> {
                 st.page = 0;
                 st.total = None;
                 st.pk_cols.clear();
+                st.mongo_filter.clear();
             }
+            w.set_mongo_filter(SharedString::default());
             {
                 let tabs = w.get_tabs();
                 let ti = w.get_active_tab().max(0) as usize;
@@ -3818,6 +3829,38 @@ fn main() -> Result<(), slint::PlatformError> {
                 st.page = 0;
             }
             echo(&w, l);
+            run_browse();
+        });
+    }
+
+    // ----- Mongo browse filter bar (Compass-style filter document) -----
+    {
+        let weak = window.as_weak();
+        let browse = browse.clone();
+        let run_browse = run_browse.clone();
+        let guard_pending = guard_pending.clone();
+        window.on_apply_mongo_filter(move || {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            if guard_pending(&w) {
+                return;
+            }
+            let raw = w.get_mongo_filter().to_string();
+            let trimmed = raw.trim();
+            // Empty clears the filter; otherwise it must be a JSON document.
+            if !trimmed.is_empty() {
+                if let Err(e) = serde_json::from_str::<serde_json::Value>(trimmed) {
+                    w.set_status_error(true);
+                    w.set_result_status(SharedString::from(format!("invalid filter JSON: {e}")));
+                    return;
+                }
+            }
+            {
+                let mut st = browse.lock().unwrap();
+                st.mongo_filter = trimmed.to_string();
+                st.page = 0;
+            }
             run_browse();
         });
     }
@@ -5411,15 +5454,15 @@ mod tests {
             name: "users".into(),
         };
         assert_eq!(
-            browse_text(rdbs_connstore::Engine::Postgres, &t, 1, 300),
+            browse_text(rdbs_connstore::Engine::Postgres, &t, 1, 300, ""),
             "SELECT * FROM \"public\".\"users\" LIMIT 300 OFFSET 300"
         );
         assert_eq!(
-            browse_text(rdbs_connstore::Engine::MySql, &t, 0, 50),
+            browse_text(rdbs_connstore::Engine::MySql, &t, 0, 50, ""),
             "SELECT * FROM `users` LIMIT 50 OFFSET 0"
         );
         assert_eq!(
-            browse_text(rdbs_connstore::Engine::Redis, &t, 2, 100),
+            browse_text(rdbs_connstore::Engine::Redis, &t, 2, 100, ""),
             "BROWSE users 200 100"
         );
         let m = rdbs_core::write::TableRef {
@@ -5428,8 +5471,13 @@ mod tests {
             name: "orders".into(),
         };
         assert_eq!(
-            browse_text(rdbs_connstore::Engine::Mongo, &m, 1, 50),
+            browse_text(rdbs_connstore::Engine::Mongo, &m, 1, 50, ""),
             "{\"collection\":\"orders\",\"database\":\"shop\",\"op\":\"find\",\"body\":{},\"limit\":50,\"skip\":50}"
+        );
+        // A filter document lands in the find body.
+        assert_eq!(
+            browse_text(rdbs_connstore::Engine::Mongo, &m, 0, 20, r#"{"status":"A"}"#),
+            "{\"collection\":\"orders\",\"database\":\"shop\",\"op\":\"find\",\"body\":{\"status\":\"A\"},\"limit\":20,\"skip\":0}"
         );
     }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -3296,8 +3296,12 @@ fn main() -> Result<(), slint::PlatformError> {
             let active_result = active_result.clone();
             // ⌘\ set this; consume it so the next plain run replaces again.
             let new_tab = result_new_tab.swap(false, std::sync::atomic::Ordering::SeqCst);
+            // Currently selected database (top dropdown). Mongo line queries with
+            // no `use(...)` run against it, matching what the user sees browsing.
+            let mut cur_db = String::new();
             if let Some(w) = weak.upgrade() {
                 w.set_query_running(true);
+                cur_db = w.get_schema_name().to_string();
             }
             rt.spawn(async move {
                 let guard = current.lock().await;
@@ -3323,7 +3327,16 @@ fn main() -> Result<(), slint::PlatformError> {
                         let mut out = Err(rdbs_core::error::RdbsError::Query("empty query".into()));
                         for (i, s) in stmts.iter().enumerate() {
                             out = match crate::query_parse::parse_query(*engine, s) {
-                                Ok(q) => driver.query(&q).await,
+                                Ok(mut q) => {
+                                    // Fill the selected database for a Mongo query
+                                    // that didn't name one via `use(...)`.
+                                    if let rdbs_core::query::Query::Mongo(op) = &mut q {
+                                        if op.database.is_none() && !cur_db.is_empty() {
+                                            op.database = Some(cur_db.clone());
+                                        }
+                                    }
+                                    driver.query(&q).await
+                                }
                                 Err(msg) => Err(rdbs_core::error::RdbsError::Query(msg)),
                             };
                             if let Err(e) = &out {

--- a/app/src/query_parse.rs
+++ b/app/src/query_parse.rs
@@ -121,14 +121,14 @@ fn parse_mongo_line(s: &str) -> Result<Query, String> {
         cursor = rest.trim();
     }
 
-    Ok(Query::Mongo(MongoOp {
+    Ok(Query::Mongo(Box::new(MongoOp {
         collection,
         database: None,
         limit,
         skip,
         sort,
         kind,
-    }))
+    })))
 }
 
 /// Parse one `.name(arg)` at the start of `s`. Returns the method name, the raw
@@ -235,14 +235,14 @@ fn parse_mongo_envelope(text: &str) -> Result<Query, String> {
             ))
         }
     };
-    Ok(Query::Mongo(MongoOp {
+    Ok(Query::Mongo(Box::new(MongoOp {
         collection,
         database,
         limit,
         skip,
         sort: None,
         kind,
-    }))
+    })))
 }
 
 #[cfg(test)]

--- a/app/src/query_parse.rs
+++ b/app/src/query_parse.rs
@@ -64,18 +64,51 @@ fn strip_comment_lines(engine: Engine, text: &str) -> String {
 /// (`{"collection":"c","op":"find","body":{}}`). Anything starting with `db.`
 /// is the line form; everything else is the envelope.
 fn parse_mongo(text: &str) -> Result<Query, String> {
-    let trimmed = text.trim().trim_end_matches(';');
+    // An optional leading `use('db')` switches the target database, mongosh-style.
+    let (db_override, body) = strip_use(text.trim());
+    let trimmed = body.trim().trim_end_matches(';').trim_end();
     if trimmed.starts_with("db.") {
-        parse_mongo_line(trimmed)
+        parse_mongo_line(trimmed, db_override)
     } else {
         parse_mongo_envelope(text)
     }
 }
 
+/// Strip an optional leading `use('name')` / `use("name")` statement. Returns
+/// the database name (if any) and the remaining text after it.
+fn strip_use(s: &str) -> (Option<String>, &str) {
+    let t = s.trim_start();
+    let Some(rest) = t.strip_prefix("use") else {
+        return (None, s);
+    };
+    let Some(open) = rest.find('(') else {
+        return (None, s);
+    };
+    // Only whitespace may sit between `use` and `(`.
+    if !rest[..open].trim().is_empty() {
+        return (None, s);
+    }
+    let Some(rel_close) = rest[open..].find(')') else {
+        return (None, s);
+    };
+    let close = open + rel_close;
+    let name = rest[open + 1..close]
+        .trim()
+        .trim_matches(|c| c == '\'' || c == '"')
+        .to_string();
+    if name.is_empty() {
+        return (None, s);
+    }
+    let tail = rest[close + 1..].trim_start().trim_start_matches(';');
+    (Some(name), tail)
+}
+
 /// Parse `db.<collection>.<op>(<json>)` with optional chained
-/// `.limit(n)` / `.skip(n)` / `.sort({...})`. Bodies are strict JSON (quoted
-/// keys, no `ObjectId(...)`); the database comes from the connection default.
-fn parse_mongo_line(s: &str) -> Result<Query, String> {
+/// `.limit(n)` / `.skip(n)` / `.sort({...})`. Bodies are permissive JSON
+/// (json5: bare keys, single quotes) but not full mongosh — `ObjectId(...)`
+/// still errors. `database` overrides the connection default when a `use(...)`
+/// preceded the query.
+fn parse_mongo_line(s: &str, database: Option<String>) -> Result<Query, String> {
     let rest = &s[3..]; // drop "db."
     let dot = rest
         .find('.')
@@ -123,7 +156,7 @@ fn parse_mongo_line(s: &str) -> Result<Query, String> {
 
     Ok(Query::Mongo(Box::new(MongoOp {
         collection,
-        database: None,
+        database,
         limit,
         skip,
         sort,
@@ -187,7 +220,7 @@ fn parse_json_arg(arg: &str, ctx: &str) -> Result<serde_json::Value, String> {
     if a.is_empty() {
         return Ok(serde_json::Value::Object(Default::default()));
     }
-    serde_json::from_str(a).map_err(|e| format!("invalid JSON in {ctx}(...): {e}"))
+    json5::from_str(a).map_err(|e| format!("invalid JSON in {ctx}(...): {e}"))
 }
 
 fn parse_int_arg(arg: &str, ctx: &str) -> Result<i64, String> {
@@ -415,6 +448,34 @@ mod tests {
                 MongoKind::Find(f) => assert_eq!(f["note"], serde_json::json!("a)b")),
                 _ => panic!("expected Find"),
             },
+            _ => panic!("expected Mongo"),
+        }
+    }
+
+    #[test]
+    fn mongo_line_accepts_relaxed_json() {
+        // Real mongosh idiom: unquoted keys, single quotes, negative sort.
+        let text = r#"db.c.find({to_email:'a@b.com'}).sort({_id:-1})"#;
+        match parse_query(Engine::Mongo, text).unwrap() {
+            Query::Mongo(op) => {
+                match &op.kind {
+                    MongoKind::Find(f) => assert_eq!(f["to_email"], serde_json::json!("a@b.com")),
+                    _ => panic!("expected Find"),
+                }
+                assert_eq!(op.sort, Some(serde_json::json!({ "_id": -1 })));
+            }
+            _ => panic!("expected Mongo"),
+        }
+    }
+
+    #[test]
+    fn mongo_use_switches_database() {
+        let text = "use('shop');\ndb.orders.find({})";
+        match parse_query(Engine::Mongo, text).unwrap() {
+            Query::Mongo(op) => {
+                assert_eq!(op.database.as_deref(), Some("shop"));
+                assert_eq!(op.collection, "orders");
+            }
             _ => panic!("expected Mongo"),
         }
     }

--- a/app/src/query_parse.rs
+++ b/app/src/query_parse.rs
@@ -103,6 +103,7 @@ fn parse_mongo(text: &str) -> Result<Query, String> {
         database,
         limit,
         skip,
+        sort: None,
         kind,
     }))
 }

--- a/app/src/query_parse.rs
+++ b/app/src/query_parse.rs
@@ -34,7 +34,7 @@ pub fn editor_hint(engine: Engine) -> &'static str {
         Engine::Postgres | Engine::MySql | Engine::Sqlite => "SELECT * FROM table",
         Engine::Cassandra => "SELECT * FROM keyspace.table",
         Engine::Redis => "SET key value",
-        Engine::Mongo => r#"Mongo JSON — {"collection":"c","op":"find","body":{}}"#,
+        Engine::Mongo => r#"db.coll.find({ })  ·  or JSON envelope"#,
     }
 }
 
@@ -59,7 +59,144 @@ fn strip_comment_lines(engine: Engine, text: &str) -> String {
         .join("\n")
 }
 
+/// Mongo has two accepted editor forms: the mongosh line syntax people know
+/// (`db.coll.find({...}).limit(5).sort({...})`) and the original JSON envelope
+/// (`{"collection":"c","op":"find","body":{}}`). Anything starting with `db.`
+/// is the line form; everything else is the envelope.
 fn parse_mongo(text: &str) -> Result<Query, String> {
+    let trimmed = text.trim().trim_end_matches(';');
+    if trimmed.starts_with("db.") {
+        parse_mongo_line(trimmed)
+    } else {
+        parse_mongo_envelope(text)
+    }
+}
+
+/// Parse `db.<collection>.<op>(<json>)` with optional chained
+/// `.limit(n)` / `.skip(n)` / `.sort({...})`. Bodies are strict JSON (quoted
+/// keys, no `ObjectId(...)`); the database comes from the connection default.
+fn parse_mongo_line(s: &str) -> Result<Query, String> {
+    let rest = &s[3..]; // drop "db."
+    let dot = rest
+        .find('.')
+        .ok_or_else(|| "expected db.<collection>.<op>(...)".to_string())?;
+    let collection = rest[..dot].trim().to_string();
+    if collection.is_empty() {
+        return Err("missing collection in db.<collection>.<op>(...)".into());
+    }
+
+    let (method, arg, mut cursor) = next_call(&rest[dot..])?;
+    let kind = match method {
+        "find" => MongoKind::Find(parse_json_arg(arg, "find")?),
+        "insertOne" | "insert" => MongoKind::Insert(parse_json_arg(arg, method)?),
+        "aggregate" => {
+            let v = parse_json_arg(arg, "aggregate")?;
+            let arr = v
+                .as_array()
+                .ok_or_else(|| "aggregate([...]) needs an array of stages".to_string())?;
+            MongoKind::Aggregate(arr.clone())
+        }
+        other => {
+            return Err(format!(
+                "unknown Mongo method \"{other}\" (use find/aggregate/insertOne)"
+            ))
+        }
+    };
+
+    // Trailing chained modifiers, in any order.
+    let (mut limit, mut skip, mut sort) = (None, None, None);
+    cursor = cursor.trim();
+    while !cursor.is_empty() {
+        let (m, a, rest) = next_call(cursor)?;
+        match m {
+            "limit" => limit = Some(parse_int_arg(a, "limit")?),
+            "skip" => skip = Some(parse_int_arg(a, "skip")?),
+            "sort" => sort = Some(parse_json_arg(a, "sort")?),
+            other => {
+                return Err(format!(
+                    "unknown modifier \".{other}()\" (use limit/skip/sort)"
+                ))
+            }
+        }
+        cursor = rest.trim();
+    }
+
+    Ok(Query::Mongo(MongoOp {
+        collection,
+        database: None,
+        limit,
+        skip,
+        sort,
+        kind,
+    }))
+}
+
+/// Parse one `.name(arg)` at the start of `s`. Returns the method name, the raw
+/// text between its parens, and the remainder after the closing `)`.
+fn next_call(s: &str) -> Result<(&str, &str, &str), String> {
+    let s = s
+        .strip_prefix('.')
+        .ok_or_else(|| format!("expected '.method(...)' at \"{}\"", s.trim()))?;
+    let open = s
+        .find('(')
+        .ok_or_else(|| "expected '(' after method name".to_string())?;
+    let name = s[..open].trim();
+    let (inner, end) = extract_parens(s, open)?;
+    Ok((name, inner, &s[end..]))
+}
+
+/// Extract the balanced `(...)` whose opening paren is at byte index `open`,
+/// respecting JSON string literals so parens inside strings don't unbalance the
+/// scan. Returns the inner text and the byte index just past the closing `)`.
+/// Parens/quotes are ASCII, so all slice boundaries fall on char boundaries.
+fn extract_parens(s: &str, open: usize) -> Result<(&str, usize), String> {
+    let b = s.as_bytes();
+    let (mut depth, mut in_str, mut esc, mut i) = (0i32, false, false, open);
+    while i < b.len() {
+        let c = b[i];
+        if in_str {
+            if esc {
+                esc = false;
+            } else if c == b'\\' {
+                esc = true;
+            } else if c == b'"' {
+                in_str = false;
+            }
+        } else {
+            match c {
+                b'"' => in_str = true,
+                b'(' => depth += 1,
+                b')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Ok((&s[open + 1..i], i + 1));
+                    }
+                }
+                _ => {}
+            }
+        }
+        i += 1;
+    }
+    Err("unbalanced parentheses".into())
+}
+
+/// JSON argument for a call; an empty argument means an empty object (so
+/// `find()` browses all documents).
+fn parse_json_arg(arg: &str, ctx: &str) -> Result<serde_json::Value, String> {
+    let a = arg.trim();
+    if a.is_empty() {
+        return Ok(serde_json::Value::Object(Default::default()));
+    }
+    serde_json::from_str(a).map_err(|e| format!("invalid JSON in {ctx}(...): {e}"))
+}
+
+fn parse_int_arg(arg: &str, ctx: &str) -> Result<i64, String> {
+    arg.trim()
+        .parse::<i64>()
+        .map_err(|_| format!("{ctx}(...) expects an integer"))
+}
+
+fn parse_mongo_envelope(text: &str) -> Result<Query, String> {
     let v: serde_json::Value =
         serde_json::from_str(text).map_err(|e| format!("invalid Mongo JSON: {e}"))?;
     let collection = v
@@ -213,6 +350,89 @@ mod tests {
         }
         let bad = r#"{ "collection": "u", "op": "aggregate", "body": { "x": 1 } }"#;
         assert!(parse_query(Engine::Mongo, bad).is_err());
+    }
+
+    #[test]
+    fn mongo_line_find_with_filter() {
+        let text = r#"db.users.find({ "age": { "$gte": 18 } })"#;
+        match parse_query(Engine::Mongo, text).unwrap() {
+            Query::Mongo(op) => {
+                assert_eq!(op.collection, "users");
+                assert!(matches!(op.kind, MongoKind::Find(_)));
+                assert_eq!(op.database, None);
+            }
+            _ => panic!("expected Mongo"),
+        }
+    }
+
+    #[test]
+    fn mongo_line_empty_find_is_browse_all() {
+        match parse_query(Engine::Mongo, "db.c.find()").unwrap() {
+            Query::Mongo(op) => match op.kind {
+                MongoKind::Find(f) => assert_eq!(f, serde_json::json!({})),
+                _ => panic!("expected Find"),
+            },
+            _ => panic!("expected Mongo"),
+        }
+    }
+
+    #[test]
+    fn mongo_line_chained_limit_skip_sort() {
+        let text = r#"db.c.find({}).limit(5).skip(10).sort({ "_id": -1 });"#;
+        match parse_query(Engine::Mongo, text).unwrap() {
+            Query::Mongo(op) => {
+                assert_eq!(op.limit, Some(5));
+                assert_eq!(op.skip, Some(10));
+                assert_eq!(op.sort, Some(serde_json::json!({ "_id": -1 })));
+            }
+            _ => panic!("expected Mongo"),
+        }
+    }
+
+    #[test]
+    fn mongo_line_aggregate() {
+        let text = r#"db.u.aggregate([ { "$count": "n" } ])"#;
+        match parse_query(Engine::Mongo, text).unwrap() {
+            Query::Mongo(op) => assert!(matches!(op.kind, MongoKind::Aggregate(_))),
+            _ => panic!("expected Mongo"),
+        }
+    }
+
+    #[test]
+    fn mongo_line_insert_one() {
+        match parse_query(Engine::Mongo, r#"db.u.insertOne({ "name": "a" })"#).unwrap() {
+            Query::Mongo(op) => assert!(matches!(op.kind, MongoKind::Insert(_))),
+            _ => panic!("expected Mongo"),
+        }
+    }
+
+    #[test]
+    fn mongo_line_paren_inside_string_stays_balanced() {
+        // A ')' inside a JSON string must not close the call early.
+        let text = r#"db.c.find({ "note": "a)b" })"#;
+        match parse_query(Engine::Mongo, text).unwrap() {
+            Query::Mongo(op) => match op.kind {
+                MongoKind::Find(f) => assert_eq!(f["note"], serde_json::json!("a)b")),
+                _ => panic!("expected Find"),
+            },
+            _ => panic!("expected Mongo"),
+        }
+    }
+
+    #[test]
+    fn mongo_line_errors_are_readable() {
+        assert!(parse_query(Engine::Mongo, "db.c.find({ bad json })").is_err());
+        assert!(parse_query(Engine::Mongo, "db.c.drop()").is_err());
+        assert!(parse_query(Engine::Mongo, "db..find({})").is_err());
+    }
+
+    #[test]
+    fn mongo_non_db_text_still_parses_as_envelope() {
+        let text = r#"{ "collection": "c", "op": "find", "body": {} }"#;
+        match parse_query(Engine::Mongo, text).unwrap() {
+            Query::Mongo(op) => assert_eq!(op.collection, "c"),
+            _ => panic!("expected Mongo"),
+        }
     }
 
     #[test]

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -127,6 +127,7 @@ in-out property <string> rename-text;
     in-out property <bool> show-structure: false;
     in property <[StructField]> structure-columns;
     in-out property <string> grid-filter;
+    in-out property <string> mongo-filter;
     in property <[length]> grid-col-widths;
     callback run-query();
     callback run-selection();
@@ -143,6 +144,7 @@ in-out property <string> rename-text;
     in-out property <string> filter-op: "contains";
     in property <[IndexRow]> index-rows;
     callback apply-filter();
+    callback apply-mongo-filter();
     callback resize-grid-col(int, length);
 
     // ----- SQL editor (lexer-highlighted) -----
@@ -834,6 +836,7 @@ in-out property <string> rename-text;
                         show-structure <=> root.show-structure;
                         structure-columns: root.structure-columns;
                         grid-filter <=> root.grid-filter;
+                        mongo-filter <=> root.mongo-filter;
                         active-table: root.active-table;
                         page-start: root.page-start;
                         page-end: root.page-end;
@@ -866,6 +869,9 @@ in-out property <string> rename-text;
                         }
                         apply-filter() => {
                             root.apply-filter();
+                        }
+                        apply-mongo-filter() => {
+                            root.apply-mongo-filter();
                         }
                         toggle-sql() => {
                             self.sql-open = !self.sql-open;

--- a/app/src/ui/code-editor.slint
+++ b/app/src/ui/code-editor.slint
@@ -4,6 +4,7 @@
 import { Tokens } from "tokens.slint";
 import { Span } from "structs.slint";
 import { PaletteItem } from "palette.slint";
+import { AppIcon } from "icons.slint";
 import { ScrollView } from "std-widgets.slint";
 
 export component CodeEditor inherits Rectangle {
@@ -213,11 +214,15 @@ export component CodeEditor inherits Rectangle {
                     padding-left: Tokens.sp2;
                     padding-right: Tokens.sp2;
                     spacing: Tokens.sp2;
-                    Text {
-                        text: it.kind == "field" ? "◇" : "▦";
-                        color: Tokens.text-faint;
-                        font-size: Tokens.font-sm;
-                        vertical-alignment: center;
+                    VerticalLayout {
+                        alignment: center;
+                        AppIcon {
+                            name: it.kind == "field" ? "field"
+                                : it.kind == "table" ? "table" : "keyword";
+                            size: 13px;
+                            color: it.kind == "table" ? Tokens.db-pg
+                                : it.kind == "field" ? Tokens.text-dim : Tokens.accent;
+                        }
                     }
                     Text {
                         text: it.label;

--- a/app/src/ui/icons.slint
+++ b/app/src/ui/icons.slint
@@ -20,6 +20,8 @@ export component AppIcon inherits Image {
         name == "database"  ? @image-url("icons/database.svg") :
         name == "search"    ? @image-url("icons/search.svg")   :
         name == "refresh"   ? @image-url("icons/refresh.svg")  :
+        name == "keyword"   ? @image-url("icons/keyword.svg")  :
+        name == "field"     ? @image-url("icons/field.svg")    :
         name == "plus"      ? @image-url("icons/plus.svg")     :
         name == "close"     ? @image-url("icons/close.svg")    :
         name == "bolt"      ? @image-url("icons/bolt.svg")     :

--- a/app/src/ui/icons.slint
+++ b/app/src/ui/icons.slint
@@ -19,6 +19,7 @@ export component AppIcon inherits Image {
         name == "function"  ? @image-url("icons/function.svg") :
         name == "database"  ? @image-url("icons/database.svg") :
         name == "search"    ? @image-url("icons/search.svg")   :
+        name == "refresh"   ? @image-url("icons/refresh.svg")  :
         name == "plus"      ? @image-url("icons/plus.svg")     :
         name == "close"     ? @image-url("icons/close.svg")    :
         name == "bolt"      ? @image-url("icons/bolt.svg")     :

--- a/app/src/ui/icons/field.svg
+++ b/app/src/ui/icons/field.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="5" cy="12" r="2"/><line x1="10" y1="12" x2="20" y2="12"/></svg>

--- a/app/src/ui/icons/keyword.svg
+++ b/app/src/ui/icons/keyword.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>

--- a/app/src/ui/icons/refresh.svg
+++ b/app/src/ui/icons/refresh.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>

--- a/app/src/ui/palette.slint
+++ b/app/src/ui/palette.slint
@@ -3,6 +3,7 @@
 // References: design/4-modal-open-database.png, design/5-modal-open-connection.png.
 import { Tokens } from "tokens.slint";
 import { DbBadge, PrimaryButton, SecondaryButton, FilterField } from "components.slint";
+import { AppIcon } from "icons.slint";
 
 // `kind` picks the leading icon: "database" | "group" | engine badge keys
 // ("postgres"…) | "table" | "function" | "command". `sub` is the mono second
@@ -104,11 +105,30 @@ export component ListModal inherits Rectangle {
                                 // leading icon
                                 VerticalLayout {
                                     alignment: center;
-                                    if it.kind == "database" || it.kind == "table": Rectangle {
-                                        width: 15px;
-                                        height: 15px;
-                                        border-radius: 4px;
-                                        background: Tokens.db-pg.with-alpha(0.85);
+                                    if it.kind == "keyword": AppIcon {
+                                        name: "keyword";
+                                        size: 15px;
+                                        color: Tokens.accent;
+                                    }
+                                    if it.kind == "table": AppIcon {
+                                        name: "table";
+                                        size: 15px;
+                                        color: Tokens.db-pg;
+                                    }
+                                    if it.kind == "field": AppIcon {
+                                        name: "field";
+                                        size: 15px;
+                                        color: Tokens.text-dim;
+                                    }
+                                    if it.kind == "database": AppIcon {
+                                        name: "database";
+                                        size: 15px;
+                                        color: Tokens.db-pg;
+                                    }
+                                    if it.kind == "view": AppIcon {
+                                        name: "view";
+                                        size: 15px;
+                                        color: Tokens.text-dim;
                                     }
                                     if is-group: Rectangle {
                                         width: 20px;
@@ -116,23 +136,21 @@ export component ListModal inherits Rectangle {
                                         border-radius: 10px;
                                         border-width: 1.5px;
                                         border-color: Tokens.warn;
-                                        Text {
-                                            text: "▸";
+                                        AppIcon {
+                                            name: "caret";
+                                            size: 10px;
                                             color: Tokens.warn;
-                                            font-size: 8px;
                                         }
                                     }
-                                    if it.kind == "function": Text {
-                                        text: "ƒ";
+                                    if it.kind == "function": AppIcon {
+                                        name: "function";
+                                        size: 15px;
                                         color: Tokens.warn;
-                                        font-size: Tokens.font-md;
-                                        font-weight: 600;
                                     }
-                                    if it.kind == "command": Text {
-                                        text: "›_";
+                                    if it.kind == "command": AppIcon {
+                                        name: "terminal";
+                                        size: 15px;
                                         color: Tokens.text-faint;
-                                        font-size: 10px;
-                                        font-family: Tokens.mono;
                                     }
                                     if it.kind == "postgres" || it.kind == "mysql" || it.kind == "redis" || it.kind == "mongo" || it.kind == "sqlite" || it.kind == "cassandra": DbBadge {
                                         engine: it.kind;

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -10,6 +10,7 @@ import {
     UnderlineSegment, SecondaryButton, PrimaryButton, TextButton, FilterField, KeyCap
 } from "components.slint";
 import { ScrollView, ComboBox } from "std-widgets.slint";
+import { AppIcon } from "icons.slint";
 
 export component WorkArea inherits Rectangle {
     // ----- editor / results state (wired 1:1 from MainWindow) -----
@@ -273,10 +274,10 @@ export component WorkArea inherits Rectangle {
                         border-width: 1px;
                         border-color: Tokens.border-strong;
                         background: refresh-ta.has-hover ? Tokens.chrome : Tokens.card;
-                        Text {
-                            text: "⟳";
+                        AppIcon {
+                            name: "refresh";
+                            size: 14px;
                             color: Tokens.text-dim;
-                            font-size: 13px;
                         }
                         refresh-ta := TouchArea { clicked => { root.refresh-page(); } }
                     }

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -15,6 +15,8 @@ export component WorkArea inherits Rectangle {
     // ----- editor / results state (wired 1:1 from MainWindow) -----
     // Collapse the SQL editor pane to give the results grid more room.
     property <bool> editor-collapsed: false;
+    // Reveal the query editor while browsing a table/collection (default closed).
+    property <bool> browse-editor-open: false;
     in-out property <string> query-text;
     in property <[GridColumn]> columns;
     in property <[GridCell]> cells;
@@ -203,6 +205,15 @@ export component WorkArea inherits Rectangle {
                     vertical-alignment: center;
                 }
                 Rectangle { horizontal-stretch: 1; }
+                // Reveal the query editor over the browse grid so you can run a
+                // line query (e.g. Mongo db.coll.find(...)) without a new tab.
+                VerticalLayout {
+                    alignment: center;
+                    TextButton {
+                        text: root.browse-editor-open ? "Query ▾" : "Query ▸";
+                        clicked => { root.browse-editor-open = !root.browse-editor-open; }
+                    }
+                }
                 // Mongo document view switch (grid table ⇄ JSON tree)
                 if root.result-kind == 1: VerticalLayout {
                     alignment: center;
@@ -324,7 +335,8 @@ export component WorkArea inherits Rectangle {
 
         // ================= empty state (nothing open) =================
         // ================= SQL editor (non-browse tabs) =================
-        if !root.browse-mode && !root.fn-mode: Rectangle {
+        // Also shown over a browse grid when the user opens "Query ▸".
+        if (!root.browse-mode || root.browse-editor-open) && !root.fn-mode: Rectangle {
             height: root.editor-h;
             background: Tokens.canvas;
             VerticalLayout {
@@ -572,7 +584,7 @@ export component WorkArea inherits Rectangle {
         }
 
         // draggable splitter: grow/shrink the editor vs the results (SQL tabs)
-        if !root.browse-mode && !root.fn-mode: Rectangle {
+        if (!root.browse-mode || root.browse-editor-open) && !root.fn-mode: Rectangle {
             height: 6px;
             background: split-ta.has-hover || split-ta.pressed ? Tokens.accent : Tokens.chrome;
             split-ta := TouchArea {

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -38,6 +38,8 @@ export component WorkArea inherits Rectangle {
     in-out property <bool> show-structure: false;
     in property <[StructField]> structure-columns;
     in-out property <string> grid-filter;
+    in-out property <string> mongo-filter;   // Compass-style Mongo filter document
+    callback apply-mongo-filter();
     in property <string> active-table;
     in property <string> sort-text;      // e.g. "sort: id ↑"
     in property <int> grid-sort-col: -1; // client-side sort: display col + dir
@@ -178,6 +180,18 @@ export component WorkArea inherits Rectangle {
                         filter-ta := TouchArea {
                             clicked => { root.filter-open = !root.filter-open; }
                         }
+                    }
+                }
+                // Mongo filter document (server-side find filter). Enter runs it;
+                // gated on Documents result-kind like the Grid/Tree toggle.
+                if root.result-kind == 1: VerticalLayout {
+                    alignment: center;
+                    FilterField {
+                        width: 260px;
+                        height: 28px;
+                        placeholder: "Filter — { \"field\": value }";
+                        text <=> root.mongo-filter;
+                        submitted => { root.apply-mongo-filter(); }
                     }
                 }
                 // sort text

--- a/crates/core/src/query.rs
+++ b/crates/core/src/query.rs
@@ -24,6 +24,8 @@ pub struct MongoOp {
     pub limit: Option<i64>,
     /// Rows to skip before `limit` applies (pagination); `None` = 0.
     pub skip: Option<i64>,
+    /// Sort document for a `find` (e.g. `{ "_id": -1 }`); `None` = natural order.
+    pub sort: Option<Json>,
     pub kind: MongoKind,
 }
 
@@ -54,6 +56,7 @@ mod tests {
             database: None,
             limit: None,
             skip: None,
+            sort: None,
             kind: MongoKind::Find(serde_json::json!({ "age": { "$gt": 18 } })),
         };
         assert_eq!(op.collection, "users");

--- a/crates/core/src/query.rs
+++ b/crates/core/src/query.rs
@@ -10,8 +10,9 @@ pub enum Query {
     Sql(String),
     /// Raw command tokens — Redis, e.g. `["GET", "key"]`.
     Command(Vec<String>),
-    /// Structured Mongo operation.
-    Mongo(MongoOp),
+    /// Structured Mongo operation. Boxed so the fat Mongo variant doesn't
+    /// bloat every `Query` (the SQL path stays a bare `String`).
+    Mongo(Box<MongoOp>),
 }
 
 #[derive(Debug, Clone)]

--- a/crates/driver-mongo/src/driver.rs
+++ b/crates/driver-mongo/src/driver.rs
@@ -188,6 +188,9 @@ impl Driver for MongoDriver {
                 if let Some(s) = op.skip {
                     find = find.skip(s.max(0) as u64);
                 }
+                if let Some(sort) = &op.sort {
+                    find = find.sort(json_to_document(sort)?);
+                }
                 let cursor = find.await.map_err(|e| RdbsError::Query(e.to_string()))?;
                 let docs: Vec<Document> = cursor
                     .try_collect()

--- a/crates/driver-mongo/tests/integration.rs
+++ b/crates/driver-mongo/tests/integration.rs
@@ -32,27 +32,28 @@ async fn connect_insert_find_aggregate_schema_against_real_mongo() {
 
     for (name, age) in [("alice", 30), ("bob", 17)] {
         let inserted = driver
-            .query(&Query::Mongo(MongoOp {
+            .query(&Query::Mongo(Box::new(MongoOp {
                 collection: "users".into(),
                 database: None,
                 limit: None,
                 skip: None,
                 sort: None,
                 kind: MongoKind::Insert(serde_json::json!({ "name": name, "age": age })),
-            }))
+            })))
             .await
             .unwrap();
         assert!(matches!(inserted, ResultSet::Affected(1)));
     }
 
     let found = driver
-        .query(&Query::Mongo(MongoOp {
+        .query(&Query::Mongo(Box::new(MongoOp {
             collection: "users".into(),
             database: None,
             limit: None,
             skip: None,
+            sort: None,
             kind: MongoKind::Find(serde_json::json!({ "age": { "$gte": 18 } })),
-        }))
+        })))
         .await
         .unwrap();
     match found {
@@ -64,15 +65,16 @@ async fn connect_insert_find_aggregate_schema_against_real_mongo() {
     }
 
     let agg = driver
-        .query(&Query::Mongo(MongoOp {
+        .query(&Query::Mongo(Box::new(MongoOp {
             collection: "users".into(),
             database: None,
             limit: None,
             skip: None,
+            sort: None,
             kind: MongoKind::Aggregate(vec![
                 serde_json::json!({ "$group": { "_id": null, "total": { "$sum": 1 } } }),
             ]),
-        }))
+        })))
         .await
         .unwrap();
     match agg {

--- a/crates/driver-mongo/tests/integration.rs
+++ b/crates/driver-mongo/tests/integration.rs
@@ -37,6 +37,7 @@ async fn connect_insert_find_aggregate_schema_against_real_mongo() {
                 database: None,
                 limit: None,
                 skip: None,
+                sort: None,
                 kind: MongoKind::Insert(serde_json::json!({ "name": name, "age": age })),
             }))
             .await

--- a/crates/driver-postgres/src/driver.rs
+++ b/crates/driver-postgres/src/driver.rs
@@ -78,12 +78,15 @@ impl Driver for PostgresDriver {
     }
 
     async fn list_schemas(&self) -> Result<Vec<String>> {
+        // pg_namespace lists every schema; information_schema.schemata is
+        // filtered to those the role has privileges on, so a restricted prod
+        // login would only see "public".
         let rows = self
             .client
             .query(
-                "SELECT schema_name FROM information_schema.schemata \
-                 WHERE schema_name NOT LIKE 'pg_%' \
-                 AND schema_name <> 'information_schema' ORDER BY 1",
+                "SELECT nspname FROM pg_catalog.pg_namespace \
+                 WHERE nspname NOT LIKE 'pg_%' \
+                 AND nspname <> 'information_schema' ORDER BY 1",
                 &[],
             )
             .await

--- a/crates/driver-postgres/tests/integration.rs
+++ b/crates/driver-postgres/tests/integration.rs
@@ -101,14 +101,14 @@ async fn non_sql_queries_are_unsupported() {
     assert!(matches!(cmd, Err(RdbsError::UnsupportedQuery)));
 
     let mongo = driver
-        .query(&Query::Mongo(MongoOp {
+        .query(&Query::Mongo(Box::new(MongoOp {
             collection: "c".into(),
             database: None,
             limit: None,
             skip: None,
             sort: None,
             kind: MongoKind::Find(serde_json::json!({})),
-        }))
+        })))
         .await;
     assert!(matches!(mongo, Err(RdbsError::UnsupportedQuery)));
 

--- a/crates/driver-postgres/tests/integration.rs
+++ b/crates/driver-postgres/tests/integration.rs
@@ -106,6 +106,7 @@ async fn non_sql_queries_are_unsupported() {
             database: None,
             limit: None,
             skip: None,
+            sort: None,
             kind: MongoKind::Find(serde_json::json!({})),
         }))
         .await;


### PR DESCRIPTION
## Summary
- Give MongoDB a real query UX: mongosh line syntax in the editor and a Compass-style filter bar when browsing.
- Fix a batch of editor/UI issues found while testing (tab buffers, browse editor, autocomplete icons + suggestions, Postgres schema list).

## Changes

### Mongo query UX
- `core`: add `sort` to `MongoOp`; box the `Query::Mongo` variant to keep `Query` small.
- `driver-mongo`: apply the sort document on `find`.
- `app`: parse mongosh line syntax — `db.coll.find({...}).limit(n).skip(n).sort({...})`, `aggregate([...])`, `insertOne({...})` — alongside the old JSON envelope. Bodies use json5 (bare keys, single quotes); a leading `use('db')` switches database.
- `app`: Mongo editor queries with no `use(...)` run against the selected database (dropdown) instead of the driver default (`admin`).
- `ui`: Compass-style filter-document bar in the browse toolbar for Mongo documents.

### Editor / UI fixes
- `app`: isolate the query buffer per tab (was bleeding across tabs via the wrong buffer).
- `ui`: keep the query editor available while browsing via a "Query ▸" toggle.
- `ui`: replace tofu font glyphs with SVG icons — browse refresh button, inline autocomplete, and command palette rows (new keyword/field icons).
- `app`: autocomplete now offers clause keywords (so `FROM`/`WHERE` appear, e.g. after `*`) and lists a schema's tables for a `schema.` prefix.
- `driver-postgres`: list all schemas via `pg_catalog.pg_namespace` (a restricted role saw only `public` through `information_schema`).

## Test plan
- [x] `make fmt-check`
- [x] `make lint`
- [x] `make be-test`
- [x] `cargo test -p rdbs --bins` (query_parse, completion, browse_text)
- [x] Manual (live Mongo): `use('db'); db.c.find({to_email:'x'}).sort({_id:-1})`; browse filter bar; Query ▸ over a collection
- [x] Manual (live Postgres): schema dropdown lists all schemas; `SELECT * f` suggests `FROM`; `schema.` lists tables