### PR TITLE
ci: pin npm for Node 20 release publishing

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -203,8 +203,9 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org
       # Trusted publishing needs npm >= 11.5.1; node 20 ships npm 10.
+      # Keep this below npm 12, which no longer supports the Node 20 runner.
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.5.2
       # Pin the package version to the release tag so it can never drift from
       # the crate version (release-please's file sync can lag a release).
       - name: Set version from tag


### PR DESCRIPTION
## Summary

- Restore npm trusted publishing on the Node 20 release runner.
- Prevent npm major-version drift from blocking future releases.

## Changes

- Pin the OIDC publishing npm CLI to version 11.5.2.
- Document why npm 12 is excluded while the workflow uses Node 20.

## Test plan

- [x] Parse `.github/workflows/release-build.yml` with Ruby YAML.
- [x] Run `git diff --check`.
- [ ] Verify npm publishing in the next release workflow run.