### PR TITLE
feat: movable sidebar (left/right) with settings toggle

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1748,6 +1748,7 @@ fn main() -> Result<(), slint::PlatformError> {
         .global::<Theme>()
         .set_dark(settings.borrow().get().theme.is_dark());
     window.set_update_check_enabled(settings.borrow().get().update_check);
+    window.set_sidebar_right(settings.borrow().get().ui_state.sidebar_right);
     window.set_app_version(env!("CARGO_PKG_VERSION").into());
 
     // Fixed window size for the screenshot loop: RDB_WIN=WxH (logical px).
@@ -6572,6 +6573,16 @@ fn main() -> Result<(), slint::PlatformError> {
             if let Some(w) = weak.upgrade() {
                 w.set_update_check_enabled(v);
             }
+        });
+    }
+
+    // ----- settings: sidebar-on-the-right toggle -----
+    {
+        let settings = settings.clone();
+        window.on_set_sidebar_side(move |v| {
+            let _ = settings
+                .borrow_mut()
+                .update(|s| s.ui_state.sidebar_right = v);
         });
     }
 

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -657,7 +657,10 @@ in-out property <string> rename-text;
                     if root.connected: VerticalLayout {
                         alignment: center;
                         IconButton {
-                            icon: "columns";
+                            // Point the divider at the sidebar's side, matching the
+                            // details toggle (columns == left divider; panel-right ==
+                            // right divider).
+                            icon: root.sidebar-right ? "panel-right" : "columns";
                             tooltip: "Toggle sidebar";
                             // Collapse to the icon rail rather than fully hiding it.
                             active: !root.sidebar-rail;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -659,8 +659,7 @@ in-out property <string> rename-text;
                         IconButton {
                             icon: "columns";
                             tooltip: "Toggle sidebar";
-                            // Collapse to the icon rail (matches the sidebar's own
-                            // collapse button) rather than fully hiding it.
+                            // Collapse to the icon rail rather than fully hiding it.
                             active: !root.sidebar-rail;
                             clicked => { root.sidebar-rail = !root.sidebar-rail; }
                         }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -5,7 +5,7 @@ export { Tokens }
 import {
     SearchCommandPill, BreadcrumbChip, GlyphButton, IconButton, PrimaryButton, SecondaryButton, TextButton, Tooltip
 } from "components.slint";
-import { Sidebar } from "sidebar.slint";
+import { NavCluster } from "nav-cluster.slint";
 import { ConnPicker } from "picker.slint";
 import { WorkArea } from "workarea.slint";
 import { CommandPalette, ListModal, PaletteItem } from "palette.slint";
@@ -265,6 +265,9 @@ in-out property <string> rename-text;
     // the sidebar to a compact rail of tab icons instead of crushing the header.
     in-out property <bool> sidebar-rail: false;
     in-out property <bool> detail-visible: true;
+    // Place the sidebar on the right (detail panel flips to the left).
+    in-out property <bool> sidebar-right: false;
+    callback set-sidebar-side(bool);
     in-out property <bool> results-collapsed: false;
     callback editor-key(string, bool, bool, bool) -> bool;
     callback editor-press(int, int);
@@ -666,7 +669,9 @@ in-out property <string> rename-text;
                     if root.connected: VerticalLayout {
                         alignment: center;
                         IconButton {
-                            icon: "panel-right";
+                            // Details panel moves to the left edge when the sidebar
+                            // is on the right, so mirror the icon to match.
+                            icon: root.sidebar-right ? "panel-left" : "panel-right";
                             tooltip: "Toggle details panel";
                             active: root.detail-visible;
                             clicked => { root.detail-visible = !root.detail-visible; }
@@ -785,143 +790,36 @@ in-out property <string> rename-text;
                 max-width: 100000px;
                 spacing: 0px;
 
-                if root.sidebar-visible && !root.sidebar-rail: Sidebar {
-                    focus-tick: root.focus-filter-tick;
-                    // Keep navigation compact: the old preferred-only sizing let
-                    // the layout stretch this panel to 480px and crush the work area.
+                // Navigation cluster on the left (default). The right-side copy
+                // lives after the work column; only one renders at a time.
+                if !root.sidebar-right: NavCluster {
                     horizontal-stretch: 0;
-                    min-width: root.sidebar-w;
-                    max-width: root.sidebar-w;
+                    focus-tick: root.focus-filter-tick;
                     tree: root.schema-tree;
                     conn-name: root.status-conn;
                     active-table: root.active-table;
                     active-count: root.total-rows;
                     query-tree: root.query-tree;
-                    mode <=> root.sidebar-mode;
+                    sidebar-mode: root.sidebar-mode;
+                    sidebar-visible: root.sidebar-visible;
+                    sidebar-rail: root.sidebar-rail;
+                    sidebar-w: root.sidebar-w;
                     schema-list: root.schema-list;
-                    schema-name <=> root.schema-name;
-                    disconnect() => {
-                        root.disconnect();
-                    }
-                    open-function(f) => {
-                        root.open-function(f);
-                    }
-                    open-query(q, i) => {
-                        root.open-query(q, i);
-                    }
-                    mode-changed(m) => {
-                        root.sidebar-mode-changed(m);
-                    }
-                    open-table(db, t) => {
-                        root.open-table(db, t);
-                    }
-                    pin-table(db, t) => {
-                        root.pin-table(db, t);
-                    }
-                    toggle-fields(db, t) => {
-                        root.toggle-fields(db, t);
-                    }
-                    toggle-node(t) => {
-                        root.toggle-schema-node(t);
-                    }
-                    select-schema(s) => {
-                        root.select-schema(s);
-                    }
-                    filter-tree(t) => {
-                        root.filter-tree(t);
-                    }
-                    add-item() => {
-                        root.new-tab();
-                    }
-                    collapse() => {
-                        // Collapse to the icon rail (same as dragging to the min),
-                        // not the bare reveal sliver — keeps the two paths
-                        // consistent. Full hide stays on the header toggle.
-                        root.sidebar-rail = true;
-                    }
-                }
-
-                // icon rail: compact tab icons when dragged below the min width.
-                // Clicking a tab expands back to the full sidebar in that mode.
-                if root.sidebar-visible && root.sidebar-rail: Rectangle {
-                    width: 48px;
-                    background: Tokens.sidebar;
-                    VerticalLayout {
-                        alignment: start;
-                        padding-top: Tokens.sp2;
-                        padding-left: Tokens.sp2;
-                        padding-right: Tokens.sp2;
-                        spacing: Tokens.sp1;
-                        IconButton {
-                            icon: "layers";
-                            tooltip: "Items";
-                            active: root.sidebar-mode == 0;
-                            clicked => {
-                                root.sidebar-mode = 0;
-                                root.sidebar-mode-changed(0);
-                                root.sidebar-rail = false;
-                            }
-                        }
-                        IconButton {
-                            icon: "terminal";
-                            tooltip: "Queries";
-                            active: root.sidebar-mode == 1;
-                            clicked => {
-                                root.sidebar-mode = 1;
-                                root.sidebar-mode-changed(1);
-                                root.sidebar-rail = false;
-                            }
-                        }
-                        IconButton {
-                            icon: "clock";
-                            tooltip: "History";
-                            active: root.sidebar-mode == 2;
-                            clicked => {
-                                root.sidebar-mode = 2;
-                                root.sidebar-mode-changed(2);
-                                root.sidebar-rail = false;
-                            }
-                        }
-                        IconButton {
-                            icon: "panel-expand";
-                            tooltip: "Expand sidebar";
-                            clicked => { root.sidebar-rail = false; }
-                        }
-                    }
-                }
-
-                // reveal strip when the sidebar is hidden
-                if !root.sidebar-visible: VerticalLayout {
-                    alignment: start;
-                    padding-top: Tokens.sp2;
-                    padding-left: Tokens.sp1;
-                    padding-right: Tokens.sp1;
-                    IconButton {
-                        icon: "panel-expand";
-                        tooltip: "Show sidebar";
-                        clicked => { root.sidebar-visible = true; }
-                    }
-                }
-
-                // draggable vertical splitter (sidebar width)
-                if root.sidebar-visible: Rectangle {
-                    width: 1px;
-                    background: split-h-area.has-hover || split-h-area.pressed ? Tokens.accent : Tokens.border;
-                    split-h-area := TouchArea {
-                        mouse-cursor: col-resize;
-                        moved => {
-                            // Rail is latched: once snapped, freeze the drag so the
-                            // handle jumping left (218px → 48px rail) can't oscillate
-                            // the state. Expand via the rail's tab/expand buttons.
-                            if !root.sidebar-rail {
-                                if root.sidebar-w + (self.mouse-x - self.pressed-x) < 150px {
-                                    root.sidebar-rail = true;
-                                } else {
-                                    root.sidebar-w = clamp(root.sidebar-w + (self.mouse-x - self.pressed-x), 184px, 360px);
-                                }
-                            }
-                        }
-                    }
+                    schema-name: root.schema-name;
+                    set-rail(v) => { root.sidebar-rail = v; }
+                    set-visible(v) => { root.sidebar-visible = v; }
+                    set-w(v) => { root.sidebar-w = v; }
+                    disconnect() => { root.disconnect(); }
+                    open-function(f) => { root.open-function(f); }
+                    open-query(q, i) => { root.open-query(q, i); }
+                    mode-changed(m) => { root.sidebar-mode = m; root.sidebar-mode-changed(m); }
+                    open-table(db, t) => { root.open-table(db, t); }
+                    pin-table(db, t) => { root.pin-table(db, t); }
+                    toggle-fields(db, t) => { root.toggle-fields(db, t); }
+                    toggle-node(t) => { root.toggle-schema-node(t); }
+                    select-schema(s) => { root.select-schema(s); }
+                    filter-tree(t) => { root.filter-tree(t); }
+                    add-item() => { root.new-tab(); }
                 }
 
                 // work column: tab bar + work area (takes all remaining width)
@@ -1055,6 +953,7 @@ in-out property <string> rename-text;
                     if root.tabs.length > 0: WorkArea {
                         vertical-stretch: 1;
                         detail-visible <=> root.detail-visible;
+                        detail-left: root.sidebar-right;
                         results-collapsed <=> root.results-collapsed;
                         console-open <=> root.console-open;
                         console-count: root.query-console.length;
@@ -1316,6 +1215,39 @@ in-out property <string> rename-text;
                             }
                         }
                     }
+                }
+
+                // Navigation cluster on the right (mirrored). Only one of the
+                // two NavCluster copies renders, keyed off `sidebar-right`.
+                if root.sidebar-right: NavCluster {
+                    mirror: true;
+                    horizontal-stretch: 0;
+                    focus-tick: root.focus-filter-tick;
+                    tree: root.schema-tree;
+                    conn-name: root.status-conn;
+                    active-table: root.active-table;
+                    active-count: root.total-rows;
+                    query-tree: root.query-tree;
+                    sidebar-mode: root.sidebar-mode;
+                    sidebar-visible: root.sidebar-visible;
+                    sidebar-rail: root.sidebar-rail;
+                    sidebar-w: root.sidebar-w;
+                    schema-list: root.schema-list;
+                    schema-name: root.schema-name;
+                    set-rail(v) => { root.sidebar-rail = v; }
+                    set-visible(v) => { root.sidebar-visible = v; }
+                    set-w(v) => { root.sidebar-w = v; }
+                    disconnect() => { root.disconnect(); }
+                    open-function(f) => { root.open-function(f); }
+                    open-query(q, i) => { root.open-query(q, i); }
+                    mode-changed(m) => { root.sidebar-mode = m; root.sidebar-mode-changed(m); }
+                    open-table(db, t) => { root.open-table(db, t); }
+                    pin-table(db, t) => { root.pin-table(db, t); }
+                    toggle-fields(db, t) => { root.toggle-fields(db, t); }
+                    toggle-node(t) => { root.toggle-schema-node(t); }
+                    select-schema(s) => { root.select-schema(s); }
+                    filter-tree(t) => { root.filter-tree(t); }
+                    add-item() => { root.new-tab(); }
                 }
             }
         }
@@ -1632,6 +1564,43 @@ in-out property <string> rename-text;
                                     border-radius: 9px;
                                     background: #FFFFFF;
                                     x: Tokens.dark ? parent.width - self.width - 3px : 3px;
+                                    y: (parent.height - self.height) / 2;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // --- sidebar side ---
+                HorizontalLayout {
+                    spacing: Tokens.sp3;
+                    VerticalLayout {
+                        alignment: center;
+                        horizontal-stretch: 1;
+                        Text {
+                            text: "Sidebar on the right";
+                            color: Tokens.text;
+                            font-size: 13px;
+                        }
+                    }
+                    VerticalLayout {
+                        alignment: center;
+                        TouchArea {
+                            width: 42px;
+                            height: 24px;
+                            clicked => {
+                                root.sidebar-right = !root.sidebar-right;
+                                root.set-sidebar-side(root.sidebar-right);
+                            }
+                            Rectangle {
+                                border-radius: 12px;
+                                background: root.sidebar-right ? Tokens.accent : Tokens.border-strong;
+                                Rectangle {
+                                    width: 18px;
+                                    height: 18px;
+                                    border-radius: 9px;
+                                    background: #FFFFFF;
+                                    x: root.sidebar-right ? parent.width - self.width - 3px : 3px;
                                     y: (parent.height - self.height) / 2;
                                 }
                             }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -653,14 +653,14 @@ in-out property <string> rename-text;
                 // settings. One row so all icons share even spacing.
                 HorizontalLayout {
                     spacing: Tokens.sp1;
-                    // hide/show the left sidebar
-                    if root.connected: VerticalLayout {
+                    // Sidebar toggle sits on the sidebar's side: left of the
+                    // details toggle by default, right of it when the sidebar is
+                    // on the right — so the button lines up with the panel it
+                    // controls instead of being ambiguous.
+                    if root.connected && !root.sidebar-right: VerticalLayout {
                         alignment: center;
                         IconButton {
-                            // Point the divider at the sidebar's side, matching the
-                            // details toggle (columns == left divider; panel-right ==
-                            // right divider).
-                            icon: root.sidebar-right ? "panel-right" : "columns";
+                            icon: "columns";
                             tooltip: "Toggle sidebar";
                             // Collapse to the icon rail rather than fully hiding it.
                             active: !root.sidebar-rail;
@@ -677,6 +677,16 @@ in-out property <string> rename-text;
                             tooltip: "Toggle details panel";
                             active: root.detail-visible;
                             clicked => { root.detail-visible = !root.detail-visible; }
+                        }
+                    }
+                    // Sidebar toggle, right-hand placement (sidebar on the right).
+                    if root.connected && root.sidebar-right: VerticalLayout {
+                        alignment: center;
+                        IconButton {
+                            icon: "panel-right";
+                            tooltip: "Toggle sidebar";
+                            active: !root.sidebar-rail;
+                            clicked => { root.sidebar-rail = !root.sidebar-rail; }
                         }
                     }
                     // hide/show the results panel (grid/documents)

--- a/app/src/ui/icons.slint
+++ b/app/src/ui/icons.slint
@@ -29,6 +29,7 @@ export component AppIcon inherits Image {
         name == "columns"   ? @image-url("icons/columns.svg")  :
         name == "rows"      ? @image-url("icons/rows.svg")     :
         name == "panel-right" ? @image-url("icons/panel-right.svg") :
+        name == "panel-left" ? @image-url("icons/panel-left.svg") :
         name == "panel-collapse" ? @image-url("icons/panel-collapse.svg") :
         name == "panel-expand"   ? @image-url("icons/panel-expand.svg")   :
         name == "terminal"  ? @image-url("icons/terminal.svg") :

--- a/app/src/ui/icons/panel-left.svg
+++ b/app/src/ui/icons/panel-left.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M9 3v18"/></svg>

--- a/app/src/ui/nav-cluster.slint
+++ b/app/src/ui/nav-cluster.slint
@@ -1,0 +1,170 @@
+// Workspace navigation cluster: the Sidebar (or its collapsed icon rail / reveal
+// strip) plus the draggable width splitter, bundled so the whole thing can sit
+// on either edge of the work area. `mirror` puts the splitter on the left and
+// flips the drag direction, for when the sidebar lives on the right.
+//
+// State (mode/visible/rail/width) is owned by MainWindow and read one-way here;
+// mutations go back up through callbacks. Two NavCluster copies exist (one per
+// edge) and only one renders — a shared owner keeps them in lock-step, which a
+// duplicated two-way binding would not.
+import { Tokens } from "tokens.slint";
+import { TreeNode } from "structs.slint";
+import { IconButton } from "components.slint";
+import { Sidebar } from "sidebar.slint";
+
+export component NavCluster inherits HorizontalLayout {
+    // Sidebar on the right: splitter on the inner (left) edge, drag sign flipped.
+    in property <bool> mirror: false;
+
+    in property <[TreeNode]> tree;
+    in property <string> conn-name;
+    in property <string> active-table;
+    in property <int> active-count: -1;
+    in property <[TreeNode]> query-tree;
+    in property <[string]> schema-list;
+    in property <string> schema-name;
+    in property <int> sidebar-mode: 0;
+    in property <bool> sidebar-visible: true;
+    in property <bool> sidebar-rail: false;
+    in property <length> sidebar-w;
+    in property <int> focus-tick;
+
+    callback set-rail(bool);
+    callback set-visible(bool);
+    callback set-w(length);
+
+    callback disconnect();
+    callback open-function(string);
+    callback open-query(string, int);
+    callback mode-changed(int);
+    callback open-table(string, string);
+    callback pin-table(string, string);
+    callback toggle-fields(string, string);
+    callback toggle-node(string);
+    callback select-schema(string);
+    callback filter-tree(string);
+    callback add-item();
+
+    spacing: 0px;
+
+    // draggable vertical splitter (sidebar width) — leading edge when mirrored
+    if root.sidebar-visible && root.mirror: splitter-l := Rectangle {
+        width: 1px;
+        background: split-l-area.has-hover || split-l-area.pressed ? Tokens.accent : Tokens.border;
+        split-l-area := TouchArea {
+            mouse-cursor: col-resize;
+            moved => {
+                if !root.sidebar-rail {
+                    if root.sidebar-w - (self.mouse-x - self.pressed-x) < 150px {
+                        root.set-rail(true);
+                    } else {
+                        root.set-w(clamp(root.sidebar-w - (self.mouse-x - self.pressed-x), 184px, 360px));
+                    }
+                }
+            }
+        }
+    }
+
+    if root.sidebar-visible && !root.sidebar-rail: Sidebar {
+        focus-tick: root.focus-tick;
+        horizontal-stretch: 0;
+        min-width: root.sidebar-w;
+        max-width: root.sidebar-w;
+        tree: root.tree;
+        conn-name: root.conn-name;
+        active-table: root.active-table;
+        active-count: root.active-count;
+        query-tree: root.query-tree;
+        mode: root.sidebar-mode;
+        schema-list: root.schema-list;
+        schema-name: root.schema-name;
+        disconnect() => { root.disconnect(); }
+        open-function(f) => { root.open-function(f); }
+        open-query(q, i) => { root.open-query(q, i); }
+        mode-changed(m) => { root.mode-changed(m); }
+        open-table(db, t) => { root.open-table(db, t); }
+        pin-table(db, t) => { root.pin-table(db, t); }
+        toggle-fields(db, t) => { root.toggle-fields(db, t); }
+        toggle-node(t) => { root.toggle-node(t); }
+        select-schema(s) => { root.select-schema(s); }
+        filter-tree(t) => { root.filter-tree(t); }
+        add-item() => { root.add-item(); }
+        collapse() => { root.set-rail(true); }
+    }
+
+    // icon rail: compact tab icons when collapsed below the min width.
+    if root.sidebar-visible && root.sidebar-rail: Rectangle {
+        width: 48px;
+        background: Tokens.sidebar;
+        VerticalLayout {
+            alignment: start;
+            padding-top: Tokens.sp2;
+            padding-left: Tokens.sp2;
+            padding-right: Tokens.sp2;
+            spacing: Tokens.sp1;
+            IconButton {
+                icon: "layers";
+                tooltip: "Items";
+                active: root.sidebar-mode == 0;
+                clicked => {
+                    root.mode-changed(0);
+                    root.set-rail(false);
+                }
+            }
+            IconButton {
+                icon: "terminal";
+                tooltip: "Queries";
+                active: root.sidebar-mode == 1;
+                clicked => {
+                    root.mode-changed(1);
+                    root.set-rail(false);
+                }
+            }
+            IconButton {
+                icon: "clock";
+                tooltip: "History";
+                active: root.sidebar-mode == 2;
+                clicked => {
+                    root.mode-changed(2);
+                    root.set-rail(false);
+                }
+            }
+            IconButton {
+                icon: "panel-expand";
+                tooltip: "Expand sidebar";
+                clicked => { root.set-rail(false); }
+            }
+        }
+    }
+
+    // reveal strip when the sidebar is hidden
+    if !root.sidebar-visible: VerticalLayout {
+        alignment: start;
+        padding-top: Tokens.sp2;
+        padding-left: Tokens.sp1;
+        padding-right: Tokens.sp1;
+        IconButton {
+            icon: "panel-expand";
+            tooltip: "Show sidebar";
+            clicked => { root.set-visible(true); }
+        }
+    }
+
+    // draggable vertical splitter — trailing edge when the sidebar is on the left
+    if root.sidebar-visible && !root.mirror: splitter-r := Rectangle {
+        width: 1px;
+        background: split-r-area.has-hover || split-r-area.pressed ? Tokens.accent : Tokens.border;
+        split-r-area := TouchArea {
+            mouse-cursor: col-resize;
+            moved => {
+                if !root.sidebar-rail {
+                    if root.sidebar-w + (self.mouse-x - self.pressed-x) < 150px {
+                        root.set-rail(true);
+                    } else {
+                        root.set-w(clamp(root.sidebar-w + (self.mouse-x - self.pressed-x), 184px, 360px));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/ui/nav-cluster.slint
+++ b/app/src/ui/nav-cluster.slint
@@ -89,7 +89,6 @@ export component NavCluster inherits HorizontalLayout {
         select-schema(s) => { root.select-schema(s); }
         filter-tree(t) => { root.filter-tree(t); }
         add-item() => { root.add-item(); }
-        collapse() => { root.set-rail(true); }
     }
 
     // icon rail: compact tab icons when collapsed below the min width.

--- a/app/src/ui/sidebar.slint
+++ b/app/src/ui/sidebar.slint
@@ -30,7 +30,6 @@ export component Sidebar inherits Rectangle {
     callback filter-tree(string);
     callback mode-changed(int);
     callback add-item();
-    callback collapse();                   // hide the sidebar
     // bumped by ⌘P (app-window) to focus the filter field
     in property <int> focus-tick;
     changed focus-tick => { fld.focus-input(); }
@@ -71,21 +70,6 @@ export component Sidebar inherits Rectangle {
                     }
                 }
                 Rectangle { horizontal-stretch: 1; }
-                // collapse the sidebar (un-hide via the header toggle or the
-                // reveal button that takes this panel's place)
-                Rectangle {
-                    width: 24px;
-                    height: 24px;
-                    y: (parent.height - self.height) / 2;
-                    border-radius: 5px;
-                    background: collapse-ta.has-hover ? Tokens.border : transparent;
-                    AppIcon {
-                        name: "panel-collapse";
-                        size: Tokens.icon-sm;
-                        color: collapse-ta.has-hover ? Tokens.text : Tokens.text-faint;
-                    }
-                    collapse-ta := TouchArea { clicked => { root.collapse(); } }
-                }
             }
         }
 

--- a/app/src/ui/sidebar.slint
+++ b/app/src/ui/sidebar.slint
@@ -13,9 +13,10 @@ export component Sidebar inherits Rectangle {
     in property <string> active-table;   // highlighted (currently open) table
     in property <int> active-count: -1;  // row count badge on the active table
     in property <[string]> schema-list;
-    in-out property <string> schema-name;
-    // 0 = Items, 1 = Queries, 2 = History
-    in-out property <int> mode: 0;
+    in property <string> schema-name;
+    // 0 = Items, 1 = Queries, 2 = History. Read-only: tab clicks signal via
+    // mode-changed and the owner (MainWindow) sets the value back down.
+    in property <int> mode: 0;
     // Query tab rows reuse TreeNode: kind "qcat" headers / "query" / "recent".
     in property <[TreeNode]> query-tree;
     callback disconnect();
@@ -65,7 +66,6 @@ export component Sidebar inherits Rectangle {
                     }
                     mt := TouchArea {
                         clicked => {
-                            root.mode = m;
                             root.mode-changed(m);
                         }
                     }

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -22,6 +22,9 @@ export component WorkArea inherits Rectangle {
     // Reveal the query editor while browsing a table/collection (default closed).
     property <bool> browse-editor-open: false;
     in-out property <bool> detail-visible: true;
+    // Detail panel sits on the left edge (sidebar is on the right) instead of
+    // its default right edge.
+    in property <bool> detail-left: false;
     // SQL console (rendered by MainWindow below the work column); the footer
     // holds the toggle + clear so it reads as one bottom bar.
     in-out property <bool> console-open: false;
@@ -655,7 +658,7 @@ export component WorkArea inherits Rectangle {
 
             // Data grid — SQL/KeyValue, and Mongo documents in grid view.
             if root.view-mode == 0 && (root.browse-mode || root.sql-view-mode == 0) && (root.result-kind == 0 || root.result-kind == 2 || (root.result-kind == 1 && root.doc-view == 0)): TabularGrid {
-                x: 0;
+                x: (body.detail-shown && root.detail-left) ? body.detail-w + 1px : 0;
                 width: body.detail-shown ? body.width - body.detail-w - 1px : body.width;
                 height: 100%;
                 columns: root.columns;
@@ -684,7 +687,7 @@ export component WorkArea inherits Rectangle {
             }
 
             if body.detail-shown: Rectangle {
-                x: body.width - body.detail-w;
+                x: root.detail-left ? 0 : body.width - body.detail-w;
                 width: body.detail-w;
                 height: 100%;
                 background: Tokens.card;

--- a/crates/connstore/src/settings.rs
+++ b/crates/connstore/src/settings.rs
@@ -45,6 +45,8 @@ pub struct UiState {
     pub collapsed_groups: Vec<String>,
     /// Last connection-picker filter text.
     pub last_filter: String,
+    /// Place the workspace sidebar on the right instead of the left.
+    pub sidebar_right: bool,
 }
 
 /// Query-editor / results preferences.


### PR DESCRIPTION
## Summary

- Let users place the workspace sidebar on the right instead of the left, with the choice persisted across restarts.
- When the sidebar moves right, the selected-row details panel flips to the left so the two never collide, and the header toggle icons mirror to point at their panel's side.

## Changes

- **connstore**: add `sidebar_right` to `UiState` (serde default keeps older `settings.json` loadable).
- **app (settings)**: new `sidebar-right` property + `set-sidebar-side` callback; seed from settings on launch and persist on toggle. Adds a "Sidebar on the right" pill toggle to the Settings modal.
- **app (layout)**: extract the sidebar + icon rail + reveal strip + width splitter into a reusable `NavCluster` component, instantiated on either edge of the single work column and keyed off `sidebar-right`. On the right the splitter moves to the inner edge and the drag direction flips. Sidebar UI state (mode/visible/rail/width) is owned by `MainWindow` and read one-way with upward callbacks, so both cluster copies stay in lock-step.
- **app (details panel)**: `WorkArea` gains `detail-left`; the panel and grid swap sides when the sidebar is on the right.
- **app (header)**: the sidebar and details toggle icons mirror (`columns`/`panel-right` and `panel-right`/`panel-left`) to match the layout; add a `panel-left` icon.
- **app (cleanup)**: drop the redundant in-sidebar collapse chevron — the header toggle already collapses to the icon rail.

## Test plan

- [x] `make fe-build`
- [x] `make fmt-check`
- [x] `make lint`
- [x] Settings → toggle "Sidebar on the right": sidebar moves right, details panel moves left, header toggle icons mirror.
- [x] Collapse to the icon rail works on both edges (header toggle); splitter resize feels natural on the right.
- [x] Restart the app — the side preference persists.
- [x] Older `settings.json` (without `sidebar_right`) still loads.
