### PR TITLE
ci(release): npm OIDC trusted publishing + npm docs

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -189,12 +189,21 @@ jobs:
   publish-npm:
     needs: [build]
     runs-on: ubuntu-latest
+    # OIDC Trusted Publishing: no NPM_TOKEN. The npm package trusts this repo +
+    # workflow + `Release` environment; GitHub mints a short-lived OIDC token.
+    environment: Release
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
+      # Trusted publishing needs npm >= 11.5.1; node 20 ships npm 10.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
       # Pin the package version to the release tag so it can never drift from
       # the crate version (release-please's file sync can lag a release).
       - name: Set version from tag
@@ -202,8 +211,6 @@ jobs:
         run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version --allow-same-version
       - name: Publish to npm
         working-directory: npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public
 
   publish-scoop:

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@
 
 A native, lightweight, cross-platform database manager built with Rust and Slint — in the spirit of TablePlus but compiled from a single codebase for macOS and Linux.
 
-Install in one line via [suiflex/homebrew-tap](https://github.com/suiflex/homebrew-tap) (`brew install suiflex/tap/rdbs`) or [suiflex/scoop-bucket](https://github.com/suiflex/scoop-bucket) (`scoop install rdbs`). See [Install](#install).
-
 ## Features
 
 - **Multi-engine** — PostgreSQL, MySQL/MariaDB, Redis, MongoDB, SQLite, Cassandra in one app
@@ -95,6 +93,15 @@ pub enum ResultSet {
 ## Install
 
 Prebuilt installers are expected to be attached to GitHub Releases.
+
+### npm (all platforms)
+
+```bash
+npm i -g @suiflex/rdb
+```
+
+The postinstall step downloads the prebuilt `rdbs` binary for your platform from
+the matching GitHub Release, then `rdb` launches it.
 
 ### macOS / Linux
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,28 @@
+# @suiflex/rdb
+
+Native cross-platform database manager — PostgreSQL, MySQL, Redis, MongoDB,
+SQLite, Cassandra in one binary. No Electron.
+
+## Install
+
+```bash
+npm i -g @suiflex/rdb
+```
+
+The postinstall step downloads the prebuilt `rdbs` binary for your platform
+(macOS, Linux, Windows — x64 & arm64) from the matching
+[GitHub Release](https://github.com/suiflex/rdb/releases). Then run:
+
+```bash
+rdb
+```
+
+## Links
+
+- Source & docs: https://github.com/suiflex/rdb
+- Also available via Homebrew (`brew install suiflex/tap/rdbs`) and
+  Scoop (`scoop install rdbs`).
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
- Switch npm publishing to OIDC Trusted Publishing so the CI no longer needs a long-lived `NPM_TOKEN` (npm is deprecating 2FA-bypass tokens for CI publishing).
- Document npm install; give the npm package a README.

## Changes
- `release-build.yml` `publish-npm`: add `environment: Release`, `permissions: id-token: write` + `contents: read`, upgrade npm to ≥11.5.1, drop `NODE_AUTH_TOKEN`. Keeps version-from-tag + `npm publish --access public` (provenance auto-on).
- `README.md`: add `### npm (all platforms)` install; delete the redundant one-line install blurb.
- `npm/README.md`: new package README (npmjs page was empty).

## Prereqs (already done by maintainer)
- npmjs Trusted Publisher configured for `@suiflex/rdb`: repo `suiflex/rdb`, workflow `release-build.yml`, environment `Release`.
- GitHub `Release` environment exists.

## Test plan
- [x] workflow YAML parses
- [ ] Next tagged release publishes `@suiflex/rdb` via OIDC (only verifiable on a real `vX.Y.Z` tag)
- [ ] After first OIDC publish succeeds, delete the `NPM_TOKEN` secret
