### PR TITLE
feat(ui): workarea + sidebar UX fixes and server-side table filter

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -357,6 +357,10 @@ struct BrowseState {
     /// Compass-style Mongo filter document (raw JSON, already validated). Empty
     /// = browse all. Ignored for non-Mongo engines.
     mongo_filter: String,
+    /// Per-column server-side filters as (column-name, raw-expr) for SQL engines.
+    /// Empty expr = no filter on that column. Pushed into the browse query's
+    /// WHERE clause so filtering hits the DB, not just the fetched page.
+    col_filters: Vec<(String, String)>,
 }
 
 /// Default browse page size per engine. Mongo documents are fat, so a Mongo
@@ -762,6 +766,43 @@ fn default_col_width(name: &str, type_name: &str) -> f32 {
     }
 }
 
+/// Build a `WHERE` clause from per-column filters for SQL engines. Each entry is
+/// (column-name, raw-expr); an empty expr is skipped. A leading comparison
+/// operator (`=`, `<>`, `>=`, `<=`, `>`, `<`, `!=`) is honoured, otherwise the
+/// expr is treated as a substring match via `contains_kw` (`LIKE`/`ILIKE`).
+/// `quote` wraps/escapes the identifier for the dialect. Values are always
+/// single-quoted with `'` doubled; the DB coerces to the column type.
+/// ponytail: string literal + implicit cast; typed binds are a follow-up.
+fn sql_where(
+    cols: &[(String, String)],
+    quote: impl Fn(&str) -> String,
+    contains_kw: &str,
+) -> String {
+    let esc = |v: &str| v.replace('\'', "''");
+    let ops = ["<=", ">=", "<>", "!=", "=", ">", "<"];
+    let clauses: Vec<String> = cols
+        .iter()
+        .filter_map(|(name, raw)| {
+            let raw = raw.trim();
+            if raw.is_empty() {
+                return None;
+            }
+            Some(match ops.iter().find(|op| raw.starts_with(**op)) {
+                Some(op) => {
+                    let val = raw[op.len()..].trim();
+                    format!("{} {} '{}'", quote(name), op, esc(val))
+                }
+                None => format!("{} {} '%{}%'", quote(name), contains_kw, esc(raw)),
+            })
+        })
+        .collect();
+    if clauses.is_empty() {
+        String::new()
+    } else {
+        format!(" WHERE {}", clauses.join(" AND "))
+    }
+}
+
 fn browse_text(
     engine: rdb_connstore::Engine,
     table: &rdb_core::write::TableRef,
@@ -769,27 +810,40 @@ fn browse_text(
     limit: u64,
     // Mongo-only filter document (raw JSON, empty = all). Unused by SQL engines.
     filter: &str,
+    // Per-column (name, expr) filters → WHERE clause. Unused by Mongo/Redis.
+    col_filters: &[(String, String)],
 ) -> String {
     let offset = page * limit;
     match engine {
         rdb_connstore::Engine::Postgres => {
             let schema = table.schema.as_deref().unwrap_or("public");
             let q = |s: &str| s.replace('"', "\"\"");
+            let where_sql = sql_where(col_filters, |c| format!("\"{}\"", q(c)), "ILIKE");
             format!(
-                "SELECT * FROM \"{}\".\"{}\" LIMIT {limit} OFFSET {offset}",
+                "SELECT * FROM \"{}\".\"{}\"{where_sql} LIMIT {limit} OFFSET {offset}",
                 q(schema),
                 q(&table.name)
             )
         }
         rdb_connstore::Engine::MySql => {
+            let where_sql = sql_where(
+                col_filters,
+                |c| format!("`{}`", c.replace('`', "``")),
+                "LIKE",
+            );
             format!(
-                "SELECT * FROM `{}` LIMIT {limit} OFFSET {offset}",
+                "SELECT * FROM `{}`{where_sql} LIMIT {limit} OFFSET {offset}",
                 table.name.replace('`', "``")
             )
         }
         rdb_connstore::Engine::Sqlite => {
+            let where_sql = sql_where(
+                col_filters,
+                |c| format!("\"{}\"", c.replace('"', "\"\"")),
+                "LIKE",
+            );
             format!(
-                "SELECT * FROM \"{}\" LIMIT {limit} OFFSET {offset}",
+                "SELECT * FROM \"{}\"{where_sql} LIMIT {limit} OFFSET {offset}",
                 table.name.replace('"', "\"\"")
             )
         }
@@ -3473,6 +3527,12 @@ fn main() -> Result<(), slint::PlatformError> {
         });
     }
 
+    // Deferred handle to `run_browse` (defined later): per-column filters in
+    // browse mode re-query the DB, but this handler is wired before run_browse
+    // exists. Filled in once run_browse is built, below.
+    #[allow(clippy::type_complexity)]
+    let browse_trigger: Rc<RefCell<Option<Rc<dyn Fn()>>>> = Rc::new(RefCell::new(None));
+
     // ----- apply client-side row filter to the last result (Feature C) -----
     {
         let weak = window.as_weak();
@@ -3531,6 +3591,8 @@ fn main() -> Result<(), slint::PlatformError> {
         let sort_state = sort_state.clone();
         let col_order = col_order.clone();
         let col_filters = col_filters.clone();
+        let browse = browse.clone();
+        let browse_trigger = browse_trigger.clone();
         window.on_set_col_filter(move |display_c, text| {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -3550,6 +3612,37 @@ fn main() -> Result<(), slint::PlatformError> {
             let Some(&orig) = visible.get(display_c.max(0) as usize) else {
                 return;
             };
+            // Browse mode (a table is open): push the filter into the query's
+            // WHERE clause and re-fetch from the DB, so filtering isn't limited
+            // to the current page. SQL result mode stays client-side (below).
+            if browse.lock().unwrap().table.is_some() {
+                let name = {
+                    let guard = last_view.lock().unwrap();
+                    match guard.as_ref() {
+                        Some(model::ResultView::Table(g)) => {
+                            g.columns.get(orig).map(|c| c.name.clone())
+                        }
+                        Some(model::ResultView::Documents(d)) => {
+                            d.grid.columns.get(orig).map(|c| c.name.clone())
+                        }
+                        _ => None,
+                    }
+                };
+                if let Some(name) = name {
+                    {
+                        let mut b = browse.lock().unwrap();
+                        b.col_filters.retain(|(n, _)| n != &name);
+                        if !text.trim().is_empty() {
+                            b.col_filters.push((name, text.to_string()));
+                        }
+                        b.page = 0; // filter changes the row set → back to page 1
+                    }
+                    if let Some(run) = browse_trigger.borrow().clone() {
+                        run();
+                    }
+                }
+                return;
+            }
             let cfilters = {
                 let mut cf = col_filters.lock().unwrap();
                 if orig < cf.len() {
@@ -4979,11 +5072,20 @@ fn main() -> Result<(), slint::PlatformError> {
             } else {
                 st.limit
             };
-            let text = browse_text(engine, &table, st.page, limit, &st.mongo_filter);
+            let text = browse_text(
+                engine,
+                &table,
+                st.page,
+                limit,
+                &st.mongo_filter,
+                &st.col_filters,
+            );
             load_editor_text(&text);
             run_sql(text);
         })
     };
+    // Wire the deferred handle so per-column browse filters can re-query.
+    *browse_trigger.borrow_mut() = Some(run_browse.clone());
 
     {
         let weak = window.as_weak();
@@ -5056,6 +5158,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 st.total = None;
                 st.pk_cols.clear();
                 st.mongo_filter.clear();
+                st.col_filters.clear();
             }
             {
                 let tab = WorkspaceTab {
@@ -7133,15 +7236,15 @@ mod tests {
             name: "users".into(),
         };
         assert_eq!(
-            browse_text(rdb_connstore::Engine::Postgres, &t, 1, 300, ""),
+            browse_text(rdb_connstore::Engine::Postgres, &t, 1, 300, "", &[]),
             "SELECT * FROM \"public\".\"users\" LIMIT 300 OFFSET 300"
         );
         assert_eq!(
-            browse_text(rdb_connstore::Engine::MySql, &t, 0, 50, ""),
+            browse_text(rdb_connstore::Engine::MySql, &t, 0, 50, "", &[]),
             "SELECT * FROM `users` LIMIT 50 OFFSET 0"
         );
         assert_eq!(
-            browse_text(rdb_connstore::Engine::Redis, &t, 2, 100, ""),
+            browse_text(rdb_connstore::Engine::Redis, &t, 2, 100, "", &[]),
             "BROWSE users 200 100"
         );
         let m = rdb_core::write::TableRef {
@@ -7150,13 +7253,43 @@ mod tests {
             name: "orders".into(),
         };
         assert_eq!(
-            browse_text(rdb_connstore::Engine::Mongo, &m, 1, 50, ""),
+            browse_text(rdb_connstore::Engine::Mongo, &m, 1, 50, "", &[]),
             "{\"collection\":\"orders\",\"database\":\"shop\",\"op\":\"find\",\"body\":{},\"limit\":50,\"skip\":50}"
         );
         // A filter document lands in the find body.
         assert_eq!(
-            browse_text(rdb_connstore::Engine::Mongo, &m, 0, 20, r#"{"status":"A"}"#),
+            browse_text(rdb_connstore::Engine::Mongo, &m, 0, 20, r#"{"status":"A"}"#, &[]),
             "{\"collection\":\"orders\",\"database\":\"shop\",\"op\":\"find\",\"body\":{\"status\":\"A\"},\"limit\":20,\"skip\":0}"
+        );
+    }
+
+    #[test]
+    fn browse_text_column_filters_build_where() {
+        let t = rdb_core::write::TableRef {
+            database: None,
+            schema: Some("public".into()),
+            name: "users".into(),
+        };
+        // Bare text → contains match; Postgres uses ILIKE, other SQL LIKE.
+        // A leading operator is honoured verbatim; empty exprs are skipped.
+        let filters = [
+            ("name".to_string(), "ali".to_string()),
+            ("age".to_string(), ">= 18".to_string()),
+            ("city".to_string(), "".to_string()),
+        ];
+        assert_eq!(
+            browse_text(rdb_connstore::Engine::Postgres, &t, 0, 50, "", &filters),
+            "SELECT * FROM \"public\".\"users\" WHERE \"name\" ILIKE '%ali%' AND \"age\" >= '18' LIMIT 50 OFFSET 0"
+        );
+        assert_eq!(
+            browse_text(rdb_connstore::Engine::MySql, &t, 0, 50, "", &filters),
+            "SELECT * FROM `users` WHERE `name` LIKE '%ali%' AND `age` >= '18' LIMIT 50 OFFSET 0"
+        );
+        // Single quotes in the value are doubled (no injection).
+        let q = [("name".to_string(), "=o'brien".to_string())];
+        assert_eq!(
+            browse_text(rdb_connstore::Engine::Sqlite, &t, 0, 10, "", &q),
+            "SELECT * FROM \"users\" WHERE \"name\" = 'o''brien' LIMIT 10 OFFSET 0"
         );
     }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2755,24 +2755,31 @@ fn main() -> Result<(), slint::PlatformError> {
             // scratch tabs are schema-agnostic — keep them so a query in progress
             // survives the switch. Snapshot the live editor into the active tab
             // first (the user may not have run/switched since typing).
+            let prev_active = active_tab_id.lock().unwrap().clone();
             let keep_active: Option<String> = {
                 let mut tabs = workspace_tabs.lock().unwrap();
-                if let Some(id) = active_tab_id.lock().unwrap().clone() {
+                if let Some(id) = prev_active.clone() {
                     if let Some(tab) = tabs.iter_mut().find(|t| t.id == id) {
                         tab.query_text = ed_state.borrow().text();
                     }
                 }
                 tabs.retain(|t| t.kind == "sql");
-                tabs.first().map(|t| t.id.clone())
+                // Prefer keeping the tab the user was on (if it was SQL); else the
+                // first surviving SQL tab.
+                prev_active
+                    .clone()
+                    .filter(|id| tabs.iter().any(|t| &t.id == id))
+                    .or_else(|| tabs.first().map(|t| t.id.clone()))
             };
+            // Standby: the active SQL tab survives, so its result is still valid —
+            // leave the grid up instead of blanking it.
+            let standby = keep_active.is_some() && keep_active == prev_active;
             *active_tab_id.lock().unwrap() = keep_active.clone();
             let limit = browse.lock().unwrap().limit;
             *browse.lock().unwrap() = BrowseState {
                 limit,
                 ..Default::default()
             };
-            results.lock().unwrap().clear();
-            *displayed_grid.lock().unwrap() = None;
             {
                 let tabs = workspace_tabs.lock().unwrap();
                 set_workspace_tabs(&w, &tabs, keep_active.as_deref());
@@ -2783,7 +2790,11 @@ fn main() -> Result<(), slint::PlatformError> {
                     .unwrap_or_default();
                 load_editor_text(&text);
             }
-            clear_grid(&w);
+            if !standby {
+                results.lock().unwrap().clear();
+                *displayed_grid.lock().unwrap() = None;
+                clear_grid(&w);
+            }
             expanded_tables.lock().unwrap().clear();
             *collapsed_categories.borrow_mut() = default_collapsed_cats();
             let engine = *cur_engine.borrow();

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2682,6 +2682,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let displayed_grid = displayed_grid.clone();
         let load_editor_text = load_editor_text.clone();
         let query_console = query_console.clone();
+        let ed_state = ed_state.clone();
         window.on_schema_choose(move |idx| {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -2696,8 +2697,21 @@ fn main() -> Result<(), slint::PlatformError> {
             // Anything browsed belonged to the old schema; force a fresh pick and
             // drop expand/collapse state that referenced the old schema's tables.
             w.set_active_table(SharedString::default());
-            workspace_tabs.lock().unwrap().clear();
-            *active_tab_id.lock().unwrap() = None;
+            // Table/browse tabs referenced the old schema and must drop, but SQL
+            // scratch tabs are schema-agnostic — keep them so a query in progress
+            // survives the switch. Snapshot the live editor into the active tab
+            // first (the user may not have run/switched since typing).
+            let keep_active: Option<String> = {
+                let mut tabs = workspace_tabs.lock().unwrap();
+                if let Some(id) = active_tab_id.lock().unwrap().clone() {
+                    if let Some(tab) = tabs.iter_mut().find(|t| t.id == id) {
+                        tab.query_text = ed_state.borrow().text();
+                    }
+                }
+                tabs.retain(|t| t.kind == "sql");
+                tabs.first().map(|t| t.id.clone())
+            };
+            *active_tab_id.lock().unwrap() = keep_active.clone();
             let limit = browse.lock().unwrap().limit;
             *browse.lock().unwrap() = BrowseState {
                 limit,
@@ -2705,8 +2719,16 @@ fn main() -> Result<(), slint::PlatformError> {
             };
             results.lock().unwrap().clear();
             *displayed_grid.lock().unwrap() = None;
-            set_workspace_tabs(&w, &[], None);
-            load_editor_text("");
+            {
+                let tabs = workspace_tabs.lock().unwrap();
+                set_workspace_tabs(&w, &tabs, keep_active.as_deref());
+                let text = keep_active
+                    .as_ref()
+                    .and_then(|id| tabs.iter().find(|t| t.id == *id))
+                    .map(|t| t.query_text.clone())
+                    .unwrap_or_default();
+                load_editor_text(&text);
+            }
             clear_grid(&w);
             expanded_tables.lock().unwrap().clear();
             *collapsed_categories.borrow_mut() = default_collapsed_cats();

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -261,6 +261,9 @@ in-out property <string> rename-text;
     callback clear-console();
     in-out property <int> sidebar-mode: 0;
     in-out property <bool> sidebar-visible: true;
+    // Narrow icon-rail state: dragging the splitter below the min width snaps
+    // the sidebar to a compact rail of tab icons instead of crushing the header.
+    in-out property <bool> sidebar-rail: false;
     in-out property <bool> detail-visible: true;
     in-out property <bool> results-collapsed: false;
     callback editor-key(string, bool, bool, bool) -> bool;
@@ -780,7 +783,7 @@ in-out property <string> rename-text;
                 max-width: 100000px;
                 spacing: 0px;
 
-                if root.sidebar-visible: Sidebar {
+                if root.sidebar-visible && !root.sidebar-rail: Sidebar {
                     focus-tick: root.focus-filter-tick;
                     // Keep navigation compact: the old preferred-only sizing let
                     // the layout stretch this panel to 480px and crush the work area.
@@ -833,6 +836,55 @@ in-out property <string> rename-text;
                     }
                 }
 
+                // icon rail: compact tab icons when dragged below the min width.
+                // Clicking a tab expands back to the full sidebar in that mode.
+                if root.sidebar-visible && root.sidebar-rail: Rectangle {
+                    width: 48px;
+                    background: Tokens.sidebar;
+                    VerticalLayout {
+                        alignment: start;
+                        padding-top: Tokens.sp2;
+                        padding-left: Tokens.sp2;
+                        padding-right: Tokens.sp2;
+                        spacing: Tokens.sp1;
+                        IconButton {
+                            icon: "layers";
+                            tooltip: "Items";
+                            active: root.sidebar-mode == 0;
+                            clicked => {
+                                root.sidebar-mode = 0;
+                                root.sidebar-mode-changed(0);
+                                root.sidebar-rail = false;
+                            }
+                        }
+                        IconButton {
+                            icon: "terminal";
+                            tooltip: "Queries";
+                            active: root.sidebar-mode == 1;
+                            clicked => {
+                                root.sidebar-mode = 1;
+                                root.sidebar-mode-changed(1);
+                                root.sidebar-rail = false;
+                            }
+                        }
+                        IconButton {
+                            icon: "clock";
+                            tooltip: "History";
+                            active: root.sidebar-mode == 2;
+                            clicked => {
+                                root.sidebar-mode = 2;
+                                root.sidebar-mode-changed(2);
+                                root.sidebar-rail = false;
+                            }
+                        }
+                        IconButton {
+                            icon: "panel-expand";
+                            tooltip: "Expand sidebar";
+                            clicked => { root.sidebar-rail = false; }
+                        }
+                    }
+                }
+
                 // reveal strip when the sidebar is hidden
                 if !root.sidebar-visible: VerticalLayout {
                     alignment: start;
@@ -853,7 +905,14 @@ in-out property <string> rename-text;
                     split-h-area := TouchArea {
                         mouse-cursor: col-resize;
                         moved => {
-                            root.sidebar-w = clamp(root.sidebar-w + (self.mouse-x - self.pressed-x), 184px, 360px);
+                            // Below the min width, snap to the icon rail instead
+                            // of crushing the header; drag back out to restore.
+                            if root.sidebar-w + (self.mouse-x - self.pressed-x) < 150px {
+                                root.sidebar-rail = true;
+                            } else {
+                                root.sidebar-rail = false;
+                                root.sidebar-w = clamp(root.sidebar-w + (self.mouse-x - self.pressed-x), 184px, 360px);
+                            }
                         }
                     }
                 }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -905,13 +905,15 @@ in-out property <string> rename-text;
                     split-h-area := TouchArea {
                         mouse-cursor: col-resize;
                         moved => {
-                            // Below the min width, snap to the icon rail instead
-                            // of crushing the header; drag back out to restore.
-                            if root.sidebar-w + (self.mouse-x - self.pressed-x) < 150px {
-                                root.sidebar-rail = true;
-                            } else {
-                                root.sidebar-rail = false;
-                                root.sidebar-w = clamp(root.sidebar-w + (self.mouse-x - self.pressed-x), 184px, 360px);
+                            // Rail is latched: once snapped, freeze the drag so the
+                            // handle jumping left (218px → 48px rail) can't oscillate
+                            // the state. Expand via the rail's tab/expand buttons.
+                            if !root.sidebar-rail {
+                                if root.sidebar-w + (self.mouse-x - self.pressed-x) < 150px {
+                                    root.sidebar-rail = true;
+                                } else {
+                                    root.sidebar-w = clamp(root.sidebar-w + (self.mouse-x - self.pressed-x), 184px, 360px);
+                                }
                             }
                         }
                     }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -832,7 +832,10 @@ in-out property <string> rename-text;
                         root.new-tab();
                     }
                     collapse() => {
-                        root.sidebar-visible = false;
+                        // Collapse to the icon rail (same as dragging to the min),
+                        // not the bare reveal sliver — keeps the two paths
+                        // consistent. Full hide stays on the header toggle.
+                        root.sidebar-rail = true;
                     }
                 }
 

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -225,8 +225,10 @@ export component ExportButton inherits Rectangle {
         x: 0;
         y: parent.height + 2px;
         width: 150px;
-        height: box.preferred-height;
-        box := Rectangle {
+        // No explicit height: let the popup size to its content. Binding it to
+        // the child's preferred-height is a parent↔child cycle that collapses
+        // the popup to zero, so the menu never appears (see SelectBox above).
+        Rectangle {
             background: Tokens.card;
             border-width: 1px;
             border-color: Tokens.border-strong;

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -205,6 +205,59 @@ export component TextButton inherits Rectangle {
     ta := TouchArea { clicked => { root.clicked(); } }
 }
 
+// Export dropdown: sized/styled exactly like TextButton so it aligns and
+// spaces with the other toolbar buttons, but opens a format menu. `export(i)`
+// reports the chosen row index into the option list below.
+export component ExportButton inherits Rectangle {
+    callback export(int);
+    height: Tokens.button-h;
+    width: label.preferred-width + 2 * Tokens.sp2;
+    border-radius: Tokens.radius;
+    background: ta.has-hover ? Tokens.border : transparent;
+    animate background { duration: Tokens.fade; }
+    label := Text {
+        text: "Export ▾";
+        color: Tokens.text-dim;
+        font-size: Tokens.font-sm;
+        font-weight: 500;
+    }
+    menu := PopupWindow {
+        x: 0;
+        y: parent.height + 2px;
+        width: 150px;
+        height: box.preferred-height;
+        box := Rectangle {
+            background: Tokens.card;
+            border-width: 1px;
+            border-color: Tokens.border-strong;
+            border-radius: Tokens.radius;
+            drop-shadow-blur: 12px;
+            drop-shadow-color: #00000022;
+            VerticalLayout {
+                padding: 4px;
+                for opt[i] in ["CSV", "JSON", "TSV", "SQL INSERT", "Markdown"]: Rectangle {
+                    height: 28px;
+                    border-radius: 6px;
+                    background: row-ta.has-hover ? Tokens.accent-tint : transparent;
+                    row-ta := TouchArea {
+                        clicked => { menu.close(); root.export(i); }
+                    }
+                    HorizontalLayout {
+                        padding-left: Tokens.sp2;
+                        Text {
+                            text: opt;
+                            color: Tokens.text;
+                            font-size: Tokens.font-sm;
+                            vertical-alignment: center;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    ta := TouchArea { clicked => { menu.show(); } }
+}
+
 // Form text input (conn form): Tokens-styled card box, optional password mode.
 export component FormField inherits Rectangle {
     in property <string> placeholder;

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -621,7 +621,14 @@ export component WorkArea inherits Rectangle {
                                 }
                             }
                         }
-                        exp-btn := TextButton { text: "Export ▾"; clicked => { export-menu.show(); } }
+                        // Center vertically: the layout stretches this wrapper to
+                        // the toolbar height, so pin the button to the middle to
+                        // match the bare TextButtons beside it.
+                        exp-btn := TextButton {
+                            y: (parent.height - self.height) / 2;
+                            text: "Export ▾";
+                            clicked => { export-menu.show(); }
+                        }
                     }
                     TextButton { text: "Chart"; clicked => { root.sql-view-mode = 2; } }
                 }

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -7,7 +7,7 @@ import { CodeEditor } from "code-editor.slint";
 import { TabularGrid } from "tabular-grid.slint";
 import { PaletteItem } from "palette.slint";
 import {
-    UnderlineSegment, SecondaryButton, PrimaryButton, TextButton, FilterField, KeyCap
+    UnderlineSegment, SecondaryButton, PrimaryButton, TextButton, ExportButton, FilterField, KeyCap
 } from "components.slint";
 import { ScrollView, ComboBox } from "std-widgets.slint";
 import { AppIcon } from "icons.slint";
@@ -584,52 +584,7 @@ export component WorkArea inherits Rectangle {
                     TextButton { text: root.editor-collapsed ? "Editor ▸" : "Editor ▾"; clicked => { root.editor-collapsed = !root.editor-collapsed; } }
                     if !root.browse-mode: TextButton { text: root.filter-open ? "Filter ▲" : "Filter ▼"; clicked => { root.filter-open = !root.filter-open; } }
                     TextButton { text: "Copy"; clicked => { root.copy-results(); } }
-                    Rectangle {
-                        width: exp-btn.preferred-width;
-                        height: exp-btn.preferred-height;
-                        export-menu := PopupWindow {
-                            x: 0;
-                            y: 30px;
-                            width: 150px;
-                            height: menu-box.preferred-height;
-                            menu-box := Rectangle {
-                                background: Tokens.card;
-                                border-width: 1px;
-                                border-color: Tokens.border-strong;
-                                border-radius: Tokens.radius;
-                                drop-shadow-blur: 12px;
-                                drop-shadow-color: #00000022;
-                                VerticalLayout {
-                                    padding: 4px;
-                                    for opt[i] in ["CSV", "JSON", "TSV", "SQL INSERT", "Markdown"]: Rectangle {
-                                        height: 28px;
-                                        border-radius: 6px;
-                                        background: exp-row-ta.has-hover ? Tokens.accent-tint : transparent;
-                                        exp-row-ta := TouchArea {
-                                            clicked => { export-menu.close(); root.export-results(i); }
-                                        }
-                                        HorizontalLayout {
-                                            padding-left: Tokens.sp2;
-                                            Text {
-                                                text: opt;
-                                                color: Tokens.text;
-                                                font-size: Tokens.font-sm;
-                                                vertical-alignment: center;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        // Center vertically: the layout stretches this wrapper to
-                        // the toolbar height, so pin the button to the middle to
-                        // match the bare TextButtons beside it.
-                        exp-btn := TextButton {
-                            y: (parent.height - self.height) / 2;
-                            text: "Export ▾";
-                            clicked => { export-menu.show(); }
-                        }
-                    }
+                    ExportButton { export(i) => { root.export-results(i); } }
                     TextButton { text: "Chart"; clicked => { root.sql-view-mode = 2; } }
                 }
                 // result tabs — appear once ⌘\ has spawned a second result


### PR DESCRIPTION
## Summary

- Fix a batch of workarea/sidebar UX issues reported from live use: lost query text/results on schema switch, a squashed sidebar on drag, an off-baseline Export button, and missing server-side table filtering.
- Add an icon-rail collapse state for the sidebar and push per-column browse filters down to the database.

## Changes

**Sidebar**
- Collapse to a narrow icon rail (Items/Queries/History + expand, with tooltips) when dragged below the min width; latched to avoid drag flicker.
- Collapse button routes to the same rail instead of the bare reveal sliver; full hide stays on the header toggle.

**Query tabs / results**
- Keep SQL scratch tabs across schema switches (table/browse tabs still drop).
- Keep the result grid on standby when the active SQL tab survives the switch.

**Results toolbar**
- Extract an `ExportButton` component sized/styled like `TextButton` for consistent alignment and spacing.
- Fix the Export popup never appearing (removed a parent↔child height cycle).

**Table browse**
- Server-side per-column filtering: build a `WHERE` clause (Postgres/MySQL/SQLite) from the per-column filter row and re-query the DB, instead of filtering only the fetched page. Leading operator honoured; bare text = LIKE/ILIKE contains; values single-quote-escaped.

## Test plan

- [x] `make fmt-check`
- [x] `make lint` (clippy, app + Slint compile)
- [x] `make be-test` + `browse_text` unit tests (incl. WHERE + quote-escaping)
- [ ] `make fe-run` manual:
  - [ ] Drag splitter left → single clean snap to icon rail (no flicker); collapse button → rail; tab icon / expand → full sidebar
  - [ ] Run query → switch schema → editor + result grid remain; switch on a table tab → clears
  - [ ] Results toolbar buttons aligned + evenly spaced; Export menu pops; export a result to CSV/JSON/…
  - [ ] Open a Postgres table → per-column filter re-queries with WHERE; clear → full table
