### PR TITLE
docs: refresh SECURITY.md and add project VISION

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 
 A native, lightweight, cross-platform database manager built with Rust and Slint — in the spirit of TablePlus but compiled from a single codebase for macOS and Linux.
 
+> Where RDB is headed and why — see [**VISION.md**](./VISION.md).
+
 ## Features
 
 - **Multi-engine** — PostgreSQL, MySQL/MariaDB, Redis, MongoDB, SQLite, Cassandra in one app

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,14 +3,17 @@
 ## Supported versions
 
 RDB is pre-1.0 and ships from a single tracked package (`rdb`). Security
-fixes land on the latest release; there are no long-term support branches yet.
+fixes land on the latest release only; there are no long-term support
+branches yet.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.8.x   | :white_check_mark: |
-| < 0.8   | :x:                |
+| Version              | Supported          |
+| -------------------- | ------------------ |
+| Latest `0.x` release | :white_check_mark: |
+| Any older release    | :x:                |
 
-Please upgrade to the latest release before reporting an issue where possible.
+The current release is on the
+[Releases page](https://github.com/suiflex/rdb/releases). Please upgrade to
+the latest release before reporting an issue where possible.
 
 ## Reporting a vulnerability
 

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,49 @@
+# Vision
+
+RDB is a **native, lightweight database editor for many engines** — one small
+binary that speaks PostgreSQL, MySQL, Redis, MongoDB, SQLite, and Cassandra
+today, with room to grow.
+
+The goal is simple: give people a fast, local-first tool that opens instantly,
+stays out of the way, and handles a wide range of databases without shipping a
+browser engine to do it.
+
+## Why
+
+Most cross-engine database GUIs are Electron apps: hundreds of megabytes, slow
+to start, heavy on memory. The lightweight alternatives usually speak only one
+engine. RDB aims to sit where those two miss each other — broad engine support
+*and* a native footprint.
+
+## Principles
+
+- **Native & fast.** GPU-rendered UI via Slint, no webview. Aggressive release
+  profile (`opt-level=z`, LTO, `panic=abort`, strip) keeps the binary small and
+  startup instant.
+- **Local-first & private.** Your data and queries stay on your machine.
+  Connection secrets live in the OS keychain (AES-GCM encrypted-file fallback),
+  never in plaintext config.
+- **One tool, many engines.** A common `Driver` trait (`crates/core`) means the
+  UI never hardcodes an engine beyond a single dispatch enum. Adding an engine
+  is a new `driver-*` crate — the rest of the app doesn't change.
+- **Boring where it counts.** Predictable behavior over clever features; a
+  small, auditable codebase over a large one.
+
+## Where it's headed
+
+- More engines, added as independent `driver-*` crates behind the same trait.
+- Deeper query ergonomics: filtering, export in common formats, charts.
+- Quality-of-life for real day-to-day database work, kept lean.
+
+Further out (aspirational, not committed yet):
+
+- A community extension surface — let people add engines and panels the
+  community builds and maintains, without forking the app. An agent panel is
+  one of the things that could live here.
+
+## Non-goals
+
+- Not a hosted service — it's a desktop editor you run locally.
+- No telemetry, no account, no cloud dependency to use the core app.
+
+See [`CLAUDE.md`](./CLAUDE.md) for the current architecture and crate layout.


### PR DESCRIPTION
## Summary
- SECURITY.md advertised 0.8.x while the app is at 0.17.0 — mask the version table so it stops rotting each release.
- Add a long-term VISION.md (repo root) so contributors/users understand the goal: a native, lightweight, cross-engine database editor.

## Changes
- `SECURITY.md` — replace the hardcoded 0.8.x row with a masked table (Latest `0.x` release / any older release) + link to the Releases page.
- `VISION.md` (repo **root**) — mission, principles, roadmap (incl. an aspirational community extension surface / agent panel), and non-goals. Kept deliberately open on BI/dashboard direction.
- `README.md` — one line linking to VISION.md.

## Test plan
- [x] Docs-only; no code, no build impact.
- [x] Links point at real paths (`./VISION.md`, `./CLAUDE.md`, Releases page).