### PR TITLE
fix(ui): panel toggles eaten by tooltip; native Export Save-As

### DIFF
--- a/.github/workflows/rdbs-app.yml
+++ b/.github/workflows/rdbs-app.yml
@@ -50,7 +50,8 @@ jobs:
             libxcb-render0-dev \
             libxcb-shape0-dev \
             libxcb-xfixes0-dev \
-            libxkbcommon-dev
+            libxkbcommon-dev \
+            libgtk-3-dev
       - run: cargo fmt -p rdbs --check
       - run: cargo clippy -p rdbs --all-targets -- -D warnings
       - run: cargo build -p rdbs

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -65,7 +65,8 @@ jobs:
             libxcb-render0-dev \
             libxcb-shape0-dev \
             libxcb-xfixes0-dev \
-            libxkbcommon-dev
+            libxkbcommon-dev \
+            libgtk-3-dev
       - name: Build release binary
         run: cargo build --release -p rdbs --target ${{ matrix.target }}
       # Keep the archives for Homebrew/Scoop, and also publish files users can

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "atk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +868,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cairo-sys-rs"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
+dependencies = [
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "calloop"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,6 +947,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom 7.1.3",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -1542,6 +1574,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.13.0",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
 ]
 
@@ -2125,6 +2159,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "gdk-pixbuf-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7"
+dependencies = [
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gdk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2d13f38594ac1e66619e188c6d5a1adb98d11b2fcf7894fc416ad76aa2f3f7"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "pkg-config",
+ "system-deps",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2214,6 +2278,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "gio-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+ "winapi",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2222,6 +2299,16 @@ dependencies = [
  "khronos_api",
  "log",
  "xml-rs",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
+dependencies = [
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -2309,10 +2396,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "gobject-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "grid"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
+
+[[package]]
+name = "gtk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f29a1c21c59553eb7dd40e918be54dccd60c52b049b75119d5d96ce6b624414"
+dependencies = [
+ "atk-sys",
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gdk-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
+]
 
 [[package]]
 name = "h2"
@@ -2665,7 +2781,7 @@ dependencies = [
  "hyper",
  "libc",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -4738,6 +4854,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pango-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5104,7 +5232,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -5449,7 +5577,7 @@ dependencies = [
 
 [[package]]
 name = "rdbs"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "copypasta",
@@ -5466,6 +5594,7 @@ dependencies = [
  "rdbs-driver-postgres",
  "rdbs-driver-redis",
  "rdbs-driver-sqlite",
+ "rfd",
  "semver",
  "serde",
  "serde_json",
@@ -5743,6 +5872,30 @@ dependencies = [
  "tiny-skia 0.12.0",
  "usvg",
  "zune-jpeg",
+]
+
+[[package]]
+name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "block2 0.6.2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6262,6 +6415,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -6445,7 +6607,7 @@ dependencies = [
  "regex",
  "serde_json",
  "tar",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -6516,7 +6678,7 @@ dependencies = [
  "fontique",
  "i-slint-compiler",
  "spin_on",
- "toml_edit",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -6903,6 +7065,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-deps"
+version = "6.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
+dependencies = [
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml 0.8.23",
+ "version-compare",
+]
+
+[[package]]
 name = "taffy"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6944,13 +7119,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -7297,17 +7478,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
- "serde_spanned",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -7326,6 +7528,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -7758,6 +7973,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "version_check"
@@ -8307,6 +8528,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -8575,6 +8805,9 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -31,6 +31,9 @@ copypasta = "0.10"
 ureq = "3"
 semver = "1"
 open = "5"
+# native Save-As dialog for CSV export. gtk3 gives the blocking API on Linux
+# (needs libgtk-3-dev); macOS/Windows use their native panels.
+rfd = { version = "0.15", default-features = false, features = ["gtk3"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # Set the Dock icon even for `cargo run`; macOS ignores a window icon on an

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -4322,9 +4322,18 @@ fn main() -> Result<(), slint::PlatformError> {
                 return;
             };
             let Some(grid) = displayed_grid.lock().unwrap().clone() else {
+                w.set_results_meta(SharedString::from("nothing to export"));
                 return;
             };
-            let path = export::export_path("rdbs-export", "csv");
+            // ponytail: blocking native dialog on the UI thread, fine for a
+            // one-shot; move to async if it ever janks.
+            let Some(path) = rfd::FileDialog::new()
+                .set_file_name("rdbs-export.csv")
+                .add_filter("CSV", &["csv"])
+                .save_file()
+            else {
+                return; // user cancelled
+            };
             let msg = match std::fs::write(&path, export::to_csv(&grid)) {
                 Ok(()) => format!("exported → {}", path.display()),
                 Err(e) => format!("export failed: {e}"),

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -164,29 +164,22 @@ export component SecondaryButton inherits Rectangle {
     ta := TouchArea {
         enabled: root.enabled;
         clicked => { root.clicked(); }
-        changed has-hover => {
-            if (root.tooltip != "") {
-                if (self.has-hover) { tip-popup.show(); }
-                else { tip-popup.close(); }
-            }
-        }
     }
-    tip-popup := PopupWindow {
-        x: (root.width - (tip.preferred-width + 2 * Tokens.sp2)) / 2;
+    // Plain overlay tooltip (see IconButton): never grabs the click.
+    if root.tooltip != "": Rectangle {
+        x: (root.width - self.width) / 2;
         y: root.height + 4px;
-        close-policy: no-auto-close;
-        Rectangle {
-            width: tip.preferred-width + 2 * Tokens.sp2;
-            height: tip.preferred-height + Tokens.sp1;
-            border-radius: Tokens.radius;
-            background: Tokens.chrome;
-            border-width: 1px;
-            border-color: Tokens.border;
-            tip := Text {
-                text: root.tooltip;
-                color: Tokens.text;
-                font-size: Tokens.font-xs;
-            }
+        width: tip.preferred-width + 2 * Tokens.sp2;
+        height: tip.preferred-height + Tokens.sp1;
+        border-radius: Tokens.radius;
+        background: Tokens.chrome;
+        border-width: 1px;
+        border-color: Tokens.border;
+        visible: ta.has-hover;
+        tip := Text {
+            text: root.tooltip;
+            color: Tokens.text;
+            font-size: Tokens.font-xs;
         }
     }
 }
@@ -395,34 +388,23 @@ export component GlyphButton inherits Rectangle {
         color: ta.has-hover && root.danger-hover ? white : Tokens.text-dim;
         font-size: root.glyph-size;
     }
-    ta := TouchArea {
-        clicked => { root.clicked(); }
-        // A PopupWindow (not a child Rectangle) so the tooltip escapes the
-        // header's clip/z-order — a plain absolute rect got clipped and never
-        // showed. Toggled on hover; no-auto-close so it tracks has-hover.
-        changed has-hover => {
-            if (root.tooltip != "") {
-                if (self.has-hover) { tip-popup.show(); }
-                else { tip-popup.close(); }
-            }
-        }
-    }
-    tip-popup := PopupWindow {
-        x: (root.width - (tip.preferred-width + 2 * Tokens.sp2)) / 2;
+    ta := TouchArea { clicked => { root.clicked(); } }
+    // Plain overlay tooltip (see IconButton): a no-auto-close PopupWindow
+    // swallowed the following click, so the button never fired.
+    if root.tooltip != "": Rectangle {
+        x: (root.width - self.width) / 2;
         y: root.height + 4px;
-        close-policy: no-auto-close;
-        Rectangle {
-            width: tip.preferred-width + 2 * Tokens.sp2;
-            height: tip.preferred-height + Tokens.sp1;
-            border-radius: Tokens.radius;
-            background: Tokens.chrome;
-            border-width: 1px;
-            border-color: Tokens.border;
-            tip := Text {
-                text: root.tooltip;
-                color: Tokens.text;
-                font-size: Tokens.font-xs;
-            }
+        width: tip.preferred-width + 2 * Tokens.sp2;
+        height: tip.preferred-height + Tokens.sp1;
+        border-radius: Tokens.radius;
+        background: Tokens.chrome;
+        border-width: 1px;
+        border-color: Tokens.border;
+        visible: ta.has-hover;
+        tip := Text {
+            text: root.tooltip;
+            color: Tokens.text;
+            font-size: Tokens.font-xs;
         }
     }
 }
@@ -446,33 +428,24 @@ export component IconButton inherits Rectangle {
         size: root.icon-size;
         color: root.active ? Tokens.accent : Tokens.text-dim;
     }
-    ta := TouchArea {
-        clicked => { root.clicked(); }
-        // PopupWindow (not a child rect) so the tooltip escapes the header's
-        // clip/z-order; toggled on hover, no-auto-close to track has-hover.
-        changed has-hover => {
-            if (root.tooltip != "") {
-                if (self.has-hover) { tip-popup.show(); }
-                else { tip-popup.close(); }
-            }
-        }
-    }
-    tip-popup := PopupWindow {
-        x: (root.width - (tip.preferred-width + 2 * Tokens.sp2)) / 2;
+    ta := TouchArea { clicked => { root.clicked(); } }
+    // Tooltip as a plain overlay (no TouchArea) so it never grabs pointer
+    // input — a PopupWindow with no-auto-close swallowed the click that
+    // followed the hover, so the button never fired.
+    if root.tooltip != "": Rectangle {
+        x: (root.width - self.width) / 2;
         y: root.height + 4px;
-        close-policy: no-auto-close;
-        Rectangle {
-            width: tip.preferred-width + 2 * Tokens.sp2;
-            height: tip.preferred-height + Tokens.sp1;
-            border-radius: Tokens.radius;
-            background: Tokens.chrome;
-            border-width: 1px;
-            border-color: Tokens.border;
-            tip := Text {
-                text: root.tooltip;
-                color: Tokens.text;
-                font-size: Tokens.font-xs;
-            }
+        width: tip.preferred-width + 2 * Tokens.sp2;
+        height: tip.preferred-height + Tokens.sp1;
+        border-radius: Tokens.radius;
+        background: Tokens.chrome;
+        border-width: 1px;
+        border-color: Tokens.border;
+        visible: ta.has-hover;
+        tip := Text {
+            text: root.tooltip;
+            color: Tokens.text;
+            font-size: Tokens.font-xs;
         }
     }
 }

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -1096,24 +1096,14 @@ export component WorkArea inherits Rectangle {
                 Rectangle { horizontal-stretch: 1; }
 
                 // right-side actions + latency
+                // Export lives in the results toolbar (top-right "Export CSV");
+                // the footer only keeps the browse-mode Columns toggle.
                 if root.browse-mode: HorizontalLayout {
                     spacing: Tokens.sp2;
                     alignment: end;
                     VerticalLayout {
                         alignment: center;
                         SecondaryButton { text: "Columns"; height: 24px; clicked => { root.columns-open = !root.columns-open; } }
-                    }
-                    VerticalLayout {
-                        alignment: center;
-                        SecondaryButton { text: "Export"; height: 24px; clicked => { root.export-csv(); } }
-                    }
-                }
-                if !root.browse-mode: HorizontalLayout {
-                    spacing: Tokens.sp2;
-                    alignment: end;
-                    VerticalLayout {
-                        alignment: center;
-                        SecondaryButton { text: "Export"; height: 24px; clicked => { root.export-csv(); } }
                     }
                 }
                 if root.console-open: VerticalLayout {


### PR DESCRIPTION
## Summary
- Fix the sidebar/details header toggles that did nothing when clicked.
- Give Export CSV a native Save-As dialog; remove the redundant footer Export buttons.

## Root cause (toggles)
The hover tooltip (added recently) used a `PopupWindow` with `close-policy: no-auto-close`. Such a popup grabs pointer input while open, and since a button is hovered at the moment it's clicked, the popup swallowed the click — so the sidebar (`columns`) and details (`panel-right`) toggles, and any tooltipped button, never fired. Replaced the popup with a plain overlay `Rectangle` (no `TouchArea`), which cannot intercept the click. Applied to `IconButton`, `SecondaryButton`, `GlyphButton`.

## Changes
- `components.slint`: tooltip → non-capturing overlay (fixes clicks; tooltips still show on hover).
- `workarea.slint`: remove the footer "Export" buttons (browse + edit modes); keep the Columns toggle. Export stays in the results toolbar.
- `app/Cargo.toml` + `main.rs`: `on_export_csv` opens `rfd::FileDialog` Save-As; cancel is a no-op; empty result reports "nothing to export".
- CI: add `libgtk-3-dev` to the Linux steps (rfd's blocking dialog uses GTK3 on Linux).

## Test plan
- [x] `make fe-build`, `make lint`, `make fmt-check`
- [x] `make fe-run`: click sidebar + details toggles → panels hide/show; hover shows tooltip AND the click still toggles
- [x] Toolbar "Export CSV" → native Save dialog; choosing a path writes the CSV; cancel does nothing; footer Export gone
