### PR TITLE
feat: query UX fixes — db errors, join columns, db switch, tab persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5464,6 +5464,7 @@ dependencies = [
  "rdbs-driver-redis",
  "rdbs-driver-sqlite",
  "semver",
+ "serde",
  "serde_json",
  "slint",
  "slint-build",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -18,6 +18,7 @@ rdbs-driver-mongo = { path = "../crates/driver-mongo" }
 rdbs-driver-sqlite = { path = "../crates/driver-sqlite" }
 rdbs-driver-cassandra = { path = "../crates/driver-cassandra" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "time"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # permissive JSON for the Mongo editor: mongosh uses bare keys / single quotes
 # (`{_id:-1}`), which strict serde_json rejects.

--- a/app/src/completion.rs
+++ b/app/src/completion.rs
@@ -198,6 +198,12 @@ pub fn suggest(
     let scope = schema_scope(nodes, active_schema);
     let word = trailing_word(before_cursor);
     let head = before_cursor.strip_suffix(word).unwrap_or(before_cursor);
+    // Type-triggered: don't pop up on an empty line or right after whitespace —
+    // only once the user has typed at least one char of a word. `table.`/`alias.`
+    // is an explicit request for that table's columns, so it still fires.
+    if word.is_empty() && !head.ends_with('.') {
+        return (0, Vec::new());
+    }
     let mut cands = if let Some(before_dot) = head.strip_suffix('.') {
         // `table.` / `alias.` → that table's columns. When the name before the
         // dot is a schema/database, offer that schema's tables instead.
@@ -266,6 +272,14 @@ mod tests {
     }
 
     #[test]
+    fn empty_and_whitespace_context_suppress_popup() {
+        assert!(suggest("", &nodes(), "public").1.is_empty());
+        assert!(suggest("   ", &nodes(), "public").1.is_empty());
+        // trailing space after a keyword: wait for the user to start typing
+        assert!(suggest("select ", &nodes(), "public").1.is_empty());
+    }
+
+    #[test]
     fn from_prefix_suggests_matching_table() {
         let (n, c) = suggest("select * from ste", &nodes(), "public");
         assert_eq!(n, 3);
@@ -301,11 +315,10 @@ mod tests {
 
     #[test]
     fn select_context_offers_columns() {
-        let (_, c) = suggest("select ", &nodes(), "public");
+        // Type-triggered: a prefix is required before the popup appears.
+        let (_, c) = suggest("select n", &nodes(), "public");
         let labels: Vec<&str> = c.iter().map(|x| x.label.as_str()).collect();
-        assert!(labels.contains(&"config_id"));
         assert!(labels.contains(&"name"));
-        assert!(labels.contains(&"id"));
     }
 
     #[test]
@@ -359,21 +372,22 @@ mod tests {
         };
         let two = vec![
             mk("public", "database"),
-            mk("users", "table"),
+            mk("t_users", "table"),
             mk("id", "field"),
             mk("other", "database"),
-            mk("orders", "table"),
+            mk("t_orders", "table"),
             mk("oid", "field"),
         ];
-        let (_, c) = suggest("select * from ", &two, "public");
+        // Type-triggered: a prefix ("t") is required before the popup appears.
+        let (_, c) = suggest("select * from t", &two, "public");
         let labels: Vec<&str> = c.iter().map(|x| x.label.as_str()).collect();
-        assert!(labels.contains(&"users"));
-        assert!(!labels.contains(&"orders"));
+        assert!(labels.contains(&"t_users"));
+        assert!(!labels.contains(&"t_orders"));
 
-        let (_, c) = suggest("select * from ", &two, "other");
+        let (_, c) = suggest("select * from t", &two, "other");
         let labels: Vec<&str> = c.iter().map(|x| x.label.as_str()).collect();
-        assert!(labels.contains(&"orders"));
-        assert!(!labels.contains(&"users"));
+        assert!(labels.contains(&"t_orders"));
+        assert!(!labels.contains(&"t_users"));
     }
 
     fn two_schema_nodes() -> Vec<VmTreeNode> {
@@ -395,7 +409,8 @@ mod tests {
     /// `schema.table` can be started even when it isn't the active schema.
     #[test]
     fn from_offers_schema_names() {
-        let (_, c) = suggest("select * from ", &two_schema_nodes(), "public");
+        // Type-triggered: "a" narrows to the analytics schema name.
+        let (_, c) = suggest("select * from a", &two_schema_nodes(), "public");
         let labels: Vec<&str> = c.iter().map(|x| x.label.as_str()).collect();
         assert!(labels.contains(&"analytics"));
     }

--- a/app/src/dispatch.rs
+++ b/app/src/dispatch.rs
@@ -128,6 +128,19 @@ impl AnyDriver {
         }
     }
 
+    #[allow(dead_code)]
+    pub async fn list_databases(&self) -> Result<Vec<String>> {
+        match self {
+            AnyDriver::Postgres(d) => d.list_databases().await,
+            AnyDriver::Mysql(d) => d.list_databases().await,
+            AnyDriver::Redis(d) => d.list_databases().await,
+            AnyDriver::Mongo(d) => d.list_databases().await,
+            AnyDriver::Sqlite(d) => d.list_databases().await,
+            AnyDriver::Cassandra(d) => d.list_databases().await,
+            AnyDriver::Mock(d) => d.list_databases().await,
+        }
+    }
+
     pub async fn containers(&self, database: &str) -> Result<Vec<Container>> {
         match self {
             AnyDriver::Postgres(d) => d.containers(database).await,

--- a/app/src/editor.rs
+++ b/app/src/editor.rs
@@ -672,18 +672,28 @@ impl EditorState {
             }
             offset += l.chars().count() + 1; // +1 for the newline
         }
-        // split into statements on top-level semicolons
+        // Split into statements on top-level semicolons, ignoring `;` inside
+        // string literals and `-- line comments` (same rules as
+        // `split_statements`) — otherwise a `;` in a commented-out line would
+        // falsely cut the statement and Run would grab only the tail fragment.
         let mut segments: Vec<(usize, usize)> = Vec::new();
         let mut seg_start = 0;
         let mut in_str = false;
-        for (i, &c) in chars.iter().enumerate() {
+        let mut i = 0;
+        while i < chars.len() {
+            let c = chars[i];
             if c == '\'' {
                 in_str = !in_str;
-            }
-            if c == ';' && !in_str {
+            } else if !in_str && c == '-' && chars.get(i + 1) == Some(&'-') {
+                while i < chars.len() && chars[i] != '\n' {
+                    i += 1;
+                }
+                continue;
+            } else if c == ';' && !in_str {
                 segments.push((seg_start, i + 1));
                 seg_start = i + 1;
             }
+            i += 1;
         }
         if seg_start < chars.len() {
             segments.push((seg_start, chars.len()));
@@ -937,6 +947,17 @@ mod tests {
     fn statement_without_semicolons_is_whole_text() {
         let ed = EditorState::from_text("SELECT *\nFROM t");
         assert_eq!(ed.current_statement(), "SELECT *\nFROM t");
+    }
+
+    #[test]
+    fn statement_ignores_semicolon_in_comment() {
+        // A `;` inside a `-- comment` must not split the statement, else Run
+        // (cursor on the last line) would grab only the tail after that `;`.
+        let text = "SELECT a\nFROM t\nWHERE -- x = 1;\ny = 2";
+        let mut ed = EditorState::from_text(text);
+        ed.line = 3; // on `y = 2`, past the commented `;`
+        ed.col = 0;
+        assert_eq!(ed.current_statement(), text);
     }
 
     // ----- selection -----

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -3741,8 +3741,9 @@ fn main() -> Result<(), slint::PlatformError> {
             let mut cur_db = String::new();
             if let Some(w) = weak.upgrade() {
                 w.set_query_running(true);
-                // Reveal the SQL console so the executed statements are visible.
-                w.set_console_open(true);
+                // Don't force the SQL console open on every run — the eye toggle
+                // owns its visibility. Re-opening it here ignored a user who just
+                // hid it. The console still updates in place when it is open.
                 cur_db = w.get_schema_name().to_string();
             }
             rt.spawn(async move {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1474,6 +1474,11 @@ fn main() -> Result<(), slint::PlatformError> {
         Arc::new(std::sync::Mutex::new(None));
     let current_connection_id: Arc<std::sync::Mutex<Option<String>>> =
         Arc::new(std::sync::Mutex::new(None));
+    // One-shot database override for the next connect: the database switcher sets
+    // it, then re-invokes the connect path, which consumes it (take) so a plain
+    // reconnect from the picker still uses the connection's saved database.
+    let db_override: Arc<std::sync::Mutex<Option<String>>> =
+        Arc::new(std::sync::Mutex::new(None));
     let query_number = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let query_console: Arc<std::sync::Mutex<Vec<String>>> =
         Arc::new(std::sync::Mutex::new(Vec::new()));
@@ -2272,67 +2277,42 @@ fn main() -> Result<(), slint::PlatformError> {
             let Some(w) = weak.upgrade() else {
                 return;
             };
-            // Mock database catalogue matching the reference; real listing
-            // arrives with multi-database introspection.
-            let dbs = [
-                "ai_bot_fintech",
-                "jdih_bkpm_2025",
-                "oss_rba_master",
-                "portfolio",
-                "pos",
-                "postgres",
-                "primbon",
-                "profin",
-                "rtmanagement",
-                "suitest",
-                "suitest_m1d_9fabae77c4a44d51aedc4ffebf39eb71",
-                "suitest_test",
-                "template0",
-                "template1",
-            ];
-            let items: Vec<PaletteItem> = dbs
+            // Real databases enumerated on connect and cached in `db-list`. Empty
+            // for engines that can't switch (single/implicit database).
+            let items: Vec<PaletteItem> = w
+                .get_db_list()
                 .iter()
                 .map(|d| PaletteItem {
-                    label: (*d).into(),
+                    label: d,
                     kind: "database".into(),
                     sub: SharedString::default(),
                     local: false,
                 })
                 .collect();
+            if items.is_empty() {
+                return;
+            }
             w.set_db_items(ModelRc::from(Rc::new(VecModel::from(items))));
             w.set_db_modal_open(true);
         });
     }
     {
         let weak = window.as_weak();
-        let workspace_tabs = workspace_tabs.clone();
-        let active_tab_id = active_tab_id.clone();
-        let browse = browse.clone();
-        let results = results.clone();
-        let displayed_grid = displayed_grid.clone();
-        let load_editor_text = load_editor_text.clone();
+        let db_override = db_override.clone();
         window.on_db_choose(move |idx| {
             let Some(w) = weak.upgrade() else {
                 return;
             };
-            if let Some(it) = w.get_db_items().row_data(idx.max(0) as usize) {
-                w.set_bc_db(it.label);
-            }
-            workspace_tabs.lock().unwrap().clear();
-            *active_tab_id.lock().unwrap() = None;
-            let limit = browse.lock().unwrap().limit;
-            *browse.lock().unwrap() = BrowseState {
-                limit,
-                ..Default::default()
+            let Some(it) = w.get_db_items().row_data(idx.max(0) as usize) else {
+                return;
             };
-            results.lock().unwrap().clear();
-            *displayed_grid.lock().unwrap() = None;
-            set_workspace_tabs(&w, &[], None);
-            load_editor_text("");
-            clear_grid(&w);
-            w.set_active_table(SharedString::default());
-            w.set_query_running(false);
             w.set_db_modal_open(false);
+            // Switching database means reconnecting with a new dbname (a pg
+            // connection is bound to one database). Stash the target and re-run
+            // the connect path for the current connection; it resets tabs/schema
+            // and reloads the tree against the new database.
+            *db_override.lock().unwrap() = Some(it.label.to_string());
+            w.invoke_connect_clicked(w.get_selected_conn());
         });
     }
     // ----- schema switcher: sidebar "schema: …" selector -----
@@ -3408,14 +3388,23 @@ fn main() -> Result<(), slint::PlatformError> {
         let results = results.clone();
         let last_view = last_view.clone();
         let edit_buf = edit_buf.clone();
+        let db_override = db_override.clone();
         window.on_connect_clicked(move |idx| {
             let i = idx as usize;
+            // One-shot: set by the database switcher, empty for a fresh picker
+            // connect (which then uses the connection's saved database).
+            let db_ovr = db_override.lock().unwrap().take();
             let (sc, cfg) = {
                 let st = store.borrow();
                 let Some(sc) = st.list().get(i).cloned() else {
                     return;
                 };
-                let cfg = st.conn_config_for(&sc.id);
+                let cfg = st.conn_config_for(&sc.id).map(|mut c| {
+                    if let Some(db) = db_ovr.clone() {
+                        c.database = Some(db);
+                    }
+                    c
+                });
                 (sc, cfg)
             };
             *current_connection_id.lock().unwrap() = Some(sc.id.clone());
@@ -3442,7 +3431,9 @@ fn main() -> Result<(), slint::PlatformError> {
                     .set_accent(theme::accent_or_default(sc.color.as_deref().unwrap_or("")));
                 w.set_status_conn(SharedString::from(sc.name.clone()));
                 w.set_bc_conn(SharedString::from(sc.name.clone()));
-                w.set_bc_db(SharedString::from(sc.database.clone().unwrap_or_default()));
+                w.set_bc_db(SharedString::from(
+                    db_ovr.clone().or_else(|| sc.database.clone()).unwrap_or_default(),
+                ));
                 w.set_bc_schema(SharedString::from(
                     if matches!(sc.engine, rdbs_connstore::Engine::Postgres) {
                         "public"
@@ -3519,6 +3510,15 @@ fn main() -> Result<(), slint::PlatformError> {
                             } else {
                                 Vec::new()
                             };
+                        // Databases on the server, backing the breadcrumb switcher.
+                        // Empty for engines that can't switch database.
+                        let db_names: Vec<SharedString> = driver
+                            .list_databases()
+                            .await
+                            .unwrap_or_default()
+                            .into_iter()
+                            .map(SharedString::from)
+                            .collect();
                         *slot = Some((engine, driver));
                         drop(slot);
                         let nodes = model::to_tree_model(&schema);
@@ -3593,6 +3593,7 @@ fn main() -> Result<(), slint::PlatformError> {
                                 w.set_schema_list(ModelRc::from(Rc::new(VecModel::from(
                                     schema_names,
                                 ))));
+                                w.set_db_list(ModelRc::from(Rc::new(VecModel::from(db_names))));
                                 let sfields: Vec<StructField> = fields
                                     .into_iter()
                                     .map(|f| StructField {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -572,6 +572,78 @@ fn record_recent(list: &RefCell<Vec<String>>, text: &str) {
     }
 }
 
+/// Minimal on-disk shape of a query tab: identity + SQL text only. Results,
+/// browse state and view are transient (and may hold DB data), so they are
+/// never persisted — only SQL scratch tabs survive a restart.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct PersistedTab {
+    id: String,
+    title: String,
+    query_text: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Default)]
+struct PersistedTabs {
+    tabs: Vec<PersistedTab>,
+    active: Option<String>,
+}
+
+/// Persist the SQL tabs (kind == "sql") and the active tab id. Best-effort;
+/// I/O errors are ignored. Skipped in mock mode.
+fn save_query_tabs(tabs: &[WorkspaceTab], active: Option<&str>) {
+    if mock::mock_mode() {
+        return;
+    }
+    let Ok(path) = rdbs_connstore::ConnStore::query_tabs_path() else {
+        return;
+    };
+    let sql: Vec<PersistedTab> = tabs
+        .iter()
+        .filter(|t| t.kind == "sql")
+        .map(|t| PersistedTab {
+            id: t.id.clone(),
+            title: t.title.clone(),
+            query_text: t.query_text.clone(),
+        })
+        .collect();
+    let active = active
+        .filter(|id| sql.iter().any(|t| t.id == *id))
+        .map(|s| s.to_string());
+    let payload = PersistedTabs { tabs: sql, active };
+    if let Some(dir) = path.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    if let Ok(json) = serde_json::to_string_pretty(&payload) {
+        let _ = std::fs::write(path, json);
+    }
+}
+
+/// Load persisted SQL tabs into fresh `WorkspaceTab`s (empty results/browse).
+/// Returns the tabs and the active tab id (if it still exists).
+fn load_query_tabs() -> (Vec<WorkspaceTab>, Option<String>) {
+    let Ok(path) = rdbs_connstore::ConnStore::query_tabs_path() else {
+        return (Vec::new(), None);
+    };
+    let Some(payload): Option<PersistedTabs> = std::fs::read_to_string(path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+    else {
+        return (Vec::new(), None);
+    };
+    let tabs: Vec<WorkspaceTab> = payload
+        .tabs
+        .into_iter()
+        .map(|p| {
+            let mut t = WorkspaceTab::sql(p.id, 0);
+            t.title = p.title;
+            t.query_text = p.query_text;
+            t
+        })
+        .collect();
+    let active = payload.active.filter(|id| tabs.iter().any(|t| t.id == *id));
+    (tabs, active)
+}
+
 fn page_bounds(page: u64, limit: u64, total: Option<u64>, shown: u64) -> (u64, u64, bool, bool) {
     let start = if shown == 0 { 0 } else { page * limit + 1 };
     let end = page * limit + shown;
@@ -1477,8 +1549,10 @@ fn main() -> Result<(), slint::PlatformError> {
     // One-shot database override for the next connect: the database switcher sets
     // it, then re-invokes the connect path, which consumes it (take) so a plain
     // reconnect from the picker still uses the connection's saved database.
-    let db_override: Arc<std::sync::Mutex<Option<String>>> =
-        Arc::new(std::sync::Mutex::new(None));
+    let db_override: Arc<std::sync::Mutex<Option<String>>> = Arc::new(std::sync::Mutex::new(None));
+    // Restore persisted SQL tabs on the first connect of the session; later
+    // connects to a different connection start fresh.
+    let tabs_restored: Rc<std::cell::Cell<bool>> = Rc::new(std::cell::Cell::new(false));
     let query_number = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let query_console: Arc<std::sync::Mutex<Vec<String>>> =
         Arc::new(std::sync::Mutex::new(Vec::new()));
@@ -2837,6 +2911,9 @@ fn main() -> Result<(), slint::PlatformError> {
                     latency: w.get_status_latency().to_string(),
                 });
             }
+            // Persist SQL scratch tabs so they survive a restart. Cheap JSON
+            // write; fires on switch/new/close/run, which is when text changes.
+            save_query_tabs(&tabs, Some(&id));
         })
     };
 
@@ -3389,6 +3466,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let last_view = last_view.clone();
         let edit_buf = edit_buf.clone();
         let db_override = db_override.clone();
+        let tabs_restored = tabs_restored.clone();
         window.on_connect_clicked(move |idx| {
             let i = idx as usize;
             // One-shot: set by the database switcher, empty for a fresh picker
@@ -3408,8 +3486,18 @@ fn main() -> Result<(), slint::PlatformError> {
                 (sc, cfg)
             };
             *current_connection_id.lock().unwrap() = Some(sc.id.clone());
-            workspace_tabs.lock().unwrap().clear();
-            *active_tab_id.lock().unwrap() = None;
+            // First connect of the session (or a database switch) restores the
+            // persisted SQL scratch tabs; a later switch to another connection
+            // starts with a clean workspace.
+            let restore = !tabs_restored.get() || db_ovr.is_some();
+            tabs_restored.set(true);
+            let (init_tabs, init_active) = if restore {
+                load_query_tabs()
+            } else {
+                (Vec::new(), None)
+            };
+            *workspace_tabs.lock().unwrap() = init_tabs;
+            *active_tab_id.lock().unwrap() = init_active.clone();
             results.lock().unwrap().clear();
             *last_view.lock().unwrap() = None;
             edit_buf.lock().unwrap().clear();
@@ -3420,7 +3508,10 @@ fn main() -> Result<(), slint::PlatformError> {
             query_console.lock().unwrap().clear();
             // Reflect selection + accent immediately.
             if let Some(w) = weak.upgrade() {
-                set_workspace_tabs(&w, &[], None);
+                {
+                    let tabs = workspace_tabs.lock().unwrap();
+                    set_workspace_tabs(&w, &tabs, init_active.as_deref());
+                }
                 clear_grid(&w);
                 sync_query_console(&w, &query_console);
                 w.set_selected_conn(idx);
@@ -3432,7 +3523,10 @@ fn main() -> Result<(), slint::PlatformError> {
                 w.set_status_conn(SharedString::from(sc.name.clone()));
                 w.set_bc_conn(SharedString::from(sc.name.clone()));
                 w.set_bc_db(SharedString::from(
-                    db_ovr.clone().or_else(|| sc.database.clone()).unwrap_or_default(),
+                    db_ovr
+                        .clone()
+                        .or_else(|| sc.database.clone())
+                        .unwrap_or_default(),
                 ));
                 w.set_bc_schema(SharedString::from(
                     if matches!(sc.engine, rdbs_connstore::Engine::Postgres) {
@@ -3441,9 +3535,20 @@ fn main() -> Result<(), slint::PlatformError> {
                         ""
                     },
                 ));
-                // Start empty; the engine hint shows as a ghost placeholder
-                // (rendered by CodeEditor) instead of seeded buffer text.
-                load_editor_text("");
+                // Load the restored active tab's SQL, else empty (the engine hint
+                // shows as a ghost placeholder rendered by CodeEditor).
+                let init_text = init_active
+                    .as_deref()
+                    .and_then(|id| {
+                        workspace_tabs
+                            .lock()
+                            .unwrap()
+                            .iter()
+                            .find(|t| t.id == id)
+                            .map(|t| t.query_text.clone())
+                    })
+                    .unwrap_or_default();
+                load_editor_text(&init_text);
                 w.set_editor_placeholder(SharedString::from(if mock::mock_mode() {
                     ""
                 } else {
@@ -4703,6 +4808,7 @@ fn main() -> Result<(), slint::PlatformError> {
             tabs.push(WorkspaceTab::sql(id.clone(), number));
             *active_tab_id.lock().unwrap() = Some(id.clone());
             set_workspace_tabs(&w, &tabs, Some(&id));
+            save_query_tabs(&tabs, Some(&id));
             drop(tabs);
             load_editor_text("");
             // Fresh query tab starts with no result tabs.
@@ -4909,6 +5015,7 @@ fn main() -> Result<(), slint::PlatformError> {
             if tabs.is_empty() {
                 *active_tab_id.lock().unwrap() = None;
                 set_workspace_tabs(&w, &tabs, None);
+                save_query_tabs(&tabs, None);
                 drop(tabs);
                 load_editor_text("");
                 let limit = browse.lock().unwrap().limit;
@@ -4934,6 +5041,10 @@ fn main() -> Result<(), slint::PlatformError> {
                 let active = active_tab_id.lock().unwrap().clone();
                 set_workspace_tabs(&w, &tabs, active.as_deref());
             }
+            save_query_tabs(
+                &workspace_tabs.lock().unwrap(),
+                active_tab_id.lock().unwrap().as_deref(),
+            );
         });
     }
 
@@ -4966,6 +5077,7 @@ fn main() -> Result<(), slint::PlatformError> {
             }
             let active = active_tab_id.lock().unwrap().clone();
             set_workspace_tabs(&w, &tabs, active.as_deref());
+            save_query_tabs(&tabs, active.as_deref());
         });
     }
 
@@ -5999,12 +6111,40 @@ fn main() -> Result<(), slint::PlatformError> {
     }
 
     shot::install(&window);
-    window.run()
+    let run_result = window.run();
+    // On exit, capture the active tab's latest text (edits made without a tab
+    // switch) and persist, so a plain type-then-quit is not lost.
+    save_active_tab(&window);
+    run_result
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn persisted_tabs_round_trip() {
+        let payload = PersistedTabs {
+            tabs: vec![
+                PersistedTab {
+                    id: "query:c:1".into(),
+                    title: "Query 1".into(),
+                    query_text: "select * from users;".into(),
+                },
+                PersistedTab {
+                    id: "query:c:2".into(),
+                    title: "scratch".into(),
+                    query_text: String::new(),
+                },
+            ],
+            active: Some("query:c:2".into()),
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        let back: PersistedTabs = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.tabs.len(), 2);
+        assert_eq!(back.tabs[0].query_text, "select * from users;");
+        assert_eq!(back.active.as_deref(), Some("query:c:2"));
+    }
 
     #[test]
     fn mongo_browse_default_is_twenty() {

--- a/app/src/model.rs
+++ b/app/src/model.rs
@@ -324,18 +324,36 @@ pub fn chart_data(g: &GridModel) -> Vec<(String, String, f32)> {
         .collect()
 }
 
+/// Suffix repeated column names so a JOIN selecting same-named columns from two
+/// tables (e.g. `tnp.status`, `tpi.status`) renders every column. Grid cells map
+/// to columns by index, but name-keyed UI (the "Columns" show/hide panel,
+/// per-column filters) would collapse duplicates and hide the join's columns.
+/// First occurrence keeps its name; repeats become `name_2`, `name_3`, ...
+fn dedupe_column_names(mut cols: Vec<VmColumn>) -> Vec<VmColumn> {
+    let mut seen: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    for c in &mut cols {
+        let n = seen.entry(c.name.clone()).or_insert(0);
+        *n += 1;
+        if *n > 1 {
+            c.name = format!("{}_{}", c.name, *n);
+        }
+    }
+    cols
+}
+
 /// Convert any ResultSet into its presentation-ready view. Each variant keeps
 /// its own shape instead of collapsing to a single grid.
 pub fn to_result_view(rs: &ResultSet) -> ResultView {
     match rs {
         ResultSet::Tabular { cols, rows } => ResultView::Table(GridModel {
-            columns: cols
-                .iter()
-                .map(|c| VmColumn {
-                    name: c.name.clone(),
-                    type_name: c.type_name.clone(),
-                })
-                .collect(),
+            columns: dedupe_column_names(
+                cols.iter()
+                    .map(|c| VmColumn {
+                        name: c.name.clone(),
+                        type_name: c.type_name.clone(),
+                    })
+                    .collect(),
+            ),
             rows: rows
                 .iter()
                 .map(|row| {
@@ -570,6 +588,24 @@ mod tests {
         assert!(!grid.rows[0][0].is_null);
         assert_eq!(grid.rows[1][0].text, "NULL");
         assert!(grid.rows[1][0].is_null);
+    }
+
+    #[test]
+    fn join_duplicate_column_names_are_disambiguated() {
+        let col = |n: &str| Column {
+            name: n.into(),
+            type_name: "text".into(),
+        };
+        let rs = ResultSet::Tabular {
+            cols: vec![col("status"), col("kd_resiko"), col("status")],
+            rows: vec![vec![Cell::Int(1), Cell::Int(2), Cell::Int(3)]],
+        };
+        let grid = expect_table(&rs);
+        let names: Vec<&str> = grid.columns.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, ["status", "kd_resiko", "status_2"]);
+        // rows untouched by the rename
+        assert_eq!(grid.rows[0].len(), 3);
+        assert_eq!(grid.rows[0][2].text, "3");
     }
 
     #[test]

--- a/app/src/query_parse.rs
+++ b/app/src/query_parse.rs
@@ -9,22 +9,26 @@ use rdbs_core::query::{MongoKind, MongoOp, Query};
 /// Returns a human-readable error string on malformed input (shown in the
 /// result-status line; no driver call is made).
 pub fn parse_query(engine: Engine, text: &str) -> Result<Query, String> {
-    // Drop whole-line comments (Cmd+/ toggles them) before interpreting, so a
-    // commented-out query stays inert in the buffer for every engine.
-    let cleaned = strip_comment_lines(engine, text);
-    let text = cleaned.as_str();
     match engine {
+        // SQL engines parse `--` comments (inline and whole-line) natively, so
+        // send the buffer verbatim — same as every other SQL editor. Stripping
+        // comment lines here re-joined the surrounding lines and could shift a
+        // clause onto the wrong statement (e.g. a `WHERE` whose only condition
+        // was commented, followed by the real predicate two lines down).
         Engine::Postgres | Engine::MySql | Engine::Sqlite | Engine::Cassandra => {
             Ok(Query::Sql(text.to_string()))
         }
+        // Redis/Mongo have no server-side line comments, so drop commented lines
+        // (Cmd+/ toggles them) before interpreting.
         Engine::Redis => {
-            let tokens: Vec<String> = text.split_whitespace().map(|s| s.to_string()).collect();
+            let cleaned = strip_comment_lines(engine, text);
+            let tokens: Vec<String> = cleaned.split_whitespace().map(|s| s.to_string()).collect();
             if tokens.is_empty() {
                 return Err("empty Redis command".into());
             }
             Ok(Query::Command(tokens))
         }
-        Engine::Mongo => parse_mongo(text),
+        Engine::Mongo => parse_mongo(&strip_comment_lines(engine, text)),
     }
 }
 
@@ -295,10 +299,25 @@ mod tests {
     }
 
     #[test]
-    fn sql_commented_lines_are_stripped() {
+    fn sql_is_sent_verbatim_comments_and_all() {
+        // SQL engines parse `--` natively; the buffer must reach them unchanged
+        // so comment lines can't reflow the surrounding SQL.
         let text = "-- keep this\nSELECT 1";
         match parse_query(Engine::Postgres, text).unwrap() {
-            Query::Sql(s) => assert_eq!(s, "SELECT 1"),
+            Query::Sql(s) => assert_eq!(s, text),
+            _ => panic!("expected Sql"),
+        }
+    }
+
+    #[test]
+    fn sql_commented_where_condition_keeps_real_predicate() {
+        // Regression: a WHERE whose only inline condition is commented, with the
+        // real predicate two lines below (past more comment lines). Stripping
+        // comment lines used to fuse `where` onto the wrong token; raw passthrough
+        // keeps it valid for Postgres to parse.
+        let text = "select a\nfrom t\nwhere -- x = 1\n-- y = 2\nb = 3";
+        match parse_query(Engine::Postgres, text).unwrap() {
+            Query::Sql(s) => assert_eq!(s, text),
             _ => panic!("expected Sql"),
         }
     }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -263,6 +263,8 @@ in-out property <string> rename-text;
     in-out property <bool> db-modal-open: false;
     in-out property <bool> conn-modal-open: false;
     in property <[PaletteItem]> db-items;
+    // Databases the current connection can switch to; empty hides the switcher.
+    in property <[string]> db-list;
     in property <[PaletteItem]> conn-items;
     callback db-choose(int);
     callback conn-choose(int);
@@ -562,7 +564,16 @@ in-out property <string> rename-text;
                     }
                     if root.bc-db != "": VerticalLayout {
                         alignment: center;
-                        BreadcrumbChip { text: root.bc-db; mono: true; }
+                        // Caret + click to switch database only when the engine
+                        // enumerated more than one; otherwise a plain label.
+                        BreadcrumbChip {
+                            text: root.bc-db;
+                            mono: true;
+                            caret: root.db-list.length > 0;
+                            clicked => {
+                                if (root.db-list.length > 0) { root.open-db-modal(); }
+                            }
+                        }
                     }
                     if root.bc-schema != "": Text {
                         text: "›";

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -624,6 +624,16 @@ in-out property <string> rename-text;
                             clicked => { root.results-visible = !root.results-visible; }
                         }
                     }
+                    // divider: the two panel toggles above are a pair; the
+                    // pencil/theme/⚙ that follow are one-shot actions, not toggles.
+                    if root.connected: VerticalLayout {
+                        alignment: center;
+                        Rectangle {
+                            width: 1px;
+                            height: 16px;
+                            background: Tokens.border;
+                        }
+                    }
                     // edit the current connection (distinct from the app ⚙)
                     if root.connected: VerticalLayout {
                         alignment: center;

--- a/app/src/ui/code-editor.slint
+++ b/app/src/ui/code-editor.slint
@@ -192,10 +192,17 @@ export component CodeEditor inherits Rectangle {
 
     // ----- autocomplete popup (overlays the editor, under the caret) -----
     if root.completion-visible && root.completion-items.length > 0: Rectangle {
+        // y below the caret line by default; if that would run past the editor's
+        // bottom edge (deep in a long query / short results pane), flip it above
+        // the caret line so the list stays fully visible instead of clipped.
+        property <length> pop-h: min(root.completion-items.length * 22px + 8px, 200px);
+        property <length> below-y: (root.cursor-line + 1) * root.line-h + 6px;
         x: min(root.gutter-w + Tokens.sp3 + root.cursor-col * root.charw, root.width - self.width - Tokens.sp2);
-        y: (root.cursor-line + 1) * root.line-h + 6px;
+        y: below-y + self.pop-h > root.height && root.cursor-line * root.line-h - self.pop-h - 6px > 0
+            ? root.cursor-line * root.line-h - self.pop-h - 6px
+            : below-y;
         width: 260px;
-        height: min(root.completion-items.length * 22px + 8px, 200px);
+        height: pop-h;
         border-radius: Tokens.radius;
         border-width: 1px;
         border-color: Tokens.border-strong;

--- a/crates/connstore/src/store.rs
+++ b/crates/connstore/src/store.rs
@@ -56,6 +56,13 @@ impl ConnStore {
         Ok(dirs.config_dir().join("recent_queries.json"))
     }
 
+    /// Location of `query_tabs.json` in the same config dir — the persisted
+    /// open query tabs and their SQL text, restored on launch.
+    pub fn query_tabs_path() -> Result<PathBuf> {
+        let dirs = ProjectDirs::from("dev", "dbm", "dbm").ok_or(ConnStoreError::NoConfigDir)?;
+        Ok(dirs.config_dir().join("query_tabs.json"))
+    }
+
     /// Open the store at the platform default path with the runtime-selected
     /// secret backend (keychain, or encrypted-file fallback). Convenience
     /// wrapper over `default_path` + `secret::select_backend` + `load`.

--- a/crates/core/src/driver.rs
+++ b/crates/core/src/driver.rs
@@ -32,6 +32,13 @@ pub trait Driver: Send + Sync {
         Ok(Vec::new())
     }
 
+    /// Databases the connection can switch between (e.g. every DB on a Postgres
+    /// server). Default empty: the engine has a single/implicit database and the
+    /// UI shows its current database without a switcher.
+    async fn list_databases(&self) -> Result<Vec<String>> {
+        Ok(Vec::new())
+    }
+
     /// Schema tree scoped to one namespace (e.g. a specific Postgres schema).
     /// Default delegates to [`Driver::schema`] for engines without namespaces.
     async fn schema_for(&self, _schema: &str) -> Result<Schema> {

--- a/crates/driver-postgres/src/driver.rs
+++ b/crates/driver-postgres/src/driver.rs
@@ -77,6 +77,22 @@ impl Driver for PostgresDriver {
         schema_impl(&self.client, schema).await
     }
 
+    async fn list_databases(&self) -> Result<Vec<String>> {
+        // Every connectable, non-template database on the server. Switching to
+        // one means reconnecting with that dbname (a pg connection is bound to a
+        // single database).
+        let rows = self
+            .client
+            .query(
+                "SELECT datname FROM pg_database \
+                 WHERE NOT datistemplate AND datallowconn ORDER BY 1",
+                &[],
+            )
+            .await
+            .map_err(|e| RdbsError::Schema(pg_err(&e)))?;
+        Ok(rows.iter().map(|r| r.get::<_, String>(0)).collect())
+    }
+
     async fn list_schemas(&self) -> Result<Vec<String>> {
         // pg_namespace lists every schema; information_schema.schemata is
         // filtered to those the role has privileges on, so a restricted prod

--- a/crates/driver-postgres/src/driver.rs
+++ b/crates/driver-postgres/src/driver.rs
@@ -38,7 +38,7 @@ impl Driver for PostgresDriver {
         let (client, conn_task) = if matches!(cfg.sslmode, SslMode::Disable) {
             let (client, connection) = tokio_postgres::connect(&conn_str, NoTls)
                 .await
-                .map_err(|e| RdbsError::Connection(e.to_string()))?;
+                .map_err(|e| RdbsError::Connection(pg_err(&e)))?;
             let conn_task = tokio::spawn(async move {
                 let _ = connection.await;
             });
@@ -52,7 +52,7 @@ impl Driver for PostgresDriver {
             let connector = MakeTlsConnector::new(tls);
             let (client, connection) = tokio_postgres::connect(&conn_str, connector)
                 .await
-                .map_err(|e| RdbsError::Connection(e.to_string()))?;
+                .map_err(|e| RdbsError::Connection(pg_err(&e)))?;
             let conn_task = tokio::spawn(async move {
                 let _ = connection.await;
             });
@@ -65,7 +65,7 @@ impl Driver for PostgresDriver {
         self.client
             .query("SELECT 1", &[])
             .await
-            .map_err(|e| RdbsError::Connection(e.to_string()))?;
+            .map_err(|e| RdbsError::Connection(pg_err(&e)))?;
         Ok(())
     }
 
@@ -90,7 +90,7 @@ impl Driver for PostgresDriver {
                 &[],
             )
             .await
-            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+            .map_err(|e| RdbsError::Schema(pg_err(&e)))?;
         Ok(rows.iter().map(|r| r.get::<_, String>(0)).collect())
     }
 
@@ -113,7 +113,7 @@ impl Driver for PostgresDriver {
                 &[&table.name, &schema],
             )
             .await
-            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+            .map_err(|e| RdbsError::Schema(pg_err(&e)))?;
         Ok(rows.iter().map(|r| r.get::<_, String>(0)).collect())
     }
 
@@ -123,7 +123,7 @@ impl Driver for PostgresDriver {
             .client
             .query_one(&sql, &[])
             .await
-            .map_err(|e| RdbsError::Query(e.to_string()))?;
+            .map_err(|e| RdbsError::Query(pg_err(&e)))?;
         let n: i64 = row.get(0);
         Ok(n as u64)
     }
@@ -136,12 +136,12 @@ impl Driver for PostgresDriver {
             self.client
                 .execute(&sql, &[])
                 .await
-                .map_err(|e| RdbsError::Query(e.to_string()))
+                .map_err(|e| RdbsError::Query(pg_err(&e)))
         };
         self.client
             .execute("BEGIN", &[])
             .await
-            .map_err(|e| RdbsError::Query(e.to_string()))?;
+            .map_err(|e| RdbsError::Query(pg_err(&e)))?;
         let mut affected = 0u64;
         for op in ops {
             let sql = match op {
@@ -160,7 +160,7 @@ impl Driver for PostgresDriver {
         self.client
             .execute("COMMIT", &[])
             .await
-            .map_err(|e| RdbsError::Query(e.to_string()))?;
+            .map_err(|e| RdbsError::Query(pg_err(&e)))?;
         Ok(affected)
     }
 
@@ -174,6 +174,28 @@ impl Driver for PostgresDriver {
     }
 }
 
+/// Turn a `tokio_postgres::Error` into a message worth showing. The error's own
+/// `Display` is just the generic kind ("db error"), so a failed query would
+/// otherwise surface as "query failed: db error". The real SQLSTATE + message
+/// live in `as_db_error()`; when absent (I/O, protocol) walk the `source` chain.
+fn pg_err(e: &tokio_postgres::Error) -> String {
+    use std::error::Error;
+    if let Some(db) = e.as_db_error() {
+        let mut msg = format!("{}: {}", db.code().code(), db.message());
+        if let Some(detail) = db.detail() {
+            msg.push_str(&format!(" — {detail}"));
+        }
+        if let Some(hint) = db.hint() {
+            msg.push_str(&format!(" (hint: {hint})"));
+        }
+        return msg;
+    }
+    match e.source() {
+        Some(src) => format!("{e}: {src}"),
+        None => e.to_string(),
+    }
+}
+
 async fn query_impl(client: &Client, q: &Query) -> Result<ResultSet> {
     let sql = match q {
         Query::Sql(s) => s,
@@ -184,7 +206,7 @@ async fn query_impl(client: &Client, q: &Query) -> Result<ResultSet> {
         let rows = client
             .query(sql, &[])
             .await
-            .map_err(|e| RdbsError::Query(e.to_string()))?;
+            .map_err(|e| RdbsError::Query(pg_err(&e)))?;
         let cols = column_meta(&rows);
         let mut out_rows: Vec<Row> = Vec::with_capacity(rows.len());
         for row in &rows {
@@ -202,7 +224,7 @@ async fn query_impl(client: &Client, q: &Query) -> Result<ResultSet> {
         let affected = client
             .execute(sql, &[])
             .await
-            .map_err(|e| RdbsError::Query(e.to_string()))?;
+            .map_err(|e| RdbsError::Query(pg_err(&e)))?;
         Ok(ResultSet::Affected(affected))
     }
 }
@@ -246,10 +268,10 @@ async fn schema_impl(client: &Client, schema: &str) -> Result<Schema> {
     let db_row = client
         .query_one("SELECT current_database()", &[])
         .await
-        .map_err(|e| RdbsError::Schema(e.to_string()))?;
+        .map_err(|e| RdbsError::Schema(pg_err(&e)))?;
     let db_name: String = db_row
         .try_get(0)
-        .map_err(|e| RdbsError::Schema(e.to_string()))?;
+        .map_err(|e| RdbsError::Schema(pg_err(&e)))?;
 
     // User tables + columns from information_schema, scoped to one schema.
     // Ordered so columns of the same table are contiguous for grouping.
@@ -264,7 +286,7 @@ async fn schema_impl(client: &Client, schema: &str) -> Result<Schema> {
             &[&schema],
         )
         .await
-        .map_err(|e| RdbsError::Schema(e.to_string()))?;
+        .map_err(|e| RdbsError::Schema(pg_err(&e)))?;
 
     let mut containers: Vec<Container> = Vec::new();
     for row in &rows {


### PR DESCRIPTION
## Summary
- Batch of UI/UX + correctness fixes from operator testing against a live Postgres server.
- Fixes two real bugs (masked DB errors, dropped join columns), one persistence gap (query tabs), and several UI polish items.

## Changes
- **driver-postgres**: surface the real Postgres error (SQLSTATE + message + detail/hint) instead of the generic `db error` that `tokio_postgres::Error`'s Display yields.
- **app (result grid)**: disambiguate duplicate result column names (`status`, `status_2`) so a JOIN selecting same-named columns from two tables renders every column.
- **app (console)**: stop force-opening the SQL console on every run; the eye toggle owns its visibility.
- **app (toolbar)**: divider separates the two panel toggles from the one-shot edit-connection pencil (was reading as a third toggle box).
- **app (autocomplete)**: require at least one typed char before the popup appears (dot-completion still fires); flip the popup above the caret when it would be clipped by the editor's bottom edge.
- **core / driver-postgres / app (database switch)**: add `list_databases()` to the `Driver` trait, implement it for Postgres, and turn the breadcrumb database chip into a dropdown. Choosing a database reconnects the current connection with the new dbname and reloads the schema tree.
- **connstore / app (tab persistence)**: persist SQL scratch tabs (id, title, text) + the active tab to `query_tabs.json`; restore on the first connect of the session and across a database switch. Results/browse state stay transient.

## Test plan
- [x] `make fmt-check`
- [x] `make lint` (clippy, warnings as errors)
- [x] `make test` (all lib/unit suites pass; Postgres integration tests require Docker and run via `make test-it`)
- [x] `make fe-run`, connect Postgres:
  - [x] bad query shows the real `ERROR: ...` text, not `db error`
  - [x] JOIN selecting same-named columns from two tables shows all columns
  - [x] hide console, run a query → stays hidden
  - [x] two toggle boxes grouped; edit-connection pencil separated by a divider
  - [x] empty line shows no popup; typing shows it; near the bottom it flips up
  - [x] database breadcrumb lists databases; selecting one reloads schema/tables
  - [x] open tabs + type SQL, restart app → tabs and text restored
