### PR TITLE
refactor(ui): render button tooltips on a top overlay layer

### DIFF
--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -3,7 +3,7 @@ export { Theme }
 import { Tokens } from "tokens.slint";
 export { Tokens }
 import {
-    SearchCommandPill, BreadcrumbChip, GlyphButton, IconButton, PrimaryButton, SecondaryButton, TextButton
+    SearchCommandPill, BreadcrumbChip, GlyphButton, IconButton, PrimaryButton, SecondaryButton, TextButton, Tooltip
 } from "components.slint";
 import { Sidebar } from "sidebar.slint";
 import { ConnPicker } from "picker.slint";
@@ -1768,6 +1768,24 @@ in-out property <string> rename-text;
                     }
                 }
             }
+        }
+    }
+
+    // Shared tooltip overlay — topmost sibling so it paints above all content
+    // and modals; anchored in window coords via each button's absolute-position.
+    if Tooltip.shown && Tooltip.text != "": Rectangle {
+        x: min(max(Tooltip.x - self.width / 2, 4px), root.width - self.width - 4px);
+        y: Tooltip.y;
+        width: tip.preferred-width + 2 * Tokens.sp2;
+        height: tip.preferred-height + Tokens.sp1;
+        border-radius: Tokens.radius;
+        background: Tokens.chrome;
+        border-width: 1px;
+        border-color: Tokens.border;
+        tip := Text {
+            text: Tooltip.text;
+            color: Tokens.text;
+            font-size: Tokens.font-xs;
         }
     }
 }

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -172,22 +172,16 @@ export component SecondaryButton inherits Rectangle {
     ta := TouchArea {
         enabled: root.enabled;
         clicked => { root.clicked(); }
-    }
-    // Plain overlay tooltip (see IconButton): never grabs the click.
-    if root.tooltip != "": Rectangle {
-        x: (root.width - self.width) / 2;
-        y: root.height + 4px;
-        width: tip.preferred-width + 2 * Tokens.sp2;
-        height: tip.preferred-height + Tokens.sp1;
-        border-radius: Tokens.radius;
-        background: Tokens.chrome;
-        border-width: 1px;
-        border-color: Tokens.border;
-        visible: ta.has-hover;
-        tip := Text {
-            text: root.tooltip;
-            color: Tokens.text;
-            font-size: Tokens.font-xs;
+        // report hover to the shared Tooltip overlay (drawn in app-window)
+        changed has-hover => {
+            if self.has-hover && root.tooltip != "" {
+                Tooltip.text = root.tooltip;
+                Tooltip.x = root.absolute-position.x + root.width / 2;
+                Tooltip.y = root.absolute-position.y + root.height + 4px;
+                Tooltip.shown = true;
+            } else if Tooltip.text == root.tooltip {
+                Tooltip.shown = false;
+            }
         }
     }
 }
@@ -396,23 +390,17 @@ export component GlyphButton inherits Rectangle {
         color: ta.has-hover && root.danger-hover ? white : Tokens.text-dim;
         font-size: root.glyph-size;
     }
-    ta := TouchArea { clicked => { root.clicked(); } }
-    // Plain overlay tooltip (see IconButton): a no-auto-close PopupWindow
-    // swallowed the following click, so the button never fired.
-    if root.tooltip != "": Rectangle {
-        x: (root.width - self.width) / 2;
-        y: root.height + 4px;
-        width: tip.preferred-width + 2 * Tokens.sp2;
-        height: tip.preferred-height + Tokens.sp1;
-        border-radius: Tokens.radius;
-        background: Tokens.chrome;
-        border-width: 1px;
-        border-color: Tokens.border;
-        visible: ta.has-hover;
-        tip := Text {
-            text: root.tooltip;
-            color: Tokens.text;
-            font-size: Tokens.font-xs;
+    ta := TouchArea {
+        clicked => { root.clicked(); }
+        changed has-hover => {
+            if self.has-hover && root.tooltip != "" {
+                Tooltip.text = root.tooltip;
+                Tooltip.x = root.absolute-position.x + root.width / 2;
+                Tooltip.y = root.absolute-position.y + root.height + 4px;
+                Tooltip.shown = true;
+            } else if Tooltip.text == root.tooltip {
+                Tooltip.shown = false;
+            }
         }
     }
 }
@@ -436,24 +424,17 @@ export component IconButton inherits Rectangle {
         size: root.icon-size;
         color: root.active ? Tokens.accent : Tokens.text-dim;
     }
-    ta := TouchArea { clicked => { root.clicked(); } }
-    // Tooltip as a plain overlay (no TouchArea) so it never grabs pointer
-    // input — a PopupWindow with no-auto-close swallowed the click that
-    // followed the hover, so the button never fired.
-    if root.tooltip != "": Rectangle {
-        x: (root.width - self.width) / 2;
-        y: root.height + 4px;
-        width: tip.preferred-width + 2 * Tokens.sp2;
-        height: tip.preferred-height + Tokens.sp1;
-        border-radius: Tokens.radius;
-        background: Tokens.chrome;
-        border-width: 1px;
-        border-color: Tokens.border;
-        visible: ta.has-hover;
-        tip := Text {
-            text: root.tooltip;
-            color: Tokens.text;
-            font-size: Tokens.font-xs;
+    ta := TouchArea {
+        clicked => { root.clicked(); }
+        changed has-hover => {
+            if self.has-hover && root.tooltip != "" {
+                Tooltip.text = root.tooltip;
+                Tooltip.x = root.absolute-position.x + root.width / 2;
+                Tooltip.y = root.absolute-position.y + root.height + 4px;
+                Tooltip.shown = true;
+            } else if Tooltip.text == root.tooltip {
+                Tooltip.shown = false;
+            }
         }
     }
 }

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -2,6 +2,16 @@
 import { Tokens } from "tokens.slint";
 import { AppIcon } from "icons.slint";
 
+// Shared tooltip state. Buttons report their hovered tooltip + window-space
+// anchor here; a single overlay in app-window.slint draws it on the top layer
+// so it is never clipped by content painted after the toolbar row.
+export global Tooltip {
+    in-out property <string> text;
+    in-out property <length> x;   // window coords: button center-x
+    in-out property <length> y;   // window coords: just below the button
+    in-out property <bool> shown;
+}
+
 // Dropdown select: shows the current value + a ▾ caret so it reads as a
 // picker even when closed, then a click opens a themed option list. Replaces
 // std-widgets ComboBox, which rendered as a blank borderless box in this theme.


### PR DESCRIPTION
## Summary
- Header/toolbar tooltips were clipped/hidden by the content below. Fix by rendering all button tooltips on the app's top overlay layer (where modals live) instead of as inline children of the 44px toolbar row.
- Collapses 3 duplicated inline tooltip blocks into one shared overlay.

## Changes
- **`Tooltip` global** (`components.slint`) — holds hovered tooltip text + window-space anchor.
- **Shared overlay** (`app-window.slint`) — one topmost sibling draws the tooltip, anchored via each button's `absolute-position`; x is clamped so edge icons (⚙ / theme) stay inside the window.
- **Routed tooltips** — `IconButton`, `GlyphButton`, `SecondaryButton` now report hover to the global from their existing `TouchArea` (`changed has-hover`) and no longer draw their own inline tooltip. Click behaviour unchanged (no `PopupWindow`, so no click-swallow).

## Test plan
- [x] `make fe-build` — clean, no warnings
- [x] `make fe-run`:
  - [x] Hover each header icon — tooltip shows below the icon, fully visible over content (not clipped)
  - [x] Right-most icons (⚙ / theme) — tooltip stays inside the window
  - [x] Click a button while its tooltip shows — button still fires
  - [x] Move between adjacent icons — text switches, no blank flicker