### PR TITLE
feat: autocomplete fixes, header/sidebar UX, Details panel, npm dist

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -183,6 +183,24 @@ jobs:
           git commit -m "rdbs ${VERSION}" || { echo "no change"; exit 0; }
           git push
 
+  # Publishes @suiflex/rdb to npm. The package's postinstall downloads the
+  # matching release asset (already uploaded by `build`) at the user's install
+  # time, so this job only ships the tiny installer, not the binaries.
+  publish-npm:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+      - name: Publish to npm
+        working-directory: npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
+
   publish-scoop:
     needs: [build]
     runs-on: ubuntu-latest

--- a/app/src/completion.rs
+++ b/app/src/completion.rs
@@ -65,10 +65,12 @@ fn all_columns(nodes: &[VmTreeNode]) -> Vec<Candidate> {
 }
 
 /// Map a table name or `FROM tbl alias` alias to its underlying table name.
+/// `.` stays inside a token so a schema-qualified `schema.table alias` keeps the
+/// table reference whole and the alias is read as the next token.
 fn resolve_alias(stmt: &str, owner: &str) -> String {
     let ol = owner.to_lowercase();
     let words: Vec<&str> = stmt
-        .split(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+        .split(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == '.'))
         .filter(|w| !w.is_empty())
         .collect();
     for i in 0..words.len() {
@@ -159,7 +161,9 @@ fn schemas(nodes: &[VmTreeNode]) -> Vec<Candidate> {
 /// Columns are the `field` nodes that follow a matching table node in the flat
 /// tree (the sidebar stores parent-then-children order).
 fn columns_of(nodes: &[VmTreeNode], owner: &str) -> Vec<Candidate> {
-    let owner_l = owner.to_lowercase();
+    // Tree labels are bare table names; a schema-qualified owner
+    // (`schema.table`) matches on its last segment.
+    let owner_l = owner.rsplit('.').next().unwrap_or(owner).to_lowercase();
     for (i, n) in nodes.iter().enumerate() {
         if (n.kind == "table" || n.kind == "collection") && n.label.to_lowercase() == owner_l {
             return nodes[i + 1..]
@@ -327,6 +331,24 @@ mod tests {
         assert_eq!(
             c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
             ["config_id", "name"]
+        );
+    }
+
+    /// Schema-qualified table with an alias inside a JOIN: each alias resolves
+    /// to its own table's columns (regression for empty suggestions on joins).
+    #[test]
+    fn schema_qualified_alias_join_resolves_columns() {
+        let a = "select * from public.step_config a left join public.users b on a.";
+        let (_, c) = suggest(a, &nodes(), "public");
+        assert_eq!(
+            c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
+            ["config_id", "name"]
+        );
+        let b = "select * from public.step_config a left join public.users b on b.";
+        let (_, c) = suggest(b, &nodes(), "public");
+        assert_eq!(
+            c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
+            ["id"]
         );
     }
 

--- a/app/src/completion.rs
+++ b/app/src/completion.rs
@@ -221,7 +221,10 @@ pub fn suggest(
             cols
         }
     } else {
-        match last_keyword(before_cursor).as_deref() {
+        // Keyword context comes from the current line; `before_cursor` may span
+        // several lines (alias resolution needs the whole statement).
+        let cur_line = before_cursor.rsplit('\n').next().unwrap_or(before_cursor);
+        match last_keyword(cur_line).as_deref() {
             // table position: active-schema tables plus every schema name, so a
             // `schema.table` from another namespace can be started.
             Some("FROM") | Some("JOIN") | Some("INTO") | Some("UPDATE") | Some("TABLE") => {
@@ -349,6 +352,18 @@ mod tests {
         assert_eq!(
             c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
             ["id"]
+        );
+    }
+
+    /// Alias declared on an earlier line still resolves when completing a
+    /// later line (before_cursor spans the whole statement).
+    #[test]
+    fn multiline_join_alias_resolves_columns() {
+        let sql = "select * from public.step_config a\nleft join public.users b on a.";
+        let (_, c) = suggest(sql, &nodes(), "public");
+        assert_eq!(
+            c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
+            ["config_id", "name"]
         );
     }
 

--- a/app/src/editor.rs
+++ b/app/src/editor.rs
@@ -290,8 +290,16 @@ impl EditorState {
     }
 
     /// Text on the current line up to the cursor — the autocomplete context.
-    pub fn before_cursor(&self) -> &str {
-        &self.lines[self.line][..self.byte_col()]
+    /// The whole document up to the cursor (all prior lines joined with `\n`
+    /// plus the current line's prefix). Autocomplete needs this so a table
+    /// alias declared on an earlier line resolves when completing a later one.
+    pub fn before_cursor_doc(&self) -> String {
+        let mut s = self.lines[..self.line].join("\n");
+        if self.line > 0 {
+            s.push('\n');
+        }
+        s.push_str(&self.lines[self.line][..self.byte_col()]);
+        s
     }
 
     fn byte_at(l: &str, col: usize) -> usize {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1827,7 +1827,7 @@ fn main() -> Result<(), slint::PlatformError> {
             let Some(w) = weak.upgrade() else {
                 return;
             };
-            let before = ed_state.borrow().before_cursor().to_string();
+            let before = ed_state.borrow().before_cursor_doc();
             let schema = w.get_schema_name().to_string();
             let (word_len, cands) =
                 completion::suggest(&before, &completion_nodes.lock().unwrap(), &schema);

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -3907,12 +3907,25 @@ fn main() -> Result<(), slint::PlatformError> {
                                 | rdbs_connstore::Engine::Cassandra
                         );
                         *raw_nodes.lock().unwrap() = nodes;
-                        // Seed autocomplete with the active schema right away; the
-                        // remaining schemas load in the background below.
-                        *completion_nodes.lock().unwrap() =
-                            model::to_completion_nodes(schema_current.as_str(), &schema);
+                        // Seed autocomplete with the active schema's tables plus a
+                        // bare node for every other schema name, so `schema.`
+                        // autocompletes immediately. The remaining schemas' tables
+                        // and columns fill in from the background load below.
                         let all_schema_names: Vec<String> =
                             schema_names.iter().map(|s| s.to_string()).collect();
+                        {
+                            let mut seed =
+                                model::to_completion_nodes(schema_current.as_str(), &schema);
+                            for name in &all_schema_names {
+                                if name != schema_current.as_str() {
+                                    seed.push(model::VmTreeNode {
+                                        label: name.clone(),
+                                        kind: "database".into(),
+                                    });
+                                }
+                            }
+                            *completion_nodes.lock().unwrap() = seed;
+                        }
                         {
                             let mut defs = fn_defs.lock().unwrap();
                             defs.clear();

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -1153,6 +1153,15 @@ in-out property <string> rename-text;
                                 font-size: Tokens.font-sm;
                                 horizontal-alignment: center;
                             }
+                            HorizontalLayout {
+                                padding-top: Tokens.sp2;
+                                Rectangle { horizontal-stretch: 1; }
+                                PrimaryButton {
+                                    text: "New Query";
+                                    clicked => { root.new-tab(); }
+                                }
+                                Rectangle { horizontal-stretch: 1; }
+                            }
                         }
                     }
 

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -826,7 +826,7 @@ in-out property <string> rename-text;
                     padding-left: Tokens.sp1;
                     padding-right: Tokens.sp1;
                     IconButton {
-                        icon: "columns";
+                        icon: "panel-expand";
                         tooltip: "Show sidebar";
                         clicked => { root.sidebar-visible = true; }
                     }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -814,6 +814,22 @@ in-out property <string> rename-text;
                     add-item() => {
                         root.new-tab();
                     }
+                    collapse() => {
+                        root.sidebar-visible = false;
+                    }
+                }
+
+                // reveal strip when the sidebar is hidden
+                if !root.sidebar-visible: VerticalLayout {
+                    alignment: start;
+                    padding-top: Tokens.sp2;
+                    padding-left: Tokens.sp1;
+                    padding-right: Tokens.sp1;
+                    IconButton {
+                        icon: "columns";
+                        tooltip: "Show sidebar";
+                        clicked => { root.sidebar-visible = true; }
+                    }
                 }
 
                 // draggable vertical splitter (sidebar width)

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -619,6 +619,7 @@ in-out property <string> rename-text;
                         alignment: center;
                         SecondaryButton {
                             text: "SQL";
+                            tooltip: "New query tab  ⌘T";
                             height: 28px;
                             clicked => { root.new-tab(); }
                         }
@@ -647,6 +648,7 @@ in-out property <string> rename-text;
                         alignment: center;
                         IconButton {
                             icon: "columns";
+                            tooltip: "Toggle sidebar";
                             active: root.sidebar-visible;
                             clicked => { root.sidebar-visible = !root.sidebar-visible; }
                         }
@@ -656,6 +658,7 @@ in-out property <string> rename-text;
                         alignment: center;
                         IconButton {
                             icon: "panel-right";
+                            tooltip: "Toggle details panel";
                             active: root.detail-visible;
                             clicked => { root.detail-visible = !root.detail-visible; }
                         }
@@ -675,6 +678,7 @@ in-out property <string> rename-text;
                         alignment: center;
                         IconButton {
                             icon: "pencil";
+                            tooltip: "Edit connection";
                             clicked => {
                                 if (root.selected-conn >= 0) {
                                     root.open-edit-form(root.selected-conn);
@@ -687,6 +691,7 @@ in-out property <string> rename-text;
                         alignment: center;
                         IconButton {
                             icon: Tokens.dark ? "sun" : "moon";
+                            tooltip: "Toggle theme";
                             clicked => { root.toggle-theme(); }
                         }
                     }
@@ -694,6 +699,7 @@ in-out property <string> rename-text;
                         alignment: center;
                         GlyphButton {
                             glyph: "⚙";
+                            tooltip: "Settings";
                             clicked => { root.settings-open = true; }
                         }
                     }

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -145,6 +145,7 @@ export component PrimaryButton inherits Rectangle {
 export component SecondaryButton inherits Rectangle {
     in property <string> text;
     in property <bool> enabled: true;
+    in property <string> tooltip;            // optional hover label
     callback clicked;
     height: Tokens.button-h;
     width: label.preferred-width + 2 * Tokens.sp4;
@@ -163,6 +164,30 @@ export component SecondaryButton inherits Rectangle {
     ta := TouchArea {
         enabled: root.enabled;
         clicked => { root.clicked(); }
+        changed has-hover => {
+            if (root.tooltip != "") {
+                if (self.has-hover) { tip-popup.show(); }
+                else { tip-popup.close(); }
+            }
+        }
+    }
+    tip-popup := PopupWindow {
+        x: (root.width - (tip.preferred-width + 2 * Tokens.sp2)) / 2;
+        y: root.height + 4px;
+        close-policy: no-auto-close;
+        Rectangle {
+            width: tip.preferred-width + 2 * Tokens.sp2;
+            height: tip.preferred-height + Tokens.sp1;
+            border-radius: Tokens.radius;
+            background: Tokens.chrome;
+            border-width: 1px;
+            border-color: Tokens.border;
+            tip := Text {
+                text: root.tooltip;
+                color: Tokens.text;
+                font-size: Tokens.font-xs;
+            }
+        }
     }
 }
 
@@ -408,6 +433,7 @@ export component IconButton inherits Rectangle {
     in property <string> icon;
     in property <length> icon-size: Tokens.icon-sm;
     in property <bool> active: false;
+    in property <string> tooltip;            // optional hover label
     callback clicked;
     width: 28px;
     height: 28px;
@@ -420,7 +446,35 @@ export component IconButton inherits Rectangle {
         size: root.icon-size;
         color: root.active ? Tokens.accent : Tokens.text-dim;
     }
-    ta := TouchArea { clicked => { root.clicked(); } }
+    ta := TouchArea {
+        clicked => { root.clicked(); }
+        // PopupWindow (not a child rect) so the tooltip escapes the header's
+        // clip/z-order; toggled on hover, no-auto-close to track has-hover.
+        changed has-hover => {
+            if (root.tooltip != "") {
+                if (self.has-hover) { tip-popup.show(); }
+                else { tip-popup.close(); }
+            }
+        }
+    }
+    tip-popup := PopupWindow {
+        x: (root.width - (tip.preferred-width + 2 * Tokens.sp2)) / 2;
+        y: root.height + 4px;
+        close-policy: no-auto-close;
+        Rectangle {
+            width: tip.preferred-width + 2 * Tokens.sp2;
+            height: tip.preferred-height + Tokens.sp1;
+            border-radius: Tokens.radius;
+            background: Tokens.chrome;
+            border-width: 1px;
+            border-color: Tokens.border;
+            tip := Text {
+                text: root.tooltip;
+                color: Tokens.text;
+                font-size: Tokens.font-xs;
+            }
+        }
+    }
 }
 
 // macOS-style window controls (– □ ×), right-aligned in the design.

--- a/app/src/ui/icons.slint
+++ b/app/src/ui/icons.slint
@@ -29,6 +29,8 @@ export component AppIcon inherits Image {
         name == "columns"   ? @image-url("icons/columns.svg")  :
         name == "rows"      ? @image-url("icons/rows.svg")     :
         name == "panel-right" ? @image-url("icons/panel-right.svg") :
+        name == "panel-collapse" ? @image-url("icons/panel-collapse.svg") :
+        name == "panel-expand"   ? @image-url("icons/panel-expand.svg")   :
         name == "terminal"  ? @image-url("icons/terminal.svg") :
         name == "layers"    ? @image-url("icons/layers.svg")   :
         name == "sun"       ? @image-url("icons/sun.svg")      :

--- a/app/src/ui/icons/panel-collapse.svg
+++ b/app/src/ui/icons/panel-collapse.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M10 3v18"/><path d="M16 9l-3 3 3 3"/></svg>

--- a/app/src/ui/icons/panel-expand.svg
+++ b/app/src/ui/icons/panel-expand.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M10 3v18"/><path d="M13 9l3 3-3 3"/></svg>

--- a/app/src/ui/icons/rows.svg
+++ b/app/src/ui/icons/rows.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 12h18"/></svg>

--- a/app/src/ui/sidebar.slint
+++ b/app/src/ui/sidebar.slint
@@ -80,7 +80,7 @@ export component Sidebar inherits Rectangle {
                     border-radius: 5px;
                     background: collapse-ta.has-hover ? Tokens.border : transparent;
                     AppIcon {
-                        name: "columns";
+                        name: "panel-collapse";
                         size: Tokens.icon-sm;
                         color: collapse-ta.has-hover ? Tokens.text : Tokens.text-faint;
                     }

--- a/app/src/ui/sidebar.slint
+++ b/app/src/ui/sidebar.slint
@@ -29,6 +29,7 @@ export component Sidebar inherits Rectangle {
     callback filter-tree(string);
     callback mode-changed(int);
     callback add-item();
+    callback collapse();                   // hide the sidebar
     // bumped by ⌘P (app-window) to focus the filter field
     in property <int> focus-tick;
     changed focus-tick => { fld.focus-input(); }
@@ -68,6 +69,22 @@ export component Sidebar inherits Rectangle {
                             root.mode-changed(m);
                         }
                     }
+                }
+                Rectangle { horizontal-stretch: 1; }
+                // collapse the sidebar (un-hide via the header toggle or the
+                // reveal button that takes this panel's place)
+                Rectangle {
+                    width: 24px;
+                    height: 24px;
+                    y: (parent.height - self.height) / 2;
+                    border-radius: 5px;
+                    background: collapse-ta.has-hover ? Tokens.border : transparent;
+                    AppIcon {
+                        name: "columns";
+                        size: Tokens.icon-sm;
+                        color: collapse-ta.has-hover ? Tokens.text : Tokens.text-faint;
+                    }
+                    collapse-ta := TouchArea { clicked => { root.collapse(); } }
                 }
             }
         }

--- a/npm/bin/rdb.js
+++ b/npm/bin/rdb.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+// Thin launcher: exec the vendored `rdbs` binary fetched by install.js,
+// forwarding args and stdio, and propagating its exit code.
+"use strict";
+
+const path = require("path");
+const fs = require("fs");
+const { spawnSync } = require("child_process");
+
+const bin = process.platform === "win32" ? "rdbs.exe" : "rdbs";
+const binPath = path.join(__dirname, "..", "vendor", bin);
+
+if (!fs.existsSync(binPath)) {
+  console.error(
+    "rdb: binary not found. Reinstall with `npm i -g @suiflex/rdb` (postinstall fetches it)."
+  );
+  process.exit(1);
+}
+
+const res = spawnSync(binPath, process.argv.slice(2), { stdio: "inherit" });
+if (res.error) {
+  console.error(`rdb: ${res.error.message}`);
+  process.exit(1);
+}
+process.exit(res.status ?? 0);

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+// postinstall: download the matching prebuilt `rdbs` binary from the GitHub
+// Release whose tag equals this package's version, and drop it in vendor/.
+// ponytail: shells out to the system `tar` (bsdtar handles both .tar.gz and
+// .zip on macOS/Linux/Win10+) instead of pulling an archive dependency.
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const https = require("https");
+const { execFileSync } = require("child_process");
+
+const REPO = "suiflex/rdb";
+
+// platform/arch -> { target triple, archive ext, binary name }. Pure so it can
+// be self-checked without touching the network.
+function resolveTarget(platform, arch) {
+  const map = {
+    "darwin:arm64": ["aarch64-apple-darwin", "tar.gz", "rdbs"],
+    "darwin:x64": ["x86_64-apple-darwin", "tar.gz", "rdbs"],
+    "linux:x64": ["x86_64-unknown-linux-gnu", "tar.gz", "rdbs"],
+    "linux:arm64": ["aarch64-unknown-linux-gnu", "tar.gz", "rdbs"],
+    "win32:x64": ["x86_64-pc-windows-msvc", "zip", "rdbs.exe"],
+    "win32:arm64": ["aarch64-pc-windows-msvc", "zip", "rdbs.exe"],
+  };
+  const hit = map[`${platform}:${arch}`];
+  if (!hit) {
+    throw new Error(`unsupported platform ${platform}/${arch}`);
+  }
+  const [target, ext, bin] = hit;
+  return { target, ext, bin };
+}
+
+function download(url, dest, redirects = 0) {
+  return new Promise((resolve, reject) => {
+    if (redirects > 5) return reject(new Error("too many redirects"));
+    https
+      .get(url, { headers: { "User-Agent": "rdb-npm-installer" } }, (res) => {
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          res.resume();
+          return resolve(download(res.headers.location, dest, redirects + 1));
+        }
+        if (res.statusCode !== 200) {
+          res.resume();
+          return reject(new Error(`download failed: HTTP ${res.statusCode} for ${url}`));
+        }
+        const out = fs.createWriteStream(dest);
+        res.pipe(out);
+        out.on("finish", () => out.close(resolve));
+        out.on("error", reject);
+      })
+      .on("error", reject);
+  });
+}
+
+async function main() {
+  const version = require("./package.json").version;
+  const { target, ext, bin } = resolveTarget(process.platform, process.arch);
+  const asset = `rdbs-${target}.${ext}`;
+  const tag = `v${version}`;
+  const url = `https://github.com/${REPO}/releases/download/${tag}/${asset}`;
+
+  const vendor = path.join(__dirname, "vendor");
+  fs.mkdirSync(vendor, { recursive: true });
+  const archive = path.join(vendor, asset);
+
+  process.stdout.write(`rdb: downloading ${asset} (${tag})…\n`);
+  await download(url, archive);
+
+  // bsdtar extracts both gzip tarballs and zips with the same flags.
+  execFileSync("tar", ["-xf", archive, "-C", vendor], { stdio: "inherit" });
+  fs.unlinkSync(archive);
+
+  const binPath = path.join(vendor, bin);
+  if (!fs.existsSync(binPath)) {
+    throw new Error(`extracted archive did not contain ${bin}`);
+  }
+  if (process.platform !== "win32") fs.chmodSync(binPath, 0o755);
+  process.stdout.write(`rdb: installed ${bin}\n`);
+}
+
+// `node install.js --selftest` exercises the pure mapping without a network.
+if (process.argv.includes("--selftest")) {
+  const assert = require("assert");
+  assert.strictEqual(resolveTarget("darwin", "arm64").target, "aarch64-apple-darwin");
+  assert.strictEqual(resolveTarget("win32", "x64").bin, "rdbs.exe");
+  assert.strictEqual(resolveTarget("linux", "x64").ext, "tar.gz");
+  assert.throws(() => resolveTarget("sunos", "sparc"));
+  console.log("selftest ok");
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(`rdb: install failed: ${err.message}`);
+  process.exit(1);
+});

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@suiflex/rdb",
+  "version": "0.13.0",
+  "description": "RDB — native cross-platform database manager (PostgreSQL, MySQL, Redis, MongoDB)",
+  "homepage": "https://github.com/suiflex/rdb",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/suiflex/rdb.git"
+  },
+  "license": "MIT",
+  "bin": {
+    "rdb": "bin/rdb.js"
+  },
+  "files": [
+    "bin/rdb.js",
+    "install.js"
+  ],
+  "scripts": {
+    "postinstall": "node install.js"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,14 @@
   "include-component-in-tag": false,
   "packages": {
     "app": {
-      "package-name": "rdbs"
+      "package-name": "rdbs",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "npm/package.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Batch of dogfooding feedback fixes: SQL autocomplete correctness, header/sidebar UX, and a new npm distribution channel.
- Restores the right-hand row Details panel that a prior header refactor dropped.
- Enables `npm i -g @suiflex/rdb` on release.

## Changes
**Autocomplete**
- Resolve schema-qualified table aliases (`from schema.tbl a … on a.`) — tokenizer keeps `.`; columns match on the table's last segment.
- Resolve aliases across lines — completion now reads the whole statement, not just the current line.
- Offer every schema name immediately at connect (was only after the slow background table load).

**Header / sidebar**
- Tooltips on all top-right header buttons; SQL button names its `⌘T` shortcut.
- `rows` icon draws two rows, not three.
- New Query button on the empty workspace.
- Sidebar collapse button + edge reveal strip, with dedicated `panel-collapse`/`panel-expand` icons.

**Details panel**
- Read-only right-hand row inspector (every column of the selected row) restored, with a header toggle, in-panel collapse, and an edge reveal tab.

**npm distribution**
- `npm/` package (`@suiflex/rdb`): postinstall downloads the matching prebuilt binary from the GitHub release; thin launcher execs it.
- `publish-npm` job in `release-build.yml` (gated on `build` + `NPM_TOKEN`).
- release-please syncs `npm/package.json` version with the app crate.

## Test plan
- [x] `make fmt-check`
- [x] `make lint` (clippy -D warnings)
- [x] `cargo test -p rdbs --bin rdbs` (124 passed, incl. new autocomplete tests)
- [x] `make fe-build`
- [x] `npm/install.js --selftest`
- [ ] Visual: hover header tooltips; rows icon; empty-state button; sidebar collapse/reveal; Details panel toggle/collapse/reveal
- [ ] Autocomplete against a multi-schema Postgres: schema names, `schema.tbl a` join column suggestions
- [ ] npm: full publish path only exercisable on a real `vX.Y.Z` tag
