### PR TITLE
feat: workspace header UX + schema-aware autocomplete

### DIFF
--- a/app/src/completion.rs
+++ b/app/src/completion.rs
@@ -108,6 +108,28 @@ fn is_database(nodes: &[VmTreeNode], name: &str) -> bool {
         .any(|n| n.kind == "database" && n.label.to_lowercase() == nl)
 }
 
+/// The nodes belonging to `schema`: from its `database` node up to the next
+/// `database` node (the tree is flat, parent-then-children). An empty schema or
+/// no match falls back to the whole tree so completion still works.
+fn schema_scope<'a>(nodes: &'a [VmTreeNode], schema: &str) -> &'a [VmTreeNode] {
+    if schema.is_empty() {
+        return nodes;
+    }
+    let sl = schema.to_lowercase();
+    let Some(start) = nodes
+        .iter()
+        .position(|n| n.kind == "database" && n.label.to_lowercase() == sl)
+    else {
+        return nodes;
+    };
+    let body = &nodes[start + 1..];
+    let end = body
+        .iter()
+        .position(|n| n.kind == "database")
+        .unwrap_or(body.len());
+    &body[..end]
+}
+
 fn tables(nodes: &[VmTreeNode]) -> Vec<Candidate> {
     nodes
         .iter()
@@ -115,6 +137,20 @@ fn tables(nodes: &[VmTreeNode]) -> Vec<Candidate> {
         .map(|n| Candidate {
             label: n.label.clone(),
             kind: "table".into(),
+            sub: String::new(),
+        })
+        .collect()
+}
+
+/// Schema/database names, offered in table position so a cross-schema
+/// `schema.table` name can be started (their tables aren't in the active scope).
+fn schemas(nodes: &[VmTreeNode]) -> Vec<Candidate> {
+    nodes
+        .iter()
+        .filter(|n| n.kind == "database")
+        .map(|n| Candidate {
+            label: n.label.clone(),
+            kind: "database".into(),
             sub: String::new(),
         })
         .collect()
@@ -152,39 +188,50 @@ fn last_keyword(line: &str) -> Option<String> {
 /// Suggest completions for the text before the cursor. Returns the char length
 /// of the partial word to replace on accept, plus the (prefix-filtered, capped)
 /// candidates. An empty list means "no popup".
-pub fn suggest(before_cursor: &str, nodes: &[VmTreeNode]) -> (usize, Vec<Candidate>) {
+pub fn suggest(
+    before_cursor: &str,
+    nodes: &[VmTreeNode],
+    active_schema: &str,
+) -> (usize, Vec<Candidate>) {
+    // Default table/column suggestions come from the active schema only, so the
+    // popup follows the connected schema without the user picking it first.
+    let scope = schema_scope(nodes, active_schema);
     let word = trailing_word(before_cursor);
     let head = before_cursor.strip_suffix(word).unwrap_or(before_cursor);
     let mut cands = if let Some(before_dot) = head.strip_suffix('.') {
         // `table.` / `alias.` → that table's columns. When the name before the
         // dot is a schema/database, offer that schema's tables instead.
+        // Explicit `schema.` uses the whole tree so other schemas stay reachable.
         let owner_word = trailing_word(before_dot);
         let owner = resolve_alias(before_cursor, owner_word);
         let cols = columns_of(nodes, &owner);
         if cols.is_empty() && is_database(nodes, owner_word) {
-            tables(nodes)
+            tables(schema_scope(nodes, owner_word))
         } else {
             cols
         }
     } else {
         match last_keyword(before_cursor).as_deref() {
-            // table position
+            // table position: active-schema tables plus every schema name, so a
+            // `schema.table` from another namespace can be started.
             Some("FROM") | Some("JOIN") | Some("INTO") | Some("UPDATE") | Some("TABLE") => {
-                tables(nodes)
+                let mut c = tables(scope);
+                c.extend(schemas(nodes));
+                c
             }
             // column position: offer columns and tables, plus keywords so the
             // next clause (FROM/WHERE/…) is always reachable, e.g. after `*`.
             Some("SELECT") | Some("WHERE") | Some("AND") | Some("OR") | Some("ON")
             | Some("HAVING") | Some("SET") | Some("BY") | Some("VALUES") => {
-                let mut c = all_columns(nodes);
-                c.extend(tables(nodes));
+                let mut c = all_columns(scope);
+                c.extend(tables(scope));
                 c.extend(keywords());
                 c
             }
             // statement start / no useful context: keywords + tables
             _ => {
                 let mut c = keywords();
-                c.extend(tables(nodes));
+                c.extend(tables(scope));
                 c
             }
         }
@@ -220,7 +267,7 @@ mod tests {
 
     #[test]
     fn from_prefix_suggests_matching_table() {
-        let (n, c) = suggest("select * from ste", &nodes());
+        let (n, c) = suggest("select * from ste", &nodes(), "public");
         assert_eq!(n, 3);
         assert_eq!(
             c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
@@ -230,7 +277,11 @@ mod tests {
 
     #[test]
     fn dot_suggests_that_tables_columns() {
-        let (n, c) = suggest("select * from step_config where step_config.", &nodes());
+        let (n, c) = suggest(
+            "select * from step_config where step_config.",
+            &nodes(),
+            "public",
+        );
         assert_eq!(n, 0);
         assert_eq!(
             c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
@@ -240,7 +291,7 @@ mod tests {
 
     #[test]
     fn bare_word_completes_keyword() {
-        let (n, c) = suggest("sele", &nodes());
+        let (n, c) = suggest("sele", &nodes(), "public");
         assert_eq!(n, 4);
         assert_eq!(
             c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
@@ -250,7 +301,7 @@ mod tests {
 
     #[test]
     fn select_context_offers_columns() {
-        let (_, c) = suggest("select ", &nodes());
+        let (_, c) = suggest("select ", &nodes(), "public");
         let labels: Vec<&str> = c.iter().map(|x| x.label.as_str()).collect();
         assert!(labels.contains(&"config_id"));
         assert!(labels.contains(&"name"));
@@ -259,7 +310,7 @@ mod tests {
 
     #[test]
     fn alias_dot_resolves_to_table_columns() {
-        let (_, c) = suggest("select * from step_config sc where sc.", &nodes());
+        let (_, c) = suggest("select * from step_config sc where sc.", &nodes(), "public");
         assert_eq!(
             c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
             ["config_id", "name"]
@@ -268,14 +319,14 @@ mod tests {
 
     #[test]
     fn star_context_offers_from_keyword() {
-        let (_, c) = suggest("select * f", &nodes());
+        let (_, c) = suggest("select * f", &nodes(), "public");
         let labels: Vec<&str> = c.iter().map(|x| x.label.as_str()).collect();
         assert!(labels.contains(&"FROM"));
     }
 
     #[test]
     fn schema_dot_suggests_its_tables() {
-        let (n, c) = suggest("select * from public.", &nodes());
+        let (n, c) = suggest("select * from public.", &nodes(), "public");
         assert_eq!(n, 0);
         assert_eq!(
             c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
@@ -295,7 +346,69 @@ mod tests {
                 kind: "field".into(),
             },
         ];
-        let (_, c) = suggest("select * from users where users.", &typed);
+        let (_, c) = suggest("select * from users where users.", &typed, "public");
         assert_eq!(c[0].label, "id");
+    }
+
+    /// Two schemas loaded: table suggestions follow the active schema only.
+    #[test]
+    fn scopes_tables_to_active_schema() {
+        let mk = |l: &str, k: &str| VmTreeNode {
+            label: l.into(),
+            kind: k.into(),
+        };
+        let two = vec![
+            mk("public", "database"),
+            mk("users", "table"),
+            mk("id", "field"),
+            mk("other", "database"),
+            mk("orders", "table"),
+            mk("oid", "field"),
+        ];
+        let (_, c) = suggest("select * from ", &two, "public");
+        let labels: Vec<&str> = c.iter().map(|x| x.label.as_str()).collect();
+        assert!(labels.contains(&"users"));
+        assert!(!labels.contains(&"orders"));
+
+        let (_, c) = suggest("select * from ", &two, "other");
+        let labels: Vec<&str> = c.iter().map(|x| x.label.as_str()).collect();
+        assert!(labels.contains(&"orders"));
+        assert!(!labels.contains(&"users"));
+    }
+
+    fn two_schema_nodes() -> Vec<VmTreeNode> {
+        let mk = |l: &str, k: &str| VmTreeNode {
+            label: l.into(),
+            kind: k.into(),
+        };
+        vec![
+            mk("public", "database"),
+            mk("users", "table"),
+            mk("id", "field"),
+            mk("analytics", "database"),
+            mk("step_config", "table"),
+            mk("cfg_id", "field"),
+        ]
+    }
+
+    /// In table position, every schema name is offered so a cross-schema
+    /// `schema.table` can be started even when it isn't the active schema.
+    #[test]
+    fn from_offers_schema_names() {
+        let (_, c) = suggest("select * from ", &two_schema_nodes(), "public");
+        let labels: Vec<&str> = c.iter().map(|x| x.label.as_str()).collect();
+        assert!(labels.contains(&"analytics"));
+    }
+
+    /// `otherschema.` lists that schema's tables even while another schema is
+    /// active (all schemas live in the completion tree).
+    #[test]
+    fn dot_lists_non_active_schema_tables() {
+        let (n, c) = suggest("select * from analytics.", &two_schema_nodes(), "public");
+        assert_eq!(n, 0);
+        assert_eq!(
+            c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
+            ["step_config"]
+        );
     }
 }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1295,6 +1295,11 @@ fn main() -> Result<(), slint::PlatformError> {
     // connect task can fill it) + the set of expanded table labels.
     let raw_nodes: Arc<std::sync::Mutex<Vec<model::VmTreeNode>>> =
         Arc::new(std::sync::Mutex::new(Vec::new()));
+    // Cross-schema completion tree: every schema (labelled by schema name) with
+    // its tables/columns, so `schema.table` autocompletes across namespaces.
+    // Separate from `raw_nodes` (which stays scoped to the sidebar's one schema).
+    let completion_nodes: Arc<std::sync::Mutex<Vec<model::VmTreeNode>>> =
+        Arc::new(std::sync::Mutex::new(Vec::new()));
     // Expanded sidebar nodes. For Mongo this is the set of OPEN databases
     // (default closed → collections load lazily on expand). Arc<Mutex> so the
     // lazy-load task can read it off the UI thread.
@@ -1478,14 +1483,16 @@ fn main() -> Result<(), slint::PlatformError> {
     let refresh_completion: Rc<dyn Fn()> = {
         let weak = window.as_weak();
         let ed_state = ed_state.clone();
-        let raw_nodes = raw_nodes.clone();
+        let completion_nodes = completion_nodes.clone();
         let completion_ctx = completion_ctx.clone();
         Rc::new(move || {
             let Some(w) = weak.upgrade() else {
                 return;
             };
             let before = ed_state.borrow().before_cursor().to_string();
-            let (word_len, cands) = completion::suggest(&before, &raw_nodes.lock().unwrap());
+            let schema = w.get_schema_name().to_string();
+            let (word_len, cands) =
+                completion::suggest(&before, &completion_nodes.lock().unwrap(), &schema);
             if cands.is_empty() {
                 w.set_completion_visible(false);
                 *completion_ctx.borrow_mut() = (0, Vec::new());
@@ -3018,6 +3025,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let weak = window.as_weak();
         let rt = rt.clone();
         let store = store.clone();
+        let completion_nodes = completion_nodes.clone();
         let current = current.clone();
         let raw_nodes = raw_nodes.clone();
         let expanded_tables = expanded_tables.clone();
@@ -3084,6 +3092,7 @@ fn main() -> Result<(), slint::PlatformError> {
             let claimed = current.clone().try_lock_owned().ok();
             let engine = sc.engine;
             let raw_nodes = raw_nodes.clone();
+            let completion_nodes = completion_nodes.clone();
             let fn_defs = fn_defs.clone();
             let handle = rt.spawn(async move {
                 let mut slot = match claimed {
@@ -3176,6 +3185,12 @@ fn main() -> Result<(), slint::PlatformError> {
                                 | rdbs_connstore::Engine::Cassandra
                         );
                         *raw_nodes.lock().unwrap() = nodes;
+                        // Seed autocomplete with the active schema right away; the
+                        // remaining schemas load in the background below.
+                        *completion_nodes.lock().unwrap() =
+                            model::to_completion_nodes(schema_current.as_str(), &schema);
+                        let all_schema_names: Vec<String> =
+                            schema_names.iter().map(|s| s.to_string()).collect();
                         {
                             let mut defs = fn_defs.lock().unwrap();
                             defs.clear();
@@ -3211,6 +3226,28 @@ fn main() -> Result<(), slint::PlatformError> {
                                 w.set_connected(true);
                             }
                         });
+                        // Load every other schema's tables so cross-schema
+                        // `schema.table` autocompletes. Runs after the sidebar
+                        // (active schema) already rendered; the popup just gains
+                        // more names as this fills.
+                        // ponytail: sequential N+1 fetch, fine for typical schema
+                        // counts; make it concurrent if a wide DB feels laggy.
+                        if matches!(engine, rdbs_connstore::Engine::Postgres)
+                            && all_schema_names.len() > 1
+                        {
+                            let guard = store_driver.lock_owned().await;
+                            if let Some((_, driver)) = guard.as_ref() {
+                                let mut all = Vec::new();
+                                for name in &all_schema_names {
+                                    if let Ok(s) = driver.schema_for(name).await {
+                                        all.extend(model::to_completion_nodes(name, &s));
+                                    }
+                                }
+                                if !all.is_empty() {
+                                    *completion_nodes.lock().unwrap() = all;
+                                }
+                            }
+                        }
                     }
                     Err(e) => {
                         eprintln!("connect failed: {e}");

--- a/app/src/model.rs
+++ b/app/src/model.rs
@@ -423,6 +423,39 @@ pub fn to_tree_model(schema: &Schema) -> Vec<VmTreeNode> {
     out
 }
 
+/// Flat node list for SQL autocomplete, labelling the database node with
+/// `schema_name` instead of the driver's `db.name` (Postgres reports
+/// `current_database()` for every namespace, so the real schema name has to
+/// come from the caller). Functions are omitted — completion only needs tables
+/// and columns. Concatenating this across schemas gives a cross-schema tree
+/// where `schema.table` resolves.
+pub fn to_completion_nodes(schema_name: &str, schema: &Schema) -> Vec<VmTreeNode> {
+    let mut out = vec![VmTreeNode {
+        label: schema_name.to_string(),
+        kind: "database".into(),
+    }];
+    for db in &schema.databases {
+        for c in &db.containers {
+            let kind = match c.kind {
+                ContainerKind::Table => "table",
+                ContainerKind::Collection => "collection",
+                ContainerKind::Keyspace => "keyspace",
+            };
+            out.push(VmTreeNode {
+                label: c.name.clone(),
+                kind: kind.into(),
+            });
+            for f in &c.fields {
+                out.push(VmTreeNode {
+                    label: format!("{}: {}", f.name, f.type_name),
+                    kind: "field".into(),
+                });
+            }
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -163,6 +163,8 @@ in-out property <string> rename-text;
     in property <string> query-label;
     in property <string> results-meta;
     in-out property <int> sidebar-mode: 0;
+    in-out property <bool> sidebar-visible: true;
+    in-out property <bool> results-visible: true;
     callback editor-key(string, bool, bool, bool) -> bool;
     callback editor-press(int, int);
     callback editor-drag(int, int);
@@ -456,6 +458,7 @@ in-out property <string> rename-text;
                             text: root.bc-conn;
                             show-dot: true;
                             mono: true;
+                            clicked => { root.open-conn-modal(); }
                         }
                     }
                     // disconnect: drop the driver and return to the picker
@@ -487,13 +490,18 @@ in-out property <string> rename-text;
                     }
                     if root.bc-schema != "": VerticalLayout {
                         alignment: center;
-                        BreadcrumbChip { text: root.bc-schema; caret: true; mono: true; }
+                        BreadcrumbChip {
+                            text: root.bc-schema;
+                            caret: true;
+                            mono: true;
+                            clicked => { root.select-schema(root.schema-name); }
+                        }
                     }
                 }
 
                 Rectangle { horizontal-stretch: 1; }
 
-                // --- right: ⌘K pill + aux buttons + window controls ---
+                // --- center: ⌘K pill (flanked by stretch spacers) ---
                 VerticalLayout {
                     alignment: center;
                     SearchCommandPill {
@@ -501,23 +509,27 @@ in-out property <string> rename-text;
                         activated => { root.toggle-palette(); }
                     }
                 }
-                // aux icon cluster: app settings (always) + connection tools
-                // (when connected). One row so all four icons share even spacing.
+
+                Rectangle { horizontal-stretch: 1; }
+
+                // aux icon cluster (left→right): panel toggles, pencil, theme,
+                // settings. One row so all icons share even spacing.
                 HorizontalLayout {
                     spacing: Tokens.sp1;
-                    VerticalLayout {
-                        alignment: center;
-                        GlyphButton {
-                            glyph: "⚙";
-                            clicked => { root.settings-open = true; }
-                        }
-                    }
-                    // theme toggle: sun in dark mode, moon in light
+                    // hide/show the left sidebar
                     if root.connected: VerticalLayout {
                         alignment: center;
                         IconButton {
-                            icon: Tokens.dark ? "sun" : "moon";
-                            clicked => { root.toggle-theme(); }
+                            icon: "columns";
+                            clicked => { root.sidebar-visible = !root.sidebar-visible; }
+                        }
+                    }
+                    // hide/show the results panel (editor takes the space)
+                    if root.connected: VerticalLayout {
+                        alignment: center;
+                        IconButton {
+                            icon: "rows";
+                            clicked => { root.results-visible = !root.results-visible; }
                         }
                     }
                     // edit the current connection (distinct from the app ⚙)
@@ -530,6 +542,21 @@ in-out property <string> rename-text;
                                     root.open-edit-form(root.selected-conn);
                                 }
                             }
+                        }
+                    }
+                    // theme toggle: sun in dark mode, moon in light
+                    if root.connected: VerticalLayout {
+                        alignment: center;
+                        IconButton {
+                            icon: Tokens.dark ? "sun" : "moon";
+                            clicked => { root.toggle-theme(); }
+                        }
+                    }
+                    VerticalLayout {
+                        alignment: center;
+                        GlyphButton {
+                            glyph: "⚙";
+                            clicked => { root.settings-open = true; }
                         }
                     }
                 }
@@ -580,7 +607,7 @@ in-out property <string> rename-text;
             HorizontalLayout {
                 spacing: 0px;
 
-                sb := Sidebar {
+                if root.sidebar-visible: Sidebar {
                     focus-tick: root.focus-filter-tick;
                     // preferred (not fixed) width so the window can auto-shrink the
                     // sidebar instead of treating sidebar-w as a hard min floor
@@ -629,7 +656,7 @@ in-out property <string> rename-text;
                 }
 
                 // draggable vertical splitter (sidebar width)
-                Rectangle {
+                if root.sidebar-visible: Rectangle {
                     width: 1px;
                     background: split-h-area.has-hover || split-h-area.pressed ? Tokens.accent : Tokens.border;
                     split-h-area := TouchArea {
@@ -766,6 +793,7 @@ in-out property <string> rename-text;
 
                     WorkArea {
                         vertical-stretch: 1;
+                        results-visible: root.results-visible;
                         query-text <=> root.query-text;
                         columns: root.grid-columns;
                         cells: root.grid-cells;

--- a/app/src/ui/code-editor.slint
+++ b/app/src/ui/code-editor.slint
@@ -218,7 +218,8 @@ export component CodeEditor inherits Rectangle {
                         alignment: center;
                         AppIcon {
                             name: it.kind == "field" ? "field"
-                                : it.kind == "table" ? "table" : "keyword";
+                                : it.kind == "table" ? "table"
+                                : it.kind == "database" ? "database" : "keyword";
                             size: 13px;
                             color: it.kind == "table" ? Tokens.db-pg
                                 : it.kind == "field" ? Tokens.text-dim : Tokens.accent;

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -18,6 +18,8 @@ export component WorkArea inherits Rectangle {
     property <bool> editor-collapsed: false;
     // Reveal the query editor while browsing a table/collection (default closed).
     property <bool> browse-editor-open: false;
+    // Hide the results panel (editor takes the space) — header toggle.
+    in property <bool> results-visible: true;
     in-out property <string> query-text;
     in property <[GridColumn]> columns;
     in property <[GridCell]> cells;
@@ -338,7 +340,9 @@ export component WorkArea inherits Rectangle {
         // ================= SQL editor (non-browse tabs) =================
         // Also shown over a browse grid when the user opens "Query ▸".
         if (!root.browse-mode || root.browse-editor-open) && !root.fn-mode: Rectangle {
-            height: root.editor-h;
+            // when results are hidden the editor stretches to fill the work area
+            vertical-stretch: root.results-visible ? 0.0 : 1.0;
+            preferred-height: root.editor-h;
             background: Tokens.canvas;
             VerticalLayout {
                 width: 100%;
@@ -516,9 +520,9 @@ export component WorkArea inherits Rectangle {
                     drag-pos(l, c) => { root.editor-drag(l, c); }
                     select-word(l, c) => { root.editor-select-word(l, c); }
                 }
-                Rectangle { height: 1px; background: Tokens.border; }
+                if root.results-visible: Rectangle { height: 1px; background: Tokens.border; }
                 // results header strip
-                HorizontalLayout {
+                if root.results-visible: HorizontalLayout {
                     height: 34px;
                     padding-left: Tokens.sp3;
                     padding-right: Tokens.sp3;
@@ -545,7 +549,7 @@ export component WorkArea inherits Rectangle {
                     TextButton { text: "Chart"; clicked => { root.sql-view-mode = 2; } }
                 }
                 // result tabs — appear once ⌘\ has spawned a second result
-                if root.result-tabs.length > 1: HorizontalLayout {
+                if root.results-visible && root.result-tabs.length > 1: HorizontalLayout {
                     height: 30px;
                     padding-left: Tokens.sp3;
                     padding-right: Tokens.sp3;
@@ -585,7 +589,7 @@ export component WorkArea inherits Rectangle {
         }
 
         // draggable splitter: grow/shrink the editor vs the results (SQL tabs)
-        if (!root.browse-mode || root.browse-editor-open) && !root.fn-mode: Rectangle {
+        if (!root.browse-mode || root.browse-editor-open) && !root.fn-mode && root.results-visible: Rectangle {
             height: 6px;
             background: split-ta.has-hover || split-ta.pressed ? Tokens.accent : Tokens.chrome;
             split-ta := TouchArea {
@@ -602,7 +606,7 @@ export component WorkArea inherits Rectangle {
         // columns) and are toggled by `filter-open`; see the "Filter" button.
 
         // ================= result body =================
-        if !root.fn-mode: body := Rectangle {
+        if !root.fn-mode && root.results-visible: body := Rectangle {
             vertical-stretch: 1;
             background: Tokens.canvas;
 


### PR DESCRIPTION
## Summary
- Make the workspace header breadcrumbs interactive and tidy the icon cluster / search placement.
- Add sidebar and results panel hide toggles.
- Fix SQL autocomplete to follow the connected schema and resolve schema-qualified tables across namespaces.

## Changes
**Autocomplete (`completion.rs`, `model.rs`, `main.rs`, `code-editor.slint`)**
- New `completion_nodes` cross-schema tree, separate from the sidebar's per-schema `raw_nodes`. All schemas fetched in the background on connect (Postgres), labelled by schema name.
- `suggest()` scopes default table/column suggestions to the active schema; table position also offers schema names; a schema-qualified prefix lists that schema's tables.
- Completion popup gains a `database` icon.

**Header / panels (`app-window.slint`, `workarea.slint`)**
- Connection chip -> connection modal; schema chip -> schema switcher.
- Cmd+K search pill centered; right cluster reordered to sidebar-toggle, results-toggle, pencil, theme, settings.
- `sidebar-visible` / `results-visible` toggles; editor fills the freed space when results are hidden.

## Test plan
- [x] `cargo fmt --check` clean, `clippy` clean
- [x] `make fe-build` clean (no binding-loop warnings)
- [x] 11 completion unit tests pass
- [x] Manual (`make fe-run`, Postgres): breadcrumb chips open modals; search centered; toggles hide/show panels; schema-qualified autocomplete resolves another schema's tables while a different one is active