### PR TITLE
ci(release): pin npm publish version to the release tag

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -195,6 +195,11 @@ jobs:
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
+      # Pin the package version to the release tag so it can never drift from
+      # the crate version (release-please's file sync can lag a release).
+      - name: Set version from tag
+        working-directory: npm
+        run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version --allow-same-version
       - name: Publish to npm
         working-directory: npm
         env:

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suiflex/rdb",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "RDB — native cross-platform database manager (PostgreSQL, MySQL, Redis, MongoDB)",
   "homepage": "https://github.com/suiflex/rdb",
   "repository": {


### PR DESCRIPTION
## Summary
- The `publish-npm` job failed on the v0.14.0 release with two problems; this fixes the one that lives in the repo.
- Pin the npm package version to the release tag so it can never drift from the crate version.
- Resync `npm/package.json` to 0.14.0.

## Context
`publish-npm` failed on release v0.14.0 (all other jobs — 6 platform builds, Homebrew, Scoop — passed). Two causes:
1. **Version drift** (fixed here): the package published as `0.13.0` while the tag was `v0.14.0`, because release-please's `npm/package.json` version sync had not taken effect yet (the release PR predated the sync config).
2. **`NPM_TOKEN` not authorised for the `@suiflex` scope** (NOT fixable in the repo): npm returned `E404 PUT @suiflex/rdb`. The `suiflex` org exists on npm and the package is a valid first publish, so the 404 means the token cannot create packages under `@suiflex`. Regenerate `NPM_TOKEN` as an Automation (or scope-granted Granular) token owned by a member of the `suiflex` org with publish rights, and update the GitHub secret.

## Changes
- `release-build.yml`: add a `npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version --allow-same-version` step before publish, so the published version always equals the tag.
- `npm/package.json`: 0.13.0 → 0.14.0.

## Test plan
- [x] `npm/install.js --selftest`
- [x] `package.json` parses; workflow YAML parses
- [ ] After `NPM_TOKEN` is fixed, next tagged release publishes `@suiflex/rdb` at the tag version
- [ ] One-time: publish v0.14.0 manually once the token is fixed (re-running the old job would still publish 0.13.0 since the tagged tree is stale)
