### PR TITLE
fix(app): reliable grid scroll, export dialog, and standby tabs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5577,7 +5577,7 @@ dependencies = [
 
 [[package]]
 name = "rdb"
-version = "0.16.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "copypasta",
@@ -6664,6 +6664,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "pin-weak",
+ "raw-window-handle",
  "slint-macros",
  "unicode-segmentation",
  "vtable",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 mock = []
 
 [dependencies]
-slint = { version = "1.8", default-features = false, features = ["compat-1-2", "std", "backend-winit", "renderer-femtovg", "renderer-software"] }
+slint = { version = "1.8", default-features = false, features = ["compat-1-2", "std", "backend-winit", "renderer-femtovg", "renderer-software", "raw-window-handle-06"] }
 rdb-core = { path = "../crates/core" }
 rdb-connstore = { path = "../crates/connstore" }
 rdb-driver-postgres = { path = "../crates/driver-postgres" }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -3962,6 +3962,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let edit_buf = edit_buf.clone();
         let db_override = db_override.clone();
         let tabs_restored = tabs_restored.clone();
+        let restore_tab = restore_tab.clone();
         window.on_connect_clicked(move |idx| {
             let i = idx as usize;
             // One-shot: set by the database switcher, empty for a fresh picker
@@ -3983,13 +3984,33 @@ fn main() -> Result<(), slint::PlatformError> {
             *current_connection_id.lock().unwrap() = Some(sc.id.clone());
             // First connect of the session (or a database switch) restores the
             // persisted SQL scratch tabs; a later switch to another connection
-            // starts with a clean workspace.
+            // keeps the SQL scratch tabs so the user can hop between connections
+            // without losing their queries.
             let restore = !tabs_restored.get() || db_ovr.is_some();
             tabs_restored.set(true);
             let (init_tabs, init_active) = if restore {
                 load_query_tabs()
             } else {
-                (Vec::new(), None)
+                // Retain the SQL scratch tabs (with their results) so switching
+                // connection leaves the last result on screen — "standby". Drop
+                // the connection-scoped table/function tabs (their data would be
+                // stale) and only clear the in-flight loading flag so no tab is
+                // left showing a stuck spinner.
+                let mut kept: Vec<WorkspaceTab> =
+                    std::mem::take(&mut *workspace_tabs.lock().unwrap())
+                        .into_iter()
+                        .filter(|t| t.kind == "sql")
+                        .collect();
+                for t in &mut kept {
+                    t.loading = false;
+                }
+                let active = active_tab_id
+                    .lock()
+                    .unwrap()
+                    .clone()
+                    .filter(|id| kept.iter().any(|t| t.id == *id))
+                    .or_else(|| kept.first().map(|t| t.id.clone()));
+                (kept, active)
             };
             *workspace_tabs.lock().unwrap() = init_tabs;
             *active_tab_id.lock().unwrap() = init_active.clone();
@@ -4057,6 +4078,20 @@ fn main() -> Result<(), slint::PlatformError> {
                     sc.engine,
                 )))));
                 w.set_filter_op(SharedString::from("="));
+                // Re-present the active tab's stored result so a connection
+                // switch keeps the last result visible instead of blanking the
+                // grid. No-op (clears) when the tab has no stored result, e.g.
+                // the disk-restored tabs on the first connect of the session.
+                let active_idx = init_active.as_deref().and_then(|id| {
+                    workspace_tabs
+                        .lock()
+                        .unwrap()
+                        .iter()
+                        .position(|t| t.id == id)
+                });
+                if let Some(idx) = active_idx {
+                    restore_tab(&w, idx);
+                }
             }
             // Fresh connection: nothing browsed, nothing expanded.
             *cur_engine.borrow_mut() = Some(sc.engine);

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -4930,9 +4930,14 @@ fn main() -> Result<(), slint::PlatformError> {
             };
             // Native save dialog via rfd's async API + Slint's local executor:
             // the sync dialog blocks the winit event loop and never surfaces.
+            // Parent it to our window so macOS presents the panel as a sheet
+            // (an unparented NSSavePanel silently no-ops for a non-foreground
+            // process, so nothing appears and nothing is written).
+            let parent = w.window().window_handle();
             let weak = w.as_weak();
             let _ = slint::spawn_local(async move {
                 let Some(file) = rfd::AsyncFileDialog::new()
+                    .set_parent(&parent)
                     .set_file_name(format!("rdb-export.{ext}"))
                     .add_filter(filter, &[ext])
                     .save_file()

--- a/app/src/ui/tabular-grid.slint
+++ b/app/src/ui/tabular-grid.slint
@@ -49,6 +49,18 @@ export component TabularGrid inherits Rectangle {
         list.viewport-y = min(0px, list.visible-height - list.viewport-height);
     }
 
+    // Drive the ListView from the wheel directly. The list is nested inside the
+    // horizontal ScrollView below, and the outer Flickable intermittently
+    // swallows the vertical wheel delta — so rows only scroll "sometimes".
+    // Forwarding the delta here (clamped to the same bounds as scroll-grid-tick)
+    // makes vertical scrolling deterministic regardless of which Flickable the
+    // event lands on.
+    function scroll-rows(dy: length) {
+        list.viewport-y = max(
+            min(0px, list.visible-height - list.viewport-height),
+            min(0px, list.viewport-y + dy));
+    }
+
     // A horizontal ScrollView owns the whole grid so the header and rows pan
     // together; the header sits above the ListView so it stays put while rows
     // scroll vertically. The ListView virtualizes — only the on-screen rows are
@@ -193,7 +205,15 @@ export component TabularGrid inherits Rectangle {
                 : r == root.selected-row ? Tokens.accent-tint.with-alpha(0.55)
                 : row-ta.has-hover ? Tokens.chrome.with-alpha(0.6)
                 : transparent;
-            row-ta := TouchArea {}
+            row-ta := TouchArea {
+                scroll-event(e) => {
+                    if (abs(e.delta-y) >= abs(e.delta-x)) {
+                        root.scroll-rows(e.delta-y);
+                        return accept;
+                    }
+                    return reject;
+                }
+            }
             HorizontalLayout {
                 // row-number gutter
                 Rectangle {
@@ -224,6 +244,13 @@ export component TabularGrid inherits Rectangle {
                     cell-ta := TouchArea {
                         clicked => { root.select-cell(r, c); }
                         double-clicked => { root.edit-cell(r, c); }
+                        scroll-event(e) => {
+                            if (abs(e.delta-y) >= abs(e.delta-x)) {
+                                root.scroll-rows(e.delta-y);
+                                return accept;
+                            }
+                            return reject;
+                        }
                     }
                     if !is-bar: Text {
                         vertical-alignment: center;


### PR DESCRIPTION
## Summary

- Result grid vertical scroll no longer drops intermittently.
- Export now shows a native save dialog on macOS instead of silently doing nothing.
- Switching connections keeps open query tabs and their results on standby, instead of blanking the workspace.

## Changes

**Grid scroll (`app/src/ui/tabular-grid.slint`)**
- The result `ListView` sits inside the horizontal `ScrollView`; the outer Flickable intermittently swallowed the vertical wheel delta.
- Forward the wheel to the `ListView` directly from the row/cell touch areas — vertical delta drives `viewport-y`, horizontal falls through to the `ScrollView` — clamped to the same bounds as the programmatic scroll.

**Export save dialog (`app/src/main.rs`, `app/Cargo.toml`)**
- An unparented `NSSavePanel` silently no-ops for a non-foreground process on macOS, so nothing appeared and no file was written.
- Enable slint's `raw-window-handle-06` feature and pass the window handle to `rfd` via `set_parent` so the panel opens as a sheet.

**Standby tabs on connection switch (`app/src/main.rs`)**
- A connection switch cleared the workspace, so queries and their results vanished and had to be rerun.
- Retain the SQL scratch tabs with their stored results across a switch and re-present the active tab. Connection-scoped table/function tabs are still dropped (their data would be stale).

## Test plan

- [x] `make fe-run` — wheel-scroll and drag the scrollbar over rows/cells/gutter repeatedly; vertical scroll works every time, horizontal still pans header + rows together.
- [x] Open 2–3 SQL tabs with results, switch to another connection and back — tabs and results remain; table-browse tabs drop (expected).
- [x] Run a query, Export → CSV/JSON — native save dialog appears; file written at the chosen path; status shows `exported → <path>`.
- [x] `cargo build -p rdb`, `cargo clippy -p rdb`, `cargo fmt --check` pass.