### PR TITLE
feat(app): export connections as JSON or CSV

### DIFF
--- a/app/src/export.rs
+++ b/app/src/export.rs
@@ -1,26 +1,59 @@
-//! File-export helpers: timestamped paths in ~/Downloads (temp-dir fallback).
-//! No chrono/time dependency — the civil-date math is a dozen lines.
+//! File-export serializers: turn a result grid or the saved-connection list
+//! into CSV / TSV / JSON / SQL / Markdown text. The caller picks the path via a
+//! native save dialog.
 
-use std::path::PathBuf;
+use rdb_connstore::{Engine, SavedConnection};
 
 use crate::model::GridModel;
+
+/// RFC-4180 field escaping shared by the CSV serializers.
+fn csv_esc(s: &str) -> String {
+    if s.contains([',', '"', '\n', '\r']) {
+        format!("\"{}\"", s.replace('"', "\"\""))
+    } else {
+        s.to_string()
+    }
+}
+
+fn engine_label(e: Engine) -> &'static str {
+    match e {
+        Engine::Postgres => "postgres",
+        Engine::MySql => "mysql",
+        Engine::Redis => "redis",
+        Engine::Mongo => "mongo",
+        Engine::Sqlite => "sqlite",
+        Engine::Cassandra => "cassandra",
+    }
+}
+
+/// Saved connections as CSV. Non-secret fields only — passwords live in the
+/// keychain and are never part of `SavedConnection`, so the dump is safe.
+pub fn conns_to_csv(conns: &[SavedConnection]) -> String {
+    let mut out = String::from("name,engine,host,port,database,user\n");
+    for c in conns {
+        let row = [
+            csv_esc(&c.name),
+            engine_label(c.engine).to_string(),
+            csv_esc(&c.host),
+            c.port.to_string(),
+            csv_esc(c.database.as_deref().unwrap_or("")),
+            csv_esc(&c.user),
+        ];
+        out.push_str(&row.join(","));
+        out.push('\n');
+    }
+    out
+}
 
 /// RFC-4180-style CSV: fields quoted when they contain a comma, quote or
 /// newline; quotes doubled.
 pub fn to_csv(g: &GridModel) -> String {
-    fn esc(s: &str) -> String {
-        if s.contains([',', '"', '\n', '\r']) {
-            format!("\"{}\"", s.replace('"', "\"\""))
-        } else {
-            s.to_string()
-        }
-    }
     let mut out = String::new();
-    let header: Vec<String> = g.columns.iter().map(|c| esc(&c.name)).collect();
+    let header: Vec<String> = g.columns.iter().map(|c| csv_esc(&c.name)).collect();
     out.push_str(&header.join(","));
     out.push('\n');
     for row in &g.rows {
-        let cells: Vec<String> = row.iter().map(|c| esc(&c.text)).collect();
+        let cells: Vec<String> = row.iter().map(|c| csv_esc(&c.text)).collect();
         out.push_str(&cells.join(","));
         out.push('\n');
     }
@@ -45,60 +78,9 @@ pub fn to_tsv(g: &GridModel) -> String {
     out
 }
 
-/// `~/Downloads/<prefix>-YYYYMMDD-HHMMSS.<ext>`; temp dir when $HOME is unset
-/// or Downloads does not exist.
-pub fn export_path(prefix: &str, ext: &str) -> PathBuf {
-    let dir = std::env::var_os("HOME")
-        .map(|h| PathBuf::from(h).join("Downloads"))
-        .filter(|d| d.is_dir())
-        .unwrap_or_else(std::env::temp_dir);
-    dir.join(format!("{prefix}-{}.{ext}", timestamp()))
-}
-
-/// Current UTC time as "YYYYMMDD-HHMMSS".
-fn timestamp() -> String {
-    let secs = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-    fmt_timestamp(secs)
-}
-
-fn fmt_timestamp(secs: u64) -> String {
-    let (y, m, d) = civil_from_days((secs / 86_400) as i64);
-    let tod = secs % 86_400;
-    format!(
-        "{y:04}{m:02}{d:02}-{:02}{:02}{:02}",
-        tod / 3600,
-        (tod % 3600) / 60,
-        tod % 60
-    )
-}
-
-/// Days since 1970-01-01 → (year, month, day). Howard Hinnant's civil_from_days.
-fn civil_from_days(z: i64) -> (i64, u32, u32) {
-    let z = z + 719_468;
-    let era = z.div_euclid(146_097);
-    let doe = z.rem_euclid(146_097);
-    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
-    let y = yoe + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
-    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
-    (if m <= 2 { y + 1 } else { y }, m, d)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn civil_date_epoch_and_leap() {
-        assert_eq!(civil_from_days(0), (1970, 1, 1));
-        // 2024-02-29 is day 19782
-        assert_eq!(civil_from_days(19_782), (2024, 2, 29));
-    }
 
     fn grid() -> GridModel {
         use crate::model::{VmCell, VmColumn};
@@ -137,8 +119,15 @@ mod tests {
     }
 
     #[test]
-    fn timestamp_format() {
-        assert_eq!(fmt_timestamp(0), "19700101-000000");
-        assert_eq!(fmt_timestamp(86_399), "19700101-235959");
+    fn conns_csv_has_no_secrets_and_escapes() {
+        let mut c =
+            SavedConnection::new("db, prod", Engine::Postgres, "localhost", 5432, "postgres");
+        c.database = Some("app".into());
+        let csv = conns_to_csv(&[c]);
+        assert_eq!(
+            csv,
+            "name,engine,host,port,database,user\n\"db, prod\",postgres,localhost,5432,app,postgres\n"
+        );
+        assert!(!csv.to_lowercase().contains("password"));
     }
 }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -6578,28 +6578,48 @@ fn main() -> Result<(), slint::PlatformError> {
             }
         });
     }
-    // backup saved connections to a JSON file. Passwords are not in the
-    // list — they live in the keychain — so the dump is safe to write.
+    // export saved connections. Passwords are not in the list — they live in
+    // the keychain — so the dump is safe to write. Arg: 0 = JSON, 1 = CSV.
     {
         let weak = window.as_weak();
         let store = store.clone();
-        window.on_backup_conns(move || {
+        window.on_export_conns(move |fmt| {
             let Some(w) = weak.upgrade() else {
                 return;
             };
             let st = store.borrow();
-            let json = match serde_json::to_string_pretty(st.list()) {
+            let (ext, body) = if fmt == 1 {
+                ("csv", Ok(export::conns_to_csv(st.list())))
+            } else {
+                ("json", serde_json::to_string_pretty(st.list()))
+            };
+            let contents = match body {
                 Ok(j) => j,
                 Err(e) => {
-                    w.set_sel_footer(SharedString::from(format!("backup failed: {e}")));
+                    w.set_sel_footer(SharedString::from(format!("export failed: {e}")));
                     return;
                 }
             };
-            let path = export::export_path("rdb-connections", "json");
-            w.set_sel_footer(SharedString::from(match std::fs::write(&path, json) {
-                Ok(()) => format!("backup → {}", path.display()),
-                Err(e) => format!("backup failed: {e}"),
-            }));
+            // Native save dialog via rfd's async API + Slint's local executor:
+            // the sync dialog blocks the winit event loop and never surfaces.
+            let weak = w.as_weak();
+            let _ = slint::spawn_local(async move {
+                let Some(file) = rfd::AsyncFileDialog::new()
+                    .set_file_name(format!("rdb-connections.{ext}"))
+                    .add_filter(ext.to_uppercase(), &[ext])
+                    .save_file()
+                    .await
+                else {
+                    return; // user cancelled
+                };
+                let msg = match std::fs::write(file.path(), contents) {
+                    Ok(()) => format!("export → {}", file.path().display()),
+                    Err(e) => format!("export failed: {e}"),
+                };
+                if let Some(w) = weak.upgrade() {
+                    w.set_sel_footer(SharedString::from(msg));
+                }
+            });
         });
     }
     // quick test from the picker detail pane: saved config, result in the

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -379,7 +379,7 @@ in-out property <string> rename-text;
     in property <bool> test-busy;
     callback open-add-form();
     callback open-edit-form(int);
-    callback backup-conns();
+    callback export-conns(int);
     callback form-engine-changed(string);
     callback form-import-url();
     callback form-test-conn();
@@ -751,7 +751,7 @@ in-out property <string> rename-text;
             edit-clicked(i) => { root.open-edit-form(i); }
             toggle-group(g) => { root.toggle-group(g); }
             filter(t) => { root.conn-filter(t); }
-            backup-clicked() => { root.backup-conns(); }
+            export-conns(fmt) => { root.export-conns(fmt); }
         }
 
         // ===== workspace (shown once connected) =====

--- a/app/src/ui/picker.slint
+++ b/app/src/ui/picker.slint
@@ -31,7 +31,8 @@ export component ConnPicker inherits Rectangle {
     callback test-clicked(int);
     callback add-clicked();
     callback edit-clicked(int);
-    callback backup-clicked();
+    // Export saved connections to ~/Downloads. Arg is the format: 0 = JSON, 1 = CSV.
+    callback export-conns(int);
     callback toggle-group(string);
     callback filter(string);
 
@@ -216,7 +217,45 @@ export component ConnPicker inherits Rectangle {
                             alignment: center;
                             HorizontalLayout {
                                 spacing: Tokens.sp4;
-                                TextButton { text: "Backup"; clicked => { root.backup-clicked(); } }
+                                Rectangle {
+                                    width: exp-btn.preferred-width;
+                                    height: exp-btn.preferred-height;
+                                    export-menu := PopupWindow {
+                                        x: 0;
+                                        y: -76px;
+                                        width: 130px;
+                                        height: menu-box.preferred-height;
+                                        menu-box := Rectangle {
+                                            background: Tokens.card;
+                                            border-width: 1px;
+                                            border-color: Tokens.border-strong;
+                                            border-radius: Tokens.radius;
+                                            drop-shadow-blur: 12px;
+                                            drop-shadow-color: #00000022;
+                                            VerticalLayout {
+                                                padding: 4px;
+                                                for opt[i] in ["JSON", "CSV"]: Rectangle {
+                                                    height: 28px;
+                                                    border-radius: 6px;
+                                                    background: exp-row-ta.has-hover ? Tokens.accent-tint : transparent;
+                                                    exp-row-ta := TouchArea {
+                                                        clicked => { export-menu.close(); root.export-conns(i); }
+                                                    }
+                                                    HorizontalLayout {
+                                                        padding-left: Tokens.sp2;
+                                                        Text {
+                                                            text: opt;
+                                                            color: Tokens.text;
+                                                            font-size: Tokens.font-sm;
+                                                            vertical-alignment: center;
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                    exp-btn := TextButton { text: "Export ▾"; clicked => { export-menu.show(); } }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- The sidebar picker had a silent "Backup" button that dumped connections to JSON with no feedback. Turn it into an Export action with a format menu and a real save dialog.

## Changes
- `app/src/export.rs` — `conns_to_csv`: serialize non-secret fields (name, engine, host, port, database, user). Passwords are never part of `SavedConnection`.
- `app/src/ui/picker.slint` — "Backup" → "Export ▾" menu (JSON / CSV).
- `app/src/ui/app-window.slint`, `app/src/main.rs` — `on_export_conns(fmt)`; location chosen via native save dialog (`rfd::AsyncFileDialog` + `slint::spawn_local` so the panel actually surfaces instead of blocking the event loop).

## Test plan
- [x] `cargo test -p rdb export::` — CSV escaping + no-secrets assertions pass.
- [x] `cargo clippy -p rdb` clean, `cargo fmt --check` clean.
- [x] Manual: picker → Export ▾ → JSON/CSV → save dialog appears → file written; no password in output.