### PR TITLE
feat: SQL console UX — results toggle, export formats, filter

### DIFF
--- a/app/src/export.rs
+++ b/app/src/export.rs
@@ -78,6 +78,74 @@ pub fn to_tsv(g: &GridModel) -> String {
     out
 }
 
+/// JSON array of row objects (`[{ "col": "val", "nullcol": null }]`). Built
+/// through `serde_json` so escaping is correct.
+pub fn to_json(g: &GridModel) -> String {
+    use serde_json::{Map, Value};
+    let rows: Vec<Value> = g
+        .rows
+        .iter()
+        .map(|row| {
+            let mut obj = Map::new();
+            for (col, cell) in g.columns.iter().zip(row) {
+                let v = if cell.is_null {
+                    Value::Null
+                } else {
+                    Value::String(cell.text.clone())
+                };
+                obj.insert(col.name.clone(), v);
+            }
+            Value::Object(obj)
+        })
+        .collect();
+    serde_json::to_string_pretty(&rows).unwrap_or_else(|_| "[]".into())
+}
+
+/// GitHub-flavored Markdown table. Pipes and newlines inside cells are escaped
+/// so the table stays intact.
+pub fn to_markdown(g: &GridModel) -> String {
+    fn cell(s: &str) -> String {
+        s.replace('|', "\\|").replace(['\n', '\r'], " ")
+    }
+    let mut out = String::new();
+    let names: Vec<String> = g.columns.iter().map(|c| cell(&c.name)).collect();
+    out.push_str(&format!("| {} |\n", names.join(" | ")));
+    let sep: Vec<&str> = g.columns.iter().map(|_| "---").collect();
+    out.push_str(&format!("| {} |\n", sep.join(" | ")));
+    for row in &g.rows {
+        let cells: Vec<String> = row.iter().map(|c| cell(&c.text)).collect();
+        out.push_str(&format!("| {} |\n", cells.join(" | ")));
+    }
+    out
+}
+
+/// `INSERT INTO <table> (...) VALUES (...);` — one statement per row.
+// ponytail: every non-null value is emitted as a single-quoted string literal
+// (quotes doubled); add per-column type formatting if a driver needs typed
+// literals (numbers/bools unquoted).
+pub fn to_sql_insert(g: &GridModel, table: &str) -> String {
+    let cols: Vec<&str> = g.columns.iter().map(|c| c.name.as_str()).collect();
+    let cols_sql = cols.join(", ");
+    let mut out = String::new();
+    for row in &g.rows {
+        let vals: Vec<String> = row
+            .iter()
+            .map(|c| {
+                if c.is_null {
+                    "NULL".to_string()
+                } else {
+                    format!("'{}'", c.text.replace('\'', "''"))
+                }
+            })
+            .collect();
+        out.push_str(&format!(
+            "INSERT INTO {table} ({cols_sql}) VALUES ({});\n",
+            vals.join(", ")
+        ));
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -129,5 +197,75 @@ mod tests {
             "name,engine,host,port,database,user\n\"db, prod\",postgres,localhost,5432,app,postgres\n"
         );
         assert!(!csv.to_lowercase().contains("password"));
+    }
+
+    #[test]
+    fn json_nulls_and_escaping() {
+        use crate::model::{VmCell, VmColumn};
+        let g = GridModel {
+            columns: vec![VmColumn {
+                name: "note".into(),
+                type_name: "text".into(),
+            }],
+            rows: vec![
+                vec![VmCell {
+                    text: "he said \"hi\"".into(),
+                    is_null: false,
+                }],
+                vec![VmCell {
+                    text: String::new(),
+                    is_null: true,
+                }],
+            ],
+        };
+        assert_eq!(
+            to_json(&g),
+            "[\n  {\n    \"note\": \"he said \\\"hi\\\"\"\n  },\n  {\n    \"note\": null\n  }\n]"
+        );
+    }
+
+    #[test]
+    fn markdown_escapes_pipes() {
+        assert_eq!(
+            to_markdown(&grid()),
+            "| id | name |\n| --- | --- |\n| 1 | a,\"b\"  |\n"
+        );
+    }
+
+    #[test]
+    fn sql_insert_quotes_and_nulls() {
+        use crate::model::{VmCell, VmColumn};
+        let g = GridModel {
+            columns: vec![
+                VmColumn {
+                    name: "id".into(),
+                    type_name: "int".into(),
+                },
+                VmColumn {
+                    name: "name".into(),
+                    type_name: "text".into(),
+                },
+            ],
+            rows: vec![vec![
+                VmCell {
+                    text: "1".into(),
+                    is_null: false,
+                },
+                VmCell {
+                    text: "O'Brien".into(),
+                    is_null: true,
+                },
+            ]],
+        };
+        assert_eq!(
+            to_sql_insert(&g, "users"),
+            "INSERT INTO users (id, name) VALUES ('1', NULL);\n"
+        );
+        let mut g2 = g.clone();
+        g2.rows[0][1].is_null = false;
+        assert_eq!(
+            to_sql_insert(&g2, "users"),
+            "INSERT INTO users (id, name) VALUES ('1', 'O''Brien');\n"
+        );
     }
 }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -4776,7 +4776,7 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let weak = window.as_weak();
         let displayed_grid = displayed_grid.clone();
-        window.on_export_csv(move || {
+        window.on_export_results(move |fmt| {
             let Some(w) = weak.upgrade() else {
                 return;
             };
@@ -4784,20 +4784,42 @@ fn main() -> Result<(), slint::PlatformError> {
                 w.set_results_meta(SharedString::from("nothing to export"));
                 return;
             };
-            // ponytail: blocking native dialog on the UI thread, fine for a
-            // one-shot; move to async if it ever janks.
-            let Some(path) = rfd::FileDialog::new()
-                .set_file_name("rdb-export.csv")
-                .add_filter("CSV", &["csv"])
-                .save_file()
-            else {
-                return; // user cancelled
+            // format: 0 CSV, 1 JSON, 2 TSV, 3 SQL INSERT, 4 Markdown
+            let (ext, filter, contents) = match fmt {
+                1 => ("json", "JSON", export::to_json(&grid)),
+                2 => ("tsv", "TSV", export::to_tsv(&grid)),
+                3 => {
+                    let table = w.get_active_table();
+                    let table = if table.is_empty() {
+                        "results"
+                    } else {
+                        table.as_str()
+                    };
+                    ("sql", "SQL", export::to_sql_insert(&grid, table))
+                }
+                4 => ("md", "Markdown", export::to_markdown(&grid)),
+                _ => ("csv", "CSV", export::to_csv(&grid)),
             };
-            let msg = match std::fs::write(&path, export::to_csv(&grid)) {
-                Ok(()) => format!("exported → {}", path.display()),
-                Err(e) => format!("export failed: {e}"),
-            };
-            w.set_results_meta(SharedString::from(msg));
+            // Native save dialog via rfd's async API + Slint's local executor:
+            // the sync dialog blocks the winit event loop and never surfaces.
+            let weak = w.as_weak();
+            let _ = slint::spawn_local(async move {
+                let Some(file) = rfd::AsyncFileDialog::new()
+                    .set_file_name(format!("rdb-export.{ext}"))
+                    .add_filter(filter, &[ext])
+                    .save_file()
+                    .await
+                else {
+                    return; // user cancelled
+                };
+                let msg = match std::fs::write(file.path(), contents) {
+                    Ok(()) => format!("exported → {}", file.path().display()),
+                    Err(e) => format!("export failed: {e}"),
+                };
+                if let Some(w) = weak.upgrade() {
+                    w.set_results_meta(SharedString::from(msg));
+                }
+            });
         });
     }
 

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -224,7 +224,7 @@ in-out property <string> rename-text;
     callback format-sql();
     callback explain-query();
     callback copy-results();
-    callback export-csv();
+    callback export-results(int);
     in property <[ChartBar]> chart-bars;
     in property <[string]> all-columns;
     in property <[bool]> col-hidden;
@@ -262,6 +262,7 @@ in-out property <string> rename-text;
     in-out property <int> sidebar-mode: 0;
     in-out property <bool> sidebar-visible: true;
     in-out property <bool> detail-visible: true;
+    in-out property <bool> results-collapsed: false;
     callback editor-key(string, bool, bool, bool) -> bool;
     callback editor-press(int, int);
     callback editor-drag(int, int);
@@ -666,7 +667,17 @@ in-out property <string> rename-text;
                             clicked => { root.detail-visible = !root.detail-visible; }
                         }
                     }
-                    // divider: the two panel toggles above are a pair; the
+                    // hide/show the results panel (grid/documents)
+                    if root.connected: VerticalLayout {
+                        alignment: center;
+                        IconButton {
+                            icon: "rows";
+                            tooltip: "Toggle results";
+                            active: !root.results-collapsed;
+                            clicked => { root.results-collapsed = !root.results-collapsed; }
+                        }
+                    }
+                    // divider: the panel toggles above are a group; the
                     // pencil/theme/⚙ that follow are one-shot actions, not toggles.
                     if root.connected: VerticalLayout {
                         alignment: center;
@@ -713,6 +724,7 @@ in-out property <string> rename-text;
                         alignment: center;
                         IconButton {
                             icon: "terminal";
+                            tooltip: "Toggle SQL console";
                             active: root.console-open;
                             clicked => { root.console-open = !root.console-open; }
                         }
@@ -977,6 +989,7 @@ in-out property <string> rename-text;
                     if root.tabs.length > 0: WorkArea {
                         vertical-stretch: 1;
                         detail-visible <=> root.detail-visible;
+                        results-collapsed <=> root.results-collapsed;
                         console-open <=> root.console-open;
                         console-count: root.query-console.length;
                         clear-console => { root.clear-console(); }
@@ -1082,8 +1095,8 @@ in-out property <string> rename-text;
                         copy-results() => {
                             root.copy-results();
                         }
-                        export-csv() => {
-                            root.export-csv();
+                        export-results(fmt) => {
+                            root.export-results(fmt);
                         }
                         apply-filter() => {
                             root.apply-filter();

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -16,6 +16,9 @@ export component WorkArea inherits Rectangle {
     // ----- editor / results state (wired 1:1 from MainWindow) -----
     // Collapse the SQL editor pane to give the results grid more room.
     property <bool> editor-collapsed: false;
+    // Hide the result body (grid/docs). Toggled from the window header, next to
+    // the sidebar/details toggles.
+    in-out property <bool> results-collapsed: false;
     // Reveal the query editor while browsing a table/collection (default closed).
     property <bool> browse-editor-open: false;
     in-out property <bool> detail-visible: true;
@@ -124,7 +127,8 @@ export component WorkArea inherits Rectangle {
     callback format-sql();
     callback explain-query();
     callback copy-results();
-    callback export-csv();
+    // Export displayed results. Arg = format: 0 CSV, 1 JSON, 2 TSV, 3 SQL, 4 Markdown.
+    callback export-results(int);
 
     // SQL result footer segments: 0 Data · 1 Message · 2 Chart.
     in-out property <int> sql-view-mode: 0;
@@ -580,7 +584,45 @@ export component WorkArea inherits Rectangle {
                     TextButton { text: root.editor-collapsed ? "Editor ▸" : "Editor ▾"; clicked => { root.editor-collapsed = !root.editor-collapsed; } }
                     if !root.browse-mode: TextButton { text: root.filter-open ? "Filter ▲" : "Filter ▼"; clicked => { root.filter-open = !root.filter-open; } }
                     TextButton { text: "Copy"; clicked => { root.copy-results(); } }
-                    TextButton { text: "Export CSV"; clicked => { root.export-csv(); } }
+                    Rectangle {
+                        width: exp-btn.preferred-width;
+                        height: exp-btn.preferred-height;
+                        export-menu := PopupWindow {
+                            x: 0;
+                            y: 30px;
+                            width: 150px;
+                            height: menu-box.preferred-height;
+                            menu-box := Rectangle {
+                                background: Tokens.card;
+                                border-width: 1px;
+                                border-color: Tokens.border-strong;
+                                border-radius: Tokens.radius;
+                                drop-shadow-blur: 12px;
+                                drop-shadow-color: #00000022;
+                                VerticalLayout {
+                                    padding: 4px;
+                                    for opt[i] in ["CSV", "JSON", "TSV", "SQL INSERT", "Markdown"]: Rectangle {
+                                        height: 28px;
+                                        border-radius: 6px;
+                                        background: exp-row-ta.has-hover ? Tokens.accent-tint : transparent;
+                                        exp-row-ta := TouchArea {
+                                            clicked => { export-menu.close(); root.export-results(i); }
+                                        }
+                                        HorizontalLayout {
+                                            padding-left: Tokens.sp2;
+                                            Text {
+                                                text: opt;
+                                                color: Tokens.text;
+                                                font-size: Tokens.font-sm;
+                                                vertical-alignment: center;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        exp-btn := TextButton { text: "Export ▾"; clicked => { export-menu.show(); } }
+                    }
                     TextButton { text: "Chart"; clicked => { root.sql-view-mode = 2; } }
                 }
                 // result tabs — appear once ⌘\ has spawned a second result
@@ -624,7 +666,7 @@ export component WorkArea inherits Rectangle {
         }
 
         // draggable splitter: grow/shrink the editor vs the results (SQL tabs)
-        if (!root.browse-mode || root.browse-editor-open) && !root.fn-mode: Rectangle {
+        if (!root.browse-mode || root.browse-editor-open) && !root.fn-mode && !root.results-collapsed: Rectangle {
             height: 6px;
             background: split-ta.has-hover || split-ta.pressed ? Tokens.accent : Tokens.chrome;
             split-ta := TouchArea {
@@ -641,7 +683,7 @@ export component WorkArea inherits Rectangle {
         // columns) and are toggled by `filter-open`; see the "Filter" button.
 
         // ================= result body =================
-        if !root.fn-mode: body := Rectangle {
+        if !root.fn-mode && !root.results-collapsed: body := Rectangle {
             property <bool> detail-shown: root.detail-visible && root.view-mode == 0
                 && root.result-kind == 0 && root.col-count > 0 && root.selected-row >= 0
                 && (root.selected-row + 1) * root.col-count <= root.cells.length;
@@ -662,7 +704,7 @@ export component WorkArea inherits Rectangle {
                 sort-asc: root.grid-sort-asc;
                 sort-col(i) => { root.sort-col(i); }
                 reorder-col(i, x) => { root.reorder-col(i, x); }
-                filter-open: false;
+                filter-open: root.filter-open;
                 col-filter-values: root.grid-col-filters;
                 set-col-filter(i, t) => { root.set-col-filter(i, t); }
                 selected-row <=> root.selected-row;


### PR DESCRIPTION
## Summary
- Fill several SQL-console gaps: no way to hide the results panel, CSV-only export, a missing tooltip, and a Filter button that showed nothing.

## Changes
- `app/src/export.rs` — add `to_json`, `to_markdown`, `to_sql_insert` (CSV/TSV already existed).
- `app/src/main.rs` — `on_export_results(fmt)`; native save dialog via `rfd::AsyncFileDialog` + `slint::spawn_local`.
- `app/src/ui/workarea.slint` — Export ▾ menu (CSV/JSON/TSV/SQL/Markdown); **fix**: bind the grid's `filter-open` to the toolbar button so the per-column filter row actually appears.
- `app/src/ui/app-window.slint` — results hide/show toggle in the header icon cluster (next to sidebar/details); tooltip on the SQL console icon.

## Notes
- Depends on nothing, but overlaps `export.rs`/`main.rs` with #86 — merge #86 first, then this rebases cleanly (see merge order in the PR discussion).
- `to_sql_insert` quotes every non-null value as a string literal (marked with a `ponytail:` comment); typed literals can come later if a driver needs them.

## Test plan
- [x] `cargo test -p rdb export::` — JSON/Markdown/SQL escaping + null handling pass.
- [x] `cargo clippy -p rdb` clean, `cargo fmt --check` clean.
- [x] Manual: results toggle collapses/restores the panel; Export ▾ writes each format via save dialog; Filter ▼ shows a per-column input row that filters live; SQL console icon shows a tooltip.