### PR TITLE
feat(app): star and drag-reorder saved connections

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -3508,6 +3508,31 @@ fn main() -> Result<(), slint::PlatformError> {
         });
     }
 
+    // ----- star/unstar a saved connection -----
+    {
+        let weak = window.as_weak();
+        let store = store.clone();
+        let collapsed = collapsed.clone();
+        let conn_filter = conn_filter.clone();
+        window.on_toggle_favorite(move |idx| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let id = {
+                let s = store.borrow();
+                match s.list().get(idx as usize) {
+                    Some(c) => (c.id.clone(), c.favorite),
+                    None => return,
+                }
+            };
+            let (id, was_fav) = id;
+            let _ = store.borrow_mut().set_favorite(&id, !was_fav);
+            let items =
+                build_conn_items(&store.borrow(), &collapsed.borrow(), &conn_filter.borrow());
+            w.set_connections(ModelRc::from(Rc::new(VecModel::from(items))));
+        });
+    }
+
     // ----- disconnect: drop the driver and return to the picker -----
     {
         let weak = window.as_weak();

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -3533,6 +3533,60 @@ fn main() -> Result<(), slint::PlatformError> {
         });
     }
 
+    // ----- drag-reorder a connection within its group -----
+    {
+        let weak = window.as_weak();
+        let store = store.clone();
+        let collapsed = collapsed.clone();
+        let conn_filter = conn_filter.clone();
+        window.on_reorder_conn(move |from_idx, delta| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            if delta == 0 {
+                return;
+            }
+            // Resolve the row-step delta against the dragged connection's group,
+            // using the same (favorite desc, order asc) display order as the
+            // builder, then map back to a store index for `reorder`.
+            let (from_id, target_vec_idx) = {
+                let s = store.borrow();
+                let list = s.list();
+                let Some(from) = list.get(from_idx as usize) else {
+                    return;
+                };
+                let group_key = |c: &rdb_connstore::SavedConnection| {
+                    c.group
+                        .as_deref()
+                        .filter(|g| !g.trim().is_empty())
+                        .unwrap_or(UNGROUPED)
+                        .to_string()
+                };
+                let g = group_key(from);
+                let mut members: Vec<usize> = list
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, c)| group_key(c) == g)
+                    .map(|(i, _)| i)
+                    .collect();
+                members.sort_by_key(|&i| (!list[i].favorite, list[i].order));
+                let Some(pos) = members.iter().position(|&i| i == from_idx as usize) else {
+                    return;
+                };
+                let target_pos =
+                    (pos as i64 + delta as i64).clamp(0, members.len() as i64 - 1) as usize;
+                if target_pos == pos {
+                    return;
+                }
+                (from.id.clone(), members[target_pos])
+            };
+            let _ = store.borrow_mut().reorder(&from_id, target_vec_idx);
+            let items =
+                build_conn_items(&store.borrow(), &collapsed.borrow(), &conn_filter.borrow());
+            w.set_connections(ModelRc::from(Rc::new(VecModel::from(items))));
+        });
+    }
+
     // ----- disconnect: drop the driver and return to the picker -----
     {
         let weak = window.as_weak();

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -87,12 +87,20 @@ fn build_conn_items(
                 subline: SharedString::default(),
                 local: false,
                 count: buckets[g].len() as i32,
+                favorite: false,
             });
         }
         if !expanded {
             continue;
         }
-        for &i in &buckets[g] {
+        // Favorites float to the top of their group, then explicit sort order.
+        // Stable sort keeps store insertion order for equal keys (order == 0).
+        let mut idxs = buckets[g].clone();
+        idxs.sort_by_key(|&i| {
+            let s = &store.list()[i];
+            (!s.favorite, s.order)
+        });
+        for &i in &idxs {
             let s = &store.list()[i];
             let subline = match &s.database {
                 Some(db) => format!("{} : {}", s.host, db),
@@ -110,6 +118,7 @@ fn build_conn_items(
                 subline: subline.into(),
                 local: s.local,
                 count: 0,
+                favorite: s.favorite,
             });
         }
     }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -160,6 +160,7 @@ in-out property <bool> rename-modal-open: false;
 in-out property <int> rename-target: -1;
 in-out property <string> rename-text;
     callback toggle-group(string);
+    callback toggle-favorite(int);          // star/unstar a saved connection
     callback open-table(string, string);   // (database, container)
     callback pin-table(string, string);    // double-click pins the object tab
     callback pin-tab(int);                 // double-click pins a preview tab
@@ -784,6 +785,7 @@ in-out property <string> rename-text;
             add-clicked() => { root.open-add-form(); }
             edit-clicked(i) => { root.open-edit-form(i); }
             toggle-group(g) => { root.toggle-group(g); }
+            toggle-favorite(i) => { root.toggle-favorite(i); }
             filter(t) => { root.conn-filter(t); }
             export-conns(fmt) => { root.export-conns(fmt); }
         }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -161,6 +161,7 @@ in-out property <int> rename-target: -1;
 in-out property <string> rename-text;
     callback toggle-group(string);
     callback toggle-favorite(int);          // star/unstar a saved connection
+    callback reorder-conn(int, int);        // (dragged store index, row-step delta)
     callback open-table(string, string);   // (database, container)
     callback pin-table(string, string);    // double-click pins the object tab
     callback pin-tab(int);                 // double-click pins a preview tab
@@ -786,6 +787,7 @@ in-out property <string> rename-text;
             edit-clicked(i) => { root.open-edit-form(i); }
             toggle-group(g) => { root.toggle-group(g); }
             toggle-favorite(i) => { root.toggle-favorite(i); }
+            reorder-conn(i, d) => { root.reorder-conn(i, d); }
             filter(t) => { root.conn-filter(t); }
             export-conns(fmt) => { root.export-conns(fmt); }
         }

--- a/app/src/ui/picker.slint
+++ b/app/src/ui/picker.slint
@@ -153,6 +153,14 @@ export component ConnPicker inherits Rectangle {
                                     : row-ta.has-hover ? tint.with-alpha(0.14)
                                     : transparent;
                                 animate background { duration: Tokens.fade; }
+                                // "Grabbed" affordance while dragging the handle:
+                                // Slint can't cheaply follow the cursor without a
+                                // feedback loop, so lift + outline signals the drag
+                                // is live; the drop lands on pointer release.
+                                border-width: grip-ta.pressed ? 1px : 0;
+                                border-color: Tokens.accent;
+                                drop-shadow-blur: grip-ta.pressed ? 14px : 0;
+                                drop-shadow-color: #00000055;
 
                                 row-ta := TouchArea {
                                     clicked => { root.select-conn(item.index); }
@@ -172,7 +180,7 @@ export component ConnPicker inherits Rectangle {
                                         alignment: center;
                                         Rectangle {
                                             width: 12px;
-                                            opacity: row-ta.has-hover || grip-ta.pressed ? 1.0 : 0.0;
+                                            opacity: row-ta.has-hover || grip-ta.has-hover || grip-ta.pressed ? 1.0 : 0.0;
                                             Text {
                                                 text: "⋮⋮";
                                                 color: selected ? white.with-alpha(0.7) : Tokens.text-faint;
@@ -226,14 +234,17 @@ export component ConnPicker inherits Rectangle {
                                         alignment: center;
                                         OutlineChip { text: "LOCAL"; }
                                     }
-                                    // Star toggle: always shown when starred;
-                                    // otherwise appears on row hover so the whole
-                                    // list doesn't read as cluttered.
-                                    if item.favorite || row-ta.has-hover: VerticalLayout {
+                                    // Star toggle: always present (so its own
+                                    // TouchArea keeps receiving clicks); shown when
+                                    // starred or on hover. Gating on `if` here would
+                                    // remove the element the instant the pointer
+                                    // enters it and steals hover from the row.
+                                    VerticalLayout {
                                         alignment: center;
                                         Rectangle {
                                             width: 22px;
                                             height: 22px;
+                                            opacity: item.favorite || row-ta.has-hover || star-ta.has-hover ? 1.0 : 0.0;
                                             border-radius: Tokens.radius;
                                             background: star-ta.has-hover ? Tokens.card.with-alpha(0.4) : transparent;
                                             Text {

--- a/app/src/ui/picker.slint
+++ b/app/src/ui/picker.slint
@@ -36,6 +36,8 @@ export component ConnPicker inherits Rectangle {
     callback toggle-group(string);
     // Toggle the starred flag on a connection (arg is the store index).
     callback toggle-favorite(int);
+    // Drag-reorder: (store index of dragged row, signed number of rows moved).
+    callback reorder-conn(int, int);
     callback filter(string);
 
     background: Tokens.canvas;
@@ -161,6 +163,35 @@ export component ConnPicker inherits Rectangle {
                                     padding-left: Tokens.sp3;
                                     padding-right: Tokens.sp3;
                                     spacing: Tokens.sp3;
+                                    // Drag handle: reorders within the group.
+                                    // Always rendered (so the pointer grab isn't
+                                    // dropped mid-drag when the row loses hover);
+                                    // faint until hovered. Emits a row-step delta
+                                    // on release for Rust to resolve.
+                                    VerticalLayout {
+                                        alignment: center;
+                                        Rectangle {
+                                            width: 12px;
+                                            opacity: row-ta.has-hover || grip-ta.pressed ? 1.0 : 0.0;
+                                            Text {
+                                                text: "⋮⋮";
+                                                color: selected ? white.with-alpha(0.7) : Tokens.text-faint;
+                                                font-size: 13px;
+                                                horizontal-alignment: center;
+                                                vertical-alignment: center;
+                                            }
+                                            grip-ta := TouchArea {
+                                                mouse-cursor: grab;
+                                                pointer-event(ev) => {
+                                                    if ev.kind == PointerEventKind.up {
+                                                        root.reorder-conn(
+                                                            item.index,
+                                                            round((self.mouse-y - self.pressed-y) / 40px));
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
                                     VerticalLayout {
                                         alignment: center;
                                         // ring keeps the same-color badge visible

--- a/app/src/ui/picker.slint
+++ b/app/src/ui/picker.slint
@@ -34,6 +34,8 @@ export component ConnPicker inherits Rectangle {
     // Export saved connections to ~/Downloads. Arg is the format: 0 = JSON, 1 = CSV.
     callback export-conns(int);
     callback toggle-group(string);
+    // Toggle the starred flag on a connection (arg is the store index).
+    callback toggle-favorite(int);
     callback filter(string);
 
     background: Tokens.canvas;
@@ -192,6 +194,30 @@ export component ConnPicker inherits Rectangle {
                                     if item.local: VerticalLayout {
                                         alignment: center;
                                         OutlineChip { text: "LOCAL"; }
+                                    }
+                                    // Star toggle: always shown when starred;
+                                    // otherwise appears on row hover so the whole
+                                    // list doesn't read as cluttered.
+                                    if item.favorite || row-ta.has-hover: VerticalLayout {
+                                        alignment: center;
+                                        Rectangle {
+                                            width: 22px;
+                                            height: 22px;
+                                            border-radius: Tokens.radius;
+                                            background: star-ta.has-hover ? Tokens.card.with-alpha(0.4) : transparent;
+                                            Text {
+                                                text: item.favorite ? "★" : "☆";
+                                                color: item.favorite
+                                                    ? #f5b301
+                                                    : (selected ? white.with-alpha(0.8) : Tokens.text-faint);
+                                                font-size: 15px;
+                                                horizontal-alignment: center;
+                                                vertical-alignment: center;
+                                            }
+                                            star-ta := TouchArea {
+                                                clicked => { root.toggle-favorite(item.index); }
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/app/src/ui/structs.slint
+++ b/app/src/ui/structs.slint
@@ -32,6 +32,8 @@ export struct ConnItem {
     local: bool,
     // Direct children count shown next to a header row (headers only).
     count: int,
+    // Starred connection: renders a badge and floats to the top of its group.
+    favorite: bool,
 }
 // One Host/Port/… row of the connection-detail card.
 export struct KvRow { k: string, v: string }

--- a/crates/connstore/src/model.rs
+++ b/crates/connstore/src/model.rs
@@ -49,6 +49,13 @@ pub struct SavedConnection {
     /// (`mongodb+srv://…`). Consumed by the Mongo driver; ignored by others.
     #[serde(default)]
     pub params: Option<String>,
+    /// Starred connection: the UI shows a badge and floats it to the top.
+    #[serde(default)]
+    pub favorite: bool,
+    /// Explicit sort key for the connection list. Default `0` falls back to
+    /// insertion order; drag-reorder rewrites it.
+    #[serde(default)]
+    pub order: i64,
 }
 
 impl SavedConnection {
@@ -74,6 +81,8 @@ impl SavedConnection {
             local: false,
             tags: Vec::new(),
             params: None,
+            favorite: false,
+            order: 0,
         }
     }
 
@@ -111,6 +120,8 @@ mod tests {
             local: false,
             tags: Vec::new(),
             params: None,
+            favorite: false,
+            order: 0,
         }
     }
 

--- a/crates/connstore/src/store.rs
+++ b/crates/connstore/src/store.rs
@@ -122,6 +122,36 @@ impl ConnStore {
         }
     }
 
+    /// Toggle/set the starred flag on a connection.
+    pub fn set_favorite(&mut self, id: &str, favorite: bool) -> Result<()> {
+        match self.index_of(id) {
+            Some(i) => {
+                self.conns[i].favorite = favorite;
+                self.flush()
+            }
+            None => Err(ConnStoreError::NotFound(id.to_string())),
+        }
+    }
+
+    /// Move a connection to `new_index` in the list and renumber every
+    /// connection's `order` to its new position, so the stored order is the
+    /// source of truth for the UI.
+    ///
+    /// `new_index` is clamped to the valid range.
+    // ponytail: renumber-all on each move; O(n), fine for a hand-managed list.
+    pub fn reorder(&mut self, id: &str, new_index: usize) -> Result<()> {
+        let from = self
+            .index_of(id)
+            .ok_or_else(|| ConnStoreError::NotFound(id.to_string()))?;
+        let to = new_index.min(self.conns.len() - 1);
+        let conn = self.conns.remove(from);
+        self.conns.insert(to, conn);
+        for (i, c) in self.conns.iter_mut().enumerate() {
+            c.order = i as i64;
+        }
+        self.flush()
+    }
+
     /// Store `password` in the secret backend keyed by the connection id.
     /// Errors if the connection id is unknown.
     pub fn set_password(&self, id: &str, password: &str) -> Result<()> {
@@ -205,6 +235,54 @@ mod tests {
         let secrets = Box::new(crate::secret::EncryptedFileBackend::new(dir.path()).unwrap());
         let store = ConnStore::load(path, secrets).unwrap();
         assert_eq!(store.get(&id).unwrap().name, "persisted");
+    }
+
+    #[test]
+    fn set_favorite_toggles_flag() {
+        let (_dir, mut store) = temp_store();
+        let c = pg("star me");
+        let id = c.id.clone();
+        store.add(c).unwrap();
+        assert!(!store.get(&id).unwrap().favorite);
+
+        store.set_favorite(&id, true).unwrap();
+        assert!(store.get(&id).unwrap().favorite);
+
+        store.set_favorite(&id, false).unwrap();
+        assert!(!store.get(&id).unwrap().favorite);
+    }
+
+    #[test]
+    fn reorder_moves_and_renumbers_order() {
+        let (_dir, mut store) = temp_store();
+        let (a, b, c) = (pg("a"), pg("b"), pg("c"));
+        let (ia, ic) = (a.id.clone(), c.id.clone());
+        store.add(a).unwrap();
+        store.add(b).unwrap();
+        store.add(c).unwrap();
+
+        // Move "c" (index 2) to the front.
+        store.reorder(&ic, 0).unwrap();
+
+        let list = store.list();
+        assert_eq!(list[0].id, ic);
+        assert_eq!(list[1].id, ia);
+        // order rewritten to match position.
+        for (i, conn) in list.iter().enumerate() {
+            assert_eq!(conn.order, i as i64);
+        }
+    }
+
+    #[test]
+    fn reorder_clamps_out_of_range_index() {
+        let (_dir, mut store) = temp_store();
+        let (a, b) = (pg("a"), pg("b"));
+        let ia = a.id.clone();
+        store.add(a).unwrap();
+        store.add(b).unwrap();
+
+        store.reorder(&ia, 99).unwrap();
+        assert_eq!(store.list()[1].id, ia);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Let users **star** saved connections; starred ones show a badge and float to the top of their group.
- Let users **drag-reorder** connections within a group via a row grip handle; the order persists.

## Changes

**connstore**
- Add `favorite: bool` and `order: i64` to `SavedConnection` (both `#[serde(default)]`, so existing `connections.json` loads unchanged).
- Add `set_favorite(id, bool)` and `reorder(id, new_index)` store methods; `reorder` renumbers `order` to match position. Unit tests for both.

**app (picker)**
- Sort connections by `(favorite desc, order asc)` within each group in the list builder.
- Star toggle on each row (always-present TouchArea so the click reliably lands; shown when starred or on hover).
- Drag grip handle per row emitting a row-step delta; the Rust side resolves it against the connection's group and calls `reorder`. Grabbed rows get an outline + lift affordance while dragging.

## Test plan

- [x] `make all` (fmt-check + clippy + test + build) passes.
- [x] connstore unit tests for `set_favorite` and `reorder`.
- [x] Manual (`make fe-run`): star a connection → badge shows, floats to top, persists across restart.
- [x] Manual: drag a connection within its group → order changes and persists.
