### PR TITLE
refactor: rename rdbs to rdb across the whole project

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -46,8 +46,8 @@ body:
   - type: input
     id: version
     attributes:
-      label: rdbs version
-      description: Output of `rdbs --version`, or the release/commit you are on.
+      label: rdb version
+      description: Output of `rdb --version`, or the release/commit you are on.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,14 +6,14 @@ body:
     id: problem
     attributes:
       label: Problem
-      description: What are you trying to do that rdbs does not let you do today?
+      description: What are you trying to do that rdb does not let you do today?
     validations:
       required: true
   - type: textarea
     id: proposal
     attributes:
       label: Proposed solution
-      description: What would you like rdbs to do instead?
+      description: What would you like rdb to do instead?
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/rdb-app.yml
+++ b/.github/workflows/rdb-app.yml
@@ -1,4 +1,4 @@
-name: rdbs-app
+name: rdb-app
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
       - Cargo.toml
       - Cargo.lock
       - rust-toolchain.toml
-      - .github/workflows/rdbs-app.yml
+      - .github/workflows/rdb-app.yml
   pull_request:
     paths:
       - app/**
@@ -17,7 +17,7 @@ on:
       - Cargo.toml
       - Cargo.lock
       - rust-toolchain.toml
-      - .github/workflows/rdbs-app.yml
+      - .github/workflows/rdb-app.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -37,7 +37,7 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: rdbs-app
+          shared-key: rdb-app
       # ponytail: minimal system libs for Slint winit+femtovg build on Linux;
       # add more here if the build errors out demanding another lib.
       # macOS uses system frameworks, so no install step is needed there.
@@ -52,6 +52,6 @@ jobs:
             libxcb-xfixes0-dev \
             libxkbcommon-dev \
             libgtk-3-dev
-      - run: cargo fmt -p rdbs --check
-      - run: cargo clippy -p rdbs --all-targets -- -D warnings
-      - run: cargo build -p rdbs
+      - run: cargo fmt -p rdb --check
+      - run: cargo clippy -p rdb --all-targets -- -D warnings
+      - run: cargo build -p rdb

--- a/.github/workflows/rdb-connstore.yml
+++ b/.github/workflows/rdb-connstore.yml
@@ -1,4 +1,4 @@
-name: rdbs-connstore
+name: rdb-connstore
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
       - Cargo.toml
       - Cargo.lock
       - rust-toolchain.toml
-      - .github/workflows/rdbs-connstore.yml
+      - .github/workflows/rdb-connstore.yml
   pull_request:
     paths:
       - crates/connstore/**
@@ -17,7 +17,7 @@ on:
       - Cargo.toml
       - Cargo.lock
       - rust-toolchain.toml
-      - .github/workflows/rdbs-connstore.yml
+      - .github/workflows/rdb-connstore.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,7 +33,7 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: rdbs-connstore
-      - run: cargo fmt -p rdbs-connstore --check
-      - run: cargo clippy -p rdbs-connstore --all-targets -- -D warnings
-      - run: cargo test -p rdbs-connstore --lib
+          shared-key: rdb-connstore
+      - run: cargo fmt -p rdb-connstore --check
+      - run: cargo clippy -p rdb-connstore --all-targets -- -D warnings
+      - run: cargo test -p rdb-connstore --lib

--- a/.github/workflows/rdb-core.yml
+++ b/.github/workflows/rdb-core.yml
@@ -1,4 +1,4 @@
-name: rdbs-core
+name: rdb-core
 
 on:
   push:
@@ -8,14 +8,14 @@ on:
       - Cargo.toml
       - Cargo.lock
       - rust-toolchain.toml
-      - .github/workflows/rdbs-core.yml
+      - .github/workflows/rdb-core.yml
   pull_request:
     paths:
       - crates/core/**
       - Cargo.toml
       - Cargo.lock
       - rust-toolchain.toml
-      - .github/workflows/rdbs-core.yml
+      - .github/workflows/rdb-core.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -31,7 +31,7 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: rdbs-core
-      - run: cargo fmt -p rdbs-core --check
-      - run: cargo clippy -p rdbs-core --all-targets -- -D warnings
-      - run: cargo test -p rdbs-core --lib
+          shared-key: rdb-core
+      - run: cargo fmt -p rdb-core --check
+      - run: cargo clippy -p rdb-core --all-targets -- -D warnings
+      - run: cargo test -p rdb-core --lib

--- a/.github/workflows/rdb-driver-mongo.yml
+++ b/.github/workflows/rdb-driver-mongo.yml
@@ -1,23 +1,23 @@
-name: rdbs-driver-mysql
+name: rdb-driver-mongo
 
 on:
   push:
     branches: [develop, main]
     paths:
-      - crates/driver-mysql/**
+      - crates/driver-mongo/**
       - crates/core/**
       - Cargo.toml
       - Cargo.lock
       - rust-toolchain.toml
-      - .github/workflows/rdbs-driver-mysql.yml
+      - .github/workflows/rdb-driver-mongo.yml
   pull_request:
     paths:
-      - crates/driver-mysql/**
+      - crates/driver-mongo/**
       - crates/core/**
       - Cargo.toml
       - Cargo.lock
       - rust-toolchain.toml
-      - .github/workflows/rdbs-driver-mysql.yml
+      - .github/workflows/rdb-driver-mongo.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,7 +33,7 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: rdbs-driver-mysql
-      - run: cargo fmt -p rdbs-driver-mysql --check
-      - run: cargo clippy -p rdbs-driver-mysql --all-targets -- -D warnings
-      - run: cargo test -p rdbs-driver-mysql --lib
+          shared-key: rdb-driver-mongo
+      - run: cargo fmt -p rdb-driver-mongo --check
+      - run: cargo clippy -p rdb-driver-mongo --all-targets -- -D warnings
+      - run: cargo test -p rdb-driver-mongo --lib

--- a/.github/workflows/rdb-driver-mysql.yml
+++ b/.github/workflows/rdb-driver-mysql.yml
@@ -1,23 +1,23 @@
-name: rdbs-driver-redis
+name: rdb-driver-mysql
 
 on:
   push:
     branches: [develop, main]
     paths:
-      - crates/driver-redis/**
+      - crates/driver-mysql/**
       - crates/core/**
       - Cargo.toml
       - Cargo.lock
       - rust-toolchain.toml
-      - .github/workflows/rdbs-driver-redis.yml
+      - .github/workflows/rdb-driver-mysql.yml
   pull_request:
     paths:
-      - crates/driver-redis/**
+      - crates/driver-mysql/**
       - crates/core/**
       - Cargo.toml
       - Cargo.lock
       - rust-toolchain.toml
-      - .github/workflows/rdbs-driver-redis.yml
+      - .github/workflows/rdb-driver-mysql.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,7 +33,7 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: rdbs-driver-redis
-      - run: cargo fmt -p rdbs-driver-redis --check
-      - run: cargo clippy -p rdbs-driver-redis --all-targets -- -D warnings
-      - run: cargo test -p rdbs-driver-redis --lib
+          shared-key: rdb-driver-mysql
+      - run: cargo fmt -p rdb-driver-mysql --check
+      - run: cargo clippy -p rdb-driver-mysql --all-targets -- -D warnings
+      - run: cargo test -p rdb-driver-mysql --lib

--- a/.github/workflows/rdb-driver-postgres.yml
+++ b/.github/workflows/rdb-driver-postgres.yml
@@ -1,23 +1,23 @@
-name: rdbs-driver-mongo
+name: rdb-driver-postgres
 
 on:
   push:
     branches: [develop, main]
     paths:
-      - crates/driver-mongo/**
+      - crates/driver-postgres/**
       - crates/core/**
       - Cargo.toml
       - Cargo.lock
       - rust-toolchain.toml
-      - .github/workflows/rdbs-driver-mongo.yml
+      - .github/workflows/rdb-driver-postgres.yml
   pull_request:
     paths:
-      - crates/driver-mongo/**
+      - crates/driver-postgres/**
       - crates/core/**
       - Cargo.toml
       - Cargo.lock
       - rust-toolchain.toml
-      - .github/workflows/rdbs-driver-mongo.yml
+      - .github/workflows/rdb-driver-postgres.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,7 +33,7 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: rdbs-driver-mongo
-      - run: cargo fmt -p rdbs-driver-mongo --check
-      - run: cargo clippy -p rdbs-driver-mongo --all-targets -- -D warnings
-      - run: cargo test -p rdbs-driver-mongo --lib
+          shared-key: rdb-driver-postgres
+      - run: cargo fmt -p rdb-driver-postgres --check
+      - run: cargo clippy -p rdb-driver-postgres --all-targets -- -D warnings
+      - run: cargo test -p rdb-driver-postgres --lib

--- a/.github/workflows/rdb-driver-redis.yml
+++ b/.github/workflows/rdb-driver-redis.yml
@@ -1,23 +1,23 @@
-name: rdbs-driver-postgres
+name: rdb-driver-redis
 
 on:
   push:
     branches: [develop, main]
     paths:
-      - crates/driver-postgres/**
+      - crates/driver-redis/**
       - crates/core/**
       - Cargo.toml
       - Cargo.lock
       - rust-toolchain.toml
-      - .github/workflows/rdbs-driver-postgres.yml
+      - .github/workflows/rdb-driver-redis.yml
   pull_request:
     paths:
-      - crates/driver-postgres/**
+      - crates/driver-redis/**
       - crates/core/**
       - Cargo.toml
       - Cargo.lock
       - rust-toolchain.toml
-      - .github/workflows/rdbs-driver-postgres.yml
+      - .github/workflows/rdb-driver-redis.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,7 +33,7 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: rdbs-driver-postgres
-      - run: cargo fmt -p rdbs-driver-postgres --check
-      - run: cargo clippy -p rdbs-driver-postgres --all-targets -- -D warnings
-      - run: cargo test -p rdbs-driver-postgres --lib
+          shared-key: rdb-driver-redis
+      - run: cargo fmt -p rdb-driver-redis --check
+      - run: cargo clippy -p rdb-driver-redis --all-targets -- -D warnings
+      - run: cargo test -p rdb-driver-redis --lib

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -25,28 +25,28 @@ jobs:
           - os: macos-14 # Apple Silicon
             target: aarch64-apple-darwin
             ext: tar.gz
-            native_asset: rdbs-aarch64-apple-darwin.dmg
+            native_asset: rdb-aarch64-apple-darwin.dmg
           - os: macos-14 # cross-compile Intel on Apple Silicon (no scarce macos-13)
             target: x86_64-apple-darwin
             ext: tar.gz
-            native_asset: rdbs-x86_64-apple-darwin.dmg
+            native_asset: rdb-x86_64-apple-darwin.dmg
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             ext: tar.gz
-            native_asset: rdbs-x86_64-unknown-linux-gnu
+            native_asset: rdb-x86_64-unknown-linux-gnu
           - os: ubuntu-24.04-arm # native GitHub arm64 linux runner
             target: aarch64-unknown-linux-gnu
             ext: tar.gz
-            native_asset: rdbs-aarch64-unknown-linux-gnu
+            native_asset: rdb-aarch64-unknown-linux-gnu
             experimental: true
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             ext: zip
-            native_asset: rdbs-x86_64-pc-windows-msvc.exe
+            native_asset: rdb-x86_64-pc-windows-msvc.exe
           - os: windows-11-arm # native GitHub arm64 windows runner
             target: aarch64-pc-windows-msvc
             ext: zip
-            native_asset: rdbs-aarch64-pc-windows-msvc.exe
+            native_asset: rdb-aarch64-pc-windows-msvc.exe
             experimental: true
     runs-on: ${{ matrix.os }}
     # experimental arm legs are best-effort: a failure must not fail the `build`
@@ -74,14 +74,14 @@ jobs:
             libxkbcommon-dev \
             libgtk-3-dev
       - name: Build release binary
-        run: cargo build --release -p rdbs --target ${{ matrix.target }}
+        run: cargo build --release -p rdb --target ${{ matrix.target }}
       # Keep the archives for Homebrew/Scoop, and also publish files users can
       # launch directly from the GitHub Release page.
       - name: Package archive (unix)
         if: runner.os != 'Windows'
         run: |
-          tar -czf "rdbs-${{ matrix.target }}.tar.gz" \
-            -C "target/${{ matrix.target }}/release" rdbs
+          tar -czf "rdb-${{ matrix.target }}.tar.gz" \
+            -C "target/${{ matrix.target }}/release" rdb
       - name: Package app (macOS)
         if: runner.os == 'macOS'
         shell: bash
@@ -89,11 +89,11 @@ jobs:
           VERSION: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          app="RDBS.app"
+          app="RDB.app"
           plist="$app/Contents/Info.plist"
-          iconset="$RUNNER_TEMP/RDBS.iconset"
+          iconset="$RUNNER_TEMP/RDB.iconset"
           mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources" "$iconset"
-          cp "target/${{ matrix.target }}/release/rdbs" "$app/Contents/MacOS/rdbs"
+          cp "target/${{ matrix.target }}/release/rdb" "$app/Contents/MacOS/rdb"
 
           icon="app/assets/icon@512.png"
           sips -z 16 16 "$icon" --out "$iconset/icon_16x16.png"
@@ -105,44 +105,44 @@ jobs:
           sips -z 256 256 "$icon" --out "$iconset/icon_256x256.png"
           sips -z 512 512 "$icon" --out "$iconset/icon_256x256@2x.png"
           sips -z 512 512 "$icon" --out "$iconset/icon_512x512.png"
-          iconutil -c icns "$iconset" -o "$app/Contents/Resources/RDBS.icns"
+          iconutil -c icns "$iconset" -o "$app/Contents/Resources/RDB.icns"
 
           plutil -create xml1 "$plist"
-          plutil -insert CFBundleDisplayName -string RDBS "$plist"
-          plutil -insert CFBundleExecutable -string rdbs "$plist"
-          plutil -insert CFBundleIconFile -string RDBS.icns "$plist"
-          plutil -insert CFBundleIdentifier -string com.suiflex.rdbs "$plist"
-          plutil -insert CFBundleName -string RDBS "$plist"
+          plutil -insert CFBundleDisplayName -string RDB "$plist"
+          plutil -insert CFBundleExecutable -string rdb "$plist"
+          plutil -insert CFBundleIconFile -string RDB.icns "$plist"
+          plutil -insert CFBundleIdentifier -string com.suiflex.rdb "$plist"
+          plutil -insert CFBundleName -string RDB "$plist"
           plutil -insert CFBundlePackageType -string APPL "$plist"
           plutil -insert CFBundleShortVersionString -string "${VERSION#v}" "$plist"
           plutil -insert CFBundleVersion -string "${VERSION#v}" "$plist"
           plutil -insert NSHighResolutionCapable -bool true "$plist"
 
           codesign --force --deep --sign - "$app"
-          hdiutil create -volname RDBS -srcfolder "$app" -ov -format UDZO \
+          hdiutil create -volname RDB -srcfolder "$app" -ov -format UDZO \
             "${{ matrix.native_asset }}"
       - name: Package executable (Linux)
         if: runner.os == 'Linux'
         run: |
-          install -m 755 "target/${{ matrix.target }}/release/rdbs" \
+          install -m 755 "target/${{ matrix.target }}/release/rdb" \
             "${{ matrix.native_asset }}"
       - name: Package executables (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           Copy-Item `
-            -Path "target/${{ matrix.target }}/release/rdbs.exe" `
+            -Path "target/${{ matrix.target }}/release/rdb.exe" `
             -Destination "${{ matrix.native_asset }}"
           Compress-Archive `
-            -Path "target/${{ matrix.target }}/release/rdbs.exe" `
-            -DestinationPath "rdbs-${{ matrix.target }}.zip"
+            -Path "target/${{ matrix.target }}/release/rdb.exe" `
+            -DestinationPath "rdb-${{ matrix.target }}.zip"
       - name: Upload asset to Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
           gh release upload "${{ github.ref_name }}" \
-            "rdbs-${{ matrix.target }}.${{ matrix.ext }}" \
+            "rdb-${{ matrix.target }}.${{ matrix.ext }}" \
             "${{ matrix.native_asset }}" --clobber
 
   # ---- publish jobs: siblings, both need `build`, neither needs the other ----
@@ -168,12 +168,12 @@ jobs:
           dl() { gh release download "$TAG" -R "$REPO" -p "$1" -O "$1" --clobber; }
           sha() { shasum -a 256 "$1" | cut -d' ' -f1; }
 
-          dl "rdbs-aarch64-apple-darwin.tar.gz"
-          dl "rdbs-x86_64-apple-darwin.tar.gz"
-          dl "rdbs-x86_64-unknown-linux-gnu.tar.gz"
-          arm_sha="$(sha rdbs-aarch64-apple-darwin.tar.gz)"
-          intel_sha="$(sha rdbs-x86_64-apple-darwin.tar.gz)"
-          linux_sha="$(sha rdbs-x86_64-unknown-linux-gnu.tar.gz)"
+          dl "rdb-aarch64-apple-darwin.tar.gz"
+          dl "rdb-x86_64-apple-darwin.tar.gz"
+          dl "rdb-x86_64-unknown-linux-gnu.tar.gz"
+          arm_sha="$(sha rdb-aarch64-apple-darwin.tar.gz)"
+          intel_sha="$(sha rdb-x86_64-apple-darwin.tar.gz)"
+          linux_sha="$(sha rdb-x86_64-unknown-linux-gnu.tar.gz)"
 
           git clone "https://x-access-token:${GH_TOKEN}@github.com/suiflex/homebrew-tap.git" tap
           mkdir -p tap/Formula
@@ -182,13 +182,13 @@ jobs:
               -e "s|@ARM_SHA@|${arm_sha}|g" \
               -e "s|@INTEL_SHA@|${intel_sha}|g" \
               -e "s|@LINUX_SHA@|${linux_sha}|g" \
-              packaging/rdbs.rb.tmpl > tap/Formula/rdbs.rb
+              packaging/rdb.rb.tmpl > tap/Formula/rdb.rb
 
           cd tap
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Formula/rdbs.rb
-          git commit -m "rdbs ${VERSION}" || { echo "no change"; exit 0; }
+          git add Formula/rdb.rb
+          git commit -m "rdb ${VERSION}" || { echo "no change"; exit 0; }
           git push
 
   # Publishes @suiflex/rdb to npm. The package's postinstall downloads the
@@ -267,7 +267,7 @@ jobs:
           set -euo pipefail
           VERSION="${TAG#v}"
           base="https://github.com/${REPO}/releases/download/${TAG}"
-          asset="rdbs-x86_64-pc-windows-msvc.zip"
+          asset="rdb-x86_64-pc-windows-msvc.zip"
 
           gh release download "$TAG" -R "$REPO" -p "$asset" -O "$asset" --clobber
           win_sha="$(shasum -a 256 "$asset" | cut -d' ' -f1)"
@@ -277,11 +277,11 @@ jobs:
           sed -e "s|@VERSION@|${VERSION}|g" \
               -e "s|@BASE@|${base}|g" \
               -e "s|@WIN_SHA@|${win_sha}|g" \
-              packaging/rdbs.json.tmpl > bucket/bucket/rdbs.json
+              packaging/rdb.json.tmpl > bucket/bucket/rdb.json
 
           cd bucket
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add bucket/rdbs.json
-          git commit -m "rdbs ${VERSION}" || { echo "no change"; exit 0; }
+          git add bucket/rdb.json
+          git commit -m "rdb ${VERSION}" || { echo "no change"; exit 0; }
           git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# RDBS — Agent Instructions
+# RDB — Agent Instructions
 
 ## Project
 
@@ -7,11 +7,11 @@ Native cross-platform database manager (PostgreSQL, MySQL, Redis, MongoDB) built
 ## Build, Lint, Test
 
 A root `Makefile` wraps the common cargo invocations and splits FE (the
-`rdbs` UI binary) from BE (the `crates/*` libraries) so each side builds and
+`rdb` UI binary) from BE (the `crates/*` libraries) so each side builds and
 tests independently. Run `make help` for the full target list.
 
 ```bash
-make fe-build     # build the rdbs UI (FE)
+make fe-build     # build the rdb UI (FE)
 make fe-run       # run the UI
 make be-build     # build backend crates only (no FE)
 make be-test      # test backend crates only
@@ -19,13 +19,13 @@ make fmt-check    # format check   (make fmt to apply)
 make lint         # clippy, warnings as errors
 make test         # test the whole workspace
 make all          # fmt-check + lint + test + build (CI gate)
-cargo build --release -p rdbs   # release binary
+cargo build --release -p rdb   # release binary
 ```
 
 ## CI
 
-One GitHub Actions workflow per component in `.github/workflows/` — `rdbs-app`
-plus one per crate (`rdbs-core`, `rdbs-connstore`, `rdbs-driver-*`). Each has a
+One GitHub Actions workflow per component in `.github/workflows/` — `rdb-app`
+plus one per crate (`rdb-core`, `rdb-connstore`, `rdb-driver-*`). Each has a
 `paths:` filter, so editing one component only runs that component's CI (lean).
 
 - Dependents also watch `crates/core/**`, so a `core` change fans out to retest
@@ -34,17 +34,17 @@ plus one per crate (`rdbs-core`, `rdbs-connstore`, `rdbs-driver-*`). Each has a
   (scoped with `-p`, not the workspace-wide `make` targets). `--lib` runs unit
   tests only; the `tests/integration.rs` targets need Docker, so they stay out
   of CI and run locally via `make test-it`.
-- The app job installs Slint system libs and runs `cargo build -p rdbs`.
+- The app job installs Slint system libs and runs `cargo build -p rdb`.
 
 Releases are handled separately by `release-please.yml` (single workspace
 release on `develop`): conventional commits drive an auto-maintained release
 PR that bumps the version and `app/CHANGELOG.md`; merging it tags `vX.Y.Z`
-and cuts a GitHub Release. The `app` package (`rdbs`) is the tracked version.
+and cuts a GitHub Release. The `app` package (`rdb`) is the tracked version.
 
 ## Architecture
 
 - `app/` — Slint UI binary (main entry point)
-- `crates/core/` — `Driver` trait, `Query`, `ResultSet`, `Schema`, `RdbsError`
+- `crates/core/` — `Driver` trait, `Query`, `ResultSet`, `Schema`, `RdbError`
 - `crates/connstore/` — saved connections + OS keychain / AES-GCM
 - `crates/driver-postgres/` — tokio-postgres
 - `crates/driver-mysql/` — mysql_async
@@ -53,7 +53,7 @@ and cuts a GitHub Release. The `app` package (`rdbs`) is the tracked version.
 
 ## Key Rules
 
-- UI (`app/`) names a concrete driver crate only in `app/src/dispatch.rs` (the `AnyDriver` enum); the rest of the app depends on `rdbs-core`.
+- UI (`app/`) names a concrete driver crate only in `app/src/dispatch.rs` (the `AnyDriver` enum); the rest of the app depends on `rdb-core`.
 - Adding new engine = new `driver-*` crate implementing `Driver` trait + a variant in `AnyDriver`.
 - Async I/O on tokio runtime, results bridge back to Slint main thread via `invoke_from_event_loop`.
 - Release profile: `opt-level=z`, LTO, `panic=abort`, strip.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to RDBS
+# Contributing to RDB
 
-Thanks for your interest in RDBS — a native, cross-platform database manager
+Thanks for your interest in RDB — a native, cross-platform database manager
 (PostgreSQL, MySQL, Redis, MongoDB, and more) built with Rust and Slint.
 
 This guide covers how to build, test, and submit changes. By participating you
@@ -8,9 +8,9 @@ agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Getting started
 
-RDBS is a Cargo workspace:
+RDB is a Cargo workspace:
 
-- `app/` — the Slint UI binary (`rdbs`), the only crate that names a concrete
+- `app/` — the Slint UI binary (`rdb`), the only crate that names a concrete
   driver (in `app/src/dispatch.rs`).
 - `crates/core/` — the `Driver` trait, `Query`, `ResultSet`, `Schema`, errors.
 - `crates/connstore/` — saved connections + OS keychain / AES-GCM.
@@ -28,11 +28,11 @@ UI builds need the Slint system libraries for your platform — see the
 ## Build, lint, test
 
 A root `Makefile` wraps the common Cargo invocations and splits the frontend
-(the `rdbs` UI binary) from the backend (the `crates/*` libraries). Run
+(the `rdb` UI binary) from the backend (the `crates/*` libraries). Run
 `make help` for the full list. The most common targets:
 
 ```bash
-make fe-build     # build the rdbs UI
+make fe-build     # build the rdb UI
 make fe-run       # run the UI
 make be-build     # build backend crates only
 make be-test      # test backend crates only
@@ -49,7 +49,7 @@ are intentionally kept out of CI.
 ## Adding a database engine
 
 1. Create a new `crates/driver-<engine>/` crate that implements the `Driver`
-   trait from `rdbs-core`.
+   trait from `rdb-core`.
 2. Add a variant to the `AnyDriver` enum in `app/src/dispatch.rs` and forward
    the trait methods.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5576,43 +5576,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdbs"
-version = "0.16.0"
-dependencies = [
- "async-trait",
- "copypasta",
- "json5",
- "objc2 0.6.4",
- "objc2-app-kit 0.3.2",
- "objc2-foundation 0.3.2",
- "open",
- "rdbs-connstore",
- "rdbs-core",
- "rdbs-driver-cassandra",
- "rdbs-driver-mongo",
- "rdbs-driver-mysql",
- "rdbs-driver-postgres",
- "rdbs-driver-redis",
- "rdbs-driver-sqlite",
- "rfd",
- "semver",
- "serde",
- "serde_json",
- "slint",
- "slint-build",
- "tokio",
- "ureq",
-]
-
-[[package]]
-name = "rdbs-connstore"
+name = "rdb-connstore"
 version = "0.1.0"
 dependencies = [
  "aes-gcm",
  "directories",
  "keyring",
  "rand 0.10.1",
- "rdbs-core",
+ "rdb-core",
  "serde",
  "serde_json",
  "tempfile",
@@ -5621,7 +5592,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdbs-core"
+name = "rdb-core"
 version = "0.1.0"
 dependencies = [
  "async-trait",
@@ -5632,23 +5603,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdbs-driver-cassandra"
+name = "rdb-driver-cassandra"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "rdbs-core",
+ "rdb-core",
  "scylla",
  "tokio",
 ]
 
 [[package]]
-name = "rdbs-driver-mongo"
+name = "rdb-driver-mongo"
 version = "0.1.0"
 dependencies = [
  "async-trait",
  "futures",
  "mongodb",
- "rdbs-core",
+ "rdb-core",
  "serde_json",
  "testcontainers",
  "testcontainers-modules",
@@ -5656,19 +5627,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdbs-driver-mysql"
+name = "rdb-driver-mysql"
 version = "0.1.0"
 dependencies = [
  "async-trait",
  "mysql_async",
- "rdbs-core",
+ "rdb-core",
  "testcontainers",
  "testcontainers-modules",
  "tokio",
 ]
 
 [[package]]
-name = "rdbs-driver-postgres"
+name = "rdb-driver-postgres"
 version = "0.1.0"
 dependencies = [
  "async-trait",
@@ -5676,7 +5647,7 @@ dependencies = [
  "futures-util",
  "native-tls",
  "postgres-native-tls",
- "rdbs-core",
+ "rdb-core",
  "rust_decimal",
  "serde_json",
  "testcontainers",
@@ -5687,11 +5658,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdbs-driver-redis"
+name = "rdb-driver-redis"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "rdbs-core",
+ "rdb-core",
  "redis",
  "testcontainers",
  "testcontainers-modules",
@@ -5699,13 +5670,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdbs-driver-sqlite"
+name = "rdb-driver-sqlite"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "rdbs-core",
+ "rdb-core",
  "rusqlite",
  "tokio",
+]
+
+[[package]]
+name = "rdbs"
+version = "0.16.0"
+dependencies = [
+ "async-trait",
+ "copypasta",
+ "json5",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "open",
+ "rdb-connstore",
+ "rdb-core",
+ "rdb-driver-cassandra",
+ "rdb-driver-mongo",
+ "rdb-driver-mysql",
+ "rdb-driver-postgres",
+ "rdb-driver-redis",
+ "rdb-driver-sqlite",
+ "rfd",
+ "semver",
+ "serde",
+ "serde_json",
+ "slint",
+ "slint-build",
+ "tokio",
+ "ureq",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5576,6 +5576,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rdb"
+version = "0.16.0"
+dependencies = [
+ "async-trait",
+ "copypasta",
+ "json5",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "open",
+ "rdb-connstore",
+ "rdb-core",
+ "rdb-driver-cassandra",
+ "rdb-driver-mongo",
+ "rdb-driver-mysql",
+ "rdb-driver-postgres",
+ "rdb-driver-redis",
+ "rdb-driver-sqlite",
+ "rfd",
+ "semver",
+ "serde",
+ "serde_json",
+ "slint",
+ "slint-build",
+ "tokio",
+ "ureq",
+]
+
+[[package]]
 name = "rdb-connstore"
 version = "0.1.0"
 dependencies = [
@@ -5677,35 +5706,6 @@ dependencies = [
  "rdb-core",
  "rusqlite",
  "tokio",
-]
-
-[[package]]
-name = "rdbs"
-version = "0.16.0"
-dependencies = [
- "async-trait",
- "copypasta",
- "json5",
- "objc2 0.6.4",
- "objc2-app-kit 0.3.2",
- "objc2-foundation 0.3.2",
- "open",
- "rdb-connstore",
- "rdb-core",
- "rdb-driver-cassandra",
- "rdb-driver-mongo",
- "rdb-driver-mysql",
- "rdb-driver-postgres",
- "rdb-driver-redis",
- "rdb-driver-sqlite",
- "rfd",
- "semver",
- "serde",
- "serde_json",
- "slint",
- "slint-build",
- "tokio",
- "ureq",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Split FE/BE build entry points. BE = crates/* libs, FE = rdbs (app/).
 # Run `make` or `make help` for the target list.
 
-BE_PKGS = rdbs-core rdbs-connstore rdbs-driver-postgres rdbs-driver-mysql rdbs-driver-redis rdbs-driver-mongo
+BE_PKGS = rdb-core rdb-connstore rdb-driver-postgres rdb-driver-mysql rdb-driver-redis rdb-driver-mongo
 FE_PKG  = rdbs
 BE_FLAGS = $(addprefix -p ,$(BE_PKGS))
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-# Split FE/BE build entry points. BE = crates/* libs, FE = rdbs (app/).
+# Split FE/BE build entry points. BE = crates/* libs, FE = rdb (app/).
 # Run `make` or `make help` for the target list.
 
 BE_PKGS = rdb-core rdb-connstore rdb-driver-postgres rdb-driver-mysql rdb-driver-redis rdb-driver-mongo
-FE_PKG  = rdbs
+FE_PKG  = rdb
 BE_FLAGS = $(addprefix -p ,$(BE_PKGS))
 
 .DEFAULT_GOAL := help
@@ -23,17 +23,17 @@ be-test: ## Test backend crate unit tests (no FE, no Docker)
 be-check: ## Type-check backend crates only
 	cargo check $(BE_FLAGS)
 
-fe-build: ## Build the rdbs UI binary
+fe-build: ## Build the rdb UI binary
 	cargo build -p $(FE_PKG)
 
-fe-run: ## Run the rdbs UI binary
+fe-run: ## Run the rdb UI binary
 	cargo run -p $(FE_PKG)
 
-fe-build-run: ## Build the rdbs UI then launch it (GUI shows after build)
+fe-build-run: ## Build the rdb UI then launch it (GUI shows after build)
 	cargo build -p $(FE_PKG)
 	./$(FE_BIN)
 
-fe-show: ## Launch the rdbs UI; build it first only if missing
+fe-show: ## Launch the rdb UI; build it first only if missing
 	@test -x $(FE_BIN) || cargo build -p $(FE_PKG)
 	./$(FE_BIN)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/suiflex/rdb/actions/workflows/rdbs-app.yml"><img src="https://img.shields.io/github/actions/workflow/status/suiflex/rdb/rdbs-app.yml?branch=develop&style=for-the-badge" alt="Build status"></a>
+  <a href="https://github.com/suiflex/rdb/actions/workflows/rdb-app.yml"><img src="https://img.shields.io/github/actions/workflow/status/suiflex/rdb/rdb-app.yml?branch=develop&style=for-the-badge" alt="Build status"></a>
   <a href="https://github.com/suiflex/rdb/releases"><img src="https://img.shields.io/github/v/tag/suiflex/rdb?include_prereleases&style=for-the-badge&label=release" alt="Release"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/License-MIT-4ade80.svg?style=for-the-badge" alt="MIT License"></a>
   <img src="https://img.shields.io/badge/platform-macOS_·_Linux_·_Windows-4ade80?style=for-the-badge" alt="Platforms">
@@ -50,7 +50,7 @@ A native, lightweight, cross-platform database manager built with Rust and Slint
 
 ### Core design rule
 
-The UI (`app/`) depends only on `rdbs-core`. It never imports a concrete driver crate. Adding a new engine = a new `driver-*` crate that implements the `Driver` trait; the UI is untouched.
+The UI (`app/`) depends only on `rdb-core`. It never imports a concrete driver crate. Adding a new engine = a new `driver-*` crate that implements the `Driver` trait; the UI is untouched.
 
 ### Async bridge
 
@@ -100,7 +100,7 @@ Prebuilt installers are expected to be attached to GitHub Releases.
 npm i -g @suiflex/rdb
 ```
 
-The postinstall step downloads the prebuilt `rdbs` binary for your platform from
+The postinstall step downloads the prebuilt `rdb` binary for your platform from
 the matching GitHub Release, then `rdb` launches it.
 
 ### macOS / Linux
@@ -112,27 +112,27 @@ curl -fsSL https://raw.githubusercontent.com/suiflex/rdb/develop/scripts/install
 Optional:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/suiflex/rdb/develop/scripts/install.sh | RDBS_VERSION=v0.1.0 INSTALL_DIR="$HOME/.local/bin" bash
+curl -fsSL https://raw.githubusercontent.com/suiflex/rdb/develop/scripts/install.sh | RDB_VERSION=v0.1.0 INSTALL_DIR="$HOME/.local/bin" bash
 ```
 
-The script installs `rdbs` into `/usr/local/bin` when writable, otherwise it falls back to `~/.local/bin`.
+The script installs `rdb` into `/usr/local/bin` when writable, otherwise it falls back to `~/.local/bin`.
 
 ### Homebrew (macOS / Linux)
 
 ```bash
-brew install suiflex/tap/rdbs
+brew install suiflex/tap/rdb
 ```
 
-Upgrade later with `brew upgrade rdbs`.
+Upgrade later with `brew upgrade rdb`.
 
 ### Scoop (Windows)
 
 ```powershell
 scoop bucket add suiflex https://github.com/suiflex/scoop-bucket
-scoop install rdbs
+scoop install rdb
 ```
 
-Upgrade later with `scoop update rdbs`.
+Upgrade later with `scoop update rdb`.
 
 ## Build from source
 
@@ -157,22 +157,22 @@ sudo dnf install libxkbcommon-devel fontconfig-devel mesa-libGL-devel
 
 ```bash
 # Development
-cargo build -p rdbs
+cargo build -p rdb
 
 # Optimized release (~smaller binary)
-cargo build --release -p rdbs
+cargo build --release -p rdb
 
 # Run directly
-cargo run -p rdbs
+cargo run -p rdb
 ```
 
-The release binary lands at `target/release/rdbs`.
+The release binary lands at `target/release/rdb`.
 
 ## Usage
 
 ### Add a connection
 
-1. Launch RDBS — connection picker opens.
+1. Launch RDB — connection picker opens.
 2. Click **+** → fill in host, port, credentials, database.
 3. Or paste a DSN URL into the **Import URL** field — fields auto-fill.
 4. Click **Test** to verify, then **Save**.
@@ -200,15 +200,15 @@ Active development. Ships 6 engines (PostgreSQL, MySQL, Redis, MongoDB, SQLite, 
 
 | Crate | Description |
 |-------|-------------|
-| `rdbs` | Desktop binary (app/) |
-| `rdbs-core` | `Driver` trait, `Query`, `ResultSet`, `Schema`, `RdbsError` |
-| `rdbs-connstore` | Saved connections — JSON on disk + OS keychain / AES-GCM file |
-| `rdbs-driver-postgres` | PostgreSQL driver via `tokio-postgres` |
-| `rdbs-driver-mysql` | MySQL/MariaDB driver via `mysql_async` |
-| `rdbs-driver-redis` | Redis driver via `redis` crate |
-| `rdbs-driver-mongo` | MongoDB driver via `mongodb` crate |
-| `rdbs-driver-sqlite` | SQLite driver via `rusqlite` |
-| `rdbs-driver-cassandra` | Cassandra driver via `scylla` |
+| `rdb` | Desktop binary (app/) |
+| `rdb-core` | `Driver` trait, `Query`, `ResultSet`, `Schema`, `RdbError` |
+| `rdb-connstore` | Saved connections — JSON on disk + OS keychain / AES-GCM file |
+| `rdb-driver-postgres` | PostgreSQL driver via `tokio-postgres` |
+| `rdb-driver-mysql` | MySQL/MariaDB driver via `mysql_async` |
+| `rdb-driver-redis` | Redis driver via `redis` crate |
+| `rdb-driver-mongo` | MongoDB driver via `mongodb` crate |
+| `rdb-driver-sqlite` | SQLite driver via `rusqlite` |
+| `rdb-driver-cassandra` | Cassandra driver via `scylla` |
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-RDBS is pre-1.0 and ships from a single tracked package (`rdbs`). Security
+RDB is pre-1.0 and ships from a single tracked package (`rdb`). Security
 fixes land on the latest release; there are no long-term support branches yet.
 
 | Version | Supported          |
@@ -44,8 +44,8 @@ Please include, where you can:
 
 ## Scope
 
-RDBS stores connection secrets in the OS keychain, falling back to AES-GCM
+RDB stores connection secrets in the OS keychain, falling back to AES-GCM
 encryption. Reports touching credential handling, secret storage, or the
 database driver connection paths are especially valued.
 
-Thank you for helping keep RDBS and its users safe.
+Thank you for helping keep RDB and its users safe.

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "rdbs"
+name = "rdb"
 version = "0.16.0"
 edition = "2021"
 
 [[bin]]
-name = "rdbs"
+name = "rdb"
 path = "src/main.rs"
 
 [dependencies]

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -9,14 +9,14 @@ path = "src/main.rs"
 
 [dependencies]
 slint = { version = "1.8", default-features = false, features = ["compat-1-2", "std", "backend-winit", "renderer-femtovg", "renderer-software"] }
-rdbs-core = { path = "../crates/core" }
-rdbs-connstore = { path = "../crates/connstore" }
-rdbs-driver-postgres = { path = "../crates/driver-postgres" }
-rdbs-driver-mysql = { path = "../crates/driver-mysql" }
-rdbs-driver-redis = { path = "../crates/driver-redis" }
-rdbs-driver-mongo = { path = "../crates/driver-mongo" }
-rdbs-driver-sqlite = { path = "../crates/driver-sqlite" }
-rdbs-driver-cassandra = { path = "../crates/driver-cassandra" }
+rdb-core = { path = "../crates/core" }
+rdb-connstore = { path = "../crates/connstore" }
+rdb-driver-postgres = { path = "../crates/driver-postgres" }
+rdb-driver-mysql = { path = "../crates/driver-mysql" }
+rdb-driver-redis = { path = "../crates/driver-redis" }
+rdb-driver-mongo = { path = "../crates/driver-mongo" }
+rdb-driver-sqlite = { path = "../crates/driver-sqlite" }
+rdb-driver-cassandra = { path = "../crates/driver-cassandra" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/app/src/dispatch.rs
+++ b/app/src/dispatch.rs
@@ -28,7 +28,7 @@ pub enum AnyDriver {
     // Boxed: a scylla Session is far larger than the other drivers, so keep it
     // off the enum's inline footprint (clippy::large_enum_variant).
     Cassandra(Box<CassandraDriver>),
-    /// In-process demo driver (RDBS_MOCK=1); no network, seeded data.
+    /// In-process demo driver (RDB_MOCK=1); no network, seeded data.
     Mock(crate::mock::MockDriver),
 }
 

--- a/app/src/dispatch.rs
+++ b/app/src/dispatch.rs
@@ -4,20 +4,20 @@
 //! async trait methods. Construction is the ONLY place the app names a concrete
 //! driver crate.
 
-use rdbs_connstore::Engine;
-use rdbs_core::conn::ConnConfig;
-use rdbs_core::driver::Driver;
-use rdbs_core::error::Result;
-use rdbs_core::query::Query;
-use rdbs_core::result::ResultSet;
-use rdbs_core::schema::{Container, Schema};
-use rdbs_core::write::{TableRef, WriteOp};
-use rdbs_driver_cassandra::CassandraDriver;
-use rdbs_driver_mongo::MongoDriver;
-use rdbs_driver_mysql::MysqlDriver;
-use rdbs_driver_postgres::PostgresDriver;
-use rdbs_driver_redis::RedisDriver;
-use rdbs_driver_sqlite::SqliteDriver;
+use rdb_connstore::Engine;
+use rdb_core::conn::ConnConfig;
+use rdb_core::driver::Driver;
+use rdb_core::error::Result;
+use rdb_core::query::Query;
+use rdb_core::result::ResultSet;
+use rdb_core::schema::{Container, Schema};
+use rdb_core::write::{TableRef, WriteOp};
+use rdb_driver_cassandra::CassandraDriver;
+use rdb_driver_mongo::MongoDriver;
+use rdb_driver_mysql::MysqlDriver;
+use rdb_driver_postgres::PostgresDriver;
+use rdb_driver_redis::RedisDriver;
+use rdb_driver_sqlite::SqliteDriver;
 
 pub enum AnyDriver {
     Postgres(PostgresDriver),
@@ -173,7 +173,7 @@ impl AnyDriver {
         q: &Query,
         batch: usize,
         cancel: std::sync::Arc<std::sync::atomic::AtomicBool>,
-        sink: tokio::sync::mpsc::Sender<rdbs_core::result::StreamItem>,
+        sink: tokio::sync::mpsc::Sender<rdb_core::result::StreamItem>,
     ) -> Result<()> {
         match self {
             AnyDriver::Postgres(d) => d.query_stream(q, batch, cancel, sink).await,
@@ -229,40 +229,40 @@ pub fn write_statements(engine: Engine, ops: &[WriteOp]) -> Vec<String> {
     ops.iter()
         .map(|op| match (engine, op) {
             (Engine::Postgres, WriteOp::Update { table, pk, changes }) => {
-                rdbs_driver_postgres::write_sql::update_sql(table, pk, changes)
+                rdb_driver_postgres::write_sql::update_sql(table, pk, changes)
             }
             (Engine::Postgres, WriteOp::Insert { table, values }) => {
-                rdbs_driver_postgres::write_sql::insert_sql(table, values)
+                rdb_driver_postgres::write_sql::insert_sql(table, values)
             }
             (Engine::Postgres, WriteOp::Delete { table, pk }) => {
-                rdbs_driver_postgres::write_sql::delete_sql(table, pk)
+                rdb_driver_postgres::write_sql::delete_sql(table, pk)
             }
             (Engine::MySql, WriteOp::Update { table, pk, changes }) => {
-                rdbs_driver_mysql::write_sql::update_sql(table, pk, changes).0
+                rdb_driver_mysql::write_sql::update_sql(table, pk, changes).0
             }
             (Engine::MySql, WriteOp::Insert { table, values }) => {
-                rdbs_driver_mysql::write_sql::insert_sql(table, values).0
+                rdb_driver_mysql::write_sql::insert_sql(table, values).0
             }
             (Engine::MySql, WriteOp::Delete { table, pk }) => {
-                rdbs_driver_mysql::write_sql::delete_sql(table, pk).0
+                rdb_driver_mysql::write_sql::delete_sql(table, pk).0
             }
             (Engine::Sqlite, WriteOp::Update { table, pk, changes }) => {
-                rdbs_driver_sqlite::write_sql::update_sql(table, pk, changes)
+                rdb_driver_sqlite::write_sql::update_sql(table, pk, changes)
             }
             (Engine::Sqlite, WriteOp::Insert { table, values }) => {
-                rdbs_driver_sqlite::write_sql::insert_sql(table, values)
+                rdb_driver_sqlite::write_sql::insert_sql(table, values)
             }
             (Engine::Sqlite, WriteOp::Delete { table, pk }) => {
-                rdbs_driver_sqlite::write_sql::delete_sql(table, pk)
+                rdb_driver_sqlite::write_sql::delete_sql(table, pk)
             }
             (Engine::Cassandra, WriteOp::Update { table, pk, changes }) => {
-                rdbs_driver_cassandra::write_cql::update_sql(table, pk, changes)
+                rdb_driver_cassandra::write_cql::update_sql(table, pk, changes)
             }
             (Engine::Cassandra, WriteOp::Insert { table, values }) => {
-                rdbs_driver_cassandra::write_cql::insert_sql(table, values)
+                rdb_driver_cassandra::write_cql::insert_sql(table, values)
             }
             (Engine::Cassandra, WriteOp::Delete { table, pk }) => {
-                rdbs_driver_cassandra::write_cql::delete_sql(table, pk)
+                rdb_driver_cassandra::write_cql::delete_sql(table, pk)
             }
             (Engine::Mongo, op) => format!("MongoDB write: {op:?}"),
             (Engine::Redis, op) => format!("Redis write: {op:?}"),
@@ -273,8 +273,8 @@ pub fn write_statements(engine: Engine, ops: &[WriteOp]) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rdbs_connstore::Engine;
-    use rdbs_core::result::Cell;
+    use rdb_connstore::Engine;
+    use rdb_core::result::Cell;
 
     #[test]
     fn engine_maps_to_human_label() {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -42,7 +42,7 @@ const UNGROUPED: &str = "Ungrouped";
 /// regardless of grouping or ordering. `collapsed` holds the set of group labels
 /// currently folded shut.
 fn build_conn_items(
-    store: &rdbs_connstore::ConnStore,
+    store: &rdb_connstore::ConnStore,
     collapsed: &HashSet<String>,
     filter: &str,
 ) -> Vec<ConnItem> {
@@ -119,10 +119,10 @@ fn build_conn_items(
 /// the toggle key, so `on_toggle_schema_node` can tell a category click from a
 /// table click. The first entry is the "primary" category that holds the
 /// engine's containers. ponytail: SQL keeps the Views/Functions placeholders.
-fn sidebar_categories(engine: Option<rdbs_connstore::Engine>) -> &'static [&'static str] {
+fn sidebar_categories(engine: Option<rdb_connstore::Engine>) -> &'static [&'static str] {
     match engine {
         // Mongo/Redis use the nested database→leaf path, not these categories.
-        Some(rdbs_connstore::Engine::Mongo) => &["Collections"],
+        Some(rdb_connstore::Engine::Mongo) => &["Collections"],
         _ => &["Functions", "Tables"],
     }
 }
@@ -148,21 +148,21 @@ fn schema_display_rows(
     expanded_tables: &HashSet<String>,
     collapsed_cats: &HashSet<String>,
     loaded_dbs: &HashSet<String>,
-    engine: Option<rdbs_connstore::Engine>,
+    engine: Option<rdb_connstore::Engine>,
     filter: &str,
 ) -> Vec<TreeNode> {
     // Mongo (database→collection) and Redis (database→key) both render as a
     // collapsible database header nesting its own lazily-loaded leaves.
     // `expanded_tables` is the set of OPEN databases (default closed).
     match engine {
-        Some(rdbs_connstore::Engine::Mongo) => {
+        Some(rdb_connstore::Engine::Mongo) => {
             return nested_display_rows(nodes, expanded_tables, loaded_dbs, "collection", filter);
         }
-        Some(rdbs_connstore::Engine::Redis) => {
+        Some(rdb_connstore::Engine::Redis) => {
             return nested_display_rows(nodes, expanded_tables, loaded_dbs, "key", filter);
         }
         // Cassandra nests keyspace→table like Mongo nests database→collection.
-        Some(rdbs_connstore::Engine::Cassandra) => {
+        Some(rdb_connstore::Engine::Cassandra) => {
             return nested_display_rows(nodes, expanded_tables, loaded_dbs, "table", filter);
         }
         _ => {}
@@ -349,7 +349,7 @@ fn nested_display_rows(
 /// sits. Shared (Arc<Mutex>) so async count/pk fetches can update it.
 #[derive(Default, Clone)]
 struct BrowseState {
-    table: Option<rdbs_core::write::TableRef>,
+    table: Option<rdb_core::write::TableRef>,
     page: u64,
     limit: u64,
     total: Option<u64>,
@@ -362,17 +362,17 @@ struct BrowseState {
 /// Default browse page size per engine. Mongo documents are fat, so a Mongo
 /// collection opens 20 at a time (matching Compass) instead of the SQL default.
 /// ponytail: per-engine default only; the stepper + paging handle the rest.
-fn default_browse_limit(engine: rdbs_connstore::Engine) -> u64 {
+fn default_browse_limit(engine: rdb_connstore::Engine) -> u64 {
     match engine {
-        rdbs_connstore::Engine::Mongo => 20,
+        rdb_connstore::Engine::Mongo => 20,
         _ => 300,
     }
 }
 
 /// Operators exposed by the active engine. The filter itself is evaluated on
 /// the fetched page, but the vocabulary mirrors what that engine accepts.
-fn filter_operators(engine: rdbs_connstore::Engine) -> Vec<SharedString> {
-    use rdbs_connstore::Engine;
+fn filter_operators(engine: rdb_connstore::Engine) -> Vec<SharedString> {
+    use rdb_connstore::Engine;
     let ops: &[&str] = match engine {
         Engine::Postgres => &[
             "=",
@@ -463,7 +463,7 @@ struct WorkspaceTab {
     title: String,
     kind: String,
     query_text: String,
-    table: Option<rdbs_core::write::TableRef>,
+    table: Option<rdb_core::write::TableRef>,
     browse: BrowseState,
     results: Vec<StoredResult>,
     active_result: usize,
@@ -562,19 +562,19 @@ fn sync_query_console(w: &MainWindow, log: &Arc<std::sync::Mutex<Vec<String>>>) 
 // ponytail: timeout-bounded, no hard abort; add CancellationToken if a true
 // cancel button is ever needed.
 async fn try_connect(
-    engine: rdbs_connstore::Engine,
-    cfg: rdbs_core::conn::ConnConfig,
-) -> Result<u64, rdbs_core::error::RdbsError> {
+    engine: rdb_connstore::Engine,
+    cfg: rdb_core::conn::ConnConfig,
+) -> Result<u64, rdb_core::error::RdbsError> {
     let t0 = std::time::Instant::now();
     let attempt = async {
         let driver = AnyDriver::connect(engine, &cfg).await?;
         driver.ping().await?;
-        Ok::<_, rdbs_core::error::RdbsError>(())
+        Ok::<_, rdb_core::error::RdbsError>(())
     };
     match tokio::time::timeout(std::time::Duration::from_secs(8), attempt).await {
         Ok(Ok(())) => Ok(t0.elapsed().as_millis().max(1) as u64),
         Ok(Err(e)) => Err(e),
-        Err(_) => Err(rdbs_core::error::RdbsError::Connection(
+        Err(_) => Err(rdb_core::error::RdbsError::Connection(
             "connection timed out".into(),
         )),
     }
@@ -616,7 +616,7 @@ const RECENT_CAP: usize = 50;
 
 /// Load persisted recent-query history; empty on a missing/unreadable file.
 fn load_recent() -> Vec<String> {
-    let Ok(path) = rdbs_connstore::ConnStore::recent_queries_path() else {
+    let Ok(path) = rdb_connstore::ConnStore::recent_queries_path() else {
         return Vec::new();
     };
     std::fs::read_to_string(path)
@@ -627,7 +627,7 @@ fn load_recent() -> Vec<String> {
 
 /// Persist the recent-query history (best-effort; I/O errors are ignored).
 fn save_recent(list: &[String]) {
-    let Ok(path) = rdbs_connstore::ConnStore::recent_queries_path() else {
+    let Ok(path) = rdb_connstore::ConnStore::recent_queries_path() else {
         return;
     };
     if let Some(dir) = path.parent() {
@@ -676,7 +676,7 @@ fn save_query_tabs(tabs: &[WorkspaceTab], active: Option<&str>) {
     if mock::mock_mode() {
         return;
     }
-    let Ok(path) = rdbs_connstore::ConnStore::query_tabs_path() else {
+    let Ok(path) = rdb_connstore::ConnStore::query_tabs_path() else {
         return;
     };
     let sql: Vec<PersistedTab> = tabs
@@ -703,7 +703,7 @@ fn save_query_tabs(tabs: &[WorkspaceTab], active: Option<&str>) {
 /// Load persisted SQL tabs into fresh `WorkspaceTab`s (empty results/browse).
 /// Returns the tabs and the active tab id (if it still exists).
 fn load_query_tabs() -> (Vec<WorkspaceTab>, Option<String>) {
-    let Ok(path) = rdbs_connstore::ConnStore::query_tabs_path() else {
+    let Ok(path) = rdb_connstore::ConnStore::query_tabs_path() else {
         return (Vec::new(), None);
     };
     let Some(payload): Option<PersistedTabs> = std::fs::read_to_string(path)
@@ -763,8 +763,8 @@ fn default_col_width(name: &str, type_name: &str) -> f32 {
 }
 
 fn browse_text(
-    engine: rdbs_connstore::Engine,
-    table: &rdbs_core::write::TableRef,
+    engine: rdb_connstore::Engine,
+    table: &rdb_core::write::TableRef,
     page: u64,
     limit: u64,
     // Mongo-only filter document (raw JSON, empty = all). Unused by SQL engines.
@@ -772,7 +772,7 @@ fn browse_text(
 ) -> String {
     let offset = page * limit;
     match engine {
-        rdbs_connstore::Engine::Postgres => {
+        rdb_connstore::Engine::Postgres => {
             let schema = table.schema.as_deref().unwrap_or("public");
             let q = |s: &str| s.replace('"', "\"\"");
             format!(
@@ -781,19 +781,19 @@ fn browse_text(
                 q(&table.name)
             )
         }
-        rdbs_connstore::Engine::MySql => {
+        rdb_connstore::Engine::MySql => {
             format!(
                 "SELECT * FROM `{}` LIMIT {limit} OFFSET {offset}",
                 table.name.replace('`', "``")
             )
         }
-        rdbs_connstore::Engine::Sqlite => {
+        rdb_connstore::Engine::Sqlite => {
             format!(
                 "SELECT * FROM \"{}\" LIMIT {limit} OFFSET {offset}",
                 table.name.replace('"', "\"\"")
             )
         }
-        rdbs_connstore::Engine::Cassandra => {
+        rdb_connstore::Engine::Cassandra => {
             // ponytail: CQL is LIMIT-only (no OFFSET); real paging state is a
             // follow-up. Keyspace travels in `database`.
             let q = |s: &str| s.replace('"', "\"\"");
@@ -806,7 +806,7 @@ fn browse_text(
                 _ => format!("SELECT * FROM \"{}\" LIMIT {limit}", q(&table.name)),
             }
         }
-        rdbs_connstore::Engine::Mongo => {
+        rdb_connstore::Engine::Mongo => {
             let db = table
                 .database
                 .as_deref()
@@ -821,7 +821,7 @@ fn browse_text(
                 table.name
             )
         }
-        rdbs_connstore::Engine::Redis => {
+        rdb_connstore::Engine::Redis => {
             format!("BROWSE {} {offset} {limit}", table.name)
         }
     }
@@ -841,8 +841,8 @@ fn browse_text(
 /// Writes, DDL, `EXPLAIN`, `SELECT ... INTO`, an existing `LIMIT`, and non-SQL
 /// engines are all false (word-scan, not a real parser: a `limit`/`insert`
 /// inside a subquery conservatively returns false, so we never mangle it).
-fn is_bare_select(engine: rdbs_connstore::Engine, sql: &str) -> bool {
-    use rdbs_connstore::Engine;
+fn is_bare_select(engine: rdb_connstore::Engine, sql: &str) -> bool {
+    use rdb_connstore::Engine;
     if !matches!(
         engine,
         Engine::Postgres | Engine::MySql | Engine::Sqlite | Engine::Cassandra
@@ -868,7 +868,7 @@ fn is_bare_select(engine: rdbs_connstore::Engine, sql: &str) -> bool {
 
 /// TablePlus-style row cap for a manually-run statement. `limit == 0` means
 /// "No limit" (the streaming path owns that case), so the SQL is left as-is.
-fn cap_select(engine: rdbs_connstore::Engine, sql: &str, limit: u64) -> String {
+fn cap_select(engine: rdb_connstore::Engine, sql: &str, limit: u64) -> String {
     if limit == 0 || !is_bare_select(engine, sql) {
         return sql.to_string();
     }
@@ -879,7 +879,7 @@ fn cap_select(engine: rdbs_connstore::Engine, sql: &str, limit: u64) -> String {
 #[cfg(test)]
 mod cap_select_tests {
     use super::cap_select;
-    use rdbs_connstore::Engine;
+    use rdb_connstore::Engine;
 
     #[test]
     fn bare_select_gets_limit() {
@@ -953,7 +953,7 @@ const STREAM_SOFT_CAP: usize = 200_000;
 /// timer. Carries plain `Send` data only (no Slint types cross the boundary).
 enum StreamMsg {
     Meta(Vec<model::VmColumn>),
-    Batch(Vec<rdbs_core::result::Row>),
+    Batch(Vec<rdb_core::result::Row>),
     Done { capped: bool, elapsed_ms: u64 },
     Err(String),
 }
@@ -1084,19 +1084,19 @@ fn filter_grid(g: &model::GridModel, needle: &str) -> model::GridModel {
 /// List a table's indexes as (name, definition) via the engine catalog.
 /// Empty for engines without one (Redis, Mongo) and on any query error.
 async fn fetch_indexes(
-    engine: rdbs_connstore::Engine,
+    engine: rdb_connstore::Engine,
     driver: &AnyDriver,
-    table: &rdbs_core::write::TableRef,
+    table: &rdb_core::write::TableRef,
 ) -> Vec<(String, String)> {
     let esc = |s: &str| s.replace('\'', "''");
     let sql = match engine {
-        rdbs_connstore::Engine::Postgres => format!(
+        rdb_connstore::Engine::Postgres => format!(
             "SELECT indexname, indexdef FROM pg_indexes \
              WHERE tablename = '{}' AND schemaname = '{}' ORDER BY 1",
             esc(&table.name),
             esc(table.schema.as_deref().unwrap_or("public")),
         ),
-        rdbs_connstore::Engine::MySql => format!(
+        rdb_connstore::Engine::MySql => format!(
             "SELECT index_name, GROUP_CONCAT(column_name ORDER BY seq_in_index \
              SEPARATOR ', ') FROM information_schema.statistics \
              WHERE table_name = '{}' AND table_schema = \
@@ -1106,8 +1106,8 @@ async fn fetch_indexes(
         ),
         _ => return Vec::new(),
     };
-    match driver.query(&rdbs_core::query::Query::Sql(sql)).await {
-        Ok(rdbs_core::result::ResultSet::Tabular { rows, .. }) => rows
+    match driver.query(&rdb_core::query::Query::Sql(sql)).await {
+        Ok(rdb_core::result::ResultSet::Tabular { rows, .. }) => rows
             .into_iter()
             .filter_map(|r| {
                 let mut it = r.into_iter();
@@ -1573,7 +1573,7 @@ mod fmt_tests {
     }
     #[test]
     fn ilike_is_postgres_only() {
-        use rdbs_connstore::Engine;
+        use rdb_connstore::Engine;
         assert!(filter_operators(Engine::Postgres)
             .iter()
             .any(|op| op == "ILIKE"));
@@ -1644,23 +1644,23 @@ fn main() -> Result<(), slint::PlatformError> {
 
     // One store for the app lifetime; all CRUD + password ops go through it.
     // RDBS_MOCK=1 swaps in a seeded temp store (never the user's real one).
-    let store: Rc<RefCell<rdbs_connstore::ConnStore>> = Rc::new(RefCell::new(
+    let store: Rc<RefCell<rdb_connstore::ConnStore>> = Rc::new(RefCell::new(
         if let Ok(dir) = std::env::var("RDBS_STORE_DIR") {
             // Explicit store dir (e2e harness): file-backed, real drivers.
             let dir = std::path::PathBuf::from(dir);
             let backend = Box::new(
-                rdbs_connstore::EncryptedFileBackend::new(&dir).expect("file secret backend"),
+                rdb_connstore::EncryptedFileBackend::new(&dir).expect("file secret backend"),
             );
-            rdbs_connstore::ConnStore::load(dir.join("connections.json"), backend)
+            rdb_connstore::ConnStore::load(dir.join("connections.json"), backend)
                 .expect("load RDBS_STORE_DIR store")
         } else if mock::mock_mode() {
             mock::mock_store(std::env::temp_dir().join(format!("rdbs-mock-{}", std::process::id())))
         } else {
-            rdbs_connstore::ConnStore::open_default().unwrap_or_else(|_| {
+            rdb_connstore::ConnStore::open_default().unwrap_or_else(|_| {
                 let dir = std::env::temp_dir().join("dbm");
                 let _ = std::fs::create_dir_all(&dir);
-                let backend = rdbs_connstore::secret::select_backend(&dir).expect("secret backend");
-                rdbs_connstore::ConnStore::new(dir.join("connections.json"), backend)
+                let backend = rdb_connstore::secret::select_backend(&dir).expect("secret backend");
+                rdb_connstore::ConnStore::new(dir.join("connections.json"), backend)
             })
         },
     ));
@@ -1668,20 +1668,20 @@ fn main() -> Result<(), slint::PlatformError> {
     // App preferences (theme, update-check, UI state), persisted alongside the
     // connection store. Follows the same RDBS_STORE_DIR / mock overrides so
     // tests and the reference screenshots never touch the user's real file.
-    let settings: Rc<RefCell<rdbs_connstore::SettingsStore>> = Rc::new(RefCell::new(
+    let settings: Rc<RefCell<rdb_connstore::SettingsStore>> = Rc::new(RefCell::new(
         if let Ok(dir) = std::env::var("RDBS_STORE_DIR") {
             let dir = std::path::PathBuf::from(dir);
-            rdbs_connstore::SettingsStore::load(dir.join("settings.json"))
+            rdb_connstore::SettingsStore::load(dir.join("settings.json"))
                 .expect("load RDBS_STORE_DIR settings")
         } else if mock::mock_mode() {
             let dir = std::env::temp_dir().join(format!("rdbs-mock-{}", std::process::id()));
             let _ = std::fs::create_dir_all(&dir);
-            rdbs_connstore::SettingsStore::load(dir.join("settings.json")).expect("mock settings")
+            rdb_connstore::SettingsStore::load(dir.join("settings.json")).expect("mock settings")
         } else {
-            rdbs_connstore::SettingsStore::open_default().unwrap_or_else(|_| {
+            rdb_connstore::SettingsStore::open_default().unwrap_or_else(|_| {
                 let dir = std::env::temp_dir().join("dbm");
                 let _ = std::fs::create_dir_all(&dir);
-                rdbs_connstore::SettingsStore::load(dir.join("settings.json"))
+                rdb_connstore::SettingsStore::load(dir.join("settings.json"))
                     .expect("settings fallback")
             })
         },
@@ -1705,7 +1705,7 @@ fn main() -> Result<(), slint::PlatformError> {
     }
 
     // (engine, driver) so run-query can parse text for the right paradigm.
-    let current: Arc<tokio::sync::Mutex<Option<(rdbs_connstore::Engine, AnyDriver)>>> =
+    let current: Arc<tokio::sync::Mutex<Option<(rdb_connstore::Engine, AnyDriver)>>> =
         Arc::new(tokio::sync::Mutex::new(None));
 
     // Set of group labels the user has collapsed in the sidebar.
@@ -1823,7 +1823,7 @@ fn main() -> Result<(), slint::PlatformError> {
     }
     // Engine of the live connection, kept on the UI thread so table clicks can
     // build an engine-appropriate "browse this table" query synchronously.
-    let cur_engine: Rc<RefCell<Option<rdbs_connstore::Engine>>> = Rc::new(RefCell::new(None));
+    let cur_engine: Rc<RefCell<Option<rdb_connstore::Engine>>> = Rc::new(RefCell::new(None));
 
     // Reusable sidebar rebuild: buckets the store's list into grouped rows.
     let rebuild_sidebar = {
@@ -2144,7 +2144,7 @@ fn main() -> Result<(), slint::PlatformError> {
                             // language; default to SQL when not yet connected.
                             let engine = cur_engine
                                 .borrow()
-                                .unwrap_or(rdbs_connstore::Engine::Postgres);
+                                .unwrap_or(rdb_connstore::Engine::Postgres);
                             ed.toggle_comment(crate::query_parse::comment_prefix(engine));
                             true
                         }
@@ -2734,9 +2734,9 @@ fn main() -> Result<(), slint::PlatformError> {
                 // chosen database; open it so its collections show at once.
                 let nested = matches!(
                     engine,
-                    rdbs_connstore::Engine::Mongo
-                        | rdbs_connstore::Engine::Redis
-                        | rdbs_connstore::Engine::Cassandra
+                    rdb_connstore::Engine::Mongo
+                        | rdb_connstore::Engine::Redis
+                        | rdb_connstore::Engine::Cassandra
                 );
                 let (exp, loaded) = if nested {
                     let mut e = expanded_tables.lock().unwrap();
@@ -2847,9 +2847,9 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_sel_sub(sub.into());
             w.set_sel_local(s.local);
             let ssl = match s.sslmode {
-                rdbs_core::conn::SslMode::Disable => "disable",
-                rdbs_core::conn::SslMode::Prefer => "prefer",
-                rdbs_core::conn::SslMode::Require => "require",
+                rdb_core::conn::SslMode::Disable => "disable",
+                rdb_core::conn::SslMode::Prefer => "prefer",
+                rdb_core::conn::SslMode::Require => "require",
             };
             let mut rows = vec![
                 KvRow {
@@ -2875,7 +2875,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 k: "SSL".into(),
                 v: ssl.into(),
             });
-            if mock::mock_mode() && s.engine == rdbs_connstore::Engine::Postgres {
+            if mock::mock_mode() && s.engine == rdb_connstore::Engine::Postgres {
                 rows.push(KvRow {
                     k: "Server".into(),
                     v: "PostgreSQL 16.14".into(),
@@ -3896,7 +3896,7 @@ fn main() -> Result<(), slint::PlatformError> {
                         .unwrap_or_default(),
                 ));
                 w.set_bc_schema(SharedString::from(
-                    if matches!(sc.engine, rdbs_connstore::Engine::Postgres) {
+                    if matches!(sc.engine, rdb_connstore::Engine::Postgres) {
                         "public"
                     } else {
                         ""
@@ -3955,15 +3955,15 @@ fn main() -> Result<(), slint::PlatformError> {
                 // the Cancel button aborts sooner.
                 let attempt = async {
                     let cfg =
-                        cfg.map_err(|e| rdbs_core::error::RdbsError::Connection(e.to_string()))?;
+                        cfg.map_err(|e| rdb_core::error::RdbsError::Connection(e.to_string()))?;
                     let driver = AnyDriver::connect(engine, &cfg).await?;
                     let schema = driver.schema().await?;
-                    Ok::<_, rdbs_core::error::RdbsError>((driver, schema))
+                    Ok::<_, rdb_core::error::RdbsError>((driver, schema))
                 };
                 let result =
                     match tokio::time::timeout(std::time::Duration::from_secs(15), attempt).await {
                         Ok(r) => r,
-                        Err(_) => Err(rdbs_core::error::RdbsError::Connection(
+                        Err(_) => Err(rdb_core::error::RdbsError::Connection(
                             "connection timed out".into(),
                         )),
                     };
@@ -3974,7 +3974,7 @@ fn main() -> Result<(), slint::PlatformError> {
                         // switcher offers more than "public". Engine-specific SQL
                         // lives in the driver, not here.
                         let pg_schemas: Vec<SharedString> =
-                            if matches!(engine, rdbs_connstore::Engine::Postgres) {
+                            if matches!(engine, rdb_connstore::Engine::Postgres) {
                                 driver
                                     .list_schemas()
                                     .await
@@ -4014,7 +4014,7 @@ fn main() -> Result<(), slint::PlatformError> {
                         // selector must say "public", never the db name (a
                         // `"dbname"."table"` query would fail).
                         let mut schema_names: Vec<SharedString> =
-                            if matches!(engine, rdbs_connstore::Engine::Postgres) {
+                            if matches!(engine, rdb_connstore::Engine::Postgres) {
                                 if pg_schemas.is_empty() {
                                     vec![SharedString::from("public")]
                                 } else {
@@ -4039,10 +4039,10 @@ fn main() -> Result<(), slint::PlatformError> {
                         // SQL editor only makes sense for the SQL engines.
                         let sql_capable = matches!(
                             engine,
-                            rdbs_connstore::Engine::Postgres
-                                | rdbs_connstore::Engine::MySql
-                                | rdbs_connstore::Engine::Sqlite
-                                | rdbs_connstore::Engine::Cassandra
+                            rdb_connstore::Engine::Postgres
+                                | rdb_connstore::Engine::MySql
+                                | rdb_connstore::Engine::Sqlite
+                                | rdb_connstore::Engine::Cassandra
                         );
                         *raw_nodes.lock().unwrap() = nodes;
                         // Seed autocomplete with the active schema's tables plus a
@@ -4106,7 +4106,7 @@ fn main() -> Result<(), slint::PlatformError> {
                         // more names as this fills.
                         // ponytail: sequential N+1 fetch, fine for typical schema
                         // counts; make it concurrent if a wide DB feels laggy.
-                        if matches!(engine, rdbs_connstore::Engine::Postgres)
+                        if matches!(engine, rdb_connstore::Engine::Postgres)
                             && all_schema_names.len() > 1
                         {
                             let guard = store_driver.lock_owned().await;
@@ -4246,10 +4246,10 @@ fn main() -> Result<(), slint::PlatformError> {
                     Some((engine, driver)) => {
                         let stmts = if matches!(
                             engine,
-                            rdbs_connstore::Engine::Postgres
-                                | rdbs_connstore::Engine::MySql
-                                | rdbs_connstore::Engine::Sqlite
-                                | rdbs_connstore::Engine::Cassandra
+                            rdb_connstore::Engine::Postgres
+                                | rdb_connstore::Engine::MySql
+                                | rdb_connstore::Engine::Sqlite
+                                | rdb_connstore::Engine::Cassandra
                         ) {
                             editor::split_statements(&sql)
                         } else {
@@ -4261,7 +4261,7 @@ fn main() -> Result<(), slint::PlatformError> {
                         // in and freeze the grid. Browse text already carries its
                         // own LIMIT, so cap_select leaves it untouched.
                         let row_limit = browse.lock().unwrap().limit;
-                        let mut out = Err(rdbs_core::error::RdbsError::Query("empty query".into()));
+                        let mut out = Err(rdb_core::error::RdbsError::Query("empty query".into()));
                         for (i, s) in stmts.iter().enumerate() {
                             let s = cap_select(*engine, s, row_limit);
                             append_query_console(&query_console, s.clone());
@@ -4269,19 +4269,19 @@ fn main() -> Result<(), slint::PlatformError> {
                                 Ok(mut q) => {
                                     // Fill the selected database for a Mongo query
                                     // that didn't name one via `use(...)`.
-                                    if let rdbs_core::query::Query::Mongo(op) = &mut q {
+                                    if let rdb_core::query::Query::Mongo(op) = &mut q {
                                         if op.database.is_none() && !cur_db.is_empty() {
                                             op.database = Some(cur_db.clone());
                                         }
                                     }
                                     driver.query(&q).await
                                 }
-                                Err(msg) => Err(rdbs_core::error::RdbsError::Query(msg)),
+                                Err(msg) => Err(rdb_core::error::RdbsError::Query(msg)),
                             };
                             if let Err(e) = &out {
                                 // Point the user at the offending statement.
                                 if n > 1 {
-                                    out = Err(rdbs_core::error::RdbsError::Query(format!(
+                                    out = Err(rdb_core::error::RdbsError::Query(format!(
                                         "statement {}/{n}: {e}",
                                         i + 1
                                     )));
@@ -4292,7 +4292,7 @@ fn main() -> Result<(), slint::PlatformError> {
                         (out, n)
                     }
                     None => (
-                        Err(rdbs_core::error::RdbsError::Connection(
+                        Err(rdb_core::error::RdbsError::Connection(
                             "not connected".into(),
                         )),
                         1,
@@ -4522,7 +4522,7 @@ fn main() -> Result<(), slint::PlatformError> {
                                             let mut vmrow = Vec::with_capacity(row.len());
                                             for cell in row {
                                                 let is_null =
-                                                    matches!(cell, rdbs_core::result::Cell::Null);
+                                                    matches!(cell, rdb_core::result::Cell::Null);
                                                 let text = cell.render();
                                                 vm.push(GridCell {
                                                     text: text.clone().into(),
@@ -4633,12 +4633,12 @@ fn main() -> Result<(), slint::PlatformError> {
             // Producer task: stream from the driver, forward Send batches to the
             // UI channel. Holds the driver lock for the whole stream (like a DB
             // client cursor); Cancel or a new run stops it at the next batch.
-            let q = rdbs_core::query::Query::Sql(sql);
+            let q = rdb_core::query::Query::Sql(sql);
             let current = current.clone();
             rt.spawn(async move {
                 let t0 = std::time::Instant::now();
                 let guard = current.lock().await;
-                let (ctx, mut crx) = tokio::sync::mpsc::channel::<rdbs_core::result::StreamItem>(4);
+                let (ctx, mut crx) = tokio::sync::mpsc::channel::<rdb_core::result::StreamItem>(4);
                 let cancel_prod = cancel.clone();
                 let producer = async move {
                     match guard.as_ref() {
@@ -4647,7 +4647,7 @@ fn main() -> Result<(), slint::PlatformError> {
                                 .query_stream(&q, STREAM_BATCH, cancel_prod, ctx)
                                 .await
                         }
-                        None => Err(rdbs_core::error::RdbsError::Connection(
+                        None => Err(rdb_core::error::RdbsError::Connection(
                             "not connected".into(),
                         )),
                     }
@@ -4659,7 +4659,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     let mut capped = false;
                     while let Some(item) = crx.recv().await {
                         match item {
-                            rdbs_core::result::StreamItem::Meta(cols) => {
+                            rdb_core::result::StreamItem::Meta(cols) => {
                                 let vmcols: Vec<model::VmColumn> = cols
                                     .iter()
                                     .map(|c| model::VmColumn {
@@ -4672,7 +4672,7 @@ fn main() -> Result<(), slint::PlatformError> {
                                     break;
                                 }
                             }
-                            rdbs_core::result::StreamItem::Batch(rows) => {
+                            rdb_core::result::StreamItem::Batch(rows) => {
                                 total += rows.len();
                                 if ui_tx2.send(StreamMsg::Batch(rows)).is_err() {
                                     cancel_cons.store(true, std::sync::atomic::Ordering::SeqCst);
@@ -4976,7 +4976,7 @@ fn main() -> Result<(), slint::PlatformError> {
             } else {
                 db.clone()
             };
-            let schema_name = if matches!(engine, rdbs_connstore::Engine::Postgres) {
+            let schema_name = if matches!(engine, rdb_connstore::Engine::Postgres) {
                 w.get_schema_name().to_string()
             } else {
                 String::new()
@@ -4997,9 +4997,9 @@ fn main() -> Result<(), slint::PlatformError> {
                 restore_tab(&w, index);
                 return;
             }
-            let table = rdbs_core::write::TableRef {
+            let table = rdb_core::write::TableRef {
                 database: (!db.is_empty()).then(|| db.clone()),
-                schema: matches!(engine, rdbs_connstore::Engine::Postgres)
+                schema: matches!(engine, rdb_connstore::Engine::Postgres)
                     .then(|| w.get_schema_name().to_string()),
                 name: label.clone(),
             };
@@ -5371,13 +5371,13 @@ fn main() -> Result<(), slint::PlatformError> {
             // keys / tables) lazily on first expand.
             if matches!(
                 engine,
-                Some(rdbs_connstore::Engine::Mongo)
-                    | Some(rdbs_connstore::Engine::Redis)
-                    | Some(rdbs_connstore::Engine::Cassandra)
+                Some(rdb_connstore::Engine::Mongo)
+                    | Some(rdb_connstore::Engine::Redis)
+                    | Some(rdb_connstore::Engine::Cassandra)
             ) {
                 let leaf_kind = match engine {
-                    Some(rdbs_connstore::Engine::Redis) => "key",
-                    Some(rdbs_connstore::Engine::Cassandra) => "table",
+                    Some(rdb_connstore::Engine::Redis) => "key",
+                    Some(rdb_connstore::Engine::Cassandra) => "table",
                     _ => "collection",
                 };
                 let now_open = {
@@ -5501,9 +5501,9 @@ fn main() -> Result<(), slint::PlatformError> {
             // existing open-table handler instead of duplicating its browse setup.
             if !matches!(
                 engine,
-                Some(rdbs_connstore::Engine::Postgres)
-                    | Some(rdbs_connstore::Engine::MySql)
-                    | Some(rdbs_connstore::Engine::Sqlite)
+                Some(rdb_connstore::Engine::Postgres)
+                    | Some(rdb_connstore::Engine::MySql)
+                    | Some(rdb_connstore::Engine::Sqlite)
             ) {
                 w.invoke_open_table(db, label);
                 return;
@@ -6269,7 +6269,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     let guard = current.lock().await;
                     match guard.as_ref() {
                         Some((_, driver)) => driver.commit(&ops).await,
-                        None => Err(rdbs_core::error::RdbsError::Connection(
+                        None => Err(rdb_core::error::RdbsError::Connection(
                             "not connected".into(),
                         )),
                     }
@@ -6399,7 +6399,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 t.set_dark(!now);
                 let _ = settings
                     .borrow_mut()
-                    .update(|s| s.theme = rdbs_connstore::ThemeMode::from_dark(!now));
+                    .update(|s| s.theme = rdb_connstore::ThemeMode::from_dark(!now));
             }
         });
     }
@@ -6427,14 +6427,14 @@ fn main() -> Result<(), slint::PlatformError> {
             _ => "5432",
         }
     }
-    fn label_to_engine(label: &str) -> rdbs_connstore::Engine {
+    fn label_to_engine(label: &str) -> rdb_connstore::Engine {
         match label {
-            "MySQL" => rdbs_connstore::Engine::MySql,
-            "Redis" => rdbs_connstore::Engine::Redis,
-            "MongoDB" => rdbs_connstore::Engine::Mongo,
-            "SQLite" => rdbs_connstore::Engine::Sqlite,
-            "Cassandra" => rdbs_connstore::Engine::Cassandra,
-            _ => rdbs_connstore::Engine::Postgres,
+            "MySQL" => rdb_connstore::Engine::MySql,
+            "Redis" => rdb_connstore::Engine::Redis,
+            "MongoDB" => rdb_connstore::Engine::Mongo,
+            "SQLite" => rdb_connstore::Engine::Sqlite,
+            "Cassandra" => rdb_connstore::Engine::Cassandra,
+            _ => rdb_connstore::Engine::Postgres,
         }
     }
     let editing_id: Rc<RefCell<String>> = Rc::new(RefCell::new(String::new()));
@@ -6490,9 +6490,9 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_f_database(SharedString::from(sc.database.unwrap_or_default()));
             w.set_f_password(SharedString::default());
             w.set_f_sslmode(SharedString::from(match sc.sslmode {
-                rdbs_core::conn::SslMode::Disable => "Disable",
-                rdbs_core::conn::SslMode::Prefer => "Prefer",
-                rdbs_core::conn::SslMode::Require => "Require",
+                rdb_core::conn::SslMode::Disable => "Disable",
+                rdb_core::conn::SslMode::Prefer => "Prefer",
+                rdb_core::conn::SslMode::Require => "Require",
             }));
             w.set_f_params(SharedString::from(sc.params.unwrap_or_default()));
             w.set_f_color(SharedString::from(
@@ -6526,7 +6526,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 return;
             };
             let raw = w.get_f_import_url().to_string();
-            match rdbs_connstore::parse_conn_url(&raw) {
+            match rdb_connstore::parse_conn_url(&raw) {
                 Ok(parsed) => {
                     if let Some(engine) = parsed.engine {
                         w.set_f_engine(SharedString::from(AnyDriver::label(engine)));
@@ -6552,9 +6552,9 @@ fn main() -> Result<(), slint::PlatformError> {
                     }
                     if let Some(sslmode) = parsed.sslmode {
                         w.set_f_sslmode(SharedString::from(match sslmode {
-                            rdbs_core::conn::SslMode::Disable => "Disable",
-                            rdbs_core::conn::SslMode::Prefer => "Prefer",
-                            rdbs_core::conn::SslMode::Require => "Require",
+                            rdb_core::conn::SslMode::Disable => "Disable",
+                            rdb_core::conn::SslMode::Prefer => "Prefer",
+                            rdb_core::conn::SslMode::Require => "Require",
                         }));
                     }
                     w.set_form_error(SharedString::default());
@@ -6666,9 +6666,9 @@ fn main() -> Result<(), slint::PlatformError> {
             };
             let engine = label_to_engine(w.get_f_engine().as_ref());
             let sslmode = match w.get_f_sslmode().to_string().as_str() {
-                "Disable" => rdbs_core::conn::SslMode::Disable,
-                "Require" => rdbs_core::conn::SslMode::Require,
-                _ => rdbs_core::conn::SslMode::Prefer,
+                "Disable" => rdb_core::conn::SslMode::Disable,
+                "Require" => rdb_core::conn::SslMode::Require,
+                _ => rdb_core::conn::SslMode::Prefer,
             };
             let database = {
                 let d = w.get_f_database().to_string();
@@ -6694,7 +6694,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     Some(p)
                 }
             };
-            let cfg = rdbs_core::conn::ConnConfig {
+            let cfg = rdb_core::conn::ConnConfig {
                 host,
                 port,
                 user: w.get_f_user().to_string(),
@@ -6772,9 +6772,9 @@ fn main() -> Result<(), slint::PlatformError> {
             };
             let engine = label_to_engine(w.get_f_engine().as_ref());
             let sslmode = match w.get_f_sslmode().to_string().as_str() {
-                "Disable" => rdbs_core::conn::SslMode::Disable,
-                "Require" => rdbs_core::conn::SslMode::Require,
-                _ => rdbs_core::conn::SslMode::Prefer,
+                "Disable" => rdb_core::conn::SslMode::Disable,
+                "Require" => rdb_core::conn::SslMode::Require,
+                _ => rdb_core::conn::SslMode::Prefer,
             };
             let database = {
                 let d = w.get_f_database().to_string();
@@ -6796,10 +6796,10 @@ fn main() -> Result<(), slint::PlatformError> {
             let password = w.get_f_password().to_string();
             let id = editing_id.borrow().clone();
 
-            let result: rdbs_connstore::Result<()> = (|| {
+            let result: rdb_connstore::Result<()> = (|| {
                 let mut st = store.borrow_mut();
                 let conn_id = if id.is_empty() {
-                    let mut sc = rdbs_connstore::SavedConnection::new(
+                    let mut sc = rdb_connstore::SavedConnection::new(
                         name,
                         engine,
                         host,
@@ -6817,7 +6817,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     let mut sc = st
                         .get(&id)
                         .cloned()
-                        .ok_or_else(|| rdbs_connstore::ConnStoreError::NotFound(id.clone()))?;
+                        .ok_or_else(|| rdb_connstore::ConnStoreError::NotFound(id.clone()))?;
                     sc.name = name;
                     sc.engine = engine;
                     sc.host = host;
@@ -6979,7 +6979,7 @@ mod tests {
 
     #[test]
     fn mongo_browse_default_is_twenty() {
-        use rdbs_connstore::Engine;
+        use rdb_connstore::Engine;
         assert_eq!(default_browse_limit(Engine::Mongo), 20);
         assert_eq!(default_browse_limit(Engine::Postgres), 300);
         assert_eq!(default_browse_limit(Engine::MySql), 300);
@@ -7010,7 +7010,7 @@ mod tests {
             &HashSet::new(),
             &HashSet::new(),
             &HashSet::new(),
-            Some(rdbs_connstore::Engine::Postgres),
+            Some(rdb_connstore::Engine::Postgres),
             "or",
         );
         let tables: Vec<_> = rows.iter().filter(|r| r.kind == "table").collect();
@@ -7027,7 +7027,7 @@ mod tests {
             &HashSet::new(),
             &HashSet::new(),
             &HashSet::new(),
-            Some(rdbs_connstore::Engine::Postgres),
+            Some(rdb_connstore::Engine::Postgres),
             "",
         );
         assert_eq!(rows.iter().filter(|r| r.kind == "table").count(), 3);
@@ -7063,35 +7063,35 @@ mod tests {
 
     #[test]
     fn browse_text_per_engine() {
-        let t = rdbs_core::write::TableRef {
+        let t = rdb_core::write::TableRef {
             database: None,
             schema: Some("public".into()),
             name: "users".into(),
         };
         assert_eq!(
-            browse_text(rdbs_connstore::Engine::Postgres, &t, 1, 300, ""),
+            browse_text(rdb_connstore::Engine::Postgres, &t, 1, 300, ""),
             "SELECT * FROM \"public\".\"users\" LIMIT 300 OFFSET 300"
         );
         assert_eq!(
-            browse_text(rdbs_connstore::Engine::MySql, &t, 0, 50, ""),
+            browse_text(rdb_connstore::Engine::MySql, &t, 0, 50, ""),
             "SELECT * FROM `users` LIMIT 50 OFFSET 0"
         );
         assert_eq!(
-            browse_text(rdbs_connstore::Engine::Redis, &t, 2, 100, ""),
+            browse_text(rdb_connstore::Engine::Redis, &t, 2, 100, ""),
             "BROWSE users 200 100"
         );
-        let m = rdbs_core::write::TableRef {
+        let m = rdb_core::write::TableRef {
             database: Some("shop".into()),
             schema: None,
             name: "orders".into(),
         };
         assert_eq!(
-            browse_text(rdbs_connstore::Engine::Mongo, &m, 1, 50, ""),
+            browse_text(rdb_connstore::Engine::Mongo, &m, 1, 50, ""),
             "{\"collection\":\"orders\",\"database\":\"shop\",\"op\":\"find\",\"body\":{},\"limit\":50,\"skip\":50}"
         );
         // A filter document lands in the find body.
         assert_eq!(
-            browse_text(rdbs_connstore::Engine::Mongo, &m, 0, 20, r#"{"status":"A"}"#),
+            browse_text(rdb_connstore::Engine::Mongo, &m, 0, 20, r#"{"status":"A"}"#),
             "{\"collection\":\"orders\",\"database\":\"shop\",\"op\":\"find\",\"body\":{\"status\":\"A\"},\"limit\":20,\"skip\":0}"
         );
     }
@@ -7103,7 +7103,7 @@ mod tests {
             &HashSet::new(),
             &HashSet::new(),
             &HashSet::new(),
-            Some(rdbs_connstore::Engine::Postgres),
+            Some(rdb_connstore::Engine::Postgres),
             "USERS",
         );
         assert_eq!(rows.iter().filter(|r| r.kind == "table").count(), 1);

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1,4 +1,4 @@
-//! rdbs-app: Slint desktop binary.
+//! rdb-app: Slint desktop binary.
 //!
 //! Async bridge pattern (canonical):
 //!   - A `tokio` multi-thread runtime (`Arc<Runtime>`) lives for the whole
@@ -1643,18 +1643,18 @@ fn main() -> Result<(), slint::PlatformError> {
     let window = MainWindow::new()?;
 
     // One store for the app lifetime; all CRUD + password ops go through it.
-    // RDBS_MOCK=1 swaps in a seeded temp store (never the user's real one).
+    // RDB_MOCK=1 swaps in a seeded temp store (never the user's real one).
     let store: Rc<RefCell<rdb_connstore::ConnStore>> = Rc::new(RefCell::new(
-        if let Ok(dir) = std::env::var("RDBS_STORE_DIR") {
+        if let Ok(dir) = std::env::var("RDB_STORE_DIR") {
             // Explicit store dir (e2e harness): file-backed, real drivers.
             let dir = std::path::PathBuf::from(dir);
             let backend = Box::new(
                 rdb_connstore::EncryptedFileBackend::new(&dir).expect("file secret backend"),
             );
             rdb_connstore::ConnStore::load(dir.join("connections.json"), backend)
-                .expect("load RDBS_STORE_DIR store")
+                .expect("load RDB_STORE_DIR store")
         } else if mock::mock_mode() {
-            mock::mock_store(std::env::temp_dir().join(format!("rdbs-mock-{}", std::process::id())))
+            mock::mock_store(std::env::temp_dir().join(format!("rdb-mock-{}", std::process::id())))
         } else {
             rdb_connstore::ConnStore::open_default().unwrap_or_else(|_| {
                 let dir = std::env::temp_dir().join("dbm");
@@ -1666,15 +1666,15 @@ fn main() -> Result<(), slint::PlatformError> {
     ));
 
     // App preferences (theme, update-check, UI state), persisted alongside the
-    // connection store. Follows the same RDBS_STORE_DIR / mock overrides so
+    // connection store. Follows the same RDB_STORE_DIR / mock overrides so
     // tests and the reference screenshots never touch the user's real file.
     let settings: Rc<RefCell<rdb_connstore::SettingsStore>> = Rc::new(RefCell::new(
-        if let Ok(dir) = std::env::var("RDBS_STORE_DIR") {
+        if let Ok(dir) = std::env::var("RDB_STORE_DIR") {
             let dir = std::path::PathBuf::from(dir);
             rdb_connstore::SettingsStore::load(dir.join("settings.json"))
-                .expect("load RDBS_STORE_DIR settings")
+                .expect("load RDB_STORE_DIR settings")
         } else if mock::mock_mode() {
-            let dir = std::env::temp_dir().join(format!("rdbs-mock-{}", std::process::id()));
+            let dir = std::env::temp_dir().join(format!("rdb-mock-{}", std::process::id()));
             let _ = std::fs::create_dir_all(&dir);
             rdb_connstore::SettingsStore::load(dir.join("settings.json")).expect("mock settings")
         } else {
@@ -1695,8 +1695,8 @@ fn main() -> Result<(), slint::PlatformError> {
     window.set_update_check_enabled(settings.borrow().get().update_check);
     window.set_app_version(env!("CARGO_PKG_VERSION").into());
 
-    // Fixed window size for the screenshot loop: RDBS_WIN=WxH (logical px).
-    if let Ok(spec) = std::env::var("RDBS_WIN") {
+    // Fixed window size for the screenshot loop: RDB_WIN=WxH (logical px).
+    if let Ok(spec) = std::env::var("RDB_WIN") {
         if let Some((w, h)) = spec.split_once('x') {
             if let (Ok(w), Ok(h)) = (w.parse::<f32>(), h.parse::<f32>()) {
                 window.window().set_size(slint::LogicalSize::new(w, h));
@@ -2908,10 +2908,10 @@ fn main() -> Result<(), slint::PlatformError> {
         fill_detail(idx);
     }
 
-    // RDBS_SCREEN drives the app to a reference state for screenshots and the
+    // RDB_SCREEN drives the app to a reference state for screenshots and the
     // e2e harness: "workspace" connects + opens emiten; "sql" opens + runs the
     // saved query; the rest open a specific modal/view.
-    if let Ok(screen) = std::env::var("RDBS_SCREEN") {
+    if let Ok(screen) = std::env::var("RDB_SCREEN") {
         let idx = store
             .borrow()
             .list()
@@ -4787,7 +4787,7 @@ fn main() -> Result<(), slint::PlatformError> {
             // ponytail: blocking native dialog on the UI thread, fine for a
             // one-shot; move to async if it ever janks.
             let Some(path) = rfd::FileDialog::new()
-                .set_file_name("rdbs-export.csv")
+                .set_file_name("rdb-export.csv")
                 .add_filter("CSV", &["csv"])
                 .save_file()
             else {
@@ -6595,7 +6595,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     return;
                 }
             };
-            let path = export::export_path("rdbs-connections", "json");
+            let path = export::export_path("rdb-connections", "json");
             w.set_sel_footer(SharedString::from(match std::fs::write(&path, json) {
                 Ok(()) => format!("backup → {}", path.display()),
                 Err(e) => format!("backup failed: {e}"),

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -564,17 +564,17 @@ fn sync_query_console(w: &MainWindow, log: &Arc<std::sync::Mutex<Vec<String>>>) 
 async fn try_connect(
     engine: rdb_connstore::Engine,
     cfg: rdb_core::conn::ConnConfig,
-) -> Result<u64, rdb_core::error::RdbsError> {
+) -> Result<u64, rdb_core::error::RdbError> {
     let t0 = std::time::Instant::now();
     let attempt = async {
         let driver = AnyDriver::connect(engine, &cfg).await?;
         driver.ping().await?;
-        Ok::<_, rdb_core::error::RdbsError>(())
+        Ok::<_, rdb_core::error::RdbError>(())
     };
     match tokio::time::timeout(std::time::Duration::from_secs(8), attempt).await {
         Ok(Ok(())) => Ok(t0.elapsed().as_millis().max(1) as u64),
         Ok(Err(e)) => Err(e),
-        Err(_) => Err(rdb_core::error::RdbsError::Connection(
+        Err(_) => Err(rdb_core::error::RdbError::Connection(
             "connection timed out".into(),
         )),
     }
@@ -3955,15 +3955,15 @@ fn main() -> Result<(), slint::PlatformError> {
                 // the Cancel button aborts sooner.
                 let attempt = async {
                     let cfg =
-                        cfg.map_err(|e| rdb_core::error::RdbsError::Connection(e.to_string()))?;
+                        cfg.map_err(|e| rdb_core::error::RdbError::Connection(e.to_string()))?;
                     let driver = AnyDriver::connect(engine, &cfg).await?;
                     let schema = driver.schema().await?;
-                    Ok::<_, rdb_core::error::RdbsError>((driver, schema))
+                    Ok::<_, rdb_core::error::RdbError>((driver, schema))
                 };
                 let result =
                     match tokio::time::timeout(std::time::Duration::from_secs(15), attempt).await {
                         Ok(r) => r,
-                        Err(_) => Err(rdb_core::error::RdbsError::Connection(
+                        Err(_) => Err(rdb_core::error::RdbError::Connection(
                             "connection timed out".into(),
                         )),
                     };
@@ -4261,7 +4261,7 @@ fn main() -> Result<(), slint::PlatformError> {
                         // in and freeze the grid. Browse text already carries its
                         // own LIMIT, so cap_select leaves it untouched.
                         let row_limit = browse.lock().unwrap().limit;
-                        let mut out = Err(rdb_core::error::RdbsError::Query("empty query".into()));
+                        let mut out = Err(rdb_core::error::RdbError::Query("empty query".into()));
                         for (i, s) in stmts.iter().enumerate() {
                             let s = cap_select(*engine, s, row_limit);
                             append_query_console(&query_console, s.clone());
@@ -4276,12 +4276,12 @@ fn main() -> Result<(), slint::PlatformError> {
                                     }
                                     driver.query(&q).await
                                 }
-                                Err(msg) => Err(rdb_core::error::RdbsError::Query(msg)),
+                                Err(msg) => Err(rdb_core::error::RdbError::Query(msg)),
                             };
                             if let Err(e) = &out {
                                 // Point the user at the offending statement.
                                 if n > 1 {
-                                    out = Err(rdb_core::error::RdbsError::Query(format!(
+                                    out = Err(rdb_core::error::RdbError::Query(format!(
                                         "statement {}/{n}: {e}",
                                         i + 1
                                     )));
@@ -4292,7 +4292,7 @@ fn main() -> Result<(), slint::PlatformError> {
                         (out, n)
                     }
                     None => (
-                        Err(rdb_core::error::RdbsError::Connection(
+                        Err(rdb_core::error::RdbError::Connection(
                             "not connected".into(),
                         )),
                         1,
@@ -4647,7 +4647,7 @@ fn main() -> Result<(), slint::PlatformError> {
                                 .query_stream(&q, STREAM_BATCH, cancel_prod, ctx)
                                 .await
                         }
-                        None => Err(rdb_core::error::RdbsError::Connection(
+                        None => Err(rdb_core::error::RdbError::Connection(
                             "not connected".into(),
                         )),
                     }
@@ -6269,7 +6269,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     let guard = current.lock().await;
                     match guard.as_ref() {
                         Some((_, driver)) => driver.commit(&ops).await,
-                        None => Err(rdb_core::error::RdbsError::Connection(
+                        None => Err(rdb_core::error::RdbError::Connection(
                             "not connected".into(),
                         )),
                     }

--- a/app/src/mock.rs
+++ b/app/src/mock.rs
@@ -157,7 +157,7 @@ use std::sync::Mutex;
 use async_trait::async_trait;
 use rdb_core::conn::ConnConfig;
 use rdb_core::driver::Driver;
-use rdb_core::error::{RdbsError, Result};
+use rdb_core::error::{RdbError, Result};
 use rdb_core::query::Query;
 use rdb_core::result::{Cell, Column, ResultSet, Row};
 use rdb_core::schema::{Container, ContainerKind, Database, Field, Function, Schema};
@@ -592,7 +592,7 @@ impl Driver for MockDriver {
         // Believable latency for the “● 12 ms” readout.
         tokio::time::sleep(std::time::Duration::from_millis(11)).await;
         let Query::Sql(sql) = q else {
-            return Err(RdbsError::UnsupportedQuery);
+            return Err(RdbError::UnsupportedQuery);
         };
         let sql = sql.trim();
         let upper = sql.to_uppercase();
@@ -644,11 +644,11 @@ impl Driver for MockDriver {
                         rows: vec![vec![Cell::Text(expr.to_string())]],
                     });
                 }
-                return Err(RdbsError::UnsupportedQuery);
+                return Err(RdbError::UnsupportedQuery);
             };
             let tables = self.tables.lock().unwrap();
             let Some(t) = tables.get(&table) else {
-                return Err(RdbsError::Query(format!(
+                return Err(RdbError::Query(format!(
                     "relation \"{table}\" does not exist"
                 )));
             };
@@ -681,7 +681,7 @@ impl Driver for MockDriver {
         tables
             .get(&table.name)
             .map(|t| t.rows.len() as u64)
-            .ok_or_else(|| RdbsError::Query(format!("relation \"{}\" does not exist", table.name)))
+            .ok_or_else(|| RdbError::Query(format!("relation \"{}\" does not exist", table.name)))
     }
 
     async fn commit(&self, ops: &[WriteOp]) -> Result<u64> {
@@ -690,7 +690,7 @@ impl Driver for MockDriver {
         for op in ops {
             let t = tables
                 .get_mut(&op.table().name)
-                .ok_or_else(|| RdbsError::Query("unknown table".into()))?;
+                .ok_or_else(|| RdbError::Query("unknown table".into()))?;
             let find = |rows: &Vec<Row>, pk: &[(String, Cell)]| -> Option<usize> {
                 let pk_idx: Vec<(usize, &Cell)> = pk
                     .iter()

--- a/app/src/mock.rs
+++ b/app/src/mock.rs
@@ -1,4 +1,4 @@
-//! Demo seeding for design parity: `RDBS_MOCK=1` swaps the user's real
+//! Demo seeding for design parity: `RDB_MOCK=1` swaps the user's real
 //! connection store for an in-memory temp store matching the reference
 //! design, and (later) routes "connect" to the in-process MockDriver.
 
@@ -145,7 +145,7 @@ pub fn mock_store(dir: std::path::PathBuf) -> ConnStore {
 
 /// True when the app runs in design-mock mode.
 pub fn mock_mode() -> bool {
-    std::env::var("RDBS_MOCK").is_ok_and(|v| v == "1")
+    std::env::var("RDB_MOCK").is_ok_and(|v| v == "1")
 }
 
 // ===========================================================================

--- a/app/src/mock.rs
+++ b/app/src/mock.rs
@@ -2,7 +2,7 @@
 //! connection store for an in-memory temp store matching the reference
 //! design, and (later) routes "connect" to the in-process MockDriver.
 
-use rdbs_connstore::{ConnStore, Engine, SavedConnection};
+use rdb_connstore::{ConnStore, Engine, SavedConnection};
 
 fn conn(
     name: &str,
@@ -26,7 +26,7 @@ pub fn mock_store(dir: std::path::PathBuf) -> ConnStore {
     let _ = std::fs::create_dir_all(&dir);
     // File backend only: demo mode must never touch the OS keychain.
     let backend =
-        Box::new(rdbs_connstore::EncryptedFileBackend::new(&dir).expect("file secret backend"));
+        Box::new(rdb_connstore::EncryptedFileBackend::new(&dir).expect("file secret backend"));
     let mut store = ConnStore::new(dir.join("connections.json"), backend);
 
     let host = "128.199.74.52";
@@ -77,7 +77,7 @@ pub fn mock_store(dir: std::path::PathBuf) -> ConnStore {
             "PROFIN",
             true,
         );
-        c.sslmode = rdbs_core::conn::SslMode::Require;
+        c.sslmode = rdb_core::conn::SslMode::Require;
         c.tags = vec!["profin".into(), "fintech".into()];
         add(c);
     }
@@ -155,13 +155,13 @@ pub fn mock_mode() -> bool {
 use std::sync::Mutex;
 
 use async_trait::async_trait;
-use rdbs_core::conn::ConnConfig;
-use rdbs_core::driver::Driver;
-use rdbs_core::error::{RdbsError, Result};
-use rdbs_core::query::Query;
-use rdbs_core::result::{Cell, Column, ResultSet, Row};
-use rdbs_core::schema::{Container, ContainerKind, Database, Field, Function, Schema};
-use rdbs_core::write::{TableRef, WriteOp};
+use rdb_core::conn::ConnConfig;
+use rdb_core::driver::Driver;
+use rdb_core::error::{RdbsError, Result};
+use rdb_core::query::Query;
+use rdb_core::result::{Cell, Column, ResultSet, Row};
+use rdb_core::schema::{Container, ContainerKind, Database, Field, Function, Schema};
+use rdb_core::write::{TableRef, WriteOp};
 
 /// (name, weight) — weights sum to 986 like the reference `emiten` table.
 const SECTORS: &[(&str, i64)] = &[

--- a/app/src/model.rs
+++ b/app/src/model.rs
@@ -1,4 +1,4 @@
-//! Pure conversion from rdbs-core result/schema types into flat view-model
+//! Pure conversion from rdb-core result/schema types into flat view-model
 //! structs the UI binds to. No Slint imports here so it stays unit-testable;
 //! `main.rs` maps these into the Slint-generated structs.
 

--- a/app/src/model.rs
+++ b/app/src/model.rs
@@ -2,8 +2,8 @@
 //! structs the UI binds to. No Slint imports here so it stays unit-testable;
 //! `main.rs` maps these into the Slint-generated structs.
 
-use rdbs_core::result::{Cell, RedisValue, ResultSet};
-use rdbs_core::schema::{ContainerKind, Schema};
+use rdb_core::result::{Cell, RedisValue, ResultSet};
+use rdb_core::schema::{ContainerKind, Schema};
 
 #[derive(Debug, Default, Clone)]
 pub struct VmCell {
@@ -477,8 +477,8 @@ pub fn to_completion_nodes(schema_name: &str, schema: &Schema) -> Vec<VmTreeNode
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rdbs_core::result::{Cell, Column, RedisValue, ResultSet};
-    use rdbs_core::schema::{Container, ContainerKind, Database, Field, Schema};
+    use rdb_core::result::{Cell, Column, RedisValue, ResultSet};
+    use rdb_core::schema::{Container, ContainerKind, Database, Field, Schema};
 
     #[test]
     fn doc_tree_folds_nested_and_toggles() {
@@ -696,7 +696,7 @@ mod tests {
 
 // ===== buffered edits (TablePlus-style pending writes) =====
 
-use rdbs_core::write::{TableRef, WriteOp};
+use rdb_core::write::{TableRef, WriteOp};
 use std::collections::{BTreeSet, HashMap};
 
 /// Buffered, uncommitted grid mutations for the open browse container.

--- a/app/src/query_parse.rs
+++ b/app/src/query_parse.rs
@@ -1,9 +1,9 @@
-//! Pure seam between the editor text box and a typed `rdbs_core::Query`.
+//! Pure seam between the editor text box and a typed `rdb_core::Query`.
 //! The connected `Engine` decides how the text is interpreted, so a single
 //! editor drives all four paradigms.
 
-use rdbs_connstore::Engine;
-use rdbs_core::query::{MongoKind, MongoOp, Query};
+use rdb_connstore::Engine;
+use rdb_core::query::{MongoKind, MongoOp, Query};
 
 /// Turn raw editor text into a typed `Query` for the connected engine.
 /// Returns a human-readable error string on malformed input (shown in the
@@ -285,8 +285,8 @@ fn parse_mongo_envelope(text: &str) -> Result<Query, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rdbs_connstore::Engine;
-    use rdbs_core::query::{MongoKind, Query};
+    use rdb_connstore::Engine;
+    use rdb_core::query::{MongoKind, Query};
 
     #[test]
     fn sql_engines_pass_text_through() {

--- a/app/src/shot.rs
+++ b/app/src/shot.rs
@@ -1,14 +1,14 @@
-//! Dev-only window capture: when `RDBS_SHOT=<path.bmp>` is set, snapshot the
-//! window after `RDBS_SHOT_DELAY_MS` (default 1200) and quit. Used by the
+//! Dev-only window capture: when `RDB_SHOT=<path.bmp>` is set, snapshot the
+//! window after `RDB_SHOT_DELAY_MS` (default 1200) and quit. Used by the
 //! design-parity screenshot loop; inert in normal runs.
 
 use slint::ComponentHandle;
 
 pub fn install<W: ComponentHandle + 'static>(window: &W) {
-    let Ok(path) = std::env::var("RDBS_SHOT") else {
+    let Ok(path) = std::env::var("RDB_SHOT") else {
         return;
     };
-    let delay: u64 = std::env::var("RDBS_SHOT_DELAY_MS")
+    let delay: u64 = std::env::var("RDB_SHOT_DELAY_MS")
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(1200);
@@ -39,12 +39,12 @@ pub fn install<W: ComponentHandle + 'static>(window: &W) {
                     Ok(buf) => {
                         let (wd, ht) = (buf.width(), buf.height());
                         if let Err(e) = write_bmp(&path, wd, ht, buf.as_bytes()) {
-                            eprintln!("RDBS_SHOT write failed: {e}");
+                            eprintln!("RDB_SHOT write failed: {e}");
                         } else {
-                            eprintln!("RDBS_SHOT saved {path} ({wd}x{ht})");
+                            eprintln!("RDB_SHOT saved {path} ({wd}x{ht})");
                         }
                     }
-                    Err(e) => eprintln!("RDBS_SHOT snapshot failed: {e}"),
+                    Err(e) => eprintln!("RDB_SHOT snapshot failed: {e}"),
                 }
             }
             let _ = slint::quit_event_loop();

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -116,7 +116,7 @@ export component MainWindow inherits Window {
                 activated => { root.shortcuts-open = true; }
             }
             MenuItem {
-                title: "About RDBS";
+                title: "About RDB";
                 activated => { root.about-open = true; }
             }
         }
@@ -1608,7 +1608,7 @@ in-out property <string> rename-text;
                 // --- about ---
                 HorizontalLayout {
                     SecondaryButton {
-                        text: "About RDBS";
+                        text: "About RDB";
                         clicked => {
                             root.settings-open = false;
                             root.about-open = true;
@@ -1733,7 +1733,7 @@ in-out property <string> rename-text;
                 spacing: Tokens.sp2;
 
                 Text {
-                    text: "RDBS";
+                    text: "RDB";
                     color: Tokens.text;
                     font-size: 22px;
                     font-weight: 700;

--- a/app/src/update.rs
+++ b/app/src/update.rs
@@ -44,8 +44,8 @@ impl InstallMethod {
     /// One-line upgrade instruction to show in the banner.
     pub fn upgrade_hint(self) -> &'static str {
         match self {
-            InstallMethod::Homebrew => "Run: brew upgrade rdbs",
-            InstallMethod::Scoop => "Run: scoop update rdbs",
+            InstallMethod::Homebrew => "Run: brew upgrade rdb",
+            InstallMethod::Scoop => "Run: scoop update rdb",
             InstallMethod::Other => "Open the download page",
         }
     }
@@ -82,7 +82,7 @@ pub fn due_for_check(last_check: Option<i64>, now: i64) -> bool {
 /// any network/parse error — a failed check is silent, never fatal.
 pub fn fetch_latest_tag() -> Option<String> {
     let mut response = ureq::get(RELEASES_LATEST)
-        .header("User-Agent", "rdbs-update-check")
+        .header("User-Agent", "rdb-update-check")
         .header("Accept", "application/vnd.github+json")
         .config()
         .timeout_global(Some(std::time::Duration::from_secs(8)))
@@ -101,17 +101,17 @@ mod tests {
 
     #[test]
     fn detects_homebrew_and_scoop_from_path() {
-        let brew = PathBuf::from("/opt/homebrew/Cellar/rdbs/1.0.0/bin/rdbs");
+        let brew = PathBuf::from("/opt/homebrew/Cellar/rdb/1.0.0/bin/rdb");
         assert_eq!(
             InstallMethod::from_exe_path(Some(&brew)),
             InstallMethod::Homebrew
         );
-        let scoop = PathBuf::from(r"C:\Users\me\scoop\apps\rdbs\current\rdbs.exe");
+        let scoop = PathBuf::from(r"C:\Users\me\scoop\apps\rdb\current\rdb.exe");
         assert_eq!(
             InstallMethod::from_exe_path(Some(&scoop)),
             InstallMethod::Scoop
         );
-        let other = PathBuf::from("/usr/local/bin/rdbs");
+        let other = PathBuf::from("/usr/local/bin/rdb");
         assert_eq!(
             InstallMethod::from_exe_path(Some(&other)),
             InstallMethod::Other

--- a/crates/connstore/Cargo.toml
+++ b/crates/connstore/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "rdbs-connstore"
+name = "rdb-connstore"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rdbs-core = { path = "../core" }
+rdb-core = { path = "../core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 keyring = "3"

--- a/crates/connstore/src/conn_url.rs
+++ b/crates/connstore/src/conn_url.rs
@@ -10,7 +10,7 @@
 //! UI can fall back to its per-engine defaults.
 
 use crate::model::Engine;
-use rdbs_core::conn::SslMode;
+use rdb_core::conn::SslMode;
 use thiserror::Error;
 
 /// Error returned when a connection URL cannot be parsed.

--- a/crates/connstore/src/lib.rs
+++ b/crates/connstore/src/lib.rs
@@ -1,4 +1,4 @@
-//! rdbs-connstore: saved connections (JSON, no passwords) + OS keychain secrets
+//! rdb-connstore: saved connections (JSON, no passwords) + OS keychain secrets
 //! with an encrypted-file fallback for headless Linux.
 
 pub mod conn_url;

--- a/crates/connstore/src/model.rs
+++ b/crates/connstore/src/model.rs
@@ -77,7 +77,7 @@ impl SavedConnection {
         }
     }
 
-    /// Rebuild a `rdbs-core::ConnConfig`, injecting the password fetched from the
+    /// Rebuild a `rdb-core::ConnConfig`, injecting the password fetched from the
     /// secret backend. The password is the only secret that ever lives in memory.
     pub fn to_conn_config(&self, password: Option<String>) -> ConnConfig {
         ConnConfig {

--- a/crates/connstore/src/model.rs
+++ b/crates/connstore/src/model.rs
@@ -1,4 +1,4 @@
-use rdbs_core::conn::{ConnConfig, SslMode};
+use rdb_core::conn::{ConnConfig, SslMode};
 use serde::{Deserialize, Serialize};
 
 /// Database engine of a saved connection. The MVP ships four; the variant set

--- a/crates/connstore/src/secret/keyring.rs
+++ b/crates/connstore/src/secret/keyring.rs
@@ -57,12 +57,12 @@ mod tests {
     use crate::secret::SecretBackend;
 
     // Requires a real OS keychain / desktop session. Run locally with:
-    //   cargo test -p rdbs-connstore keyring -- --ignored
+    //   cargo test -p rdb-connstore keyring -- --ignored
     #[test]
     #[ignore]
     fn keyring_roundtrip_on_a_real_desktop_session() {
         let backend = KeyringBackend::new();
-        let id = "rdbs-test-keyring-roundtrip";
+        let id = "rdb-test-keyring-roundtrip";
         backend.set(id, "hunter2").unwrap();
         assert_eq!(backend.get(id).unwrap().as_deref(), Some("hunter2"));
         backend.delete(id).unwrap();

--- a/crates/connstore/src/secret/mod.rs
+++ b/crates/connstore/src/secret/mod.rs
@@ -33,7 +33,7 @@ pub fn select_backend(fallback_dir: &Path) -> crate::error::Result<Box<dyn Secre
     // value never persists, so `get` keeps returning None and every saved
     // password is silently lost. Only trust the keychain if a written sentinel
     // reads back identical; otherwise fall back to the encrypted file.
-    const PROBE_ID: &str = "__rdbs_probe__";
+    const PROBE_ID: &str = "__rdb_probe__";
     const PROBE_VAL: &str = "rdbs-probe-value";
     let keyring_ok = keyring.set(PROBE_ID, PROBE_VAL).is_ok()
         && matches!(keyring.get(PROBE_ID), Ok(Some(v)) if v == PROBE_VAL);

--- a/crates/connstore/src/secret/mod.rs
+++ b/crates/connstore/src/secret/mod.rs
@@ -34,7 +34,7 @@ pub fn select_backend(fallback_dir: &Path) -> crate::error::Result<Box<dyn Secre
     // password is silently lost. Only trust the keychain if a written sentinel
     // reads back identical; otherwise fall back to the encrypted file.
     const PROBE_ID: &str = "__rdb_probe__";
-    const PROBE_VAL: &str = "rdbs-probe-value";
+    const PROBE_VAL: &str = "rdb-probe-value";
     let keyring_ok = keyring.set(PROBE_ID, PROBE_VAL).is_ok()
         && matches!(keyring.get(PROBE_ID), Ok(Some(v)) if v == PROBE_VAL);
     let _ = keyring.delete(PROBE_ID);

--- a/crates/connstore/src/settings.rs
+++ b/crates/connstore/src/settings.rs
@@ -149,7 +149,7 @@ mod tests {
 
     fn tmp() -> PathBuf {
         let dir = std::env::temp_dir().join(format!(
-            "rdbs-settings-test-{}-{}",
+            "rdb-settings-test-{}-{}",
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)

--- a/crates/connstore/src/store.rs
+++ b/crates/connstore/src/store.rs
@@ -143,7 +143,7 @@ impl ConnStore {
 
     /// Build a `rdbs-core::ConnConfig` for a saved connection with its stored
     /// password injected. Errors if the connection id is unknown.
-    pub fn conn_config_for(&self, id: &str) -> Result<rdbs_core::conn::ConnConfig> {
+    pub fn conn_config_for(&self, id: &str) -> Result<rdb_core::conn::ConnConfig> {
         let conn = self
             .get(id)
             .ok_or_else(|| ConnStoreError::NotFound(id.to_string()))?;

--- a/crates/connstore/src/store.rs
+++ b/crates/connstore/src/store.rs
@@ -141,7 +141,7 @@ impl ConnStore {
         self.secrets.delete(id)
     }
 
-    /// Build a `rdbs-core::ConnConfig` for a saved connection with its stored
+    /// Build a `rdb-core::ConnConfig` for a saved connection with its stored
     /// password injected. Errors if the connection id is unknown.
     pub fn conn_config_for(&self, id: &str) -> Result<rdb_core::conn::ConnConfig> {
         let conn = self

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rdbs-core"
+name = "rdb-core"
 version = "0.1.0"
 edition = "2021"
 

--- a/crates/core/src/driver.rs
+++ b/crates/core/src/driver.rs
@@ -52,7 +52,7 @@ pub trait Driver: Send + Sync {
     }
 
     /// Run a query. Drivers handle the `Query` variant(s) they support and
-    /// return `RdbsError::UnsupportedQuery` for the rest.
+    /// return `RdbError::UnsupportedQuery` for the rest.
     async fn query(&self, q: &Query) -> Result<ResultSet>;
 
     /// Stream a row-returning query in batches so a huge result never buffers
@@ -87,7 +87,7 @@ pub trait Driver: Send + Sync {
                 }
                 Ok(())
             }
-            _ => Err(crate::error::RdbsError::UnsupportedQuery),
+            _ => Err(crate::error::RdbError::UnsupportedQuery),
         }
     }
 
@@ -99,14 +99,14 @@ pub trait Driver: Send + Sync {
 
     /// Total rows/members of `table`, for the pagination footer.
     async fn count(&self, _table: &TableRef) -> Result<u64> {
-        Err(crate::error::RdbsError::UnsupportedQuery)
+        Err(crate::error::RdbError::UnsupportedQuery)
     }
 
     /// Apply buffered writes. SQL engines run the batch in one transaction
     /// (all-or-nothing); document/KV engines apply sequentially and stop at
     /// the first failure. Returns the number of ops applied.
     async fn commit(&self, _ops: &[WriteOp]) -> Result<u64> {
-        Err(crate::error::RdbsError::UnsupportedQuery)
+        Err(crate::error::RdbError::UnsupportedQuery)
     }
 
     /// Close the connection, consuming the driver.
@@ -138,7 +138,7 @@ mod tests {
         async fn query(&self, q: &Query) -> crate::error::Result<ResultSet> {
             match q {
                 Query::Sql(_) => Ok(ResultSet::Affected(0)),
-                _ => Err(crate::error::RdbsError::UnsupportedQuery),
+                _ => Err(crate::error::RdbError::UnsupportedQuery),
             }
         }
         async fn close(self) -> crate::error::Result<()> {

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 /// All fallible operations in dbm return this error.
 #[derive(Error, Debug)]
-pub enum RdbsError {
+pub enum RdbError {
     #[error("connection failed: {0}")]
     Connection(String),
     #[error("query failed: {0}")]
@@ -13,7 +13,7 @@ pub enum RdbsError {
     Schema(String),
 }
 
-pub type Result<T> = std::result::Result<T, RdbsError>;
+pub type Result<T> = std::result::Result<T, RdbError>;
 
 #[cfg(test)]
 mod tests {
@@ -21,13 +21,13 @@ mod tests {
 
     #[test]
     fn unsupported_query_has_stable_message() {
-        let e = RdbsError::UnsupportedQuery;
+        let e = RdbError::UnsupportedQuery;
         assert_eq!(e.to_string(), "unsupported query for this driver");
     }
 
     #[test]
     fn connection_error_includes_detail() {
-        let e = RdbsError::Connection("refused".into());
+        let e = RdbError::Connection("refused".into());
         assert_eq!(e.to_string(), "connection failed: refused");
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,4 +1,4 @@
-//! rdbs-core: paradigm-agnostic Driver trait + unified result model.
+//! rdb-core: paradigm-agnostic Driver trait + unified result model.
 
 pub mod conn;
 pub mod driver;

--- a/crates/core/src/query.rs
+++ b/crates/core/src/query.rs
@@ -3,7 +3,7 @@ use serde_json::Value as Json;
 /// A request to a driver. An enum (not a string) so non-SQL engines are
 /// first-class and SQL assumptions never leak into the abstraction. Each
 /// driver handles the variant it understands and returns
-/// `RdbsError::UnsupportedQuery` for the rest.
+/// `RdbError::UnsupportedQuery` for the rest.
 #[derive(Debug, Clone)]
 pub enum Query {
     /// SQL text — Postgres, MySQL.

--- a/crates/driver-cassandra/Cargo.toml
+++ b/crates/driver-cassandra/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "rdbs-driver-cassandra"
+name = "rdb-driver-cassandra"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rdbs-core = { path = "../core" }
+rdb-core = { path = "../core" }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 scylla = "1"

--- a/crates/driver-cassandra/src/driver.rs
+++ b/crates/driver-cassandra/src/driver.rs
@@ -5,7 +5,7 @@ use scylla::value::Row;
 
 use rdb_core::conn::ConnConfig;
 use rdb_core::driver::Driver;
-use rdb_core::error::{RdbsError, Result};
+use rdb_core::error::{RdbError, Result};
 use rdb_core::query::Query;
 use rdb_core::result::{Column, ResultSet};
 use rdb_core::schema::{Container, ContainerKind, Database, Field, Schema};
@@ -45,7 +45,7 @@ impl Driver for CassandraDriver {
         let session = builder
             .build()
             .await
-            .map_err(|e| RdbsError::Connection(e.to_string()))?;
+            .map_err(|e| RdbError::Connection(e.to_string()))?;
         Ok(CassandraDriver { session })
     }
 
@@ -53,7 +53,7 @@ impl Driver for CassandraDriver {
         self.session
             .query_unpaged("SELECT now() FROM system.local", ())
             .await
-            .map_err(|e| RdbsError::Connection(e.to_string()))?;
+            .map_err(|e| RdbError::Connection(e.to_string()))?;
         Ok(())
     }
 
@@ -64,15 +64,15 @@ impl Driver for CassandraDriver {
             .session
             .query_unpaged("SELECT keyspace_name FROM system_schema.keyspaces", ())
             .await
-            .map_err(|e| RdbsError::Schema(e.to_string()))?
+            .map_err(|e| RdbError::Schema(e.to_string()))?
             .into_rows_result()
-            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+            .map_err(|e| RdbError::Schema(e.to_string()))?;
         let mut databases = Vec::new();
         for row in res
             .rows::<(String,)>()
-            .map_err(|e| RdbsError::Schema(e.to_string()))?
+            .map_err(|e| RdbError::Schema(e.to_string()))?
         {
-            let (name,) = row.map_err(|e| RdbsError::Schema(e.to_string()))?;
+            let (name,) = row.map_err(|e| RdbError::Schema(e.to_string()))?;
             if SYSTEM_KEYSPACES.contains(&name.as_str()) {
                 continue;
             }
@@ -94,16 +94,16 @@ impl Driver for CassandraDriver {
                 (database,),
             )
             .await
-            .map_err(|e| RdbsError::Schema(e.to_string()))?
+            .map_err(|e| RdbError::Schema(e.to_string()))?
             .into_rows_result()
-            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+            .map_err(|e| RdbError::Schema(e.to_string()))?;
 
         let mut containers = Vec::new();
         for row in tables_res
             .rows::<(String,)>()
-            .map_err(|e| RdbsError::Schema(e.to_string()))?
+            .map_err(|e| RdbError::Schema(e.to_string()))?
         {
-            let (table,) = row.map_err(|e| RdbsError::Schema(e.to_string()))?;
+            let (table,) = row.map_err(|e| RdbError::Schema(e.to_string()))?;
             let fields = self.columns_of(database, &table).await?;
             containers.push(Container {
                 name: table,
@@ -117,20 +117,20 @@ impl Driver for CassandraDriver {
     async fn query(&self, q: &Query) -> Result<ResultSet> {
         let cql = match q {
             Query::Sql(s) => s,
-            Query::Command(_) | Query::Mongo(_) => return Err(RdbsError::UnsupportedQuery),
+            Query::Command(_) | Query::Mongo(_) => return Err(RdbError::UnsupportedQuery),
         };
         let res = self
             .session
             .query_unpaged(cql.as_str(), ())
             .await
-            .map_err(|e| RdbsError::Query(e.to_string()))?;
+            .map_err(|e| RdbError::Query(e.to_string()))?;
         if !res.is_rows() {
             // ponytail: CQL DML returns no affected-row count.
             return Ok(ResultSet::Affected(0));
         }
         let rows_res = res
             .into_rows_result()
-            .map_err(|e| RdbsError::Query(e.to_string()))?;
+            .map_err(|e| RdbError::Query(e.to_string()))?;
         let cols: Vec<Column> = rows_res
             .column_specs()
             .iter()
@@ -142,9 +142,9 @@ impl Driver for CassandraDriver {
         let mut out = Vec::new();
         for row in rows_res
             .rows::<Row>()
-            .map_err(|e| RdbsError::Query(e.to_string()))?
+            .map_err(|e| RdbError::Query(e.to_string()))?
         {
-            let row = row.map_err(|e| RdbsError::Query(e.to_string()))?;
+            let row = row.map_err(|e| RdbError::Query(e.to_string()))?;
             out.push(row.columns.iter().map(type_map::cell).collect());
         }
         Ok(ResultSet::Tabular { cols, rows: out })
@@ -160,17 +160,17 @@ impl Driver for CassandraDriver {
                 (keyspace, table.name.as_str()),
             )
             .await
-            .map_err(|e| RdbsError::Schema(e.to_string()))?
+            .map_err(|e| RdbError::Schema(e.to_string()))?
             .into_rows_result()
-            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+            .map_err(|e| RdbError::Schema(e.to_string()))?;
         // Partition keys first (by position), then clustering keys (by position).
         let mut partition: Vec<(i32, String)> = Vec::new();
         let mut clustering: Vec<(i32, String)> = Vec::new();
         for row in res
             .rows::<(String, String, i32)>()
-            .map_err(|e| RdbsError::Schema(e.to_string()))?
+            .map_err(|e| RdbError::Schema(e.to_string()))?
         {
-            let (name, kind, position) = row.map_err(|e| RdbsError::Schema(e.to_string()))?;
+            let (name, kind, position) = row.map_err(|e| RdbError::Schema(e.to_string()))?;
             match kind.as_str() {
                 "partition_key" => partition.push((position, name)),
                 "clustering" => clustering.push((position, name)),
@@ -192,12 +192,12 @@ impl Driver for CassandraDriver {
             .session
             .query_unpaged(cql, ())
             .await
-            .map_err(|e| RdbsError::Query(e.to_string()))?
+            .map_err(|e| RdbError::Query(e.to_string()))?
             .into_rows_result()
-            .map_err(|e| RdbsError::Query(e.to_string()))?;
+            .map_err(|e| RdbError::Query(e.to_string()))?;
         let (n,): (i64,) = res
             .first_row()
-            .map_err(|e| RdbsError::Query(e.to_string()))?;
+            .map_err(|e| RdbError::Query(e.to_string()))?;
         Ok(n as u64)
     }
 
@@ -214,7 +214,7 @@ impl Driver for CassandraDriver {
             match self.session.query_unpaged(cql, ()).await {
                 Ok(_) => applied += 1,
                 Err(e) => {
-                    return Err(RdbsError::Query(format!(
+                    return Err(RdbError::Query(format!(
                         "{e} (applied {applied} of {} ops)",
                         ops.len()
                     )))
@@ -241,15 +241,15 @@ impl CassandraDriver {
                 (keyspace, table),
             )
             .await
-            .map_err(|e| RdbsError::Schema(e.to_string()))?
+            .map_err(|e| RdbError::Schema(e.to_string()))?
             .into_rows_result()
-            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+            .map_err(|e| RdbError::Schema(e.to_string()))?;
         let mut fields = Vec::new();
         for row in res
             .rows::<(String, String)>()
-            .map_err(|e| RdbsError::Schema(e.to_string()))?
+            .map_err(|e| RdbError::Schema(e.to_string()))?
         {
-            let (name, type_name) = row.map_err(|e| RdbsError::Schema(e.to_string()))?;
+            let (name, type_name) = row.map_err(|e| RdbError::Schema(e.to_string()))?;
             // CQL columns are nullable except primary-key parts; the schema
             // table doesn't flag that cheaply, so report nullable.
             fields.push(Field {

--- a/crates/driver-cassandra/src/driver.rs
+++ b/crates/driver-cassandra/src/driver.rs
@@ -3,13 +3,13 @@ use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
 use scylla::value::Row;
 
-use rdbs_core::conn::ConnConfig;
-use rdbs_core::driver::Driver;
-use rdbs_core::error::{RdbsError, Result};
-use rdbs_core::query::Query;
-use rdbs_core::result::{Column, ResultSet};
-use rdbs_core::schema::{Container, ContainerKind, Database, Field, Schema};
-use rdbs_core::write::{TableRef, WriteOp};
+use rdb_core::conn::ConnConfig;
+use rdb_core::driver::Driver;
+use rdb_core::error::{RdbsError, Result};
+use rdb_core::query::Query;
+use rdb_core::result::{Column, ResultSet};
+use rdb_core::schema::{Container, ContainerKind, Database, Field, Schema};
+use rdb_core::write::{TableRef, WriteOp};
 
 use crate::type_map;
 use crate::write_cql;

--- a/crates/driver-cassandra/src/lib.rs
+++ b/crates/driver-cassandra/src/lib.rs
@@ -1,4 +1,4 @@
-//! rdbs-driver-cassandra: a `rdb_core::driver::Driver` backed by scylla.
+//! rdb-driver-cassandra: a `rdb_core::driver::Driver` backed by scylla.
 //!
 //! Cassandra speaks CQL: results are tabular, but the namespace is
 //! keyspace→table (a keyspace maps to a `Database`, its tables to `Container`s).

--- a/crates/driver-cassandra/src/lib.rs
+++ b/crates/driver-cassandra/src/lib.rs
@@ -1,4 +1,4 @@
-//! rdbs-driver-cassandra: a `rdbs_core::driver::Driver` backed by scylla.
+//! rdbs-driver-cassandra: a `rdb_core::driver::Driver` backed by scylla.
 //!
 //! Cassandra speaks CQL: results are tabular, but the namespace is
 //! keyspace→table (a keyspace maps to a `Database`, its tables to `Container`s).

--- a/crates/driver-cassandra/src/type_map.rs
+++ b/crates/driver-cassandra/src/type_map.rs
@@ -2,7 +2,7 @@
 //! and the temporal/decimal types fall back to their debug string, which is
 //! always safe to display in the grid.
 
-use rdbs_core::result::Cell;
+use rdb_core::result::Cell;
 use scylla::value::CqlValue;
 
 /// One column of a row (`None` = NULL) into a `Cell`.

--- a/crates/driver-cassandra/src/write_cql.rs
+++ b/crates/driver-cassandra/src/write_cql.rs
@@ -3,8 +3,8 @@
 //! (`0x..` blobs, lowercase `null`). No `IS NULL` — a CQL primary key is never
 //! null, so identity comparisons are always `=`.
 
-use rdbs_core::result::Cell;
-use rdbs_core::write::TableRef;
+use rdb_core::result::Cell;
+use rdb_core::write::TableRef;
 
 /// `"ident"` with embedded double quotes doubled.
 pub fn quote_ident(ident: &str) -> String {

--- a/crates/driver-cassandra/tests/integration.rs
+++ b/crates/driver-cassandra/tests/integration.rs
@@ -2,7 +2,7 @@
 //! driver's tests), so it is `#[ignore]` by default. Run with:
 //!
 //!   docker run --rm -d -p 9042:9042 cassandra:5
-//!   cargo test -p rdbs-driver-cassandra -- --ignored
+//!   cargo test -p rdb-driver-cassandra -- --ignored
 
 use rdb_core::conn::{ConnConfig, SslMode};
 use rdb_core::driver::Driver;

--- a/crates/driver-cassandra/tests/integration.rs
+++ b/crates/driver-cassandra/tests/integration.rs
@@ -4,12 +4,12 @@
 //!   docker run --rm -d -p 9042:9042 cassandra:5
 //!   cargo test -p rdbs-driver-cassandra -- --ignored
 
-use rdbs_core::conn::{ConnConfig, SslMode};
-use rdbs_core::driver::Driver;
-use rdbs_core::query::Query;
-use rdbs_core::result::{Cell, ResultSet};
-use rdbs_core::write::{TableRef, WriteOp};
-use rdbs_driver_cassandra::CassandraDriver;
+use rdb_core::conn::{ConnConfig, SslMode};
+use rdb_core::driver::Driver;
+use rdb_core::query::Query;
+use rdb_core::result::{Cell, ResultSet};
+use rdb_core::write::{TableRef, WriteOp};
+use rdb_driver_cassandra::CassandraDriver;
 
 fn cfg() -> ConnConfig {
     ConnConfig {
@@ -25,7 +25,7 @@ fn cfg() -> ConnConfig {
 
 fn table() -> TableRef {
     TableRef {
-        database: Some("rdbs_it".into()),
+        database: Some("rdb_it".into()),
         schema: None,
         name: "users".into(),
     }
@@ -39,7 +39,7 @@ async fn connect_schema_query_count_commit() {
 
     driver
         .query(&Query::Sql(
-            "CREATE KEYSPACE IF NOT EXISTS rdbs_it WITH replication = \
+            "CREATE KEYSPACE IF NOT EXISTS rdb_it WITH replication = \
              {'class':'SimpleStrategy','replication_factor':1}"
                 .into(),
         ))
@@ -47,13 +47,13 @@ async fn connect_schema_query_count_commit() {
         .expect("create keyspace");
     driver
         .query(&Query::Sql(
-            "CREATE TABLE IF NOT EXISTS rdbs_it.users (id int PRIMARY KEY, name text)".into(),
+            "CREATE TABLE IF NOT EXISTS rdb_it.users (id int PRIMARY KEY, name text)".into(),
         ))
         .await
         .expect("create table");
     driver
         .query(&Query::Sql(
-            "INSERT INTO rdbs_it.users (id, name) VALUES (1, 'ada')".into(),
+            "INSERT INTO rdb_it.users (id, name) VALUES (1, 'ada')".into(),
         ))
         .await
         .expect("insert");
@@ -65,9 +65,9 @@ async fn connect_schema_query_count_commit() {
         .unwrap()
         .databases
         .iter()
-        .any(|d| d.name == "rdbs_it"));
+        .any(|d| d.name == "rdb_it"));
     assert!(driver
-        .containers("rdbs_it")
+        .containers("rdb_it")
         .await
         .unwrap()
         .iter()
@@ -88,7 +88,7 @@ async fn connect_schema_query_count_commit() {
 
     match driver
         .query(&Query::Sql(
-            "SELECT name FROM rdbs_it.users WHERE id = 1".into(),
+            "SELECT name FROM rdb_it.users WHERE id = 1".into(),
         ))
         .await
         .unwrap()
@@ -98,7 +98,7 @@ async fn connect_schema_query_count_commit() {
     }
 
     driver
-        .query(&Query::Sql("DROP KEYSPACE rdbs_it".into()))
+        .query(&Query::Sql("DROP KEYSPACE rdb_it".into()))
         .await
         .expect("drop keyspace");
     driver.close().await.expect("close");

--- a/crates/driver-mongo/Cargo.toml
+++ b/crates/driver-mongo/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "rdbs-driver-mongo"
+name = "rdb-driver-mongo"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rdbs-core = { path = "../core" }
+rdb-core = { path = "../core" }
 async-trait = "0.1"
 mongodb = "3"
 serde_json = "1"

--- a/crates/driver-mongo/src/convert.rs
+++ b/crates/driver-mongo/src/convert.rs
@@ -6,8 +6,8 @@ use rdb_core::error::{RdbError, Result};
 /// aggregation stages all arrive as JSON objects, so a non-object is a usage
 /// error and is rejected.
 pub fn json_to_document(value: &serde_json::Value) -> Result<Document> {
-    let bson: Bson = mongodb::bson::to_bson(value)
-        .map_err(|e| RdbError::Query(format!("invalid BSON: {e}")))?;
+    let bson: Bson =
+        mongodb::bson::to_bson(value).map_err(|e| RdbError::Query(format!("invalid BSON: {e}")))?;
     match bson {
         Bson::Document(d) => Ok(d),
         other => Err(RdbError::Query(format!(

--- a/crates/driver-mongo/src/convert.rs
+++ b/crates/driver-mongo/src/convert.rs
@@ -1,16 +1,16 @@
 use mongodb::bson::{Bson, Document};
 
-use rdb_core::error::{RdbsError, Result};
+use rdb_core::error::{RdbError, Result};
 
 /// Convert a JSON object into a BSON `Document`. Filters, insert payloads, and
 /// aggregation stages all arrive as JSON objects, so a non-object is a usage
 /// error and is rejected.
 pub fn json_to_document(value: &serde_json::Value) -> Result<Document> {
     let bson: Bson = mongodb::bson::to_bson(value)
-        .map_err(|e| RdbsError::Query(format!("invalid BSON: {e}")))?;
+        .map_err(|e| RdbError::Query(format!("invalid BSON: {e}")))?;
     match bson {
         Bson::Document(d) => Ok(d),
-        other => Err(RdbsError::Query(format!(
+        other => Err(RdbError::Query(format!(
             "expected a JSON object, got {:?}",
             other.element_type()
         ))),

--- a/crates/driver-mongo/src/convert.rs
+++ b/crates/driver-mongo/src/convert.rs
@@ -1,6 +1,6 @@
 use mongodb::bson::{Bson, Document};
 
-use rdbs_core::error::{RdbsError, Result};
+use rdb_core::error::{RdbsError, Result};
 
 /// Convert a JSON object into a BSON `Document`. Filters, insert payloads, and
 /// aggregation stages all arrive as JSON objects, so a non-object is a usage

--- a/crates/driver-mongo/src/driver.rs
+++ b/crates/driver-mongo/src/driver.rs
@@ -8,7 +8,7 @@ use mongodb::{Client, Collection};
 
 use rdb_core::conn::{ConnConfig, SslMode};
 use rdb_core::driver::Driver;
-use rdb_core::error::{RdbsError, Result};
+use rdb_core::error::{RdbError, Result};
 use rdb_core::query::{MongoKind, MongoOp, Query};
 use rdb_core::result::{Cell, ResultSet};
 use rdb_core::schema::{Container, ContainerKind, Database, Schema};
@@ -94,13 +94,13 @@ impl Driver for MongoDriver {
     async fn connect(cfg: &ConnConfig) -> Result<Self> {
         let mut options = ClientOptions::parse(build_uri(cfg))
             .await
-            .map_err(|e| RdbsError::Connection(e.to_string()))?;
+            .map_err(|e| RdbError::Connection(e.to_string()))?;
         // Fail fast on an unreachable host/replica set instead of the 30s default
         // server-selection hang.
         options.server_selection_timeout = Some(Duration::from_secs(8));
         options.connect_timeout = Some(Duration::from_secs(8));
         let client =
-            Client::with_options(options).map_err(|e| RdbsError::Connection(e.to_string()))?;
+            Client::with_options(options).map_err(|e| RdbError::Connection(e.to_string()))?;
         let default_db = cfg.database.clone().unwrap_or_else(|| "admin".to_string());
         Ok(MongoDriver { client, default_db })
     }
@@ -110,7 +110,7 @@ impl Driver for MongoDriver {
             .database("admin")
             .run_command(doc! { "ping": 1 })
             .await
-            .map_err(|e| RdbsError::Connection(e.to_string()))?;
+            .map_err(|e| RdbError::Connection(e.to_string()))?;
         Ok(())
     }
 
@@ -122,7 +122,7 @@ impl Driver for MongoDriver {
             .client
             .list_database_names()
             .await
-            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+            .map_err(|e| RdbError::Schema(e.to_string()))?;
         let databases = db_names
             .into_iter()
             .filter(|n| !is_system_db(n))
@@ -158,7 +158,7 @@ impl Driver for MongoDriver {
             .database(database)
             .list_collection_names()
             .await
-            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+            .map_err(|e| RdbError::Schema(e.to_string()))?;
         Ok(coll_names
             .into_iter()
             .take(MAX_COLLECTIONS)
@@ -174,7 +174,7 @@ impl Driver for MongoDriver {
     async fn query(&self, q: &Query) -> Result<ResultSet> {
         let op: &MongoOp = match q {
             Query::Mongo(op) => op,
-            _ => return Err(RdbsError::UnsupportedQuery),
+            _ => return Err(RdbError::UnsupportedQuery),
         };
         let coll = self.collection(op);
 
@@ -191,11 +191,11 @@ impl Driver for MongoDriver {
                 if let Some(sort) = &op.sort {
                     find = find.sort(json_to_document(sort)?);
                 }
-                let cursor = find.await.map_err(|e| RdbsError::Query(e.to_string()))?;
+                let cursor = find.await.map_err(|e| RdbError::Query(e.to_string()))?;
                 let docs: Vec<Document> = cursor
                     .try_collect()
                     .await
-                    .map_err(|e| RdbsError::Query(e.to_string()))?;
+                    .map_err(|e| RdbError::Query(e.to_string()))?;
                 Ok(ResultSet::Documents(
                     docs.into_iter().map(document_to_json).collect(),
                 ))
@@ -204,7 +204,7 @@ impl Driver for MongoDriver {
                 let doc = json_to_document(payload)?;
                 coll.insert_one(doc)
                     .await
-                    .map_err(|e| RdbsError::Query(e.to_string()))?;
+                    .map_err(|e| RdbError::Query(e.to_string()))?;
                 Ok(ResultSet::Affected(1))
             }
             MongoKind::Aggregate(stages) => {
@@ -215,11 +215,11 @@ impl Driver for MongoDriver {
                 let cursor = coll
                     .aggregate(pipeline)
                     .await
-                    .map_err(|e| RdbsError::Query(e.to_string()))?;
+                    .map_err(|e| RdbError::Query(e.to_string()))?;
                 let docs: Vec<Document> = cursor
                     .try_collect()
                     .await
-                    .map_err(|e| RdbsError::Query(e.to_string()))?;
+                    .map_err(|e| RdbError::Query(e.to_string()))?;
                 Ok(ResultSet::Documents(
                     docs.into_iter().map(document_to_json).collect(),
                 ))
@@ -239,7 +239,7 @@ impl Driver for MongoDriver {
             .collection::<Document>(&table.name)
             .count_documents(doc! {})
             .await
-            .map_err(|e| RdbsError::Query(e.to_string()))
+            .map_err(|e| RdbError::Query(e.to_string()))
     }
 
     /// Sequential (no multi-doc transaction — standalone servers lack them);
@@ -276,7 +276,7 @@ impl Driver for MongoDriver {
             match res {
                 Ok(()) => applied += 1,
                 Err(e) => {
-                    return Err(RdbsError::Query(format!(
+                    return Err(RdbError::Query(format!(
                         "{e} (applied {applied} of {} ops)",
                         ops.len()
                     )))
@@ -301,7 +301,7 @@ fn pk_id(pk: &[(String, Cell)]) -> Result<mongodb::bson::Bson> {
         .iter()
         .find(|(k, _)| k == "_id")
         .or_else(|| pk.first())
-        .ok_or_else(|| RdbsError::Query("write op without a row identity".into()))?;
+        .ok_or_else(|| RdbError::Query("write op without a row identity".into()))?;
     if let Cell::Text(s) = cell {
         if let Ok(oid) = mongodb::bson::oid::ObjectId::parse_str(s) {
             return Ok(mongodb::bson::Bson::ObjectId(oid));

--- a/crates/driver-mongo/src/driver.rs
+++ b/crates/driver-mongo/src/driver.rs
@@ -6,13 +6,13 @@ use mongodb::bson::{doc, Document};
 use mongodb::options::ClientOptions;
 use mongodb::{Client, Collection};
 
-use rdbs_core::conn::{ConnConfig, SslMode};
-use rdbs_core::driver::Driver;
-use rdbs_core::error::{RdbsError, Result};
-use rdbs_core::query::{MongoKind, MongoOp, Query};
-use rdbs_core::result::{Cell, ResultSet};
-use rdbs_core::schema::{Container, ContainerKind, Database, Schema};
-use rdbs_core::write::{TableRef, WriteOp};
+use rdb_core::conn::{ConnConfig, SslMode};
+use rdb_core::driver::Driver;
+use rdb_core::error::{RdbsError, Result};
+use rdb_core::query::{MongoKind, MongoOp, Query};
+use rdb_core::result::{Cell, ResultSet};
+use rdb_core::schema::{Container, ContainerKind, Database, Schema};
+use rdb_core::write::{TableRef, WriteOp};
 
 use crate::convert::{document_to_json, json_to_document};
 

--- a/crates/driver-mongo/src/lib.rs
+++ b/crates/driver-mongo/src/lib.rs
@@ -1,4 +1,4 @@
-//! rdbs-driver-mongo: MongoDB Driver impl via the mongodb crate.
+//! rdb-driver-mongo: MongoDB Driver impl via the mongodb crate.
 
 mod convert;
 

--- a/crates/driver-mongo/tests/integration.rs
+++ b/crates/driver-mongo/tests/integration.rs
@@ -1,6 +1,6 @@
 //! Real-engine test: spins a MongoDB container, then exercises the driver.
 //! Requires Docker. Ignored by default; run with
-//! `cargo test -p rdbs-driver-mongo -- --ignored`.
+//! `cargo test -p rdb-driver-mongo -- --ignored`.
 
 use rdb_core::conn::{ConnConfig, SslMode};
 use rdb_core::driver::Driver;

--- a/crates/driver-mongo/tests/integration.rs
+++ b/crates/driver-mongo/tests/integration.rs
@@ -2,11 +2,11 @@
 //! Requires Docker. Ignored by default; run with
 //! `cargo test -p rdbs-driver-mongo -- --ignored`.
 
-use rdbs_core::conn::{ConnConfig, SslMode};
-use rdbs_core::driver::Driver;
-use rdbs_core::query::{MongoKind, MongoOp, Query};
-use rdbs_core::result::ResultSet;
-use rdbs_driver_mongo::MongoDriver;
+use rdb_core::conn::{ConnConfig, SslMode};
+use rdb_core::driver::Driver;
+use rdb_core::query::{MongoKind, MongoOp, Query};
+use rdb_core::result::ResultSet;
+use rdb_driver_mongo::MongoDriver;
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::mongo::Mongo;
 

--- a/crates/driver-mysql/Cargo.toml
+++ b/crates/driver-mysql/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "rdbs-driver-mysql"
+name = "rdb-driver-mysql"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rdbs-core = { path = "../core" }
+rdb-core = { path = "../core" }
 async-trait = "0.1"
 mysql_async = "0.37"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/crates/driver-mysql/src/convert.rs
+++ b/crates/driver-mysql/src/convert.rs
@@ -2,7 +2,7 @@ use mysql_async::consts::ColumnType;
 use mysql_async::Value;
 use rdb_core::result::Cell;
 
-/// Map a mysql_async cell value into rdbs-core's `Cell`.
+/// Map a mysql_async cell value into rdb-core's `Cell`.
 ///
 /// Bytes are treated as text when valid UTF-8 (covers CHAR/VARCHAR/TEXT and
 /// DECIMAL, which mysql returns as bytes), otherwise as raw `Bytes`

--- a/crates/driver-mysql/src/convert.rs
+++ b/crates/driver-mysql/src/convert.rs
@@ -1,6 +1,6 @@
 use mysql_async::consts::ColumnType;
 use mysql_async::Value;
-use rdbs_core::result::Cell;
+use rdb_core::result::Cell;
 
 /// Map a mysql_async cell value into rdbs-core's `Cell`.
 ///
@@ -33,7 +33,7 @@ pub fn column_type_name(ct: ColumnType) -> String {
 mod tests {
     use super::*;
     use mysql_async::Value;
-    use rdbs_core::result::Cell;
+    use rdb_core::result::Cell;
 
     #[test]
     fn null_maps_to_cell_null() {

--- a/crates/driver-mysql/src/driver.rs
+++ b/crates/driver-mysql/src/driver.rs
@@ -2,13 +2,13 @@ use async_trait::async_trait;
 use mysql_async::prelude::Queryable;
 use mysql_async::{OptsBuilder, Pool, Row, SslOpts};
 
-use rdbs_core::conn::{ConnConfig, SslMode};
-use rdbs_core::driver::Driver;
-use rdbs_core::error::{RdbsError, Result};
-use rdbs_core::query::Query;
-use rdbs_core::result::{Column, ResultSet};
-use rdbs_core::schema::Schema;
-use rdbs_core::write::{TableRef, WriteOp};
+use rdb_core::conn::{ConnConfig, SslMode};
+use rdb_core::driver::Driver;
+use rdb_core::error::{RdbsError, Result};
+use rdb_core::query::Query;
+use rdb_core::result::{Column, ResultSet};
+use rdb_core::schema::Schema;
+use rdb_core::write::{TableRef, WriteOp};
 
 use crate::convert::{column_type_name, value_to_cell};
 use crate::schema::{columns_query, fold_rows, SchemaRow};
@@ -145,7 +145,7 @@ impl Driver for MysqlDriver {
                 (0..r.len())
                     .map(|i| match r.as_ref(i) {
                         Some(v) => value_to_cell(v),
-                        None => rdbs_core::result::Cell::Null,
+                        None => rdb_core::result::Cell::Null,
                     })
                     .collect::<Vec<_>>()
             })

--- a/crates/driver-mysql/src/driver.rs
+++ b/crates/driver-mysql/src/driver.rs
@@ -4,7 +4,7 @@ use mysql_async::{OptsBuilder, Pool, Row, SslOpts};
 
 use rdb_core::conn::{ConnConfig, SslMode};
 use rdb_core::driver::Driver;
-use rdb_core::error::{RdbsError, Result};
+use rdb_core::error::{RdbError, Result};
 use rdb_core::query::Query;
 use rdb_core::result::{Column, ResultSet};
 use rdb_core::schema::Schema;
@@ -48,7 +48,7 @@ impl Driver for MysqlDriver {
         let mut conn = pool
             .get_conn()
             .await
-            .map_err(|e| RdbsError::Connection(e.to_string()))?;
+            .map_err(|e| RdbError::Connection(e.to_string()))?;
         drop(conn.ping().await);
         Ok(MysqlDriver { pool })
     }
@@ -58,11 +58,11 @@ impl Driver for MysqlDriver {
             .pool
             .get_conn()
             .await
-            .map_err(|e| RdbsError::Connection(e.to_string()))?;
+            .map_err(|e| RdbError::Connection(e.to_string()))?;
         let _: Vec<i64> = conn
             .query("SELECT 1")
             .await
-            .map_err(|e| RdbsError::Query(e.to_string()))?;
+            .map_err(|e| RdbError::Query(e.to_string()))?;
         Ok(())
     }
 
@@ -71,7 +71,7 @@ impl Driver for MysqlDriver {
             .pool
             .get_conn()
             .await
-            .map_err(|e| RdbsError::Connection(e.to_string()))?;
+            .map_err(|e| RdbError::Connection(e.to_string()))?;
         let rows: Vec<SchemaRow> = conn
             .query_map(
                 columns_query(),
@@ -86,26 +86,26 @@ impl Driver for MysqlDriver {
                 },
             )
             .await
-            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+            .map_err(|e| RdbError::Schema(e.to_string()))?;
         Ok(fold_rows(rows))
     }
 
     async fn query(&self, q: &Query) -> Result<ResultSet> {
         let sql = match q {
             Query::Sql(s) => s,
-            _ => return Err(RdbsError::UnsupportedQuery),
+            _ => return Err(RdbError::UnsupportedQuery),
         };
 
         let mut conn = self
             .pool
             .get_conn()
             .await
-            .map_err(|e| RdbsError::Connection(e.to_string()))?;
+            .map_err(|e| RdbError::Connection(e.to_string()))?;
 
         let mut result = conn
             .query_iter(sql.as_str())
             .await
-            .map_err(|e| RdbsError::Query(e.to_string()))?;
+            .map_err(|e| RdbError::Query(e.to_string()))?;
 
         // A statement with no result set (INSERT/UPDATE/DELETE/DDL) reports
         // affected rows and yields no columns.
@@ -118,7 +118,7 @@ impl Driver for MysqlDriver {
             result
                 .drop_result()
                 .await
-                .map_err(|e| RdbsError::Query(e.to_string()))?;
+                .map_err(|e| RdbError::Query(e.to_string()))?;
             return Ok(ResultSet::Affected(affected));
         }
 
@@ -137,7 +137,7 @@ impl Driver for MysqlDriver {
         let mysql_rows: Vec<Row> = result
             .collect()
             .await
-            .map_err(|e| RdbsError::Query(e.to_string()))?;
+            .map_err(|e| RdbError::Query(e.to_string()))?;
 
         let rows = mysql_rows
             .into_iter()
@@ -159,7 +159,7 @@ impl Driver for MysqlDriver {
             .pool
             .get_conn()
             .await
-            .map_err(|e| RdbsError::Connection(e.to_string()))?;
+            .map_err(|e| RdbError::Connection(e.to_string()))?;
         let cols: Vec<String> = conn
             .exec(
                 "SELECT column_name FROM information_schema.key_column_usage \
@@ -169,7 +169,7 @@ impl Driver for MysqlDriver {
                 (&table.name, &table.database),
             )
             .await
-            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+            .map_err(|e| RdbError::Schema(e.to_string()))?;
         Ok(cols)
     }
 
@@ -178,14 +178,14 @@ impl Driver for MysqlDriver {
             .pool
             .get_conn()
             .await
-            .map_err(|e| RdbsError::Connection(e.to_string()))?;
+            .map_err(|e| RdbError::Connection(e.to_string()))?;
         let n: Option<u64> = conn
             .query_first(format!(
                 "SELECT COUNT(*) FROM {}",
                 write_sql::table_name(table)
             ))
             .await
-            .map_err(|e| RdbsError::Query(e.to_string()))?;
+            .map_err(|e| RdbError::Query(e.to_string()))?;
         Ok(n.unwrap_or(0))
     }
 
@@ -197,11 +197,11 @@ impl Driver for MysqlDriver {
             .pool
             .get_conn()
             .await
-            .map_err(|e| RdbsError::Connection(e.to_string()))?;
+            .map_err(|e| RdbError::Connection(e.to_string()))?;
         let mut tx = conn
             .start_transaction(mysql_async::TxOpts::default())
             .await
-            .map_err(|e| RdbsError::Query(e.to_string()))?;
+            .map_err(|e| RdbError::Query(e.to_string()))?;
         let mut affected = 0u64;
         for op in ops {
             let (sql, params) = match op {
@@ -212,12 +212,12 @@ impl Driver for MysqlDriver {
             // A failed statement drops `tx`, which rolls the batch back.
             tx.exec_drop(sql, params)
                 .await
-                .map_err(|e| RdbsError::Query(e.to_string()))?;
+                .map_err(|e| RdbError::Query(e.to_string()))?;
             affected += tx.affected_rows();
         }
         tx.commit()
             .await
-            .map_err(|e| RdbsError::Query(e.to_string()))?;
+            .map_err(|e| RdbError::Query(e.to_string()))?;
         Ok(affected)
     }
 
@@ -225,7 +225,7 @@ impl Driver for MysqlDriver {
         self.pool
             .disconnect()
             .await
-            .map_err(|e| RdbsError::Connection(e.to_string()))?;
+            .map_err(|e| RdbError::Connection(e.to_string()))?;
         Ok(())
     }
 }

--- a/crates/driver-mysql/src/lib.rs
+++ b/crates/driver-mysql/src/lib.rs
@@ -1,4 +1,4 @@
-//! rdbs-driver-mysql: MySQL/MariaDB Driver impl via mysql_async.
+//! rdb-driver-mysql: MySQL/MariaDB Driver impl via mysql_async.
 
 mod convert;
 mod schema;

--- a/crates/driver-mysql/src/schema.rs
+++ b/crates/driver-mysql/src/schema.rs
@@ -1,4 +1,4 @@
-use rdbs_core::schema::{Container, ContainerKind, Database, Field, Schema};
+use rdb_core::schema::{Container, ContainerKind, Database, Field, Schema};
 
 /// One row of the schema query: (database, table, column, type_name, nullable).
 pub type SchemaRow = (String, String, String, String, bool);
@@ -56,7 +56,7 @@ pub fn fold_rows(rows: Vec<SchemaRow>) -> Schema {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rdbs_core::schema::ContainerKind;
+    use rdb_core::schema::ContainerKind;
 
     #[test]
     fn columns_query_targets_information_schema() {

--- a/crates/driver-mysql/src/write_sql.rs
+++ b/crates/driver-mysql/src/write_sql.rs
@@ -3,8 +3,8 @@
 //! builder returns `(sql, params)`; identifiers are backtick-quoted.
 
 use mysql_async::Value;
-use rdbs_core::result::Cell;
-use rdbs_core::write::TableRef;
+use rdb_core::result::Cell;
+use rdb_core::write::TableRef;
 
 /// `` `ident` `` with embedded backticks doubled.
 pub fn quote_ident(ident: &str) -> String {

--- a/crates/driver-mysql/tests/integration.rs
+++ b/crates/driver-mysql/tests/integration.rs
@@ -2,11 +2,11 @@
 //! Requires a running Docker daemon. Ignored by default so plain `cargo test`
 //! stays offline; run with `cargo test -p rdbs-driver-mysql -- --ignored`.
 
-use rdbs_core::conn::{ConnConfig, SslMode};
-use rdbs_core::driver::Driver;
-use rdbs_core::query::Query;
-use rdbs_core::result::{Cell, ResultSet};
-use rdbs_driver_mysql::MysqlDriver;
+use rdb_core::conn::{ConnConfig, SslMode};
+use rdb_core::driver::Driver;
+use rdb_core::query::Query;
+use rdb_core::result::{Cell, ResultSet};
+use rdb_driver_mysql::MysqlDriver;
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::mysql::Mysql;
 

--- a/crates/driver-mysql/tests/integration.rs
+++ b/crates/driver-mysql/tests/integration.rs
@@ -1,6 +1,6 @@
 //! Real-engine test: spins a MySQL container, then exercises the driver.
 //! Requires a running Docker daemon. Ignored by default so plain `cargo test`
-//! stays offline; run with `cargo test -p rdbs-driver-mysql -- --ignored`.
+//! stays offline; run with `cargo test -p rdb-driver-mysql -- --ignored`.
 
 use rdb_core::conn::{ConnConfig, SslMode};
 use rdb_core::driver::Driver;

--- a/crates/driver-postgres/Cargo.toml
+++ b/crates/driver-postgres/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "rdbs-driver-postgres"
+name = "rdb-driver-postgres"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rdbs-core = { path = "../core" }
+rdb-core = { path = "../core" }
 async-trait = "0.1"
 futures-util = "0.3"
 tokio = { version = "1", features = ["full"] }

--- a/crates/driver-postgres/src/conn_string.rs
+++ b/crates/driver-postgres/src/conn_string.rs
@@ -1,4 +1,4 @@
-use rdbs_core::conn::{ConnConfig, SslMode};
+use rdb_core::conn::{ConnConfig, SslMode};
 
 /// Map our `SslMode` to a libpq `sslmode` token.
 ///
@@ -35,7 +35,7 @@ pub fn build_conn_string(cfg: &ConnConfig) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rdbs_core::conn::{ConnConfig, SslMode};
+    use rdb_core::conn::{ConnConfig, SslMode};
 
     fn base() -> ConnConfig {
         ConnConfig {

--- a/crates/driver-postgres/src/driver.rs
+++ b/crates/driver-postgres/src/driver.rs
@@ -4,13 +4,13 @@ use postgres_native_tls::MakeTlsConnector;
 use tokio::task::JoinHandle;
 use tokio_postgres::{Client, NoTls};
 
-use rdbs_core::conn::{ConnConfig, SslMode};
-use rdbs_core::driver::Driver;
-use rdbs_core::error::{RdbsError, Result};
-use rdbs_core::query::Query;
-use rdbs_core::result::{Column, ResultSet, Row};
-use rdbs_core::schema::{Container, ContainerKind, Database, Field, Schema};
-use rdbs_core::write::{TableRef, WriteOp};
+use rdb_core::conn::{ConnConfig, SslMode};
+use rdb_core::driver::Driver;
+use rdb_core::error::{RdbsError, Result};
+use rdb_core::query::Query;
+use rdb_core::result::{Column, ResultSet, Row};
+use rdb_core::schema::{Container, ContainerKind, Database, Field, Schema};
+use rdb_core::write::{TableRef, WriteOp};
 
 use crate::conn_string::build_conn_string;
 use crate::write_sql;
@@ -119,7 +119,7 @@ impl Driver for PostgresDriver {
         q: &Query,
         batch: usize,
         cancel: std::sync::Arc<std::sync::atomic::AtomicBool>,
-        sink: tokio::sync::mpsc::Sender<rdbs_core::result::StreamItem>,
+        sink: tokio::sync::mpsc::Sender<rdb_core::result::StreamItem>,
     ) -> Result<()> {
         query_stream_impl(&self.client, q, batch.max(1), cancel, sink).await
     }
@@ -265,10 +265,10 @@ async fn query_stream_impl(
     q: &Query,
     batch: usize,
     cancel: std::sync::Arc<std::sync::atomic::AtomicBool>,
-    sink: tokio::sync::mpsc::Sender<rdbs_core::result::StreamItem>,
+    sink: tokio::sync::mpsc::Sender<rdb_core::result::StreamItem>,
 ) -> Result<()> {
     use futures_util::TryStreamExt;
-    use rdbs_core::result::StreamItem;
+    use rdb_core::result::StreamItem;
 
     let sql = match q {
         Query::Sql(s) => s,
@@ -424,7 +424,7 @@ async fn schema_impl(client: &Client, schema: &str) -> Result<Schema> {
     // Stored functions (public schema): name + full CREATE source for the
     // function view. Per-row source failures (e.g. C-language internals that
     // pg_get_functiondef rejects) are skipped, never fatal.
-    let mut functions: Vec<rdbs_core::schema::Function> = Vec::new();
+    let mut functions: Vec<rdb_core::schema::Function> = Vec::new();
     if let Ok(rows) = client
         .query(
             "SELECT p.proname, pg_catalog.pg_get_functiondef(p.oid) \
@@ -439,7 +439,7 @@ async fn schema_impl(client: &Client, schema: &str) -> Result<Schema> {
         for row in &rows {
             let name: String = row.get(0);
             if let Ok(def) = row.try_get::<_, String>(1) {
-                functions.push(rdbs_core::schema::Function {
+                functions.push(rdb_core::schema::Function {
                     name,
                     definition: def,
                 });

--- a/crates/driver-postgres/src/driver.rs
+++ b/crates/driver-postgres/src/driver.rs
@@ -6,7 +6,7 @@ use tokio_postgres::{Client, NoTls};
 
 use rdb_core::conn::{ConnConfig, SslMode};
 use rdb_core::driver::Driver;
-use rdb_core::error::{RdbsError, Result};
+use rdb_core::error::{RdbError, Result};
 use rdb_core::query::Query;
 use rdb_core::result::{Column, ResultSet, Row};
 use rdb_core::schema::{Container, ContainerKind, Database, Field, Schema};
@@ -38,7 +38,7 @@ impl Driver for PostgresDriver {
         let (client, conn_task) = if matches!(cfg.sslmode, SslMode::Disable) {
             let (client, connection) = tokio_postgres::connect(&conn_str, NoTls)
                 .await
-                .map_err(|e| RdbsError::Connection(pg_err(&e)))?;
+                .map_err(|e| RdbError::Connection(pg_err(&e)))?;
             let conn_task = tokio::spawn(async move {
                 let _ = connection.await;
             });
@@ -48,11 +48,11 @@ impl Driver for PostgresDriver {
                 .danger_accept_invalid_certs(true)
                 .danger_accept_invalid_hostnames(true)
                 .build()
-                .map_err(|e| RdbsError::Connection(e.to_string()))?;
+                .map_err(|e| RdbError::Connection(e.to_string()))?;
             let connector = MakeTlsConnector::new(tls);
             let (client, connection) = tokio_postgres::connect(&conn_str, connector)
                 .await
-                .map_err(|e| RdbsError::Connection(pg_err(&e)))?;
+                .map_err(|e| RdbError::Connection(pg_err(&e)))?;
             let conn_task = tokio::spawn(async move {
                 let _ = connection.await;
             });
@@ -65,7 +65,7 @@ impl Driver for PostgresDriver {
         self.client
             .query("SELECT 1", &[])
             .await
-            .map_err(|e| RdbsError::Connection(pg_err(&e)))?;
+            .map_err(|e| RdbError::Connection(pg_err(&e)))?;
         Ok(())
     }
 
@@ -89,7 +89,7 @@ impl Driver for PostgresDriver {
                 &[],
             )
             .await
-            .map_err(|e| RdbsError::Schema(pg_err(&e)))?;
+            .map_err(|e| RdbError::Schema(pg_err(&e)))?;
         Ok(rows.iter().map(|r| r.get::<_, String>(0)).collect())
     }
 
@@ -106,7 +106,7 @@ impl Driver for PostgresDriver {
                 &[],
             )
             .await
-            .map_err(|e| RdbsError::Schema(pg_err(&e)))?;
+            .map_err(|e| RdbError::Schema(pg_err(&e)))?;
         Ok(rows.iter().map(|r| r.get::<_, String>(0)).collect())
     }
 
@@ -139,7 +139,7 @@ impl Driver for PostgresDriver {
                 &[&table.name, &schema],
             )
             .await
-            .map_err(|e| RdbsError::Schema(pg_err(&e)))?;
+            .map_err(|e| RdbError::Schema(pg_err(&e)))?;
         Ok(rows.iter().map(|r| r.get::<_, String>(0)).collect())
     }
 
@@ -149,7 +149,7 @@ impl Driver for PostgresDriver {
             .client
             .query_one(&sql, &[])
             .await
-            .map_err(|e| RdbsError::Query(pg_err(&e)))?;
+            .map_err(|e| RdbError::Query(pg_err(&e)))?;
         let n: i64 = row.get(0);
         Ok(n as u64)
     }
@@ -162,12 +162,12 @@ impl Driver for PostgresDriver {
             self.client
                 .execute(&sql, &[])
                 .await
-                .map_err(|e| RdbsError::Query(pg_err(&e)))
+                .map_err(|e| RdbError::Query(pg_err(&e)))
         };
         self.client
             .execute("BEGIN", &[])
             .await
-            .map_err(|e| RdbsError::Query(pg_err(&e)))?;
+            .map_err(|e| RdbError::Query(pg_err(&e)))?;
         let mut affected = 0u64;
         for op in ops {
             let sql = match op {
@@ -186,7 +186,7 @@ impl Driver for PostgresDriver {
         self.client
             .execute("COMMIT", &[])
             .await
-            .map_err(|e| RdbsError::Query(pg_err(&e)))?;
+            .map_err(|e| RdbError::Query(pg_err(&e)))?;
         Ok(affected)
     }
 
@@ -225,14 +225,14 @@ fn pg_err(e: &tokio_postgres::Error) -> String {
 async fn query_impl(client: &Client, q: &Query) -> Result<ResultSet> {
     let sql = match q {
         Query::Sql(s) => s,
-        Query::Command(_) | Query::Mongo(_) => return Err(RdbsError::UnsupportedQuery),
+        Query::Command(_) | Query::Mongo(_) => return Err(RdbError::UnsupportedQuery),
     };
 
     if is_row_returning(sql) {
         let rows = client
             .query(sql, &[])
             .await
-            .map_err(|e| RdbsError::Query(pg_err(&e)))?;
+            .map_err(|e| RdbError::Query(pg_err(&e)))?;
         let cols = column_meta(&rows);
         let mut out_rows: Vec<Row> = Vec::with_capacity(rows.len());
         for row in &rows {
@@ -250,7 +250,7 @@ async fn query_impl(client: &Client, q: &Query) -> Result<ResultSet> {
         let affected = client
             .execute(sql, &[])
             .await
-            .map_err(|e| RdbsError::Query(pg_err(&e)))?;
+            .map_err(|e| RdbError::Query(pg_err(&e)))?;
         Ok(ResultSet::Affected(affected))
     }
 }
@@ -272,13 +272,13 @@ async fn query_stream_impl(
 
     let sql = match q {
         Query::Sql(s) => s,
-        Query::Command(_) | Query::Mongo(_) => return Err(RdbsError::UnsupportedQuery),
+        Query::Command(_) | Query::Mongo(_) => return Err(RdbError::UnsupportedQuery),
     };
     if !is_row_returning(sql) {
         client
             .execute(sql, &[])
             .await
-            .map_err(|e| RdbsError::Query(pg_err(&e)))?;
+            .map_err(|e| RdbError::Query(pg_err(&e)))?;
         let _ = sink.send(StreamItem::Meta(Vec::new())).await;
         return Ok(());
     }
@@ -286,7 +286,7 @@ async fn query_stream_impl(
     let stmt = client
         .prepare(sql)
         .await
-        .map_err(|e| RdbsError::Query(pg_err(&e)))?;
+        .map_err(|e| RdbError::Query(pg_err(&e)))?;
     let cols: Vec<Column> = stmt
         .columns()
         .iter()
@@ -305,7 +305,7 @@ async fn query_stream_impl(
     let row_stream = client
         .query_raw(&stmt, no_params)
         .await
-        .map_err(|e| RdbsError::Query(pg_err(&e)))?;
+        .map_err(|e| RdbError::Query(pg_err(&e)))?;
     tokio::pin!(row_stream);
 
     let mut buf: Vec<Row> = Vec::with_capacity(batch);
@@ -313,7 +313,7 @@ async fn query_stream_impl(
         match row_stream
             .try_next()
             .await
-            .map_err(|e| RdbsError::Query(pg_err(&e)))?
+            .map_err(|e| RdbError::Query(pg_err(&e)))?
         {
             Some(row) => {
                 let mut cells: Row = Vec::with_capacity(ncols);
@@ -380,10 +380,10 @@ async fn schema_impl(client: &Client, schema: &str) -> Result<Schema> {
     let db_row = client
         .query_one("SELECT current_database()", &[])
         .await
-        .map_err(|e| RdbsError::Schema(pg_err(&e)))?;
+        .map_err(|e| RdbError::Schema(pg_err(&e)))?;
     let db_name: String = db_row
         .try_get(0)
-        .map_err(|e| RdbsError::Schema(pg_err(&e)))?;
+        .map_err(|e| RdbError::Schema(pg_err(&e)))?;
 
     // User tables + columns from information_schema, scoped to one schema.
     // Ordered so columns of the same table are contiguous for grouping.
@@ -398,7 +398,7 @@ async fn schema_impl(client: &Client, schema: &str) -> Result<Schema> {
             &[&schema],
         )
         .await
-        .map_err(|e| RdbsError::Schema(pg_err(&e)))?;
+        .map_err(|e| RdbError::Schema(pg_err(&e)))?;
 
     let mut containers: Vec<Container> = Vec::new();
     for row in &rows {

--- a/crates/driver-postgres/src/lib.rs
+++ b/crates/driver-postgres/src/lib.rs
@@ -1,4 +1,4 @@
-//! rdbs-driver-postgres: a `rdbs_core::driver::Driver` backed by tokio-postgres.
+//! rdbs-driver-postgres: a `rdb_core::driver::Driver` backed by tokio-postgres.
 
 mod conn_string;
 mod driver;

--- a/crates/driver-postgres/src/lib.rs
+++ b/crates/driver-postgres/src/lib.rs
@@ -1,4 +1,4 @@
-//! rdbs-driver-postgres: a `rdb_core::driver::Driver` backed by tokio-postgres.
+//! rdb-driver-postgres: a `rdb_core::driver::Driver` backed by tokio-postgres.
 
 mod conn_string;
 mod driver;

--- a/crates/driver-postgres/src/type_map.rs
+++ b/crates/driver-postgres/src/type_map.rs
@@ -1,4 +1,4 @@
-use rdbs_core::result::Cell;
+use rdb_core::result::Cell;
 use tokio_postgres::types::Type;
 use tokio_postgres::Row;
 

--- a/crates/driver-postgres/src/write_sql.rs
+++ b/crates/driver-postgres/src/write_sql.rs
@@ -6,8 +6,8 @@
 //! match each column's wire type exactly. Escaping doubles single quotes and
 //! strips NUL; identifiers are double-quoted with `"` doubling.
 
-use rdbs_core::result::Cell;
-use rdbs_core::write::TableRef;
+use rdb_core::result::Cell;
+use rdb_core::write::TableRef;
 
 /// `"ident"` with embedded double quotes doubled.
 pub fn quote_ident(ident: &str) -> String {

--- a/crates/driver-postgres/tests/integration.rs
+++ b/crates/driver-postgres/tests/integration.rs
@@ -89,7 +89,7 @@ async fn select_returns_tabular_rows() {
 
 #[tokio::test]
 async fn non_sql_queries_are_unsupported() {
-    use rdb_core::error::RdbsError;
+    use rdb_core::error::RdbError;
     use rdb_core::query::{MongoKind, MongoOp, Query};
 
     let (_container, cfg) = start_pg().await;
@@ -98,7 +98,7 @@ async fn non_sql_queries_are_unsupported() {
     let cmd = driver
         .query(&Query::Command(vec!["GET".into(), "k".into()]))
         .await;
-    assert!(matches!(cmd, Err(RdbsError::UnsupportedQuery)));
+    assert!(matches!(cmd, Err(RdbError::UnsupportedQuery)));
 
     let mongo = driver
         .query(&Query::Mongo(Box::new(MongoOp {
@@ -110,7 +110,7 @@ async fn non_sql_queries_are_unsupported() {
             kind: MongoKind::Find(serde_json::json!({})),
         })))
         .await;
-    assert!(matches!(mongo, Err(RdbsError::UnsupportedQuery)));
+    assert!(matches!(mongo, Err(RdbError::UnsupportedQuery)));
 
     driver.close().await.expect("close");
 }

--- a/crates/driver-postgres/tests/integration.rs
+++ b/crates/driver-postgres/tests/integration.rs
@@ -3,9 +3,9 @@
 // is present (CI, dev with Docker Desktop) they run; without Docker they fail
 // fast at container start, which is the intended signal.
 
-use rdbs_core::conn::{ConnConfig, SslMode};
-use rdbs_core::driver::Driver;
-use rdbs_driver_postgres::PostgresDriver;
+use rdb_core::conn::{ConnConfig, SslMode};
+use rdb_core::driver::Driver;
+use rdb_driver_postgres::PostgresDriver;
 use testcontainers::runners::AsyncRunner;
 use testcontainers::ContainerAsync;
 use testcontainers_modules::postgres::Postgres;
@@ -44,8 +44,8 @@ async fn connect_ping_close() {
 
 #[tokio::test]
 async fn select_returns_tabular_rows() {
-    use rdbs_core::query::Query;
-    use rdbs_core::result::{Cell, ResultSet};
+    use rdb_core::query::Query;
+    use rdb_core::result::{Cell, ResultSet};
 
     let (_container, cfg) = start_pg().await;
     let driver = PostgresDriver::connect(&cfg).await.expect("connect");
@@ -89,8 +89,8 @@ async fn select_returns_tabular_rows() {
 
 #[tokio::test]
 async fn non_sql_queries_are_unsupported() {
-    use rdbs_core::error::RdbsError;
-    use rdbs_core::query::{MongoKind, MongoOp, Query};
+    use rdb_core::error::RdbsError;
+    use rdb_core::query::{MongoKind, MongoOp, Query};
 
     let (_container, cfg) = start_pg().await;
     let driver = PostgresDriver::connect(&cfg).await.expect("connect");
@@ -117,8 +117,8 @@ async fn non_sql_queries_are_unsupported() {
 
 #[tokio::test]
 async fn schema_lists_created_table_and_fields() {
-    use rdbs_core::query::Query;
-    use rdbs_core::schema::ContainerKind;
+    use rdb_core::query::Query;
+    use rdb_core::schema::ContainerKind;
 
     let (_container, cfg) = start_pg().await;
     let driver = PostgresDriver::connect(&cfg).await.expect("connect");

--- a/crates/driver-redis/Cargo.toml
+++ b/crates/driver-redis/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "rdbs-driver-redis"
+name = "rdb-driver-redis"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rdbs-core = { path = "../core" }
+rdb-core = { path = "../core" }
 async-trait = "0.1"
 redis = { version = "1.3", features = ["tokio-comp", "tls-native-tls", "tokio-native-tls-comp"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/crates/driver-redis/src/convert.rs
+++ b/crates/driver-redis/src/convert.rs
@@ -1,5 +1,5 @@
-use rdbs_core::conn::{ConnConfig, SslMode};
-use rdbs_core::result::{RedisValue, ResultSet};
+use rdb_core::conn::{ConnConfig, SslMode};
+use rdb_core::result::{RedisValue, ResultSet};
 use redis::Value;
 
 /// Build a `redis://[:password@]host:port[/db]` URL from connection config.
@@ -95,8 +95,8 @@ fn scalar_to_string(value: Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rdbs_core::conn::{ConnConfig, SslMode};
-    use rdbs_core::result::{RedisValue, ResultSet};
+    use rdb_core::conn::{ConnConfig, SslMode};
+    use rdb_core::result::{RedisValue, ResultSet};
     use redis::Value;
 
     fn cfg(pw: Option<&str>, db: Option<&str>) -> ConnConfig {

--- a/crates/driver-redis/src/driver.rs
+++ b/crates/driver-redis/src/driver.rs
@@ -3,14 +3,14 @@ use redis::aio::MultiplexedConnection;
 use redis::{Client, Value};
 use tokio::sync::Mutex;
 
-use rdbs_core::conn::ConnConfig;
-use rdbs_core::driver::Driver;
-use rdbs_core::error::{RdbsError, Result};
-use rdbs_core::query::Query;
-use rdbs_core::result::RedisValue;
-use rdbs_core::result::{Cell, ResultSet};
-use rdbs_core::schema::{Container, ContainerKind, Database, Schema};
-use rdbs_core::write::{TableRef, WriteOp};
+use rdb_core::conn::ConnConfig;
+use rdb_core::driver::Driver;
+use rdb_core::error::{RdbsError, Result};
+use rdb_core::query::Query;
+use rdb_core::result::RedisValue;
+use rdb_core::result::{Cell, ResultSet};
+use rdb_core::schema::{Container, ContainerKind, Database, Schema};
+use rdb_core::write::{TableRef, WriteOp};
 
 use crate::convert::{connection_url, pairs_from_flat, pairs_from_members, value_to_resultset};
 
@@ -274,11 +274,11 @@ impl RedisDriver {
                     "list" => {
                         // Lists delete by index: LSET a sentinel, then LREM it.
                         let idx = pair_text(pk, "index").ok_or_else(|| missing("index"))?;
-                        build_cmd("LSET", &[key, &idx, "__rdbs_deleted__"])
+                        build_cmd("LSET", &[key, &idx, "__rdb_deleted__"])
                             .query_async::<()>(&mut *conn)
                             .await
                             .map_err(qerr)?;
-                        build_cmd("LREM", &[key, "1", "__rdbs_deleted__"])
+                        build_cmd("LREM", &[key, "1", "__rdb_deleted__"])
                     }
                     "set" => {
                         let member = pair_text(pk, "member").ok_or_else(|| missing("member"))?;

--- a/crates/driver-redis/src/driver.rs
+++ b/crates/driver-redis/src/driver.rs
@@ -5,7 +5,7 @@ use tokio::sync::Mutex;
 
 use rdb_core::conn::ConnConfig;
 use rdb_core::driver::Driver;
-use rdb_core::error::{RdbsError, Result};
+use rdb_core::error::{RdbError, Result};
 use rdb_core::query::Query;
 use rdb_core::result::RedisValue;
 use rdb_core::result::{Cell, ResultSet};
@@ -30,11 +30,11 @@ pub struct RedisDriver {
 impl Driver for RedisDriver {
     async fn connect(cfg: &ConnConfig) -> Result<Self> {
         let client =
-            Client::open(connection_url(cfg)).map_err(|e| RdbsError::Connection(e.to_string()))?;
+            Client::open(connection_url(cfg)).map_err(|e| RdbError::Connection(e.to_string()))?;
         let conn = client
             .get_multiplexed_async_connection()
             .await
-            .map_err(|e| RdbsError::Connection(e.to_string()))?;
+            .map_err(|e| RdbError::Connection(e.to_string()))?;
         let db = cfg.database.clone().unwrap_or_else(|| "0".to_string());
         Ok(RedisDriver {
             conn: Mutex::new(conn),
@@ -47,11 +47,11 @@ impl Driver for RedisDriver {
         let reply: String = redis::cmd("PING")
             .query_async(&mut *conn)
             .await
-            .map_err(|e| RdbsError::Connection(e.to_string()))?;
+            .map_err(|e| RdbError::Connection(e.to_string()))?;
         if reply == "PONG" {
             Ok(())
         } else {
-            Err(RdbsError::Connection(format!(
+            Err(RdbError::Connection(format!(
                 "unexpected PING reply: {reply}"
             )))
         }
@@ -78,7 +78,7 @@ impl Driver for RedisDriver {
             .arg(MAX_KEYS as i64)
             .query_async(&mut *conn)
             .await
-            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+            .map_err(|e| RdbError::Schema(e.to_string()))?;
         Ok(keys
             .into_iter()
             .map(|k| Container {
@@ -92,10 +92,10 @@ impl Driver for RedisDriver {
     async fn query(&self, q: &Query) -> Result<ResultSet> {
         let tokens = match q {
             Query::Command(tokens) => tokens,
-            _ => return Err(RdbsError::UnsupportedQuery),
+            _ => return Err(RdbError::UnsupportedQuery),
         };
         if tokens.is_empty() {
-            return Err(RdbsError::Query("empty command".into()));
+            return Err(RdbError::Query("empty command".into()));
         }
 
         // `BROWSE <key> [offset limit]` is a UI-only convention (not a real
@@ -104,7 +104,7 @@ impl Driver for RedisDriver {
         if tokens[0].eq_ignore_ascii_case("BROWSE") {
             let key = tokens
                 .get(1)
-                .ok_or_else(|| RdbsError::Query("BROWSE needs a key".into()))?;
+                .ok_or_else(|| RdbError::Query("BROWSE needs a key".into()))?;
             let offset = tokens.get(2).and_then(|t| t.parse::<usize>().ok());
             let limit = tokens.get(3).and_then(|t| t.parse::<usize>().ok());
             return self.browse_key(key, offset, limit).await;
@@ -119,7 +119,7 @@ impl Driver for RedisDriver {
         let value: Value = cmd
             .query_async(&mut *conn)
             .await
-            .map_err(|e| RdbsError::Query(e.to_string()))?;
+            .map_err(|e| RdbError::Query(e.to_string()))?;
 
         Ok(value_to_resultset(tokens[0].to_uppercase(), value))
     }
@@ -152,7 +152,7 @@ impl Driver for RedisDriver {
             .arg(&table.name)
             .query_async(&mut *conn)
             .await
-            .map_err(|e| RdbsError::Query(e.to_string()))
+            .map_err(|e| RdbError::Query(e.to_string()))
     }
 
     /// Sequential type-aware writes; stops at the first failure and reports
@@ -163,7 +163,7 @@ impl Driver for RedisDriver {
             let key = &op.table().name;
             let kind = self.key_type(key).await?;
             self.apply_op(key, &kind, op).await.map_err(|e| {
-                RdbsError::Query(format!("{e} (applied {applied} of {} ops)", ops.len()))
+                RdbError::Query(format!("{e} (applied {applied} of {} ops)", ops.len()))
             })?;
             applied += 1;
         }
@@ -202,15 +202,15 @@ impl RedisDriver {
             .arg(key)
             .query_async(&mut *conn)
             .await
-            .map_err(|e| RdbsError::Query(e.to_string()))
+            .map_err(|e| RdbError::Query(e.to_string()))
     }
 
     /// One buffered write against `key` of type `kind`. The op payload uses
     /// the browse-grid column names: identity under `field`/`index`/`member`/
     /// `key`, the new content under `value` (zsets: value = score).
     async fn apply_op(&self, key: &str, kind: &str, op: &WriteOp) -> Result<()> {
-        let qerr = |e: redis::RedisError| RdbsError::Query(e.to_string());
-        let missing = |what: &str| RdbsError::Query(format!("write op missing \"{what}\""));
+        let qerr = |e: redis::RedisError| RdbError::Query(e.to_string());
+        let missing = |what: &str| RdbError::Query(format!("write op missing \"{what}\""));
         let mut conn = self.conn.lock().await;
         match op {
             WriteOp::Update { pk, changes, .. } => {
@@ -238,7 +238,7 @@ impl RedisDriver {
                             .map_err(qerr)?;
                         build_cmd("SADD", &[key, &value])
                     }
-                    other => return Err(RdbsError::Query(format!("cannot edit type {other}"))),
+                    other => return Err(RdbError::Query(format!("cannot edit type {other}"))),
                 };
                 cmd.query_async::<()>(&mut *conn).await.map_err(qerr)
             }
@@ -259,7 +259,7 @@ impl RedisDriver {
                         build_cmd("ZADD", &[key, &value, &member])
                     }
                     other => {
-                        return Err(RdbsError::Query(format!("cannot insert into type {other}")))
+                        return Err(RdbError::Query(format!("cannot insert into type {other}")))
                     }
                 };
                 cmd.query_async::<()>(&mut *conn).await.map_err(qerr)
@@ -289,7 +289,7 @@ impl RedisDriver {
                         build_cmd("ZREM", &[key, &member])
                     }
                     other => {
-                        return Err(RdbsError::Query(format!("cannot delete from type {other}")))
+                        return Err(RdbError::Query(format!("cannot delete from type {other}")))
                     }
                 };
                 cmd.query_async::<()>(&mut *conn).await.map_err(qerr)
@@ -308,7 +308,7 @@ impl RedisDriver {
         offset: Option<usize>,
         limit: Option<usize>,
     ) -> Result<ResultSet> {
-        let qerr = |e: redis::RedisError| RdbsError::Query(e.to_string());
+        let qerr = |e: redis::RedisError| RdbError::Query(e.to_string());
         let off = offset.unwrap_or(0);
         // Range end for LRANGE/ZRANGE: inclusive; no limit → -1 (to the end).
         let end: i64 = match limit {

--- a/crates/driver-redis/src/lib.rs
+++ b/crates/driver-redis/src/lib.rs
@@ -1,4 +1,4 @@
-//! rdbs-driver-redis: Redis Driver impl via the redis crate.
+//! rdb-driver-redis: Redis Driver impl via the redis crate.
 
 mod convert;
 

--- a/crates/driver-redis/tests/integration.rs
+++ b/crates/driver-redis/tests/integration.rs
@@ -1,6 +1,6 @@
 //! Real-engine test: spins a Redis container, then exercises the driver.
 //! Requires Docker. Ignored by default; run with
-//! `cargo test -p rdbs-driver-redis -- --ignored`.
+//! `cargo test -p rdb-driver-redis -- --ignored`.
 
 use rdb_core::conn::{ConnConfig, SslMode};
 use rdb_core::driver::Driver;

--- a/crates/driver-redis/tests/integration.rs
+++ b/crates/driver-redis/tests/integration.rs
@@ -2,12 +2,12 @@
 //! Requires Docker. Ignored by default; run with
 //! `cargo test -p rdbs-driver-redis -- --ignored`.
 
-use rdbs_core::conn::{ConnConfig, SslMode};
-use rdbs_core::driver::Driver;
-use rdbs_core::query::Query;
-use rdbs_core::result::{RedisValue, ResultSet};
-use rdbs_core::schema::ContainerKind;
-use rdbs_driver_redis::RedisDriver;
+use rdb_core::conn::{ConnConfig, SslMode};
+use rdb_core::driver::Driver;
+use rdb_core::query::Query;
+use rdb_core::result::{RedisValue, ResultSet};
+use rdb_core::schema::ContainerKind;
+use rdb_driver_redis::RedisDriver;
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::redis::Redis;
 

--- a/crates/driver-sqlite/Cargo.toml
+++ b/crates/driver-sqlite/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "rdbs-driver-sqlite"
+name = "rdb-driver-sqlite"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rdbs-core = { path = "../core" }
+rdb-core = { path = "../core" }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
 # `bundled` compiles SQLite in-tree: no system libsqlite, no network.

--- a/crates/driver-sqlite/src/driver.rs
+++ b/crates/driver-sqlite/src/driver.rs
@@ -4,13 +4,13 @@ use async_trait::async_trait;
 use rusqlite::types::ValueRef;
 use rusqlite::Connection;
 
-use rdbs_core::conn::ConnConfig;
-use rdbs_core::driver::Driver;
-use rdbs_core::error::{RdbsError, Result};
-use rdbs_core::query::Query;
-use rdbs_core::result::{Cell, Column, ResultSet, Row};
-use rdbs_core::schema::{Container, ContainerKind, Database, Field, Schema};
-use rdbs_core::write::{TableRef, WriteOp};
+use rdb_core::conn::ConnConfig;
+use rdb_core::driver::Driver;
+use rdb_core::error::{RdbsError, Result};
+use rdb_core::query::Query;
+use rdb_core::result::{Cell, Column, ResultSet, Row};
+use rdb_core::schema::{Container, ContainerKind, Database, Field, Schema};
+use rdb_core::write::{TableRef, WriteOp};
 
 use crate::write_sql;
 

--- a/crates/driver-sqlite/src/driver.rs
+++ b/crates/driver-sqlite/src/driver.rs
@@ -180,9 +180,7 @@ fn is_row_returning(sql: &str) -> bool {
 
 fn run_sql(c: &Connection, sql: &str) -> Result<ResultSet> {
     if is_row_returning(sql) {
-        let mut stmt = c
-            .prepare(sql)
-            .map_err(|e| RdbError::Query(e.to_string()))?;
+        let mut stmt = c.prepare(sql).map_err(|e| RdbError::Query(e.to_string()))?;
         let cols: Vec<Column> = stmt
             .column_names()
             .into_iter()
@@ -192,9 +190,7 @@ fn run_sql(c: &Connection, sql: &str) -> Result<ResultSet> {
             })
             .collect();
         let ncol = cols.len();
-        let mut rows = stmt
-            .query([])
-            .map_err(|e| RdbError::Query(e.to_string()))?;
+        let mut rows = stmt.query([]).map_err(|e| RdbError::Query(e.to_string()))?;
         let mut out: Vec<Row> = Vec::new();
         while let Some(r) = rows.next().map_err(|e| RdbError::Query(e.to_string()))? {
             let mut cells: Row = Vec::with_capacity(ncol);

--- a/crates/driver-sqlite/src/driver.rs
+++ b/crates/driver-sqlite/src/driver.rs
@@ -6,7 +6,7 @@ use rusqlite::Connection;
 
 use rdb_core::conn::ConnConfig;
 use rdb_core::driver::Driver;
-use rdb_core::error::{RdbsError, Result};
+use rdb_core::error::{RdbError, Result};
 use rdb_core::query::Query;
 use rdb_core::result::{Cell, Column, ResultSet, Row};
 use rdb_core::schema::{Container, ContainerKind, Database, Field, Schema};
@@ -38,7 +38,7 @@ impl SqliteDriver {
             f(&guard)
         })
         .await
-        .map_err(|e| RdbsError::Query(e.to_string()))?
+        .map_err(|e| RdbError::Query(e.to_string()))?
     }
 }
 
@@ -57,8 +57,8 @@ impl Driver for SqliteDriver {
             }
         })
         .await
-        .map_err(|e| RdbsError::Connection(e.to_string()))?
-        .map_err(|e| RdbsError::Connection(e.to_string()))?;
+        .map_err(|e| RdbError::Connection(e.to_string()))?
+        .map_err(|e| RdbError::Connection(e.to_string()))?;
         Ok(SqliteDriver {
             conn: Arc::new(Mutex::new(conn)),
             db_name,
@@ -68,7 +68,7 @@ impl Driver for SqliteDriver {
     async fn ping(&self) -> Result<()> {
         self.with_conn(|c| {
             c.query_row("SELECT 1", [], |_| Ok(()))
-                .map_err(|e| RdbsError::Connection(e.to_string()))
+                .map_err(|e| RdbError::Connection(e.to_string()))
         })
         .await
     }
@@ -81,7 +81,7 @@ impl Driver for SqliteDriver {
     async fn query(&self, q: &Query) -> Result<ResultSet> {
         let sql = match q {
             Query::Sql(s) => s.clone(),
-            Query::Command(_) | Query::Mongo(_) => return Err(RdbsError::UnsupportedQuery),
+            Query::Command(_) | Query::Mongo(_) => return Err(RdbError::UnsupportedQuery),
         };
         self.with_conn(move |c| run_sql(c, &sql)).await
     }
@@ -96,7 +96,7 @@ impl Driver for SqliteDriver {
         self.with_conn(move |c| {
             let n: i64 = c
                 .query_row(&sql, [], |r| r.get(0))
-                .map_err(|e| RdbsError::Query(e.to_string()))?;
+                .map_err(|e| RdbError::Query(e.to_string()))?;
             Ok(n as u64)
         })
         .await
@@ -116,19 +116,19 @@ impl Driver for SqliteDriver {
             .collect();
         self.with_conn(move |c| {
             c.execute_batch("BEGIN")
-                .map_err(|e| RdbsError::Query(e.to_string()))?;
+                .map_err(|e| RdbError::Query(e.to_string()))?;
             let mut affected = 0u64;
             for sql in &stmts {
                 match c.execute(sql, []) {
                     Ok(n) => affected += n as u64,
                     Err(e) => {
                         let _ = c.execute_batch("ROLLBACK");
-                        return Err(RdbsError::Query(e.to_string()));
+                        return Err(RdbError::Query(e.to_string()));
                     }
                 }
             }
             c.execute_batch("COMMIT")
-                .map_err(|e| RdbsError::Query(e.to_string()))?;
+                .map_err(|e| RdbError::Query(e.to_string()))?;
             Ok(affected)
         })
         .await
@@ -182,7 +182,7 @@ fn run_sql(c: &Connection, sql: &str) -> Result<ResultSet> {
     if is_row_returning(sql) {
         let mut stmt = c
             .prepare(sql)
-            .map_err(|e| RdbsError::Query(e.to_string()))?;
+            .map_err(|e| RdbError::Query(e.to_string()))?;
         let cols: Vec<Column> = stmt
             .column_names()
             .into_iter()
@@ -194,12 +194,12 @@ fn run_sql(c: &Connection, sql: &str) -> Result<ResultSet> {
         let ncol = cols.len();
         let mut rows = stmt
             .query([])
-            .map_err(|e| RdbsError::Query(e.to_string()))?;
+            .map_err(|e| RdbError::Query(e.to_string()))?;
         let mut out: Vec<Row> = Vec::new();
-        while let Some(r) = rows.next().map_err(|e| RdbsError::Query(e.to_string()))? {
+        while let Some(r) = rows.next().map_err(|e| RdbError::Query(e.to_string()))? {
             let mut cells: Row = Vec::with_capacity(ncol);
             for i in 0..ncol {
-                let v = r.get_ref(i).map_err(|e| RdbsError::Query(e.to_string()))?;
+                let v = r.get_ref(i).map_err(|e| RdbError::Query(e.to_string()))?;
                 cells.push(value_to_cell(v));
             }
             out.push(cells);
@@ -208,7 +208,7 @@ fn run_sql(c: &Connection, sql: &str) -> Result<ResultSet> {
     } else {
         let n = c
             .execute(sql, [])
-            .map_err(|e| RdbsError::Query(e.to_string()))?;
+            .map_err(|e| RdbError::Query(e.to_string()))?;
         Ok(ResultSet::Affected(n as u64))
     }
 }
@@ -220,12 +220,12 @@ fn schema_impl(c: &Connection, db_name: &str) -> Result<Schema> {
                 "SELECT name FROM sqlite_master \
                  WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
             )
-            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+            .map_err(|e| RdbError::Schema(e.to_string()))?;
         let rows = stmt
             .query_map([], |r| r.get::<_, String>(0))
-            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+            .map_err(|e| RdbError::Schema(e.to_string()))?;
         rows.collect::<rusqlite::Result<Vec<_>>>()
-            .map_err(|e| RdbsError::Schema(e.to_string()))?
+            .map_err(|e| RdbError::Schema(e.to_string()))?
     };
 
     let mut containers: Vec<Container> = Vec::with_capacity(tables.len());
@@ -233,7 +233,7 @@ fn schema_impl(c: &Connection, db_name: &str) -> Result<Schema> {
         let pragma = format!("PRAGMA table_info({})", write_sql::quote_ident(&table));
         let mut stmt = c
             .prepare(&pragma)
-            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+            .map_err(|e| RdbError::Schema(e.to_string()))?;
         // table_info columns: cid, name, type, notnull, dflt_value, pk
         let rows = stmt
             .query_map([], |r| {
@@ -243,10 +243,10 @@ fn schema_impl(c: &Connection, db_name: &str) -> Result<Schema> {
                     r.get::<_, i64>(3)?,
                 ))
             })
-            .map_err(|e| RdbsError::Schema(e.to_string()))?;
+            .map_err(|e| RdbError::Schema(e.to_string()))?;
         let mut fields = Vec::new();
         for row in rows {
-            let (name, type_name, notnull) = row.map_err(|e| RdbsError::Schema(e.to_string()))?;
+            let (name, type_name, notnull) = row.map_err(|e| RdbError::Schema(e.to_string()))?;
             fields.push(Field {
                 name,
                 type_name,
@@ -275,14 +275,14 @@ fn primary_key_impl(c: &Connection, table: &str) -> Result<Vec<String>> {
     let pragma = format!("PRAGMA table_info({})", write_sql::quote_ident(table));
     let mut stmt = c
         .prepare(&pragma)
-        .map_err(|e| RdbsError::Schema(e.to_string()))?;
+        .map_err(|e| RdbError::Schema(e.to_string()))?;
     // (name, pk-ordinal); pk == 0 means not part of the primary key.
     let rows = stmt
         .query_map([], |r| Ok((r.get::<_, String>(1)?, r.get::<_, i64>(5)?)))
-        .map_err(|e| RdbsError::Schema(e.to_string()))?;
+        .map_err(|e| RdbError::Schema(e.to_string()))?;
     let mut pk: Vec<(String, i64)> = Vec::new();
     for row in rows {
-        let (name, ord) = row.map_err(|e| RdbsError::Schema(e.to_string()))?;
+        let (name, ord) = row.map_err(|e| RdbError::Schema(e.to_string()))?;
         if ord > 0 {
             pk.push((name, ord));
         }

--- a/crates/driver-sqlite/src/lib.rs
+++ b/crates/driver-sqlite/src/lib.rs
@@ -1,4 +1,4 @@
-//! rdbs-driver-sqlite: a `rdbs_core::driver::Driver` backed by rusqlite.
+//! rdbs-driver-sqlite: a `rdb_core::driver::Driver` backed by rusqlite.
 //!
 //! SQLite is a single local file, so `ConnConfig.database` carries the file
 //! path (host/port/user are unused). rusqlite is synchronous; every call runs

--- a/crates/driver-sqlite/src/lib.rs
+++ b/crates/driver-sqlite/src/lib.rs
@@ -1,4 +1,4 @@
-//! rdbs-driver-sqlite: a `rdb_core::driver::Driver` backed by rusqlite.
+//! rdb-driver-sqlite: a `rdb_core::driver::Driver` backed by rusqlite.
 //!
 //! SQLite is a single local file, so `ConnConfig.database` carries the file
 //! path (host/port/user are unused). rusqlite is synchronous; every call runs

--- a/crates/driver-sqlite/src/write_sql.rs
+++ b/crates/driver-sqlite/src/write_sql.rs
@@ -2,8 +2,8 @@
 //! Postgres builder, minus schema qualification (SQLite has no schema
 //! namespace) and with SQLite literal spellings (`X'..'` blobs, 0/1 bools).
 
-use rdbs_core::result::Cell;
-use rdbs_core::write::TableRef;
+use rdb_core::result::Cell;
+use rdb_core::write::TableRef;
 
 /// `"ident"` with embedded double quotes doubled.
 pub fn quote_ident(ident: &str) -> String {

--- a/crates/driver-sqlite/tests/integration.rs
+++ b/crates/driver-sqlite/tests/integration.rs
@@ -1,12 +1,12 @@
 //! SQLite driver end-to-end. No Docker: uses a temp file, so this runs in
 //! normal `cargo test` (unlike the network-engine drivers).
 
-use rdbs_core::conn::{ConnConfig, SslMode};
-use rdbs_core::driver::Driver;
-use rdbs_core::query::Query;
-use rdbs_core::result::{Cell, ResultSet};
-use rdbs_core::write::{TableRef, WriteOp};
-use rdbs_driver_sqlite::SqliteDriver;
+use rdb_core::conn::{ConnConfig, SslMode};
+use rdb_core::driver::Driver;
+use rdb_core::query::Query;
+use rdb_core::result::{Cell, ResultSet};
+use rdb_core::write::{TableRef, WriteOp};
+use rdb_driver_sqlite::SqliteDriver;
 
 fn cfg(path: &str) -> ConnConfig {
     ConnConfig {

--- a/crates/driver-sqlite/tests/integration.rs
+++ b/crates/driver-sqlite/tests/integration.rs
@@ -22,7 +22,7 @@ fn cfg(path: &str) -> ConnConfig {
 
 fn temp_db() -> String {
     let mut p = std::env::temp_dir();
-    p.push(format!("rdbs-sqlite-test-{}.db", std::process::id()));
+    p.push(format!("rdb-sqlite-test-{}.db", std::process::id()));
     let _ = std::fs::remove_file(&p);
     p.to_string_lossy().into_owned()
 }

--- a/npm/README.md
+++ b/npm/README.md
@@ -9,7 +9,7 @@ SQLite, Cassandra in one binary. No Electron.
 npm i -g @suiflex/rdb
 ```
 
-The postinstall step downloads the prebuilt `rdbs` binary for your platform
+The postinstall step downloads the prebuilt `rdb` binary for your platform
 (macOS, Linux, Windows — x64 & arm64) from the matching
 [GitHub Release](https://github.com/suiflex/rdb/releases). Then run:
 
@@ -20,8 +20,8 @@ rdb
 ## Links
 
 - Source & docs: https://github.com/suiflex/rdb
-- Also available via Homebrew (`brew install suiflex/tap/rdbs`) and
-  Scoop (`scoop install rdbs`).
+- Also available via Homebrew (`brew install suiflex/tap/rdb`) and
+  Scoop (`scoop install rdb`).
 
 ## License
 

--- a/npm/bin/rdb.js
+++ b/npm/bin/rdb.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Thin launcher: exec the vendored `rdbs` binary fetched by install.js,
+// Thin launcher: exec the vendored `rdb` binary fetched by install.js,
 // forwarding args and stdio, and propagating its exit code.
 "use strict";
 
@@ -7,7 +7,7 @@ const path = require("path");
 const fs = require("fs");
 const { spawnSync } = require("child_process");
 
-const bin = process.platform === "win32" ? "rdbs.exe" : "rdbs";
+const bin = process.platform === "win32" ? "rdb.exe" : "rdb";
 const binPath = path.join(__dirname, "..", "vendor", bin);
 
 if (!fs.existsSync(binPath)) {

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// postinstall: download the matching prebuilt `rdbs` binary from the GitHub
+// postinstall: download the matching prebuilt `rdb` binary from the GitHub
 // Release whose tag equals this package's version, and drop it in vendor/.
 // ponytail: shells out to the system `tar` (bsdtar handles both .tar.gz and
 // .zip on macOS/Linux/Win10+) instead of pulling an archive dependency.
@@ -16,12 +16,12 @@ const REPO = "suiflex/rdb";
 // be self-checked without touching the network.
 function resolveTarget(platform, arch) {
   const map = {
-    "darwin:arm64": ["aarch64-apple-darwin", "tar.gz", "rdbs"],
-    "darwin:x64": ["x86_64-apple-darwin", "tar.gz", "rdbs"],
-    "linux:x64": ["x86_64-unknown-linux-gnu", "tar.gz", "rdbs"],
-    "linux:arm64": ["aarch64-unknown-linux-gnu", "tar.gz", "rdbs"],
-    "win32:x64": ["x86_64-pc-windows-msvc", "zip", "rdbs.exe"],
-    "win32:arm64": ["aarch64-pc-windows-msvc", "zip", "rdbs.exe"],
+    "darwin:arm64": ["aarch64-apple-darwin", "tar.gz", "rdb"],
+    "darwin:x64": ["x86_64-apple-darwin", "tar.gz", "rdb"],
+    "linux:x64": ["x86_64-unknown-linux-gnu", "tar.gz", "rdb"],
+    "linux:arm64": ["aarch64-unknown-linux-gnu", "tar.gz", "rdb"],
+    "win32:x64": ["x86_64-pc-windows-msvc", "zip", "rdb.exe"],
+    "win32:arm64": ["aarch64-pc-windows-msvc", "zip", "rdb.exe"],
   };
   const hit = map[`${platform}:${arch}`];
   if (!hit) {
@@ -56,7 +56,7 @@ function download(url, dest, redirects = 0) {
 async function main() {
   const version = require("./package.json").version;
   const { target, ext, bin } = resolveTarget(process.platform, process.arch);
-  const asset = `rdbs-${target}.${ext}`;
+  const asset = `rdb-${target}.${ext}`;
   const tag = `v${version}`;
   const url = `https://github.com/${REPO}/releases/download/${tag}/${asset}`;
 
@@ -83,7 +83,7 @@ async function main() {
 if (process.argv.includes("--selftest")) {
   const assert = require("assert");
   assert.strictEqual(resolveTarget("darwin", "arm64").target, "aarch64-apple-darwin");
-  assert.strictEqual(resolveTarget("win32", "x64").bin, "rdbs.exe");
+  assert.strictEqual(resolveTarget("win32", "x64").bin, "rdb.exe");
   assert.strictEqual(resolveTarget("linux", "x64").ext, "tar.gz");
   assert.throws(() => resolveTarget("sunos", "sparc"));
   console.log("selftest ok");

--- a/packaging/rdb.json.tmpl
+++ b/packaging/rdb.json.tmpl
@@ -5,16 +5,16 @@
   "license": "MIT",
   "architecture": {
     "64bit": {
-      "url": "@BASE@/rdbs-x86_64-pc-windows-msvc.zip",
+      "url": "@BASE@/rdb-x86_64-pc-windows-msvc.zip",
       "hash": "@WIN_SHA@"
     }
   },
-  "bin": "rdbs.exe",
+  "bin": "rdb.exe",
   "checkver": "github",
   "autoupdate": {
     "architecture": {
       "64bit": {
-        "url": "https://github.com/suiflex/rdb/releases/download/v$version/rdbs-x86_64-pc-windows-msvc.zip"
+        "url": "https://github.com/suiflex/rdb/releases/download/v$version/rdb-x86_64-pc-windows-msvc.zip"
       }
     }
   }

--- a/packaging/rdb.rb.tmpl
+++ b/packaging/rdb.rb.tmpl
@@ -1,7 +1,7 @@
 # Rendered by .github/workflows/release-build.yml into suiflex/homebrew-tap.
 # Placeholders (@VERSION@, @BASE@, @ARM_SHA@, @INTEL_SHA@, @LINUX_SHA@) are
 # filled in via sed on each release. Edit the template, not the generated file.
-class Rdbs < Formula
+class Rdb < Formula
   desc "Native cross-platform database manager (PostgreSQL, MySQL, Redis, MongoDB)"
   homepage "https://github.com/suiflex/rdb"
   version "@VERSION@"

--- a/packaging/rdb.rb.tmpl
+++ b/packaging/rdb.rb.tmpl
@@ -9,25 +9,25 @@ class Rdbs < Formula
 
   on_macos do
     on_arm do
-      url "@BASE@/rdbs-aarch64-apple-darwin.tar.gz"
+      url "@BASE@/rdb-aarch64-apple-darwin.tar.gz"
       sha256 "@ARM_SHA@"
     end
     on_intel do
-      url "@BASE@/rdbs-x86_64-apple-darwin.tar.gz"
+      url "@BASE@/rdb-x86_64-apple-darwin.tar.gz"
       sha256 "@INTEL_SHA@"
     end
   end
 
   on_linux do
-    url "@BASE@/rdbs-x86_64-unknown-linux-gnu.tar.gz"
+    url "@BASE@/rdb-x86_64-unknown-linux-gnu.tar.gz"
     sha256 "@LINUX_SHA@"
   end
 
   def install
-    bin.install "rdbs"
+    bin.install "rdb"
   end
 
   test do
-    assert_match "rdbs", shell_output("#{bin}/rdbs --version")
+    assert_match "rdb", shell_output("#{bin}/rdb --version")
   end
 end

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,7 @@
   "include-component-in-tag": false,
   "packages": {
     "app": {
-      "package-name": "rdbs",
+      "package-name": "rdb",
       "extra-files": [
         {
           "type": "json",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 REPO="suiflex/rdb"
-BINARY="rdbs"
-VERSION="${RDBS_VERSION:-latest}"
+BINARY="rdb"
+VERSION="${RDB_VERSION:-latest}"
 
 log() {
   printf '==> %s\n' "$*"


### PR DESCRIPTION
## Summary
- Make the whole project consistently named **rdb** (matches the UI brand, npm `@suiflex/rdb`, and repo `suiflex/rdb`). The legacy `rdbs` name was still in ~597 places: crates, imports, the app binary, CI, release/packaging, env vars, and docs.
- **Breaking, ships with the next release**: the command becomes `rdb` (was `rdbs`), release assets become `rdb-<target>.*`, macOS bundle id → `com.suiflex.rdb`, and Homebrew/Scoop casks reinstall.

## Changes (and why)
- **Library crates** — `rdbs-core/connstore/driver-*` → `rdb-*`, plus 310 `rdbs_`→`rdb_` import idents. Code-level consistency.
- **Error type** — `RdbsError` → `RdbError` (163 uses, 13 files). Still carried the old name.
- **App package/binary** — `rdbs` → `rdb` (`Cargo.toml`, `[[bin]]`, `Makefile`). The command + `cargo -p` target.
- **Env vars** — `RDBS_{MOCK,SHOT,SHOT_DELAY_MS,SCREEN,STORE_DIR,VERSION,WIN}` → `RDB_*`. Dev/test knobs, internal.
- **CI** — 7 `rdbs-*.yml` workflows → `rdb-*.yml` (+ `-p` pkg refs, job names); `release-please-config.json` `package-name` → `rdb`.
- **Release/packaging** — `release-build.yml` artifact + bundle names (`rdb-<target>`, `RDB.app`/`RDB.icns`, `CFBundle*`, `com.suiflex.rdb`); Homebrew template (`class Rdb`, `bin.install "rdb"`); Scoop template (`rdb.exe`); `scripts/install.sh`, `npm/install.js`, `npm/bin/rdb.js`, `npm/README.md`.
- **Docs** — `README`, `CONTRIBUTING`, `SECURITY`, `AGENTS.md`, `CLAUDE.md` ×2, issue templates: `RDBS` → `RDB`.

## Not touched
- `app/CHANGELOG.md` — release-please owns it; historical entries left as-is to avoid bot conflicts.

## Compatibility notes
- Git tags stay `vX.Y.Z` (`include-component-in-tag: false`); release-please manifest is keyed by path (`"app"`), so version continuity is preserved despite the `package-name` label change.
- Crates are workspace path-deps (not published to crates.io), so no external Rust consumers break.

## Test plan
- [x] `make all` — fmt-check + lint + test + build all green
- [x] `node npm/install.js --selftest` — `selftest ok` (resolves `rdb-<target>` / `rdb.exe`)
- [x] Repo sweep: no `rdbs`/`RDBS`/`Rdbs` remain (except excluded `app/CHANGELOG.md` history)
- [ ] Post-merge release run produces `rdb-<target>` assets + updated brew/scoop casks