### PR TITLE
feat(ui): improve data grid editing and native releases

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -19,22 +19,28 @@ jobs:
           - os: macos-14 # Apple Silicon
             target: aarch64-apple-darwin
             ext: tar.gz
+            native_asset: rdbs-aarch64-apple-darwin.dmg
           - os: macos-14 # cross-compile Intel on Apple Silicon (no scarce macos-13)
             target: x86_64-apple-darwin
             ext: tar.gz
+            native_asset: rdbs-x86_64-apple-darwin.dmg
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             ext: tar.gz
+            native_asset: rdbs-x86_64-unknown-linux-gnu
           - os: ubuntu-24.04-arm # native GitHub arm64 linux runner
             target: aarch64-unknown-linux-gnu
             ext: tar.gz
+            native_asset: rdbs-aarch64-unknown-linux-gnu
             experimental: true
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             ext: zip
+            native_asset: rdbs-x86_64-pc-windows-msvc.exe
           - os: windows-11-arm # native GitHub arm64 windows runner
             target: aarch64-pc-windows-msvc
             ext: zip
+            native_asset: rdbs-aarch64-pc-windows-msvc.exe
             experimental: true
     runs-on: ${{ matrix.os }}
     # experimental arm legs are best-effort: a failure must not fail the `build`
@@ -62,15 +68,64 @@ jobs:
             libxkbcommon-dev
       - name: Build release binary
         run: cargo build --release -p rdbs --target ${{ matrix.target }}
-      - name: Package (unix)
+      # Keep the archives for Homebrew/Scoop, and also publish files users can
+      # launch directly from the GitHub Release page.
+      - name: Package archive (unix)
         if: runner.os != 'Windows'
         run: |
           tar -czf "rdbs-${{ matrix.target }}.tar.gz" \
             -C "target/${{ matrix.target }}/release" rdbs
-      - name: Package (windows)
+      - name: Package app (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          app="RDBS.app"
+          plist="$app/Contents/Info.plist"
+          iconset="$RUNNER_TEMP/RDBS.iconset"
+          mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources" "$iconset"
+          cp "target/${{ matrix.target }}/release/rdbs" "$app/Contents/MacOS/rdbs"
+
+          icon="app/assets/icon@512.png"
+          sips -z 16 16 "$icon" --out "$iconset/icon_16x16.png"
+          sips -z 32 32 "$icon" --out "$iconset/icon_16x16@2x.png"
+          sips -z 32 32 "$icon" --out "$iconset/icon_32x32.png"
+          sips -z 64 64 "$icon" --out "$iconset/icon_32x32@2x.png"
+          sips -z 128 128 "$icon" --out "$iconset/icon_128x128.png"
+          sips -z 256 256 "$icon" --out "$iconset/icon_128x128@2x.png"
+          sips -z 256 256 "$icon" --out "$iconset/icon_256x256.png"
+          sips -z 512 512 "$icon" --out "$iconset/icon_256x256@2x.png"
+          sips -z 512 512 "$icon" --out "$iconset/icon_512x512.png"
+          iconutil -c icns "$iconset" -o "$app/Contents/Resources/RDBS.icns"
+
+          plutil -create xml1 "$plist"
+          plutil -insert CFBundleDisplayName -string RDBS "$plist"
+          plutil -insert CFBundleExecutable -string rdbs "$plist"
+          plutil -insert CFBundleIconFile -string RDBS.icns "$plist"
+          plutil -insert CFBundleIdentifier -string com.suiflex.rdbs "$plist"
+          plutil -insert CFBundleName -string RDBS "$plist"
+          plutil -insert CFBundlePackageType -string APPL "$plist"
+          plutil -insert CFBundleShortVersionString -string "${VERSION#v}" "$plist"
+          plutil -insert CFBundleVersion -string "${VERSION#v}" "$plist"
+          plutil -insert NSHighResolutionCapable -bool true "$plist"
+
+          codesign --force --deep --sign - "$app"
+          hdiutil create -volname RDBS -srcfolder "$app" -ov -format UDZO \
+            "${{ matrix.native_asset }}"
+      - name: Package executable (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          install -m 755 "target/${{ matrix.target }}/release/rdbs" \
+            "${{ matrix.native_asset }}"
+      - name: Package executables (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
+          Copy-Item `
+            -Path "target/${{ matrix.target }}/release/rdbs.exe" `
+            -Destination "${{ matrix.native_asset }}"
           Compress-Archive `
             -Path "target/${{ matrix.target }}/release/rdbs.exe" `
             -DestinationPath "rdbs-${{ matrix.target }}.zip"
@@ -80,7 +135,8 @@ jobs:
         shell: bash
         run: |
           gh release upload "${{ github.ref_name }}" \
-            "rdbs-${{ matrix.target }}.${{ matrix.ext }}" --clobber
+            "rdbs-${{ matrix.target }}.${{ matrix.ext }}" \
+            "${{ matrix.native_asset }}" --clobber
 
   # ---- publish jobs: siblings, both need `build`, neither needs the other ----
   # A failure in one does NOT cancel the other (GitHub only cancels a job's own

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5615,11 +5615,14 @@ dependencies = [
 
 [[package]]
 name = "rdbs"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "copypasta",
  "json5",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "open",
  "rdbs-connstore",
  "rdbs-core",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -31,5 +31,12 @@ ureq = "2"
 semver = "1"
 open = "5"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+# Set the Dock icon even for `cargo run`; macOS ignores a window icon on an
+# unbundled executable. These crates are already in Slint's winit dependency tree.
+objc2 = "0.6.4"
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["std", "NSApplication", "NSImage"] }
+objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "NSData"] }
+
 [build-dependencies]
 slint-build = "1.8"

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -369,6 +369,83 @@ fn default_browse_limit(engine: rdbs_connstore::Engine) -> u64 {
     }
 }
 
+/// Operators exposed by the active engine. The filter itself is evaluated on
+/// the fetched page, but the vocabulary mirrors what that engine accepts.
+fn filter_operators(engine: rdbs_connstore::Engine) -> Vec<SharedString> {
+    use rdbs_connstore::Engine;
+    let ops: &[&str] = match engine {
+        Engine::Postgres => &[
+            "=",
+            "<>",
+            ">",
+            ">=",
+            "<",
+            "<=",
+            "LIKE",
+            "ILIKE",
+            "IN",
+            "IS NULL",
+            "IS NOT NULL",
+        ],
+        Engine::MySql | Engine::Sqlite => &[
+            "=",
+            "<>",
+            ">",
+            ">=",
+            "<",
+            "<=",
+            "LIKE",
+            "IN",
+            "IS NULL",
+            "IS NOT NULL",
+        ],
+        Engine::Cassandra => &[
+            "=",
+            "<>",
+            ">",
+            ">=",
+            "<",
+            "<=",
+            "IN",
+            "IS NULL",
+            "IS NOT NULL",
+        ],
+        Engine::Redis | Engine::Mongo => &[
+            "=",
+            "<>",
+            ">",
+            ">=",
+            "<",
+            "<=",
+            "IN",
+            "IS NULL",
+            "IS NOT NULL",
+        ],
+    };
+    ops.iter().copied().map(SharedString::from).collect()
+}
+
+#[cfg(target_os = "macos")]
+fn install_macos_app_icon() {
+    use objc2::{AllocAnyThread, MainThreadMarker};
+    use objc2_app_kit::{NSApplication, NSImage};
+    use objc2_foundation::NSData;
+
+    let Some(main_thread) = MainThreadMarker::new() else {
+        return;
+    };
+    let data = NSData::with_bytes(include_bytes!("../assets/icon@512.png"));
+    let Some(icon) = NSImage::initWithData(NSImage::alloc(), &data) else {
+        return;
+    };
+    let app = NSApplication::sharedApplication(main_thread);
+    // SAFETY: `icon` is a live NSImage and AppKit is called on the main thread.
+    unsafe { app.setApplicationIconImage(Some(&icon)) };
+}
+
+#[cfg(not(target_os = "macos"))]
+fn install_macos_app_icon() {}
+
 /// One cached SQL result, shown as a result tab. ⌘⏎ replaces the active one;
 /// ⌘\ appends a new one.
 #[derive(Clone)]
@@ -413,6 +490,10 @@ impl WorkspaceTab {
             pinned: true,
         }
     }
+
+    fn is_preview(&self) -> bool {
+        self.kind == "table" && !self.pinned
+    }
 }
 
 fn table_tab_id(connection_id: &str, database: &str, schema: &str, table: &str) -> String {
@@ -427,7 +508,7 @@ fn workspace_tab_index(tabs: &[WorkspaceTab], active_id: Option<&str>) -> Option
 fn replaceable_table_tab_index(tabs: &[WorkspaceTab], active_id: Option<&str>) -> Option<usize> {
     let index = workspace_tab_index(tabs, active_id)?;
     let tab = &tabs[index];
-    (tab.kind == "table" && !tab.pinned).then_some(index)
+    tab.is_preview().then_some(index)
 }
 
 fn set_workspace_tabs(w: &MainWindow, tabs: &[WorkspaceTab], active_id: Option<&str>) {
@@ -436,6 +517,7 @@ fn set_workspace_tabs(w: &MainWindow, tabs: &[WorkspaceTab], active_id: Option<&
         .map(|tab| TabItem {
             kind: tab.kind.clone().into(),
             title: tab.title.clone().into(),
+            preview: tab.is_preview(),
         })
         .collect();
     w.set_tabs(ModelRc::from(Rc::new(VecModel::from(items))));
@@ -760,6 +842,18 @@ fn view_grid(v: &model::ResultView) -> Option<model::GridModel> {
     }
 }
 
+fn guard_pending_edits(w: &MainWindow, edit_buf: &std::sync::Mutex<model::EditBuffer>) -> bool {
+    let n = edit_buf.lock().unwrap().pending_count();
+    if n == 0 {
+        return false;
+    }
+    w.set_status_error(true);
+    w.set_result_status(SharedString::from(format!(
+        "{n} pending change(s) — ⌘S to commit, or Discard"
+    )));
+    true
+}
+
 /// Clear the tabular grid properties (used by non-tabular result kinds).
 fn clear_grid(w: &MainWindow) {
     w.set_grid_col_count(0);
@@ -827,10 +921,10 @@ async fn fetch_indexes(
 fn cell_matches(cell: &model::VmCell, op: &str, needle: &str) -> bool {
     use std::cmp::Ordering;
     match op {
-        "is null" => cell.is_null,
-        "not null" => !cell.is_null,
+        "is null" | "IS NULL" => cell.is_null,
+        "not null" | "IS NOT NULL" => !cell.is_null,
         "=" => cell.text.to_lowercase() == needle,
-        "≠" | "!=" => cell.text.to_lowercase() != needle,
+        "≠" | "!=" | "<>" => cell.text.to_lowercase() != needle,
         ">" | "<" | ">=" | "<=" => {
             let ord = match (cell.text.parse::<f64>(), needle.parse::<f64>()) {
                 (Ok(a), Ok(b)) => a.partial_cmp(&b),
@@ -843,6 +937,16 @@ fn cell_matches(cell: &model::VmCell, op: &str, needle: &str) -> bool {
                 None => false,
             }
         }
+        "IN" => needle
+            .trim()
+            .trim_matches(['(', ')'])
+            .split(',')
+            .map(|v| v.trim().trim_matches(['\'', '"']).to_lowercase())
+            .any(|v| v == cell.text.to_lowercase()),
+        "LIKE" | "ILIKE" => cell
+            .text
+            .to_lowercase()
+            .contains(needle.trim().trim_matches(['\'', '"']).trim_matches('%')),
         _ => cell.text.to_lowercase().contains(needle),
     }
 }
@@ -860,7 +964,12 @@ fn filter_grid_cond(
     };
     // null checks ignore the value box; other operators with an empty value
     // keep every row (matches the plain filter's behavior)
-    if needle.is_empty() && op != "is null" && op != "not null" {
+    if needle.is_empty()
+        && op != "is null"
+        && op != "not null"
+        && op != "IS NULL"
+        && op != "IS NOT NULL"
+    {
         return g.clone();
     }
     model::GridModel {
@@ -1178,6 +1287,12 @@ fn present_view(
     let mut fcols: Vec<SharedString> = vec![SharedString::from("any column")];
     fcols.extend(colnames.iter().cloned());
     w.set_filter_columns(ModelRc::from(Rc::new(VecModel::from(fcols))));
+    w.set_filter_col(
+        colnames
+            .first()
+            .cloned()
+            .unwrap_or_else(|| SharedString::from("any column")),
+    );
     w.set_all_columns(ModelRc::from(Rc::new(VecModel::from(colnames))));
     *displayed_grid.lock().unwrap() = view_grid(&v);
     {
@@ -1235,25 +1350,11 @@ fn set_result_tabs(w: &MainWindow, count: usize, active: usize) {
     w.set_active_result(active as i32);
 }
 
-/// Format a number with `.` thousands separators (e.g. 1000 → "1.000").
-fn group_thousands(n: u64) -> String {
-    let s = n.to_string();
-    let bytes = s.as_bytes();
-    let mut out = String::with_capacity(s.len() + s.len() / 3);
-    for (i, b) in bytes.iter().enumerate() {
-        if i > 0 && (bytes.len() - i).is_multiple_of(3) {
-            out.push('.');
-        }
-        out.push(*b as char);
-    }
-    out
-}
-
 #[cfg(test)]
 mod fmt_tests {
     use super::{
-        group_thousands, parse_col_filter, replaceable_table_tab_index, table_tab_id,
-        workspace_tab_index, WorkspaceTab,
+        cell_matches, filter_operators, parse_col_filter, replaceable_table_tab_index,
+        table_tab_id, workspace_tab_index, WorkspaceTab,
     };
     #[test]
     fn col_filter_prefix_ops() {
@@ -1268,12 +1369,26 @@ mod fmt_tests {
         );
     }
     #[test]
-    fn groups_thousands_with_dots() {
-        assert_eq!(group_thousands(0), "0");
-        assert_eq!(group_thousands(999), "999");
-        assert_eq!(group_thousands(1000), "1.000");
-        assert_eq!(group_thousands(10_000), "10.000");
-        assert_eq!(group_thousands(1_234_567), "1.234.567");
+    fn ilike_is_postgres_only() {
+        use rdbs_connstore::Engine;
+        assert!(filter_operators(Engine::Postgres)
+            .iter()
+            .any(|op| op == "ILIKE"));
+        assert!(!filter_operators(Engine::MySql)
+            .iter()
+            .any(|op| op == "ILIKE"));
+    }
+
+    #[test]
+    fn table_filter_operators_match_values() {
+        let cell = crate::model::VmCell {
+            text: "Mitra Investindo".into(),
+            is_null: false,
+        };
+        assert!(cell_matches(&cell, "ILIKE", "mitra"));
+        assert!(cell_matches(&cell, "IN", "bank, mitra investindo"));
+        assert!(cell_matches(&cell, "<>", "other"));
+        assert!(!cell_matches(&cell, "=", "other"));
     }
 
     #[test]
@@ -2654,6 +2769,7 @@ fn main() -> Result<(), slint::PlatformError> {
         }
         if screen == "modal-db"
             || screen == "modal-conn"
+            || screen == "modal-add-mongo"
             || screen == "function"
             || screen == "palette"
         {
@@ -2668,6 +2784,12 @@ fn main() -> Result<(), slint::PlatformError> {
                         match which.as_str() {
                             "modal-db" => w.invoke_open_db_modal(),
                             "modal-conn" => w.invoke_open_conn_modal(),
+                            "modal-add-mongo" => {
+                                w.invoke_open_add_form();
+                                w.set_f_engine("MongoDB".into());
+                                w.set_f_port("27017".into());
+                                w.set_f_import_url("mongodb://root:secret@10.1.237.31:32343/admin?authMechanism=DEFAULT&replicaSet=production-rs".into());
+                            }
                             "palette" => w.invoke_toggle_palette(),
                             _ => w.invoke_open_function("uuid_generate_v3".into()),
                         }
@@ -2677,13 +2799,18 @@ fn main() -> Result<(), slint::PlatformError> {
         }
         if screen.starts_with("workspace") {
             let weak = window.as_weak();
+            let table = if screen.starts_with("workspace-users") {
+                "users"
+            } else {
+                "emiten"
+            };
             let t2 = Box::leak(Box::new(slint::Timer::default()));
             t2.start(
                 slint::TimerMode::SingleShot,
                 std::time::Duration::from_millis(1800),
                 move || {
                     if let Some(w) = weak.upgrade() {
-                        w.invoke_open_table("".into(), "emiten".into());
+                        w.invoke_open_table("".into(), table.into());
                     }
                 },
             );
@@ -2722,6 +2849,63 @@ fn main() -> Result<(), slint::PlatformError> {
             when(
                 grid_ready.clone(),
                 Rc::new(|w| w.invoke_cell_edited(0, 2, "Bayan EDITED".into())),
+            );
+        }
+        if screen == "workspace-active-commit" {
+            when(
+                grid_ready.clone(),
+                Rc::new(|w| {
+                    w.invoke_edit_cell(0, 2);
+                    w.set_editing_value("Bayan ACTIVE SAVE".into());
+                    w.invoke_commit_edits();
+                }),
+            );
+        }
+        if screen == "workspace-detail-commit" {
+            when(
+                grid_ready.clone(),
+                Rc::new(|w| {
+                    w.invoke_stage_cell(
+                        0,
+                        2,
+                        "Bayan Resources — long detail value saved from the right panel".into(),
+                    );
+                    w.invoke_commit_edits();
+                }),
+            );
+        }
+        if screen == "workspace-long-edit" {
+            when(
+                grid_ready.clone(),
+                Rc::new(|w| {
+                    w.invoke_cell_edited(
+                        0,
+                        2,
+                        "Bayan Resources — a deliberately long inline value remains visible while editing, wraps inside a bounded overlay, and still supports cursor navigation all the way to the final character."
+                            .into(),
+                    );
+                    w.invoke_edit_cell(0, 2);
+                }),
+            );
+        }
+        if screen == "workspace-pointer-edit" {
+            when(
+                grid_ready.clone(),
+                Rc::new(|w| {
+                    use slint::platform::{PointerEventButton, WindowEvent};
+                    let position = slint::LogicalPosition::new(650.0, 164.0);
+                    for _ in 0..2 {
+                        w.window().dispatch_event(WindowEvent::PointerPressed {
+                            position,
+                            button: PointerEventButton::Left,
+                        });
+                        w.window().dispatch_event(WindowEvent::PointerReleased {
+                            position,
+                            button: PointerEventButton::Left,
+                        });
+                    }
+                    assert_eq!((w.get_editing_row(), w.get_editing_col()), (0, 2));
+                }),
             );
         }
         if screen == "workspace-dirty" {
@@ -2774,6 +2958,38 @@ fn main() -> Result<(), slint::PlatformError> {
             when(
                 Rc::new(|w| w.get_active_table() == "sectors" && w.get_tabs().row_count() == 2),
                 Rc::new(|w| w.invoke_new_tab()),
+            );
+        }
+        if screen == "workspace-filter" {
+            when(
+                grid_ready.clone(),
+                Rc::new(|w| {
+                    w.set_data_filter_open(true);
+                    w.set_filter_col("name".into());
+                    w.set_filter_op("ILIKE".into());
+                    w.set_grid_filter("mitra".into());
+                    w.invoke_apply_filter();
+                }),
+            );
+        }
+        if screen == "workspace-limit" {
+            when(
+                grid_ready.clone(),
+                Rc::new(|w| w.invoke_set_limit("25".into())),
+            );
+        }
+        if screen == "workspace-insert" {
+            when(grid_ready.clone(), Rc::new(|w| w.invoke_add_row()));
+        }
+        if screen == "workspace-users-bool" || screen == "workspace-users-date" {
+            when(grid_ready.clone(), Rc::new(|w| w.invoke_add_row()));
+            let date = screen == "workspace-users-date";
+            when(
+                has_pending.clone(),
+                Rc::new(move |w| {
+                    let rows = w.get_grid_cells().row_count() / w.get_grid_col_count() as usize;
+                    w.invoke_edit_cell(rows.saturating_sub(1) as i32, if date { 4 } else { 3 });
+                }),
             );
         }
         if screen == "sql-select" {
@@ -3054,6 +3270,9 @@ fn main() -> Result<(), slint::PlatformError> {
             let Some(w) = weak.upgrade() else {
                 return;
             };
+            if guard_pending_edits(&w, &edit_buf) {
+                return;
+            }
             let needle = w.get_grid_filter().to_string().to_lowercase();
             let fcol = w.get_filter_col().to_string();
             let fop = w.get_filter_op().to_string();
@@ -3099,6 +3318,9 @@ fn main() -> Result<(), slint::PlatformError> {
             let Some(w) = weak.upgrade() else {
                 return;
             };
+            if guard_pending_edits(&w, &edit_buf) {
+                return;
+            }
             let hidden = hidden_cols.lock().unwrap().clone();
             let order = col_order.lock().unwrap().clone();
             let (scol, sasc) = *sort_state.lock().unwrap();
@@ -3161,6 +3383,9 @@ fn main() -> Result<(), slint::PlatformError> {
             let Some(w) = weak.upgrade() else {
                 return;
             };
+            if guard_pending_edits(&w, &edit_buf) {
+                return;
+            }
             let hidden = hidden_cols.lock().unwrap().clone();
             let order = col_order.lock().unwrap().clone();
             let cfilters = col_filters.lock().unwrap().clone();
@@ -3222,6 +3447,9 @@ fn main() -> Result<(), slint::PlatformError> {
             let Some(w) = weak.upgrade() else {
                 return;
             };
+            if guard_pending_edits(&w, &edit_buf) {
+                return;
+            }
             let from = from.max(0) as usize;
             let widths: Vec<f32> = w.get_grid_col_widths().iter().collect();
             if from >= widths.len() {
@@ -3322,6 +3550,9 @@ fn main() -> Result<(), slint::PlatformError> {
             let Some(w) = weak.upgrade() else {
                 return;
             };
+            if guard_pending_edits(&w, &edit_buf) {
+                return;
+            }
             let idx = i.max(0) as usize;
             let hidden = {
                 let mut h = hidden_cols.lock().unwrap();
@@ -3356,9 +3587,7 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_pending_count(0);
             w.set_editing_row(-1);
             w.set_editing_col(-1);
-            if !hidden.is_empty() {
-                w.set_grid_read_only(true);
-            }
+            w.set_grid_read_only(!hidden.is_empty() || edit_buf.lock().unwrap().pk_cols.is_empty());
             let cfilters = col_filters.lock().unwrap().clone();
             w.set_grid_col_filters(ModelRc::from(Rc::new(VecModel::from(display_col_filters(
                 &cfilters, &order, &hidden,
@@ -3461,8 +3690,11 @@ fn main() -> Result<(), slint::PlatformError> {
                 w.set_active_table(SharedString::default());
                 // Seed the browse page size from the engine default (Mongo = 20).
                 let dft_limit = default_browse_limit(sc.engine);
-                w.set_limit_value(dft_limit as i32);
                 w.set_limit_text(SharedString::from(dft_limit.to_string()));
+                w.set_filter_operators(ModelRc::from(Rc::new(VecModel::from(filter_operators(
+                    sc.engine,
+                )))));
+                w.set_filter_op(SharedString::from("="));
             }
             // Fresh connection: nothing browsed, nothing expanded.
             *cur_engine.borrow_mut() = Some(sc.engine);
@@ -4064,17 +4296,7 @@ fn main() -> Result<(), slint::PlatformError> {
     // silently drop them. Returns true (and says so) when edits are pending.
     let guard_pending: Rc<dyn Fn(&MainWindow) -> bool> = {
         let edit_buf = edit_buf.clone();
-        Rc::new(move |w: &MainWindow| {
-            let n = edit_buf.lock().unwrap().pending_count();
-            if n == 0 {
-                return false;
-            }
-            w.set_status_error(true);
-            w.set_result_status(SharedString::from(format!(
-                "{n} pending change(s) — ⌘S to commit, or Discard"
-            )));
-            true
-        })
+        Rc::new(move |w: &MainWindow| guard_pending_edits(w, &edit_buf))
     };
 
     let run_browse: Rc<dyn Fn()> = {
@@ -4142,12 +4364,12 @@ fn main() -> Result<(), slint::PlatformError> {
                 .clone()
                 .unwrap_or_default();
             let tab_id = table_tab_id(&connection_id, &database_name, &schema_name, &label);
-            if let Some(index) = workspace_tabs
-                .lock()
-                .unwrap()
-                .iter()
-                .position(|tab| tab.id == tab_id)
-            {
+            // Drop the lookup guard before save/restore lock the same tab list.
+            let existing_index = {
+                let tabs = workspace_tabs.lock().unwrap();
+                workspace_tab_index(&tabs, Some(&tab_id))
+            };
+            if let Some(index) = existing_index {
                 save_active_tab(&w);
                 restore_tab(&w, index);
                 return;
@@ -4279,19 +4501,38 @@ fn main() -> Result<(), slint::PlatformError> {
     }
 
     {
+        let weak = window.as_weak();
         let workspace_tabs = workspace_tabs.clone();
         let active_tab_id = active_tab_id.clone();
         window.on_pin_table(move |_db, label| {
             let Some(id) = active_tab_id.lock().unwrap().clone() else {
                 return;
             };
-            if let Some(tab) = workspace_tabs
-                .lock()
-                .unwrap()
+            let mut tabs = workspace_tabs.lock().unwrap();
+            if let Some(tab) = tabs
                 .iter_mut()
                 .find(|tab| tab.id == id && tab.table.as_ref().is_some_and(|t| label == t.name))
             {
                 tab.pinned = true;
+                if let Some(w) = weak.upgrade() {
+                    set_workspace_tabs(&w, &tabs, Some(&id));
+                }
+            }
+        });
+    }
+
+    {
+        let weak = window.as_weak();
+        let workspace_tabs = workspace_tabs.clone();
+        let active_tab_id = active_tab_id.clone();
+        window.on_pin_tab(move |index| {
+            let active = active_tab_id.lock().unwrap().clone();
+            let mut tabs = workspace_tabs.lock().unwrap();
+            if let Some(tab) = tabs.get_mut(index as usize) {
+                tab.pinned = true;
+                if let Some(w) = weak.upgrade() {
+                    set_workspace_tabs(&w, &tabs, active.as_deref());
+                }
             }
         });
     }
@@ -4371,12 +4612,9 @@ fn main() -> Result<(), slint::PlatformError> {
             let Some(w) = weak.upgrade() else {
                 return;
             };
-            // Echo the current limit into both the raw value (stepper math) and
-            // the dotted display, so the field always shows a clean number.
+            // Echo the validated limit so manual edits and paging stay in sync.
             let echo = |w: &MainWindow, l: u64| {
-                w.set_limit_value(l as i32);
                 w.set_limit_text(SharedString::from(l.to_string()));
-                w.set_limit_display(SharedString::from(group_thousands(l)));
             };
             if guard_pending(&w) {
                 echo(&w, browse.lock().unwrap().limit);
@@ -5015,28 +5253,6 @@ fn main() -> Result<(), slint::PlatformError> {
             if let Some(w) = weak.upgrade() {
                 w.set_selected_row(r);
                 w.set_selected_col(c);
-                // Feed the bottom inspector: full cell value, pretty-printed
-                // when it parses as JSON so json/jsonb columns are readable.
-                let cols = w.get_grid_col_count();
-                let val = if cols > 0 && c >= 0 && r >= 0 {
-                    let idx = (r * cols + c) as usize;
-                    w.get_grid_cells().row_data(idx).map(|cell| {
-                        if cell.is_null {
-                            "NULL".to_string()
-                        } else {
-                            let t = cell.text.to_string();
-                            match serde_json::from_str::<serde_json::Value>(&t) {
-                                Ok(v) if v.is_object() || v.is_array() => {
-                                    serde_json::to_string_pretty(&v).unwrap_or(t)
-                                }
-                                _ => t,
-                            }
-                        }
-                    })
-                } else {
-                    None
-                };
-                w.set_selected_cell_value(SharedString::from(val.unwrap_or_default()));
             }
         });
     }
@@ -5055,9 +5271,51 @@ fn main() -> Result<(), slint::PlatformError> {
         })
     };
 
+    // Detail-panel edits join the same buffer as inline grid edits. Avoid a
+    // full-grid repaint per keystroke; selection and commit repaint naturally.
+    {
+        let weak = window.as_weak();
+        let edit_buf = edit_buf.clone();
+        let displayed_grid = displayed_grid.clone();
+        window.on_stage_cell(move |r, c, text| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            if w.get_grid_read_only() || r < 0 || c < 0 {
+                return;
+            }
+            let base = displayed_grid
+                .lock()
+                .unwrap()
+                .as_ref()
+                .map(|g| g.rows.len())
+                .unwrap_or(0);
+            let pending = {
+                let mut buf = edit_buf.lock().unwrap();
+                buf.set_cell(base, r as usize, c as usize, text.to_string());
+                buf.pending_count()
+            };
+            let cols = w.get_grid_col_count();
+            if cols > 0 {
+                let idx = (r * cols + c) as usize;
+                let cells = w.get_grid_cells();
+                if let Some(mut cell) = cells.row_data(idx) {
+                    cell.text = text;
+                    cell.is_null = false;
+                    if cell.state != 3 {
+                        cell.state = 1;
+                    }
+                    cells.set_row_data(idx, cell);
+                }
+            }
+            w.set_pending_count(pending as i32);
+        });
+    }
+
     // ----- inline editing: open editor on double-click -----
     {
         let weak = window.as_weak();
+        let displayed_grid = displayed_grid.clone();
         window.on_edit_cell(move |r, c| {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -5076,8 +5334,28 @@ fn main() -> Result<(), slint::PlatformError> {
                 }
                 return;
             }
+            let cols = w.get_grid_col_count();
+            let value = if r >= 0 && c >= 0 && cols > 0 {
+                w.get_grid_cells()
+                    .row_data((r * cols + c) as usize)
+                    .filter(|cell| !cell.is_null)
+                    .map(|cell| cell.text)
+                    .unwrap_or_default()
+            } else {
+                SharedString::default()
+            };
+            w.set_editing_value(value);
             w.set_editing_row(r);
             w.set_editing_col(c);
+            let base = displayed_grid
+                .lock()
+                .unwrap()
+                .as_ref()
+                .map(|g| g.rows.len())
+                .unwrap_or(0);
+            if r >= base as i32 {
+                w.set_scroll_grid_tick(w.get_scroll_grid_tick() + 1);
+            }
         });
     }
 
@@ -5101,20 +5379,12 @@ fn main() -> Result<(), slint::PlatformError> {
                 .unwrap_or(0);
             {
                 let mut buf = edit_buf.lock().unwrap();
-                let (r, c) = (r as usize, c as usize);
-                if r >= base {
-                    // rows below the fetched page are pending inserts
-                    let i = r - base;
-                    if let Some(row) = buf.inserts.get_mut(i) {
-                        if c < row.len() {
-                            row[c] = text.to_string();
-                        }
-                    }
-                } else {
-                    buf.changes.insert((r, c), text.to_string());
-                }
+                buf.set_cell(base, r as usize, c as usize, text.to_string());
             }
             repaint_edits(&w);
+            if r as usize >= base {
+                w.set_scroll_grid_tick(w.get_scroll_grid_tick() + 1);
+            }
         });
     }
 
@@ -5150,19 +5420,10 @@ fn main() -> Result<(), slint::PlatformError> {
             }
             let nrows = base + edit_buf.lock().unwrap().inserts.len();
             {
-                // same buffer write as cell-edited
-                let mut buf = edit_buf.lock().unwrap();
-                let (r, c) = (r as usize, c as usize);
-                if r >= base {
-                    let i = r - base;
-                    if let Some(row) = buf.inserts.get_mut(i) {
-                        if c < row.len() {
-                            row[c] = text.to_string();
-                        }
-                    }
-                } else {
-                    buf.changes.insert((r, c), text.to_string());
-                }
+                edit_buf
+                    .lock()
+                    .unwrap()
+                    .set_cell(base, r as usize, c as usize, text.to_string());
             }
             // neighbour cell, wrapping across row ends (TablePlus-style)
             let (mut nr, mut nc) = (r, c);
@@ -5190,6 +5451,9 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_selected_col(nc);
             w.set_editing_row(nr);
             w.set_editing_col(nc);
+            if nr as usize >= base {
+                w.set_scroll_grid_tick(w.get_scroll_grid_tick() + 1);
+            }
         });
     }
 
@@ -5221,6 +5485,7 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_selected_row(row_idx as i32);
             w.set_editing_row(row_idx as i32);
             w.set_editing_col(0);
+            w.set_scroll_grid_tick(w.get_scroll_grid_tick() + 1);
         });
     }
 
@@ -5291,10 +5556,28 @@ fn main() -> Result<(), slint::PlatformError> {
         let commit_buf = edit_buf.clone();
         let cur_engine = cur_engine.clone();
         let query_console = query_console.clone();
+        let repaint_edits = repaint_edits.clone();
         window.on_commit_edits(move || {
             let Some(w) = weak.upgrade() else {
                 return;
             };
+            if w.get_editing_row() >= 0 && w.get_editing_col() >= 0 {
+                let base = displayed_grid
+                    .lock()
+                    .unwrap()
+                    .as_ref()
+                    .map(|g| g.rows.len())
+                    .unwrap_or(0);
+                edit_buf.lock().unwrap().set_cell(
+                    base,
+                    w.get_editing_row() as usize,
+                    w.get_editing_col() as usize,
+                    w.get_editing_value().to_string(),
+                );
+                w.set_editing_row(-1);
+                w.set_editing_col(-1);
+                repaint_edits(&w);
+            }
             let ops = {
                 let buf = edit_buf.lock().unwrap();
                 if buf.is_empty() {
@@ -5995,6 +6278,16 @@ fn main() -> Result<(), slint::PlatformError> {
             });
         }
     }
+
+    // AppKit replaces the process icon while Slint initializes its native
+    // window. Apply ours once the event loop has started so raw `cargo run`
+    // binaries get the same Dock icon as packaged builds.
+    let app_icon_timer = slint::Timer::default();
+    app_icon_timer.start(
+        slint::TimerMode::SingleShot,
+        std::time::Duration::from_millis(100),
+        install_macos_app_icon,
+    );
 
     shot::install(&window);
     window.run()

--- a/app/src/mock.rs
+++ b/app/src/mock.rs
@@ -485,6 +485,7 @@ impl MockDriver {
                     Cell::Int(i + 1),
                     Cell::Text(format!("user{:03}@fintech.id", i + 1)),
                     Cell::Text(if i % 3 == 0 { "admin" } else { "member" }.into()),
+                    Cell::Bool(i % 2 == 0),
                     Cell::Null,
                 ]
             })
@@ -496,6 +497,7 @@ impl MockDriver {
                     ("id", "int8"),
                     ("email", "varchar"),
                     ("role", "varchar"),
+                    ("is_active", "bool"),
                     ("deleted_at", "timestamptz"),
                 ],
                 user_rows,

--- a/app/src/model.rs
+++ b/app/src/model.rs
@@ -677,6 +677,16 @@ pub struct EditBuffer {
 }
 
 impl EditBuffer {
+    pub fn set_cell(&mut self, base_rows: usize, row: usize, col: usize, value: String) {
+        if row < base_rows {
+            self.changes.insert((row, col), value);
+        } else if let Some(insert) = self.inserts.get_mut(row - base_rows) {
+            if col < insert.len() {
+                insert[col] = value;
+            }
+        }
+    }
+
     pub fn is_empty(&self) -> bool {
         self.changes.is_empty() && self.deletes.is_empty() && self.inserts.is_empty()
     }
@@ -898,6 +908,16 @@ mod edit_tests {
             pk_cols: vec!["id".into()],
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn set_cell_routes_existing_and_inserted_rows() {
+        let mut b = buf();
+        b.inserts.push(vec![String::new(), String::new()]);
+        b.set_cell(2, 0, 1, "updated".into());
+        b.set_cell(2, 2, 1, "inserted".into());
+        assert_eq!(b.changes.get(&(0, 1)).map(String::as_str), Some("updated"));
+        assert_eq!(b.inserts[0][1], "inserted");
     }
 
     #[test]

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -51,6 +51,14 @@ export component MainWindow inherits Window {
                 enabled: root.connected && root.active-tab >= 0;
                 activated => { root.close-tab(root.active-tab); }
             }
+            MenuItem {
+                title: "Save Changes";
+                // Slint maps Control to the platform primary modifier:
+                // Command on macOS, Control on Windows/Linux.
+                shortcut: @keys(Control + S);
+                enabled: root.connected && (root.pending-count > 0 || root.editing-row >= 0);
+                activated => { root.commit-edits(); }
+            }
             MenuSeparator {}
             MenuItem {
                 title: "Settings…";
@@ -70,9 +78,17 @@ export component MainWindow inherits Window {
                 activated => { root.explain-query(); }
             }
             MenuItem {
-                title: "Find";
+                title: root.active-table != "" ? "Filter Rows" : "Find";
+                shortcut: @keys(Control + F);
                 enabled: root.connected;
-                activated => { root.toggle-find(); }
+                activated => {
+                    if (root.active-table != "") {
+                        root.data-filter-open = true;
+                        root.focus-data-filter-tick += 1;
+                    } else {
+                        root.toggle-find();
+                    }
+                }
             }
         }
         Menu {
@@ -83,9 +99,9 @@ export component MainWindow inherits Window {
                 activated => { root.sidebar-visible = !root.sidebar-visible; }
             }
             MenuItem {
-                title: "Toggle Results";
+                title: "Toggle Details";
                 enabled: root.connected;
-                activated => { root.results-visible = !root.results-visible; }
+                activated => { root.detail-visible = !root.detail-visible; }
             }
             MenuItem {
                 title: "Toggle SQL Console";
@@ -146,6 +162,7 @@ in-out property <string> rename-text;
     callback toggle-group(string);
     callback open-table(string, string);   // (database, container)
     callback pin-table(string, string);    // double-click pins the object tab
+    callback pin-tab(int);                 // double-click pins a preview tab
     callback toggle-fields(string, string); // (database, table) — expand columns inline
     callback toggle-schema-node(string);
     callback select-schema(string);
@@ -189,13 +206,14 @@ in-out property <string> rename-text;
     in property <string> result-status;
     in-out property <int> selected-row: 0;
     in-out property <int> selected-col: -1;
-    in property <string> selected-cell-value;
     in property <int> editing-row: -1;
     in property <int> editing-col: -1;
+    in-out property <string> editing-value;
     callback select-cell(int, int);
     callback edit-cell(int, int);
     callback cell-edited(int, int, string);
     callback edit-cancelled();
+    callback stage-cell(int, int, string);
     in-out property <bool> show-structure: false;
     in property <[StructField]> structure-columns;
     in-out property <string> grid-filter;
@@ -213,7 +231,11 @@ in-out property <string> rename-text;
     callback toggle-column(int);
     in property <[string]> filter-columns;
     in-out property <string> filter-col: "any column";
-    in-out property <string> filter-op: "contains";
+    in property <[string]> filter-operators;
+    in-out property <string> filter-op: "=";
+    in-out property <bool> data-filter-open: false;
+    in-out property <int> focus-data-filter-tick: 0;
+    in-out property <int> scroll-grid-tick: 0;
     in property <[IndexRow]> index-rows;
     callback apply-filter();
     callback apply-mongo-filter();
@@ -239,7 +261,7 @@ in-out property <string> rename-text;
     callback clear-console();
     in-out property <int> sidebar-mode: 0;
     in-out property <bool> sidebar-visible: true;
-    in-out property <bool> results-visible: true;
+    in-out property <bool> detail-visible: true;
     callback editor-key(string, bool, bool, bool) -> bool;
     callback editor-press(int, int);
     callback editor-drag(int, int);
@@ -285,8 +307,6 @@ in-out property <string> rename-text;
     in property <bool> status-error;
     in property <bool> query-running;
     in-out property <string> limit-text: "300";
-    in-out property <int> limit-value: 300;      // raw limit for stepper math
-    in-out property <string> limit-display: "300"; // dotted, e.g. "1.000"
     callback prev-page();
     callback next-page();
     callback refresh-page();
@@ -423,7 +443,12 @@ in-out property <string> rename-text;
                     return accept;
                 }
                 if (e.text == "f") {
-                    root.toggle-find();
+                    if (root.active-table != "") {
+                        root.data-filter-open = true;
+                        root.focus-data-filter-tick += 1;
+                    } else {
+                        root.toggle-find();
+                    }
                     return accept;
                 }
                 if (e.text == "t") {
@@ -615,13 +640,13 @@ in-out property <string> rename-text;
                             clicked => { root.sidebar-visible = !root.sidebar-visible; }
                         }
                     }
-                    // hide/show the results panel (editor takes the space)
+                    // hide/show the selected-row details panel
                     if root.connected: VerticalLayout {
                         alignment: center;
                         IconButton {
-                            icon: "rows";
-                            active: root.results-visible;
-                            clicked => { root.results-visible = !root.results-visible; }
+                            icon: "panel-right";
+                            active: root.detail-visible;
+                            clicked => { root.detail-visible = !root.detail-visible; }
                         }
                     }
                     // edit the current connection (distinct from the app ⚙)
@@ -649,6 +674,15 @@ in-out property <string> rename-text;
                         GlyphButton {
                             glyph: "⚙";
                             clicked => { root.settings-open = true; }
+                        }
+                    }
+                    // SQL log stays available without ever hiding the table.
+                    if root.connected: VerticalLayout {
+                        alignment: center;
+                        IconButton {
+                            icon: "terminal";
+                            active: root.console-open;
+                            clicked => { root.console-open = !root.console-open; }
                         }
                     }
                 }
@@ -792,7 +826,7 @@ in-out property <string> rename-text;
                                         root.select-tab(i);
                                     }
                                     double-clicked => {
-                                        root.open-rename(i, tab.title);
+                                        root.pin-tab(i);
                                     }
                                 }
 
@@ -837,6 +871,7 @@ in-out property <string> rename-text;
                                         color: i == root.active-tab ? Tokens.text : Tokens.text-dim;
                                         font-size: Tokens.font-sm;
                                         font-weight: i == root.active-tab ? Tokens.weight-emphasis : 400;
+                                        font-italic: tab.preview;
                                         overflow: elide;
                                     }
                                     // rename affordance (active or hovered tab)
@@ -881,24 +916,6 @@ in-out property <string> rename-text;
                                     }
                                 }
                             }
-                            // new-tab (+) button, sits right after the last tab
-                            VerticalLayout {
-                                alignment: center;
-                                Rectangle {
-                                    width: 28px;
-                                    height: 26px;
-                                    border-radius: Tokens.radius;
-                                    background: add-tab-ta.has-hover ? Tokens.card : transparent;
-                                    AppIcon {
-                                        name: "plus";
-                                        size: 13px;
-                                        color: add-tab-ta.has-hover ? Tokens.text : Tokens.text-dim;
-                                    }
-                                    add-tab-ta := TouchArea {
-                                        clicked => { root.new-tab(); }
-                                    }
-                                }
-                            }
                             // trailing filler: gives the tab bar an infinite max-width
                             // so the work column (and the window) can stretch full-width
                             Rectangle {
@@ -914,10 +931,9 @@ in-out property <string> rename-text;
 
                     if root.tabs.length > 0: WorkArea {
                         vertical-stretch: 1;
-                        results-visible: root.results-visible;
+                        detail-visible <=> root.detail-visible;
                         console-open <=> root.console-open;
                         console-count: root.query-console.length;
-                        toggle-console => { root.console-open = !root.console-open; }
                         clear-console => { root.clear-console(); }
                         query-text <=> root.query-text;
                         columns: root.grid-columns;
@@ -968,7 +984,11 @@ in-out property <string> rename-text;
                         }
                         filter-columns: root.filter-columns;
                         filter-col <=> root.filter-col;
+                        filter-operators: root.filter-operators;
                         filter-op <=> root.filter-op;
+                        filter-open <=> root.data-filter-open;
+                        focus-filter-tick: root.focus-data-filter-tick;
+                        scroll-grid-tick: root.scroll-grid-tick;
                         index-rows: root.index-rows;
                         editor-key(t, cmd, alt, shift) => { root.editor-key(t, cmd, alt, shift) }
                         editor-press(l, c) => { root.editor-press(l, c); }
@@ -983,9 +1003,9 @@ in-out property <string> rename-text;
                         find-close() => { root.find-close(); }
                         selected-row: root.selected-row;
                         selected-col: root.selected-col;
-                        selected-cell-value: root.selected-cell-value;
                         editing-row: root.editing-row;
                         editing-col: root.editing-col;
+                        editing-value <=> root.editing-value;
                         show-structure <=> root.show-structure;
                         structure-columns: root.structure-columns;
                         grid-filter <=> root.grid-filter;
@@ -1000,8 +1020,6 @@ in-out property <string> rename-text;
                         read-only: root.grid-read-only;
                         query-running: root.query-running;
                         limit-text <=> root.limit-text;
-                        limit-value: root.limit-value;
-                        limit-display: root.limit-display;
                         run => {
                             root.run-query();
                         }
@@ -1043,6 +1061,9 @@ in-out property <string> rename-text;
                         }
                         cell-advance(r, c, t, fwd) => {
                             root.cell-advance(r, c, t, fwd);
+                        }
+                        stage-cell(r, c, t) => {
+                            root.stage-cell(r, c, t);
                         }
                         edit-cancelled() => {
                             root.edit-cancelled();
@@ -1108,9 +1129,7 @@ in-out property <string> rename-text;
                         }
                     }
 
-                    // SQL console body: only shown when toggled open from the
-                    // footer. Collapsed by default; the footer terminal icon is
-                    // the toggle, Clear also lives in the footer.
+                    // SQL console body: toggled from the header terminal icon.
                     if root.console-open: Rectangle {
                         horizontal-stretch: 1;
                         max-width: 100000px;

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -192,6 +192,7 @@ export component FormField inherits Rectangle {
     in property <InputType> input-type: InputType.text;
     callback accepted;
     height: 30px;
+    clip: true;
     border-radius: Tokens.radius;
     border-width: 1px;
     border-color: input.has-focus ? Tokens.accent : Tokens.border;

--- a/app/src/ui/conn-form.slint
+++ b/app/src/ui/conn-form.slint
@@ -15,6 +15,14 @@ export global Swatches {
     ];
 }
 
+component FormLabel inherits Text {
+    width: 82px;
+    color: Tokens.text-dim;
+    font-size: Tokens.font-sm;
+    horizontal-alignment: right;
+    vertical-alignment: center;
+}
+
 export component ConnForm inherits Rectangle {
     in property <bool> open;
     in property <bool> edit-mode;
@@ -45,15 +53,13 @@ export component ConnForm inherits Rectangle {
     background: Tokens.veil;
 
     if root.open: Rectangle {
-        width: 460px;
-        // Hug the content height: a bare Rectangle fills its parent (the full
-        // overlay), which stretched every input. Binding to the layout's
-        // preferred height sizes the card to its rows — buttons stay inside and
-        // inputs keep their natural height.
+        width: min(520px, parent.width - 2 * Tokens.sp4);
+        // Hug the compact row layout; add scrolling only if future fields make
+        // the form taller than the window.
         // ponytail: wrap vbox in a ScrollView only if content ever exceeds the window.
         height: vbox.preferred-height;
         x: (parent.width - self.width) / 2;
-        y: 60px;
+        y: max(Tokens.sp4, (parent.height - self.height) / 2);
         border-radius: Tokens.radius-lg;
         background: Tokens.card;
         border-width: 1px;
@@ -66,130 +72,175 @@ export component ConnForm inherits Rectangle {
             spacing: Tokens.sp2;
 
             Text {
-                text: root.edit-mode ? "Edit Connection" : "New Connection";
+                text: (root.edit-mode ? "Edit " : "") + root.f-engine + " connection";
                 color: Tokens.text;
                 font-size: Tokens.font-md;
+                font-weight: Tokens.weight-emphasis;
+                horizontal-alignment: center;
             }
 
-            Text { text: "Import URL"; color: Tokens.text-dim; font-size: Tokens.font-sm; }
             HorizontalLayout {
+                height: 30px;
                 spacing: Tokens.sp2;
+                FormLabel { text: "Name"; }
+                FormField { horizontal-stretch: 1; text <=> root.f-name; }
+            }
+
+            HorizontalLayout {
+                height: 30px;
+                spacing: Tokens.sp2;
+                FormLabel { text: "Engine"; }
+                SelectBox {
+                    horizontal-stretch: 1;
+                    model: ["PostgreSQL", "MySQL", "Redis", "MongoDB", "SQLite", "Cassandra"];
+                    current-value <=> root.f-engine;
+                    selected(v) => { root.engine-changed(v); }
+                }
+            }
+
+            HorizontalLayout {
+                height: 30px;
+                spacing: Tokens.sp2;
+                FormLabel { text: "Color"; }
+                HorizontalLayout {
+                    alignment: center;
+                    spacing: Tokens.sp2;
+                    for col[i] in Swatches.colors: Rectangle {
+                        width: 22px;
+                        height: 22px;
+                        border-radius: 11px;
+                        background: col;
+                        border-width: Swatches.hexes[i] == root.f-color ? 2px : 0px;
+                        border-color: Tokens.text;
+                        TouchArea { clicked => { root.f-color = Swatches.hexes[i]; } }
+                    }
+                }
+                Rectangle { horizontal-stretch: 1; }
+            }
+
+            import-row := HorizontalLayout {
+                height: 30px;
+                spacing: Tokens.sp2;
+                FormLabel { text: "URL"; }
                 FormField {
+                    horizontal-stretch: 1;
+                    min-width: 0px;
                     text <=> root.f-import-url;
                     placeholder: "postgresql://user:pass@host:5432/db?sslmode=require";
                     accepted => { root.import-url(); }
                 }
-                SecondaryButton { text: "Import"; height: 30px; clicked => { root.import-url(); } }
-            }
-
-            Text { text: "Name"; color: Tokens.text-dim; font-size: Tokens.font-sm; }
-            FormField { text <=> root.f-name; }
-
-            Text { text: "Engine"; color: Tokens.text-dim; font-size: Tokens.font-sm; }
-            SelectBox {
-                model: ["PostgreSQL", "MySQL", "Redis", "MongoDB", "SQLite", "Cassandra"];
-                current-value <=> root.f-engine;
-                selected(v) => { root.engine-changed(v); }
+                SecondaryButton {
+                    text: "Import";
+                    height: 30px;
+                    clicked => { root.import-url(); }
+                }
             }
 
             // SQLite is a local file: one path field, no host/port/user/ssl.
-            if root.f-engine == "SQLite": Text {
-                text: "File"; color: Tokens.text-dim; font-size: Tokens.font-sm;
-            }
-            if root.f-engine == "SQLite": FormField {
-                text <=> root.f-database;
-                placeholder: "/path/to/database.db";
+            if root.f-engine == "SQLite": HorizontalLayout {
+                height: 30px;
+                spacing: Tokens.sp2;
+                FormLabel { text: "File"; }
+                FormField {
+                    horizontal-stretch: 1;
+                    text <=> root.f-database;
+                    placeholder: "/path/to/database.db";
+                }
             }
 
             if root.f-engine != "SQLite": HorizontalLayout {
+                height: 30px;
                 spacing: Tokens.sp2;
-                VerticalLayout {
-                    Text { text: "Host"; color: Tokens.text-dim; font-size: Tokens.font-sm; }
-                    FormField { text <=> root.f-host; }
+                FormLabel { text: "Host"; }
+                FormField { horizontal-stretch: 1; text <=> root.f-host; }
+                Text {
+                    width: 32px;
+                    text: "Port";
+                    color: Tokens.text-dim;
+                    font-size: Tokens.font-sm;
+                    vertical-alignment: center;
                 }
-                VerticalLayout {
-                    width: 110px;
-                    Text { text: "Port"; color: Tokens.text-dim; font-size: Tokens.font-sm; }
-                    FormField { text <=> root.f-port; }
-                }
+                FormField { width: 94px; text <=> root.f-port; }
             }
 
             // Redis has no user/database concept — hide those for it (and SQLite).
             if root.f-engine != "Redis" && root.f-engine != "SQLite": HorizontalLayout {
+                height: 30px;
                 spacing: Tokens.sp2;
-                VerticalLayout {
-                    Text { text: "User"; color: Tokens.text-dim; font-size: Tokens.font-sm; }
-                    FormField { text <=> root.f-user; }
+                FormLabel { text: "User"; }
+                FormField { horizontal-stretch: 1; text <=> root.f-user; }
+                Text {
+                    width: 56px;
+                    text: "Database";
+                    color: Tokens.text-dim;
+                    font-size: Tokens.font-sm;
+                    vertical-alignment: center;
                 }
-                VerticalLayout {
-                    Text { text: "Database"; color: Tokens.text-dim; font-size: Tokens.font-sm; }
-                    FormField { text <=> root.f-database; }
-                }
+                FormField { horizontal-stretch: 1; text <=> root.f-database; }
             }
 
-            if root.f-engine != "SQLite": Text {
-                text: "Password"; color: Tokens.text-dim; font-size: Tokens.font-sm;
-            }
-            if root.f-engine != "SQLite": FormField {
-                text <=> root.f-password; input-type: InputType.password;
+            if root.f-engine != "SQLite": HorizontalLayout {
+                height: 30px;
+                spacing: Tokens.sp2;
+                FormLabel { text: "Password"; }
+                FormField {
+                    horizontal-stretch: 1;
+                    text <=> root.f-password;
+                    input-type: InputType.password;
+                }
             }
 
             // SSL mode only applies to the SQL engines.
-            if root.f-engine == "PostgreSQL" || root.f-engine == "MySQL": Text {
-                text: "SSL"; color: Tokens.text-dim; font-size: Tokens.font-sm;
-            }
-            if root.f-engine == "PostgreSQL" || root.f-engine == "MySQL": SelectBox {
-                model: ["Disable", "Prefer", "Require"];
-                current-value <=> root.f-sslmode;
+            if root.f-engine == "PostgreSQL" || root.f-engine == "MySQL": HorizontalLayout {
+                height: 30px;
+                spacing: Tokens.sp2;
+                FormLabel { text: "SSL mode"; }
+                SelectBox {
+                    horizontal-stretch: 1;
+                    model: ["Disable", "Prefer", "Require"];
+                    current-value <=> root.f-sslmode;
+                }
             }
 
             // Mongo connection options: a query string merged into the URI, or a
             // full mongodb://…/mongodb+srv://… override for Atlas / replica sets.
-            if root.f-engine == "MongoDB": Text {
-                text: "Options / URI"; color: Tokens.text-dim; font-size: Tokens.font-sm;
-            }
-            if root.f-engine == "MongoDB": FormField {
-                text <=> root.f-params;
-                placeholder: "?replicaSet=rs0&authSource=admin  ·  or  mongodb+srv://…";
-            }
-
-            Text { text: "Color"; color: Tokens.text-dim; font-size: Tokens.font-sm; }
-            HorizontalLayout {
+            if root.f-engine == "MongoDB": HorizontalLayout {
+                height: 30px;
                 spacing: Tokens.sp2;
-                for col[i] in Swatches.colors: Rectangle {
-                    width: 22px;
-                    height: 22px;
-                    border-radius: 11px;
-                    background: col;
-                    border-width: Swatches.hexes[i] == root.f-color ? 2px : 0px;
-                    border-color: Tokens.text;
-                    TouchArea { clicked => { root.f-color = Swatches.hexes[i]; } }
+                FormLabel { text: "Options"; }
+                FormField {
+                    horizontal-stretch: 1;
+                    text <=> root.f-params;
+                    placeholder: "replicaSet=rs0&authSource=admin";
                 }
             }
 
-            Text {
+            if root.form-error != "": Text {
                 text: root.form-error;
                 color: Tokens.error;
                 font-size: Tokens.font-sm;
+                horizontal-alignment: center;
             }
 
-            Text {
+            if root.test-busy || root.test-result != "": Text {
                 text: root.test-busy ? "Testing connection…" : root.test-result;
                 color: root.test-ok ? Tokens.ok : Tokens.text-dim;
                 font-size: Tokens.font-sm;
+                horizontal-alignment: center;
             }
 
             HorizontalLayout {
+                height: 30px;
                 spacing: Tokens.sp2;
+                Rectangle { horizontal-stretch: 1; }
                 SecondaryButton {
-                    text: "Test Connection";
+                    text: "Test";
                     height: 30px;
                     enabled: !root.test-busy;
                     clicked => { root.test-conn(); }
                 }
                 PrimaryButton { text: "Save"; height: 30px; clicked => { root.save(); } }
                 SecondaryButton { text: "Cancel"; height: 30px; clicked => { root.cancel(); } }
-                Rectangle {}
                 if root.edit-mode: SecondaryButton { text: "Delete"; height: 30px; clicked => { root.delete-conn(); } }
             }
         }

--- a/app/src/ui/icons.slint
+++ b/app/src/ui/icons.slint
@@ -28,6 +28,7 @@ export component AppIcon inherits Image {
         name == "filter"    ? @image-url("icons/filter.svg")   :
         name == "columns"   ? @image-url("icons/columns.svg")  :
         name == "rows"      ? @image-url("icons/rows.svg")     :
+        name == "panel-right" ? @image-url("icons/panel-right.svg") :
         name == "terminal"  ? @image-url("icons/terminal.svg") :
         name == "layers"    ? @image-url("icons/layers.svg")   :
         name == "sun"       ? @image-url("icons/sun.svg")      :

--- a/app/src/ui/icons/panel-right.svg
+++ b/app/src/ui/icons/panel-right.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M15 3v18"/></svg>

--- a/app/src/ui/structs.slint
+++ b/app/src/ui/structs.slint
@@ -36,8 +36,8 @@ export struct ConnItem {
 // One Host/Port/… row of the connection-detail card.
 export struct KvRow { k: string, v: string }
 export struct StructField { name: string, type-name: string, nullable: bool }
-// `kind` picks the tab glyph: "table" | "sql" | "function".
-export struct TabItem { title: string, kind: string }
+// `kind` picks the tab glyph; preview table tabs are italic until pinned.
+export struct TabItem { title: string, kind: string, preview: bool }
 // One lexed editor token; `kind`: 0 plain · 1 keyword · 2 string ·
 // 3 function · 4 comment · 5 number (mirrors app/src/editor.rs).
 // `sel` = inside the selection (background highlight).

--- a/app/src/ui/tabular-grid.slint
+++ b/app/src/ui/tabular-grid.slint
@@ -3,7 +3,7 @@
 // Cells are flat row-major: row r, col c at r*col-count + c.
 import { Tokens } from "tokens.slint";
 import { GridColumn, GridCell } from "structs.slint";
-import { ScrollView } from "std-widgets.slint";
+import { ComboBox, DatePickerPopup, ScrollView } from "std-widgets.slint";
 
 export component TabularGrid inherits Rectangle {
     in property <[GridColumn]> columns;
@@ -22,14 +22,36 @@ export component TabularGrid inherits Rectangle {
     // inline edit overlay: row/col currently being edited, -1 = none
     in property <int> editing-row: -1;
     in property <int> editing-col: -1;
+    in-out property <string> editing-value;
     callback resize-col(int, length);      // (column index, drag delta)
     callback select-cell(int, int);        // (row, col)
     callback edit-cell(int, int);          // double-click → open inline editor
     callback cell-edited(int, int, string); // Enter in the inline editor
     callback cell-advance(int, int, string, bool); // Tab/Shift+Tab → commit + edit neighbour
     callback edit-cancelled();
+    in property <int> scroll-grid-tick;
+    property <int> date-row: -1;
+    property <int> date-col: -1;
+
+    pure function is-boolean(t: string) -> bool {
+        return t == "bool" || t == "boolean" || t == "BOOL" || t == "BOOLEAN"
+            || t == "MYSQL_TYPE_BIT";
+    }
+
+    pure function is-date(t: string) -> bool {
+        return t == "date" || t == "DATE" || t == "timestamp" || t == "TIMESTAMP"
+            || t == "timestamptz" || t == "TIMESTAMPTZ" || t == "datetime"
+            || t == "DATETIME" || t == "MYSQL_TYPE_DATE" || t == "MYSQL_TYPE_DATETIME"
+            || t == "MYSQL_TYPE_TIMESTAMP";
+    }
+
+    changed scroll-grid-tick => {
+        body.viewport-y = min(0px, body.visible-height - body.viewport-height);
+    }
 
     VerticalLayout {
+        width: 100%;
+        height: 100%;
         // ----- frozen header band: mirrors the body's horizontal scroll so the
         // headers stay put while rows scroll vertically -----
         Rectangle {
@@ -166,7 +188,11 @@ export component TabularGrid inherits Rectangle {
         for r in (root.col-count > 0 ? root.cells.length / root.col-count : 0): Rectangle {
             property <bool> row-deleted: root.cells[r * root.col-count].state == 2;
             property <bool> row-inserted: root.cells[r * root.col-count].state == 3;
-            height: Tokens.grid-row-h;
+            property <bool> expanded-editor: r == root.editing-row && root.editing-col >= 0
+                && root.editing-col < root.columns.length
+                && !root.is-boolean(root.columns[root.editing-col].type-name)
+                && !root.is-date(root.columns[root.editing-col].type-name);
+            height: self.expanded-editor ? 52px : Tokens.grid-row-h;
             background: row-deleted ? Tokens.error-tint
                 : row-inserted ? Tokens.ok-tint
                 : r == root.selected-row ? Tokens.accent-tint.with-alpha(0.55)
@@ -198,7 +224,7 @@ export component TabularGrid inherits Rectangle {
                         || root.columns[c].type-name == "int8"
                         || root.columns[c].type-name == "numeric";
                     width: root.col-widths.length > c ? root.col-widths[c] : 140px;
-                    clip: true;
+                    clip: !(r == root.editing-row && c == root.editing-col);
                     background: transparent;
                     cell-ta := TouchArea {
                         clicked => { root.select-cell(r, c); }
@@ -255,22 +281,89 @@ export component TabularGrid inherits Rectangle {
                     }
                     // inline editor overlay
                     if r == root.editing-row && c == root.editing-col: Rectangle {
+                        property <bool> compact-editor: root.is-boolean(root.columns[c].type-name)
+                            || root.is-date(root.columns[c].type-name);
+                        property <length> editor-w: self.compact-editor ? parent.width
+                            : max(parent.width, min(520px, root.width - 2 * Tokens.sp2));
+                        property <length> visible-x: parent.x + body.viewport-x;
+                        z: 100;
+                        x: self.compact-editor ? 0px
+                            : max(-self.visible-x, min(0px, root.width - self.visible-x - self.editor-w));
+                        width: self.editor-w;
+                        height: parent.height;
                         background: Tokens.card;
                         border-width: 2px;
                         border-color: Tokens.edit-outline;
-                        edit-input := TextInput {
+                        if root.is-boolean(root.columns[c].type-name): ComboBox {
+                            x: 1px;
+                            y: 1px;
+                            width: parent.width - 2px;
+                            height: parent.height - 2px;
+                            model: ["true", "false"];
+                            current-value: cell.is-null ? "" : cell.text;
+                            selected(value) => {
+                                root.editing-value = value;
+                                root.cell-edited(r, c, value);
+                            }
+                        }
+                        if root.is-date(root.columns[c].type-name): HorizontalLayout {
+                            padding-left: Tokens.sp2;
+                            padding-right: 2px;
+                            spacing: Tokens.sp1;
+                            date-input := TextInput {
+                                horizontal-stretch: 1;
+                                vertical-alignment: center;
+                                text: cell.is-null ? "" : cell.text;
+                                edited => { root.editing-value = self.text; }
+                                color: Tokens.text;
+                                font-family: Tokens.mono;
+                                font-size: Tokens.font-sm;
+                                single-line: true;
+                                accepted => { root.cell-edited(r, c, self.text); }
+                                key-pressed(e) => {
+                                    if (e.text == Key.Escape) { root.edit-cancelled(); return accept; }
+                                    return reject;
+                                }
+                                init => { self.focus(); self.select-all(); }
+                            }
+                            Rectangle {
+                                width: 22px;
+                                Text {
+                                    text: "▣";
+                                    color: Tokens.text-dim;
+                                    vertical-alignment: center;
+                                    horizontal-alignment: center;
+                                }
+                                TouchArea {
+                                    clicked => {
+                                        root.date-row = r;
+                                        root.date-col = c;
+                                        date-picker.show();
+                                    }
+                                }
+                            }
+                        }
+                        if !root.is-boolean(root.columns[c].type-name) && !root.is-date(root.columns[c].type-name): edit-input := TextInput {
                             x: Tokens.sp2;
+                            y: Tokens.sp1;
                             width: parent.width - 2 * Tokens.sp2;
-                            vertical-alignment: center;
+                            height: parent.height - 2 * Tokens.sp1;
+                            vertical-alignment: top;
                             text: cell.is-null ? "" : cell.text;
+                            edited => { root.editing-value = self.text; }
                             color: Tokens.text;
                             font-family: Tokens.mono;
                             font-size: Tokens.font-sm;
-                            single-line: true;
+                            single-line: false;
+                            wrap: word-wrap;
                             accepted => { root.cell-edited(r, c, self.text); }
                             key-pressed(e) => {
                                 if (e.text == Key.Escape) {
                                     root.edit-cancelled();
+                                    return accept;
+                                }
+                                if (e.text == Key.Return) {
+                                    root.cell-edited(r, c, self.text);
                                     return accept;
                                 }
                                 if (e.text == Key.Tab || e.text == Key.Backtab) {
@@ -288,6 +381,17 @@ export component TabularGrid inherits Rectangle {
                 Rectangle { horizontal-stretch: 1; }
             }
         }
+            }
+        }
+    }
+
+    date-picker := DatePickerPopup {
+        title: "Select date";
+        accepted(d) => {
+            if (root.date-row >= 0 && root.date-col >= 0) {
+                root.cell-edited(root.date-row, root.date-col,
+                    "\{d.year}-" + (d.month < 10 ? "0" : "") + "\{d.month}-"
+                    + (d.day < 10 ? "0" : "") + "\{d.day}");
             }
         }
     }

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -7,7 +7,7 @@ import { CodeEditor } from "code-editor.slint";
 import { TabularGrid } from "tabular-grid.slint";
 import { PaletteItem } from "palette.slint";
 import {
-    UnderlineSegment, SecondaryButton, PrimaryButton, TextButton, FilterField, KeyCap, IconButton
+    UnderlineSegment, SecondaryButton, PrimaryButton, TextButton, FilterField, KeyCap
 } from "components.slint";
 import { ScrollView, ComboBox } from "std-widgets.slint";
 import { AppIcon } from "icons.slint";
@@ -18,13 +18,11 @@ export component WorkArea inherits Rectangle {
     property <bool> editor-collapsed: false;
     // Reveal the query editor while browsing a table/collection (default closed).
     property <bool> browse-editor-open: false;
-    // Hide the results panel (editor takes the space) — header toggle.
-    in property <bool> results-visible: true;
+    in-out property <bool> detail-visible: true;
     // SQL console (rendered by MainWindow below the work column); the footer
     // holds the toggle + clear so it reads as one bottom bar.
     in-out property <bool> console-open: false;
     in property <int> console-count: 0;
-    callback toggle-console();
     callback clear-console();
     in-out property <string> query-text;
     in property <[GridColumn]> columns;
@@ -43,7 +41,6 @@ export component WorkArea inherits Rectangle {
     in property <string> status-latency;
     in-out property <int> selected-row: 0;
     in-out property <int> selected-col: -1;
-    in property <string> selected-cell-value;   // full text of the selected cell (pretty JSON when it parses)
     in property <int> editing-row: -1;
     in property <int> editing-col: -1;
     in-out property <bool> show-structure: false;
@@ -107,9 +104,6 @@ export component WorkArea inherits Rectangle {
     in-out property <string> limit-text;
     // Draggable height of the SQL editor pane (session-local).
     in-out property <length> editor-h: 340px;
-    in property <int> limit-value;
-    in property <string> limit-display;
-
     // Browse chrome shows whenever a table is open in this tab.
     property <bool> browse-mode: root.active-table != "";
     // Footer view segments: 0 Data · 1 Structure · 2 Indexes
@@ -118,7 +112,10 @@ export component WorkArea inherits Rectangle {
     in-out property <bool> filter-open: false;
     in property <[string]> filter-columns;   // "any column" + real columns
     in-out property <string> filter-col: "any column";
-    in-out property <string> filter-op: "contains";
+    in property <[string]> filter-operators;
+    in-out property <string> filter-op: "=";
+    in property <int> focus-filter-tick;
+    in property <int> scroll-grid-tick;
 
     callback run();
     callback run-selection();
@@ -145,6 +142,8 @@ export component WorkArea inherits Rectangle {
     callback edit-cell(int, int);
     callback cell-edited(int, int, string);
     callback cell-advance(int, int, string, bool);
+    callback stage-cell(int, int, string);
+    in-out property <string> editing-value;
     callback edit-cancelled();
     callback prev-page();
     callback next-page();
@@ -240,17 +239,6 @@ export component WorkArea inherits Rectangle {
                         }
                     }
                 }
-                // search-in-table
-                VerticalLayout {
-                    alignment: center;
-                    FilterField {
-                        width: 200px;
-                        height: 28px;
-                        placeholder: "Search in " + root.active-table + "...";
-                        text <=> root.grid-filter;
-                        edited(t) => { root.apply-filter(); }
-                    }
-                }
                 VerticalLayout {
                     alignment: center;
                     SecondaryButton {
@@ -290,6 +278,48 @@ export component WorkArea inherits Rectangle {
                         refresh-ta := TouchArea { clicked => { root.refresh-page(); } }
                     }
                 }
+            }
+        }
+
+        // One TablePlus-style condition row. Apply and Enter share the same
+        // callback; the toolbar and footer no longer expose duplicate triggers.
+        if root.browse-mode && root.filter-open: Rectangle {
+            property <int> focus-tick: root.focus-filter-tick;
+            changed focus-tick => { filter-value.focus-input(); }
+            height: 38px;
+            background: Tokens.chrome;
+            border-width: 1px;
+            border-color: Tokens.border;
+            HorizontalLayout {
+                padding-left: Tokens.sp3;
+                padding-right: Tokens.sp3;
+                padding-top: 4px;
+                padding-bottom: 4px;
+                spacing: Tokens.sp2;
+                ComboBox {
+                    width: 180px;
+                    model: root.filter-columns;
+                    current-value <=> root.filter-col;
+                }
+                ComboBox {
+                    width: 120px;
+                    model: root.filter-operators;
+                    current-value <=> root.filter-op;
+                }
+                filter-value := FilterField {
+                    horizontal-stretch: 1;
+                    max-width: 420px;
+                    placeholder: root.filter-op == "IS NULL" || root.filter-op == "IS NOT NULL"
+                        ? "No value required" : "Value";
+                    text <=> root.grid-filter;
+                    submitted => { root.apply-filter(); }
+                }
+                PrimaryButton {
+                    text: "Apply";
+                    height: 28px;
+                    clicked => { root.apply-filter(); }
+                }
+                Rectangle { horizontal-stretch: 1; }
             }
         }
 
@@ -346,8 +376,7 @@ export component WorkArea inherits Rectangle {
         // ================= SQL editor (non-browse tabs) =================
         // Also shown over a browse grid when the user opens "Query ▸".
         if (!root.browse-mode || root.browse-editor-open) && !root.fn-mode: Rectangle {
-            // when results are hidden the editor stretches to fill the work area
-            vertical-stretch: root.results-visible ? 0.0 : 1.0;
+            vertical-stretch: 0.0;
             preferred-height: root.editor-h;
             background: Tokens.canvas;
             VerticalLayout {
@@ -392,52 +421,6 @@ export component WorkArea inherits Rectangle {
                         color: Tokens.text-faint;
                         font-size: Tokens.font-sm;
                         vertical-alignment: center;
-                    }
-                    VerticalLayout {
-                        alignment: center;
-                        HorizontalLayout {
-                            // pack the label + stepper tight against the right edge
-                            // instead of stretching them apart across the row.
-                            alignment: end;
-                            spacing: Tokens.sp2;
-                            Text {
-                                text: "Limit";
-                                color: Tokens.text-faint;
-                                font-size: Tokens.font-sm;
-                                vertical-alignment: center;
-                            }
-                            SecondaryButton {
-                                text: "−";
-                                height: 28px;
-                                clicked => { root.set-limit("\{root.limit-value - 100}"); }
-                            }
-                            // editable field; Rust reformats with dot separators
-                            Rectangle {
-                                width: 76px;
-                                height: 28px;
-                                border-radius: Tokens.radius;
-                                border-width: 1px;
-                                border-color: Tokens.border-strong;
-                                background: Tokens.card;
-                                limit-input := TextInput {
-                                    x: Tokens.sp2;
-                                    width: parent.width - 2 * Tokens.sp2;
-                                    vertical-alignment: center;
-                                    horizontal-alignment: right;
-                                    text: root.limit-display;
-                                    color: Tokens.text;
-                                    font-family: Tokens.mono;
-                                    font-size: Tokens.font-sm;
-                                    single-line: true;
-                                    accepted => { root.set-limit(self.text); }
-                                }
-                            }
-                            SecondaryButton {
-                                text: "+";
-                                height: 28px;
-                                clicked => { root.set-limit("\{root.limit-value + 100}"); }
-                            }
-                        }
                     }
                 }
                 // find bar (⌘F): input + match count + prev/next + close
@@ -526,9 +509,9 @@ export component WorkArea inherits Rectangle {
                     drag-pos(l, c) => { root.editor-drag(l, c); }
                     select-word(l, c) => { root.editor-select-word(l, c); }
                 }
-                if root.results-visible: Rectangle { height: 1px; background: Tokens.border; }
+                Rectangle { height: 1px; background: Tokens.border; }
                 // results header strip
-                if root.results-visible: HorizontalLayout {
+                HorizontalLayout {
                     height: 34px;
                     padding-left: Tokens.sp3;
                     padding-right: Tokens.sp3;
@@ -549,13 +532,13 @@ export component WorkArea inherits Rectangle {
                     }
                     Rectangle { horizontal-stretch: 1; }
                     TextButton { text: root.editor-collapsed ? "Editor ▸" : "Editor ▾"; clicked => { root.editor-collapsed = !root.editor-collapsed; } }
-                    TextButton { text: root.filter-open ? "Filter ▲" : "Filter ▼"; clicked => { root.filter-open = !root.filter-open; } }
+                    if !root.browse-mode: TextButton { text: root.filter-open ? "Filter ▲" : "Filter ▼"; clicked => { root.filter-open = !root.filter-open; } }
                     TextButton { text: "Copy"; clicked => { root.copy-results(); } }
                     TextButton { text: "Export CSV"; clicked => { root.export-csv(); } }
                     TextButton { text: "Chart"; clicked => { root.sql-view-mode = 2; } }
                 }
                 // result tabs — appear once ⌘\ has spawned a second result
-                if root.results-visible && root.result-tabs.length > 1: HorizontalLayout {
+                if root.result-tabs.length > 1: HorizontalLayout {
                     height: 30px;
                     padding-left: Tokens.sp3;
                     padding-right: Tokens.sp3;
@@ -595,7 +578,7 @@ export component WorkArea inherits Rectangle {
         }
 
         // draggable splitter: grow/shrink the editor vs the results (SQL tabs)
-        if (!root.browse-mode || root.browse-editor-open) && !root.fn-mode && root.results-visible: Rectangle {
+        if (!root.browse-mode || root.browse-editor-open) && !root.fn-mode: Rectangle {
             height: 6px;
             background: split-ta.has-hover || split-ta.pressed ? Tokens.accent : Tokens.chrome;
             split-ta := TouchArea {
@@ -612,13 +595,18 @@ export component WorkArea inherits Rectangle {
         // columns) and are toggled by `filter-open`; see the "Filter" button.
 
         // ================= result body =================
-        if !root.fn-mode && root.results-visible: body := Rectangle {
+        if !root.fn-mode: body := Rectangle {
+            property <bool> detail-shown: root.detail-visible && root.view-mode == 0
+                && root.result-kind == 0 && root.col-count > 0 && root.selected-row >= 0
+                && (root.selected-row + 1) * root.col-count <= root.cells.length;
+            property <length> detail-w: min(320px, max(240px, self.width * 0.32));
             vertical-stretch: 1;
             background: Tokens.canvas;
 
             // Data grid — SQL/KeyValue, and Mongo documents in grid view.
             if root.view-mode == 0 && (root.browse-mode || root.sql-view-mode == 0) && (root.result-kind == 0 || root.result-kind == 2 || (root.result-kind == 1 && root.doc-view == 0)): TabularGrid {
-                width: 100%;
+                x: 0;
+                width: body.detail-shown ? body.width - body.detail-w - 1px : body.width;
                 height: 100%;
                 columns: root.columns;
                 cells: root.cells;
@@ -628,58 +616,117 @@ export component WorkArea inherits Rectangle {
                 sort-asc: root.grid-sort-asc;
                 sort-col(i) => { root.sort-col(i); }
                 reorder-col(i, x) => { root.reorder-col(i, x); }
-                filter-open: root.filter-open;
+                filter-open: false;
                 col-filter-values: root.grid-col-filters;
                 set-col-filter(i, t) => { root.set-col-filter(i, t); }
                 selected-row <=> root.selected-row;
                 selected-col <=> root.selected-col;
                 editing-row: root.editing-row;
                 editing-col: root.editing-col;
+                editing-value <=> root.editing-value;
                 resize-col(i, d) => { root.resize-col(i, d); }
                 select-cell(r, c) => { root.select-cell(r, c); }
                 edit-cell(r, c) => { root.edit-cell(r, c); }
                 cell-edited(r, c, t) => { root.cell-edited(r, c, t); }
                 cell-advance(r, c, t, fwd) => { root.cell-advance(r, c, t, fwd); }
                 edit-cancelled() => { root.edit-cancelled(); }
+                scroll-grid-tick: root.scroll-grid-tick;
             }
 
-            // Selected-cell inspector: full value of the clicked cell (pretty
-            // JSON when it parses). Overlays the grid's bottom edge, only while
-            // a cell is selected — lets long/JSON cells stay single-line above.
-            // Drag the top edge to resize (row-resize like the column handles).
-            if root.result-kind == 0 && root.selected-col >= 0 && root.selected-cell-value != "": panel := Rectangle {
-                property <length> panel-h: 200px;
-                y: parent.height - self.height;
-                height: clamp(self.panel-h, 60px, body.height - 60px);
-                width: 100%;
+            if body.detail-shown: Rectangle {
+                x: body.width - body.detail-w;
+                width: body.detail-w;
+                height: 100%;
                 background: Tokens.card;
-                ScrollView {
-                    y: 5px;
-                    width: 100%;
-                    height: parent.height - 5px;
-                    VerticalLayout {
-                        padding: Tokens.sp3;
-                        Text {
-                            text: root.selected-cell-value;
-                            color: Tokens.text;
-                            font-family: Tokens.mono;
-                            font-size: Tokens.font-sm;
-                            wrap: word-wrap;
+                border-width: 1px;
+                border-color: Tokens.border;
+
+                VerticalLayout {
+                    spacing: 0;
+                    Rectangle {
+                        height: 40px;
+                        background: Tokens.chrome;
+                        HorizontalLayout {
+                            padding-left: Tokens.sp3;
+                            padding-right: Tokens.sp3;
+                            Text {
+                                text: "Details";
+                                color: Tokens.text;
+                                font-size: Tokens.font-sm;
+                                font-weight: 600;
+                                vertical-alignment: center;
+                            }
+                            Rectangle { horizontal-stretch: 1; }
+                            Text {
+                                text: "Row " + (root.selected-row + 1);
+                                color: Tokens.text-faint;
+                                font-family: Tokens.mono;
+                                font-size: Tokens.font-xs;
+                                vertical-alignment: center;
+                            }
                         }
                     }
-                }
-                // top drag handle: 5px grab strip; dragging up grows the panel.
-                Rectangle {
-                    height: 5px;
-                    y: 0;
-                    width: 100%;
-                    background: grip.has-hover || grip.pressed ? Tokens.accent : Tokens.border-strong;
-                    grip := TouchArea {
-                        mouse-cursor: row-resize;
-                        moved => {
-                            panel.panel-h = clamp(
-                                panel.height - (self.mouse-y - self.pressed-y),
-                                60px, body.height - 60px);
+                    Rectangle { height: 1px; background: Tokens.border; }
+                    ScrollView {
+                        vertical-stretch: 1;
+                        VerticalLayout {
+                            padding: Tokens.sp3;
+                            spacing: Tokens.sp3;
+                            for c in root.col-count: Rectangle {
+                                property <GridCell> detail-cell: root.cells[root.selected-row * root.col-count + c];
+                                height: 96px;
+                                VerticalLayout {
+                                    spacing: Tokens.sp1;
+                                    HorizontalLayout {
+                                        Text {
+                                            text: root.columns[c].name;
+                                            color: Tokens.text-dim;
+                                            font-family: Tokens.mono;
+                                            font-size: Tokens.font-xs;
+                                            overflow: elide;
+                                        }
+                                        Rectangle { horizontal-stretch: 1; }
+                                        Text {
+                                            text: root.columns[c].type-name;
+                                            color: Tokens.text-faint;
+                                            font-family: Tokens.mono;
+                                            font-size: Tokens.font-xs;
+                                        }
+                                    }
+                                    Rectangle {
+                                        vertical-stretch: 1;
+                                        clip: true;
+                                        border-radius: Tokens.radius;
+                                        border-width: 1px;
+                                        border-color: detail-input.has-focus ? Tokens.accent : Tokens.border-strong;
+                                        background: Tokens.canvas;
+                                        detail-input := TextInput {
+                                            x: Tokens.sp2;
+                                            y: Tokens.sp2;
+                                            width: parent.width - 2 * Tokens.sp2;
+                                            height: parent.height - 2 * Tokens.sp2;
+                                            text: detail-cell.is-null ? "" : detail-cell.text;
+                                            enabled: !root.read-only;
+                                            single-line: false;
+                                            wrap: word-wrap;
+                                            vertical-alignment: top;
+                                            color: root.read-only ? Tokens.text-dim : Tokens.text;
+                                            font-family: Tokens.mono;
+                                            font-size: Tokens.font-sm;
+                                            edited => { root.stage-cell(root.selected-row, c, self.text); }
+                                        }
+                                        if detail-cell.is-null && detail-input.text == "": Text {
+                                            x: Tokens.sp2;
+                                            y: Tokens.sp2;
+                                            text: "NULL";
+                                            color: Tokens.text-ghost;
+                                            font-family: Tokens.mono;
+                                            font-size: Tokens.font-sm;
+                                            font-italic: true;
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -971,6 +1018,32 @@ export component WorkArea inherits Rectangle {
                 if root.browse-mode: HorizontalLayout {
                     spacing: Tokens.sp2;
                     alignment: center;
+                    Text {
+                        text: "Limit";
+                        color: Tokens.text-faint;
+                        font-size: Tokens.font-sm;
+                        vertical-alignment: center;
+                    }
+                    Rectangle {
+                        width: 58px;
+                        height: 24px;
+                        border-radius: Tokens.radius;
+                        border-width: 1px;
+                        border-color: Tokens.border-strong;
+                        background: Tokens.card;
+                        TextInput {
+                            x: 0;
+                            width: parent.width;
+                            text <=> root.limit-text;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                            single-line: true;
+                            color: Tokens.text;
+                            font-family: Tokens.mono;
+                            font-size: Tokens.font-sm;
+                            accepted => { root.set-limit(self.text); }
+                        }
+                    }
                     Rectangle {
                         width: 22px;
                         height: 22px;
@@ -1028,10 +1101,6 @@ export component WorkArea inherits Rectangle {
                     alignment: end;
                     VerticalLayout {
                         alignment: center;
-                        SecondaryButton { text: "Filters"; height: 24px; clicked => { root.filter-open = !root.filter-open; } }
-                    }
-                    VerticalLayout {
-                        alignment: center;
                         SecondaryButton { text: "Columns"; height: 24px; clicked => { root.columns-open = !root.columns-open; } }
                     }
                     VerticalLayout {
@@ -1047,24 +1116,11 @@ export component WorkArea inherits Rectangle {
                         SecondaryButton { text: "Export"; height: 24px; clicked => { root.export-csv(); } }
                     }
                 }
-                // SQL console: toggle (terminal icon) + Clear when open
-                HorizontalLayout {
-                    spacing: Tokens.sp1;
-                    alignment: end;
-                    if root.console-open: VerticalLayout {
-                        alignment: center;
-                        TextButton {
-                            text: "Clear";
-                            clicked => { root.clear-console(); }
-                        }
-                    }
-                    VerticalLayout {
-                        alignment: center;
-                        IconButton {
-                            icon: "view";
-                            active: root.console-open;
-                            clicked => { root.toggle-console(); }
-                        }
+                if root.console-open: VerticalLayout {
+                    alignment: center;
+                    TextButton {
+                        text: "Clear";
+                        clicked => { root.clear-console(); }
                     }
                 }
                 // ● 12 ms


### PR DESCRIPTION
## What changed

- make table limits editable and add engine-aware column/operator filters
- support inline and Details-panel row editing, keyboard save, typed insert controls, and bounded long-value editors
- publish macOS DMGs, Linux executables, and Windows EXEs while retaining Homebrew/Scoop archives
- package the macOS binary as an icon-bearing, ad-hoc-signed `.app` inside the DMG

## Why

The data grid previously exposed controls that could not complete the expected edit workflow, and release builds only uploaded compressed binaries. macOS users could not install a normal app bundle from those assets.

## Impact

Users can edit and save rows from the grid or Details panel, filter with operators supported by the active database engine, change result limits, insert typed values, and download native release assets for each platform.

## Validation

- `make all` (format, Clippy, 124 tests, workspace build)
- native Slint smoke tests: pointer edit, Details commit, filter, limit, and long-value edit
- macOS bundle launch smoke test
- `hdiutil verify`, `codesign --verify --deep --strict`, and `plutil -lint`
- workflow YAML parse and `git diff --check`

## Review note

The macOS app is ad-hoc signed. Developer ID signing and notarization require Apple credentials in repository secrets.
