### PR TITLE
feat(app): workspace tab groups (split editor with independent groups)

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1072,7 +1072,7 @@ enum StreamMsg {
 }
 
 /// Push a flat `GridModel` into the window's grid columns/cells properties.
-fn push_grid(w: &MainWindow, g: &model::GridModel) {
+fn push_grid(w: &MainWindow, pane: usize, g: &model::GridModel) {
     let cols: Vec<GridColumn> = g
         .columns
         .iter()
@@ -1091,14 +1091,14 @@ fn push_grid(w: &MainWindow, g: &model::GridModel) {
             });
         }
     }
-    w.set_grid_col_count(cols.len() as i32);
-    w.set_grid_columns(ModelRc::from(Rc::new(VecModel::from(cols))));
-    w.set_grid_cells(ModelRc::from(Rc::new(VecModel::from(flat))));
+    set_p_col_count(w, pane, cols.len() as i32);
+    set_p_columns(w, pane, ModelRc::from(Rc::new(VecModel::from(cols))));
+    set_p_cells(w, pane, ModelRc::from(Rc::new(VecModel::from(flat))));
 }
 
 /// Update only the row cells (not columns/widths), so the per-column filter
 /// inputs keep focus while the user types. Columns are assumed unchanged.
-fn set_grid_cells_only(w: &MainWindow, g: &model::GridModel) {
+fn set_grid_cells_only(w: &MainWindow, pane: usize, g: &model::GridModel) {
     let mut flat: Vec<GridCell> = Vec::new();
     for row in &g.rows {
         for cell in row {
@@ -1109,14 +1109,23 @@ fn set_grid_cells_only(w: &MainWindow, g: &model::GridModel) {
             });
         }
     }
-    w.set_grid_cells(ModelRc::from(Rc::new(VecModel::from(flat))));
-    w.set_result_status(SharedString::from(format!("{} rows", g.rows.len())));
+    set_p_cells(w, pane, ModelRc::from(Rc::new(VecModel::from(flat))));
+    set_p_result_status(
+        w,
+        pane,
+        SharedString::from(format!("{} rows", g.rows.len())),
+    );
 }
 
 /// Push `g` with the buffer's pending edits overlaid: changed cells show the
 /// new text (state 1), delete-marked rows state 2, insert rows appended as
 /// state-3 rows at the bottom.
-fn paint_grid_with_edits(w: &MainWindow, g: &model::GridModel, buf: &model::EditBuffer) {
+fn paint_grid_with_edits(
+    w: &MainWindow,
+    pane: usize,
+    g: &model::GridModel,
+    buf: &model::EditBuffer,
+) {
     let ncols = g.columns.len();
     let mut flat: Vec<GridCell> = Vec::with_capacity((g.rows.len() + buf.inserts.len()) * ncols);
     for (r, row) in g.rows.iter().enumerate() {
@@ -1146,7 +1155,7 @@ fn paint_grid_with_edits(w: &MainWindow, g: &model::GridModel, buf: &model::Edit
             });
         }
     }
-    w.set_grid_cells(ModelRc::from(Rc::new(VecModel::from(flat))));
+    set_p_cells(w, pane, ModelRc::from(Rc::new(VecModel::from(flat))));
 }
 
 /// The grid a view displays, if it has one (for edit-buffer bookkeeping).
@@ -1171,10 +1180,117 @@ fn guard_pending_edits(w: &MainWindow, edit_buf: &std::sync::Mutex<model::EditBu
 }
 
 /// Clear the tabular grid properties (used by non-tabular result kinds).
-fn clear_grid(w: &MainWindow) {
-    w.set_grid_col_count(0);
-    w.set_grid_columns(ModelRc::from(Rc::new(VecModel::<GridColumn>::default())));
-    w.set_grid_cells(ModelRc::from(Rc::new(VecModel::<GridCell>::default())));
+fn clear_grid(w: &MainWindow, pane: usize) {
+    set_p_col_count(w, pane, 0);
+    set_p_columns(
+        w,
+        pane,
+        ModelRc::from(Rc::new(VecModel::<GridColumn>::default())),
+    );
+    set_p_cells(
+        w,
+        pane,
+        ModelRc::from(Rc::new(VecModel::<GridCell>::default())),
+    );
+}
+
+// ----- per-pane result setters: pane 0 writes the base properties, pane 1 the
+// p1-* mirror. Only genuinely per-pane props are routed; tab-global props
+// (browse paging, filter chrome, status latency) always use the base setter.
+fn set_p_cells(w: &MainWindow, pane: usize, m: ModelRc<GridCell>) {
+    if pane == 0 {
+        w.set_grid_cells(m);
+    } else {
+        w.set_p1_cells(m);
+    }
+}
+fn set_p_columns(w: &MainWindow, pane: usize, m: ModelRc<GridColumn>) {
+    if pane == 0 {
+        w.set_grid_columns(m);
+    } else {
+        w.set_p1_columns(m);
+    }
+}
+fn set_p_col_count(w: &MainWindow, pane: usize, n: i32) {
+    if pane == 0 {
+        w.set_grid_col_count(n);
+    } else {
+        w.set_p1_col_count(n);
+    }
+}
+fn set_p_col_widths(w: &MainWindow, pane: usize, m: ModelRc<f32>) {
+    if pane == 0 {
+        w.set_grid_col_widths(m);
+    } else {
+        w.set_p1_col_widths(m);
+    }
+}
+fn set_p_result_kind(w: &MainWindow, pane: usize, k: i32) {
+    if pane == 0 {
+        w.set_result_kind(k);
+    } else {
+        w.set_p1_result_kind(k);
+    }
+}
+fn set_p_result_status(w: &MainWindow, pane: usize, s: SharedString) {
+    if pane == 0 {
+        w.set_result_status(s);
+    } else {
+        w.set_p1_result_status(s);
+    }
+}
+fn set_p_status_error(w: &MainWindow, pane: usize, b: bool) {
+    if pane == 0 {
+        w.set_status_error(b);
+    } else {
+        w.set_p1_status_error(b);
+    }
+}
+fn set_p_results_meta(w: &MainWindow, pane: usize, s: SharedString) {
+    if pane == 0 {
+        w.set_results_meta(s);
+    } else {
+        w.set_p1_results_meta(s);
+    }
+}
+fn set_p_chart_bars(w: &MainWindow, pane: usize, m: ModelRc<ChartBar>) {
+    if pane == 0 {
+        w.set_chart_bars(m);
+    } else {
+        w.set_p1_chart_bars(m);
+    }
+}
+fn set_p_grid_sort(w: &MainWindow, pane: usize, col: i32, asc: bool) {
+    if pane == 0 {
+        w.set_grid_sort_col(col);
+        w.set_grid_sort_asc(asc);
+    } else {
+        w.set_p1_grid_sort_col(col);
+        w.set_p1_grid_sort_asc(asc);
+    }
+}
+fn set_p_grid_col_filters(w: &MainWindow, pane: usize, m: ModelRc<SharedString>) {
+    if pane == 0 {
+        w.set_grid_col_filters(m);
+    } else {
+        w.set_p1_grid_col_filters(m);
+    }
+}
+fn set_p_editing(w: &MainWindow, pane: usize, row: i32, col: i32) {
+    if pane == 0 {
+        w.set_editing_row(row);
+        w.set_editing_col(col);
+    } else {
+        w.set_p1_editing_row(row);
+        w.set_p1_editing_col(col);
+    }
+}
+fn set_p_doc_tree(w: &MainWindow, pane: usize, m: ModelRc<DocRow>) {
+    if pane == 0 {
+        w.set_doc_tree(m);
+    } else {
+        w.set_p1_doc_tree(m);
+    }
 }
 
 /// Return a copy of `g` keeping only rows where some cell matches `needle`
@@ -1495,7 +1611,12 @@ thread_local! {
 
 /// Compute the visible JSON-tree rows for the current collapse state and push
 /// them to the window.
-fn push_doc_tree(w: &MainWindow, full: &[model::DocNode], collapsed: &HashSet<String>) {
+fn push_doc_tree(
+    w: &MainWindow,
+    pane: usize,
+    full: &[model::DocNode],
+    collapsed: &HashSet<String>,
+) {
     let rows: Vec<DocRow> = model::visible_doc_rows(full, collapsed)
         .into_iter()
         .map(|(n, expanded)| DocRow {
@@ -1507,36 +1628,41 @@ fn push_doc_tree(w: &MainWindow, full: &[model::DocNode], collapsed: &HashSet<St
             path: SharedString::from(n.path.clone()),
         })
         .collect();
-    w.set_doc_tree(ModelRc::from(Rc::new(VecModel::from(rows))));
+    set_p_doc_tree(w, pane, ModelRc::from(Rc::new(VecModel::from(rows))));
 }
 
 /// Push a `ResultView` into the window, selecting the per-kind result region
 /// via `result-kind` (0 Table, 1 Documents, 3 Affected).
-fn apply_result(w: &MainWindow, view: model::ResultView) {
+fn apply_result(w: &MainWindow, pane: usize, view: model::ResultView) {
     match view {
         model::ResultView::Table(g) => {
-            w.set_result_kind(0);
+            set_p_result_kind(w, pane, 0);
             w.set_doc_json(SharedString::default());
-            push_grid(w, &g);
-            w.set_result_status(SharedString::from(format!("{} rows", g.rows.len())));
+            push_grid(w, pane, &g);
+            set_p_result_status(
+                w,
+                pane,
+                SharedString::from(format!("{} rows", g.rows.len())),
+            );
         }
         model::ResultView::Documents(d) => {
-            w.set_result_kind(1);
+            set_p_result_kind(w, pane, 1);
             w.set_doc_json(SharedString::from(d.json));
-            push_grid(w, &d.grid);
-            w.set_result_status(SharedString::from(format!(
-                "{} documents",
-                d.grid.rows.len()
-            )));
+            push_grid(w, pane, &d.grid);
+            set_p_result_status(
+                w,
+                pane,
+                SharedString::from(format!("{} documents", d.grid.rows.len())),
+            );
             let collapsed = model::default_doc_collapsed(&d.tree);
-            push_doc_tree(w, &d.tree, &collapsed);
+            push_doc_tree(w, pane, &d.tree, &collapsed);
             DOC_TREE.with(|s| *s.borrow_mut() = (d.tree, collapsed));
         }
         model::ResultView::Affected(status) => {
-            w.set_result_kind(3);
+            set_p_result_kind(w, pane, 3);
             w.set_doc_json(SharedString::default());
-            clear_grid(w);
-            w.set_result_status(SharedString::from(status));
+            clear_grid(w, pane);
+            set_p_result_status(w, pane, SharedString::from(status));
         }
     }
 }
@@ -1548,6 +1674,7 @@ fn apply_result(w: &MainWindow, view: model::ResultView) {
 #[allow(clippy::too_many_arguments)]
 fn present_view(
     w: &MainWindow,
+    pane: usize,
     v: model::ResultView,
     meta: &str,
     latency: &str,
@@ -1576,12 +1703,15 @@ fn present_view(
     *col_order.lock().unwrap() = (0..ncols).collect();
     *sort_state.lock().unwrap() = (-1, true);
     *col_filters.lock().unwrap() = vec![String::new(); ncols];
-    w.set_grid_sort_col(-1);
-    w.set_grid_sort_asc(true);
-    w.set_grid_col_filters(ModelRc::from(Rc::new(VecModel::from(vec![
+    set_p_grid_sort(w, pane, -1, true);
+    set_p_grid_col_filters(
+        w,
+        pane,
+        ModelRc::from(Rc::new(VecModel::from(vec![
             SharedString::default();
             ncols
-        ]))));
+        ]))),
+    );
     let colnames: Vec<SharedString> = match &v {
         model::ResultView::Table(g) => g
             .columns
@@ -1619,11 +1749,10 @@ fn present_view(
         b.pk_cols = st.pk_cols.clone();
     }
     w.set_pending_count(0);
-    w.set_editing_row(-1);
-    w.set_editing_col(-1);
-    w.set_status_error(false);
+    set_p_editing(w, pane, -1, -1);
+    set_p_status_error(w, pane, false);
     w.set_status_latency(SharedString::from(latency));
-    w.set_results_meta(SharedString::from(meta));
+    set_p_results_meta(w, pane, SharedString::from(meta));
     let widths: Vec<f32> = match &v {
         model::ResultView::Table(g) => g
             .columns
@@ -1632,7 +1761,7 @@ fn present_view(
             .collect(),
         _ => vec![140.0; ncols],
     };
-    w.set_grid_col_widths(ModelRc::from(Rc::new(VecModel::from(widths))));
+    set_p_col_widths(w, pane, ModelRc::from(Rc::new(VecModel::from(widths))));
     let bars: Vec<ChartBar> = match &v {
         model::ResultView::Table(g) => model::chart_data(g)
             .into_iter()
@@ -1644,8 +1773,8 @@ fn present_view(
             .collect(),
         _ => Vec::new(),
     };
-    w.set_chart_bars(ModelRc::from(Rc::new(VecModel::from(bars))));
-    apply_result(w, v);
+    set_p_chart_bars(w, pane, ModelRc::from(Rc::new(VecModel::from(bars))));
+    apply_result(w, pane, v);
     let st = browse.lock().unwrap().clone();
     if st.table.is_some() {
         let (start, end, prev, next) = page_bounds(st.page, st.limit, st.total, shown);
@@ -1658,12 +1787,18 @@ fn present_view(
 }
 
 /// Set the result-tab strip labels ("Result 1", …) and active index.
-fn set_result_tabs(w: &MainWindow, count: usize, active: usize) {
+fn set_result_tabs(w: &MainWindow, pane: usize, count: usize, active: usize) {
     let labels: Vec<SharedString> = (1..=count)
         .map(|n| SharedString::from(format!("Result {n}")))
         .collect();
-    w.set_result_tabs(ModelRc::from(Rc::new(VecModel::from(labels))));
-    w.set_active_result(active as i32);
+    let labels = ModelRc::from(Rc::new(VecModel::from(labels)));
+    if pane == 0 {
+        w.set_result_tabs(labels);
+        w.set_active_result(active as i32);
+    } else {
+        w.set_p1_result_tabs(labels);
+        w.set_p1_active_result(active as i32);
+    }
 }
 
 #[cfg(test)]
@@ -2031,6 +2166,7 @@ fn main() -> Result<(), slint::PlatformError> {
             }
         }
     };
+    #[allow(clippy::type_complexity)]
     let load_editor_text: Rc<dyn Fn(usize, &str)> = {
         let panes = panes.clone();
         let sync_editor = sync_editor.clone();
@@ -2860,7 +2996,7 @@ fn main() -> Result<(), slint::PlatformError> {
             if !standby {
                 results.lock().unwrap().clear();
                 *displayed_grid.lock().unwrap() = None;
-                clear_grid(&w);
+                clear_grid(&w, 0);
             }
             expanded_tables.lock().unwrap().clear();
             *collapsed_categories.borrow_mut() = default_collapsed_cats();
@@ -3486,7 +3622,7 @@ fn main() -> Result<(), slint::PlatformError> {
 
             *results.lock().unwrap() = tab.results.clone();
             *active_result.lock().unwrap() = tab.active_result;
-            set_result_tabs(w, tab.results.len(), tab.active_result);
+            set_result_tabs(w, 0, tab.results.len(), tab.active_result);
             let selected = if tab.kind == "sql" {
                 tab.results.get(tab.active_result).cloned().or(tab.view)
             } else {
@@ -3495,6 +3631,7 @@ fn main() -> Result<(), slint::PlatformError> {
             if let Some(stored) = selected {
                 present_view(
                     w,
+                    0,
                     stored.view,
                     &stored.meta,
                     &stored.latency,
@@ -3510,7 +3647,7 @@ fn main() -> Result<(), slint::PlatformError> {
             } else {
                 *last_view.lock().unwrap() = None;
                 *displayed_grid.lock().unwrap() = None;
-                clear_grid(w);
+                clear_grid(w, 0);
                 w.set_results_meta(SharedString::default());
                 w.set_result_status(SharedString::default());
             }
@@ -3671,7 +3808,7 @@ fn main() -> Result<(), slint::PlatformError> {
             *active_tab_id.lock().unwrap() = None;
             *current_connection_id.lock().unwrap() = None;
             set_workspace_tabs(&w, &[], None);
-            clear_grid(&w);
+            clear_grid(&w, 0);
             *cur_engine.borrow_mut() = None;
             expanded_tables.lock().unwrap().clear();
             loaded_dbs.lock().unwrap().clear();
@@ -3734,7 +3871,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 v, &needle, &fcol, &fop, &cfilters, &hidden, &order, scol, sasc,
             );
             *displayed_grid.lock().unwrap() = view_grid(&filtered);
-            apply_result(&w, filtered);
+            apply_result(&w, 0, filtered);
         });
     }
 
@@ -3829,9 +3966,9 @@ fn main() -> Result<(), slint::PlatformError> {
             // Columns are unchanged, so update only the cells — replacing the
             // columns model would rebuild (and unfocus) the filter inputs.
             if let model::ResultView::Table(g) = &filtered {
-                set_grid_cells_only(&w, g);
+                set_grid_cells_only(&w, 0, g);
             } else {
-                apply_result(&w, filtered);
+                apply_result(&w, 0, filtered);
             }
         });
     }
@@ -3896,7 +4033,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 v, &needle, &fcol, &fop, &cfilters, &hidden, &order, scol, sasc,
             );
             *displayed_grid.lock().unwrap() = view_grid(&sorted);
-            apply_result(&w, sorted);
+            apply_result(&w, 0, sorted);
         });
     }
 
@@ -3999,7 +4136,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 v, &needle, &fcol, &fop, &cfilters, &hidden, &order, scol, sasc,
             );
             *displayed_grid.lock().unwrap() = view_grid(&transformed);
-            apply_result(&w, transformed);
+            apply_result(&w, 0, transformed);
         });
     }
 
@@ -4073,7 +4210,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 w.set_grid_col_widths(ModelRc::from(Rc::new(VecModel::from(widths))));
             }
             *displayed_grid.lock().unwrap() = view_grid(&transformed);
-            apply_result(&w, transformed);
+            apply_result(&w, 0, transformed);
         });
     }
 
@@ -4172,7 +4309,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     let tabs = workspace_tabs.lock().unwrap();
                     set_workspace_tabs(&w, &tabs, init_active.as_deref());
                 }
-                clear_grid(&w);
+                clear_grid(&w, 0);
                 sync_query_console(&w, &query_console);
                 w.set_selected_conn(idx);
                 // Show progress + clear any prior failure immediately.
@@ -4663,12 +4800,18 @@ fn main() -> Result<(), slint::PlatformError> {
                                 *results.lock().unwrap() = tab_results;
                                 *active_result.lock().unwrap() = tab_active;
                                 if is_browse {
-                                    set_result_tabs(&w, 0, 0);
+                                    set_result_tabs(&w, 0, 0, 0);
                                 } else {
-                                    set_result_tabs(&w, results.lock().unwrap().len(), tab_active);
+                                    set_result_tabs(
+                                        &w,
+                                        0,
+                                        results.lock().unwrap().len(),
+                                        tab_active,
+                                    );
                                 }
                                 present_view(
                                     &w,
+                                    0,
                                     v,
                                     &meta,
                                     &latency,
@@ -4697,6 +4840,7 @@ fn main() -> Result<(), slint::PlatformError> {
                                 *last_view.lock().unwrap() = None;
                                 apply_result(
                                     &w,
+                                    0,
                                     model::ResultView::Affected(format!("error: {e}")),
                                 );
                             }
@@ -4761,7 +4905,7 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_query_running(true);
             w.set_streaming(true);
             w.set_grid_read_only(true);
-            clear_grid(&w);
+            clear_grid(&w, 0);
             w.set_result_status(SharedString::from("streaming…"));
             w.set_results_meta(SharedString::default());
 
@@ -4875,9 +5019,10 @@ fn main() -> Result<(), slint::PlatformError> {
                                     {
                                         *results.lock().unwrap() = vec![sr];
                                         *active_result.lock().unwrap() = 0;
-                                        set_result_tabs(&w, 1, 0);
+                                        set_result_tabs(&w, 0, 1, 0);
                                         present_view(
                                             &w,
+                                            0,
                                             view,
                                             &meta,
                                             &latency,
@@ -4911,6 +5056,7 @@ fn main() -> Result<(), slint::PlatformError> {
                                     {
                                         apply_result(
                                             &w,
+                                            0,
                                             model::ResultView::Affected(format!("error: {e}")),
                                         );
                                         w.set_query_running(false);
@@ -5392,8 +5538,8 @@ fn main() -> Result<(), slint::PlatformError> {
             *last_view.lock().unwrap() = None;
             *displayed_grid.lock().unwrap() = None;
             results.lock().unwrap().clear();
-            set_result_tabs(&w, 0, 0);
-            clear_grid(&w);
+            set_result_tabs(&w, 0, 0, 0);
+            clear_grid(&w, 0);
             run_browse();
 
             // Fetch total + primary key off-thread; footer updates when done.
@@ -5671,7 +5817,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 if !collapsed.remove(&p) {
                     collapsed.insert(p);
                 }
-                push_doc_tree(&w, full, collapsed);
+                push_doc_tree(&w, 0, full, collapsed);
             });
         });
     }
@@ -5940,8 +6086,8 @@ fn main() -> Result<(), slint::PlatformError> {
                 ..Default::default()
             };
             *last_view.lock().unwrap() = None;
-            set_result_tabs(&w, 0, 0);
-            clear_grid(&w);
+            set_result_tabs(&w, 0, 0, 0);
+            clear_grid(&w, 0);
             w.set_active_table(SharedString::default());
             w.set_fn_mode(false);
             w.set_query_running(false);
@@ -6016,6 +6162,7 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_active_result(i as i32);
             present_view(
                 &w,
+                0,
                 sr.view,
                 &sr.meta,
                 &sr.latency,
@@ -6061,7 +6208,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 }
                 (rv.len(), *ar, rv.get(*ar).cloned())
             };
-            set_result_tabs(&w, count, active);
+            set_result_tabs(&w, 0, count, active);
             if let Some(id) = active_tab_id.lock().unwrap().clone() {
                 if let Some(tab) = workspace_tabs
                     .lock()
@@ -6076,6 +6223,7 @@ fn main() -> Result<(), slint::PlatformError> {
             match sr {
                 Some(sr) => present_view(
                     &w,
+                    0,
                     sr.view,
                     &sr.meta,
                     &sr.latency,
@@ -6089,7 +6237,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     &browse,
                 ),
                 None => {
-                    clear_grid(&w);
+                    clear_grid(&w, 0);
                     *last_view.lock().unwrap() = None;
                 }
             }
@@ -6146,7 +6294,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 results.lock().unwrap().clear();
                 *last_view.lock().unwrap() = None;
                 *displayed_grid.lock().unwrap() = None;
-                clear_grid(&w);
+                clear_grid(&w, 0);
                 w.set_active_table(SharedString::default());
                 w.set_fn_mode(false);
                 w.set_query_running(false);
@@ -6261,7 +6409,7 @@ fn main() -> Result<(), slint::PlatformError> {
         Rc::new(move |w: &MainWindow| {
             let buf = edit_buf.lock().unwrap();
             if let Some(g) = displayed_grid.lock().unwrap().as_ref() {
-                paint_grid_with_edits(w, g, &buf);
+                paint_grid_with_edits(w, 0, g, &buf);
             }
             w.set_pending_count(buf.pending_count() as i32);
         })

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -537,6 +537,7 @@ struct WorkspaceTab {
     // Dual-pane split state for this tab: whether the right pane is open, its
     // editor text, and its last result (single result, no result-tab strip).
     split: bool,
+    split_ratio: f32,
     pane1_query: String,
     pane1_view: Option<StoredResult>,
 }
@@ -557,6 +558,7 @@ impl WorkspaceTab {
             loading: false,
             pinned: true,
             split: false,
+            split_ratio: 0.5,
             pane1_query: String::new(),
             pane1_view: None,
         }
@@ -733,6 +735,16 @@ struct PersistedTab {
     id: String,
     title: String,
     query_text: String,
+    #[serde(default)]
+    split: bool,
+    #[serde(default)]
+    pane1_query: String,
+    #[serde(default = "default_split_ratio")]
+    split_ratio: f32,
+}
+
+fn default_split_ratio() -> f32 {
+    0.5
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Default)]
@@ -757,6 +769,9 @@ fn save_query_tabs(tabs: &[WorkspaceTab], active: Option<&str>) {
             id: t.id.clone(),
             title: t.title.clone(),
             query_text: t.query_text.clone(),
+            split: t.split,
+            pane1_query: t.pane1_query.clone(),
+            split_ratio: t.split_ratio,
         })
         .collect();
     let active = active
@@ -790,6 +805,9 @@ fn load_query_tabs() -> (Vec<WorkspaceTab>, Option<String>) {
             let mut t = WorkspaceTab::sql(p.id, 0);
             t.title = p.title;
             t.query_text = p.query_text;
+            t.split = p.split;
+            t.pane1_query = p.pane1_query;
+            t.split_ratio = p.split_ratio.clamp(0.2, 0.8);
             t
         })
         .collect();
@@ -3056,6 +3074,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     loading: false,
                     pinned: true,
                     split: false,
+                    split_ratio: 0.5,
                     pane1_query: String::new(),
                     pane1_view: None,
                 });
@@ -3757,6 +3776,7 @@ fn main() -> Result<(), slint::PlatformError> {
             tab.loading = w.get_query_running();
             // Dual-pane split rides with SQL tabs (right-pane text only).
             tab.split = tab.kind == "sql" && w.get_split();
+            tab.split_ratio = w.get_split_ratio().clamp(0.2, 0.8);
             tab.pane1_query = if tab.kind == "sql" {
                 panes[1].ed_state.borrow().text()
             } else {
@@ -3819,6 +3839,7 @@ fn main() -> Result<(), slint::PlatformError> {
             // Restore this tab's dual-pane split, right-pane editor text and its
             // last result so the split survives a tab switch intact.
             w.set_split(tab.split);
+            w.set_split_ratio(tab.split_ratio.clamp(0.2, 0.8));
             w.set_active_pane(0);
             load_editor_text(1, &tab.pane1_query);
             if let Some(stored) = tab.pane1_view.clone() {
@@ -5806,6 +5827,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     loading: true,
                     pinned: false,
                     split: false,
+                    split_ratio: 0.5,
                     pane1_query: String::new(),
                     pane1_view: None,
                 };
@@ -6381,6 +6403,7 @@ fn main() -> Result<(), slint::PlatformError> {
             clear_grid(&w, 0);
             // A fresh tab is never split; clear the right pane too.
             w.set_split(false);
+            w.set_split_ratio(0.5);
             w.set_active_pane(0);
             load_editor_text(1, "");
             clear_grid(&w, 1);
@@ -7782,11 +7805,17 @@ mod tests {
                     id: "query:c:1".into(),
                     title: "Query 1".into(),
                     query_text: "select * from users;".into(),
+                    split: true,
+                    pane1_query: "select * from orders;".into(),
+                    split_ratio: 0.35,
                 },
                 PersistedTab {
                     id: "query:c:2".into(),
                     title: "scratch".into(),
                     query_text: String::new(),
+                    split: false,
+                    pane1_query: String::new(),
+                    split_ratio: 0.5,
                 },
             ],
             active: Some("query:c:2".into()),
@@ -7795,7 +7824,21 @@ mod tests {
         let back: PersistedTabs = serde_json::from_str(&json).unwrap();
         assert_eq!(back.tabs.len(), 2);
         assert_eq!(back.tabs[0].query_text, "select * from users;");
+        assert!(back.tabs[0].split);
+        assert_eq!(back.tabs[0].pane1_query, "select * from orders;");
+        assert_eq!(back.tabs[0].split_ratio, 0.35);
         assert_eq!(back.active.as_deref(), Some("query:c:2"));
+    }
+
+    #[test]
+    fn persisted_tabs_accept_pre_split_files() {
+        let payload: PersistedTabs = serde_json::from_str(
+            r#"{"tabs":[{"id":"query:c:1","title":"Query 1","query_text":"select 1"}],"active":null}"#,
+        )
+        .unwrap();
+        assert!(!payload.tabs[0].split);
+        assert!(payload.tabs[0].pane1_query.is_empty());
+        assert_eq!(payload.tabs[0].split_ratio, 0.5);
     }
 
     #[test]

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1958,12 +1958,13 @@ fn main() -> Result<(), slint::PlatformError> {
     let folded_heads = panes[0].folded_heads.clone();
     let sync_editor = {
         let weak = window.as_weak();
-        let ed_state = ed_state.clone();
-        let folded_heads = folded_heads.clone();
-        move || {
+        let panes = panes.clone();
+        move |pane: usize| {
             let Some(w) = weak.upgrade() else {
                 return;
             };
+            let ed_state = panes[pane].ed_state.clone();
+            let folded_heads = panes[pane].folded_heads.clone();
             let ed = ed_state.borrow();
             let sel = ed.selection();
             let lines: Vec<ModelRc<Span>> = ed
@@ -1991,7 +1992,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     ModelRc::from(Rc::new(VecModel::from(spans)))
                 })
                 .collect();
-            w.set_editor_lines(ModelRc::from(Rc::new(VecModel::from(lines))));
+            let lines = ModelRc::from(Rc::new(VecModel::from(lines)));
             // Fold arrows: 1 = open head, 2 = closed head, 0 = plain line.
             // `hidden` blanks out the body lines of a closed statement.
             let n = ed.lines.len();
@@ -2009,11 +2010,25 @@ fn main() -> Result<(), slint::PlatformError> {
                     }
                 }
             }
-            w.set_editor_line_hidden(ModelRc::from(Rc::new(VecModel::from(hidden))));
-            w.set_editor_fold_state(ModelRc::from(Rc::new(VecModel::from(fold_state))));
-            w.set_cursor_line(ed.line as i32);
-            w.set_cursor_col(ed.col as i32);
-            w.set_query_text(SharedString::from(ed.text()));
+            let hidden = ModelRc::from(Rc::new(VecModel::from(hidden)));
+            let fold_state = ModelRc::from(Rc::new(VecModel::from(fold_state)));
+            if pane == 0 {
+                w.set_editor_lines(lines);
+                w.set_editor_line_hidden(hidden);
+                w.set_editor_fold_state(fold_state);
+                w.set_cursor_line(ed.line as i32);
+                w.set_cursor_col(ed.col as i32);
+                // query-text mirrors the focused editor for tab persistence; the
+                // right pane's text lives in panes[1].ed_state (persisted via
+                // p1-query in a later step).
+                w.set_query_text(SharedString::from(ed.text()));
+            } else {
+                w.set_p1_editor_lines(lines);
+                w.set_p1_editor_line_hidden(hidden);
+                w.set_p1_editor_fold_state(fold_state);
+                w.set_p1_cursor_line(ed.line as i32);
+                w.set_p1_cursor_col(ed.col as i32);
+            }
         }
     };
     let load_editor_text: Rc<dyn Fn(&str)> = {
@@ -2021,7 +2036,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let sync_editor = sync_editor.clone();
         Rc::new(move |text: &str| {
             *ed_state.borrow_mut() = editor::EditorState::from_text(text);
-            sync_editor();
+            sync_editor(0);
         })
     };
     load_editor_text("");
@@ -2055,7 +2070,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     }
                 }
             }
-            sync_editor();
+            sync_editor(0);
         });
     }
 
@@ -2118,7 +2133,7 @@ fn main() -> Result<(), slint::PlatformError> {
             }
             w.set_completion_visible(false);
             *completion_ctx.borrow_mut() = (0, Vec::new());
-            sync_editor();
+            sync_editor(0);
         })
     };
     {
@@ -2205,7 +2220,7 @@ fn main() -> Result<(), slint::PlatformError> {
                         _ => {}
                     }
                 }
-                sync_editor();
+                sync_editor(0);
                 return true;
             }
             if meta {
@@ -2258,7 +2273,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     }
                 };
                 if handled {
-                    sync_editor();
+                    sync_editor(0);
                 }
                 return handled;
             }
@@ -2334,7 +2349,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 }
             };
             if handled {
-                sync_editor();
+                sync_editor(0);
                 // Typing/deleting shifts the completion context — recompute.
                 refresh_completion();
             }
@@ -2350,7 +2365,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 w.set_completion_visible(false);
             }
             ed_state.borrow_mut().move_to(line, col, false);
-            sync_editor();
+            sync_editor(0);
         });
     }
     {
@@ -2358,7 +2373,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let sync_editor = sync_editor.clone();
         window.on_editor_drag(move |line, col| {
             ed_state.borrow_mut().move_to(line, col, true);
-            sync_editor();
+            sync_editor(0);
         });
     }
     {
@@ -2366,7 +2381,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let sync_editor = sync_editor.clone();
         window.on_editor_select_word(move |line, col| {
             ed_state.borrow_mut().select_word_at(line, col);
-            sync_editor();
+            sync_editor(0);
         });
     }
 
@@ -2382,7 +2397,7 @@ fn main() -> Result<(), slint::PlatformError> {
             let hits = find_hits.borrow();
             if let Some(&(l, s, e)) = hits.get(idx) {
                 ed_state.borrow_mut().set_selection((l, s), (l, e));
-                sync_editor();
+                sync_editor(0);
                 w.set_find_status(SharedString::from(format!("{} / {}", idx + 1, hits.len())));
             } else if w.get_find_text().is_empty() {
                 w.set_find_status(SharedString::default());

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2031,15 +2031,15 @@ fn main() -> Result<(), slint::PlatformError> {
             }
         }
     };
-    let load_editor_text: Rc<dyn Fn(&str)> = {
-        let ed_state = ed_state.clone();
+    let load_editor_text: Rc<dyn Fn(usize, &str)> = {
+        let panes = panes.clone();
         let sync_editor = sync_editor.clone();
-        Rc::new(move |text: &str| {
-            *ed_state.borrow_mut() = editor::EditorState::from_text(text);
-            sync_editor(0);
+        Rc::new(move |pane: usize, text: &str| {
+            *panes[pane].ed_state.borrow_mut() = editor::EditorState::from_text(text);
+            sync_editor(pane);
         })
     };
-    load_editor_text("");
+    load_editor_text(0, "");
 
     // ----- toggle a statement fold from the gutter arrow -----
     {
@@ -2623,7 +2623,7 @@ fn main() -> Result<(), slint::PlatformError> {
             if active_tab_id.lock().unwrap().is_none() || active_tab_kind(&w) != "sql" {
                 w.invoke_new_tab();
             }
-            load_editor_text(&text);
+            load_editor_text(0, &text);
             w.set_fn_mode(false);
             w.set_active_table(SharedString::default()); // editor mode
             w.set_query_label(SharedString::from(if is_saved {
@@ -2855,7 +2855,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     .and_then(|id| tabs.iter().find(|t| t.id == *id))
                     .map(|t| t.query_text.clone())
                     .unwrap_or_default();
-                load_editor_text(&text);
+                load_editor_text(0, &text);
             }
             if !standby {
                 results.lock().unwrap().clear();
@@ -3353,7 +3353,7 @@ fn main() -> Result<(), slint::PlatformError> {
             when(
                 Rc::new(|w| !w.get_results_meta().is_empty()),
                 Rc::new(move |w| {
-                    load("SELECT * FROM emiten OFFSET 99999");
+                    load(0, "SELECT * FROM emiten OFFSET 99999");
                     w.invoke_run_query();
                 }),
             );
@@ -3375,7 +3375,7 @@ fn main() -> Result<(), slint::PlatformError> {
             when(
                 Rc::new(|w| !w.get_results_meta().is_empty()),
                 Rc::new(move |w| {
-                    load("SELECT 1;\nSELECT * FROM emiten LIMIT 5;");
+                    load(0, "SELECT 1;\nSELECT * FROM emiten LIMIT 5;");
                     w.invoke_run_query();
                 }),
             );
@@ -3453,7 +3453,7 @@ fn main() -> Result<(), slint::PlatformError> {
             set_workspace_tabs(w, &tabs_guard, Some(&tab.id));
             drop(tabs_guard);
 
-            load_editor_text(&tab.query_text);
+            load_editor_text(0, &tab.query_text);
             w.set_fn_mode(tab.kind == "function");
             w.set_query_running(tab.loading);
             w.set_active_table(
@@ -4208,7 +4208,7 @@ fn main() -> Result<(), slint::PlatformError> {
                             .map(|t| t.query_text.clone())
                     })
                     .unwrap_or_default();
-                load_editor_text(&init_text);
+                load_editor_text(0, &init_text);
                 w.set_editor_placeholder(SharedString::from(if mock::mock_mode() {
                     ""
                 } else {
@@ -5224,7 +5224,7 @@ fn main() -> Result<(), slint::PlatformError> {
             if let Some(w) = weak.upgrade() {
                 let text = w.get_query_text().to_string();
                 if !text.trim().is_empty() {
-                    load_editor_text(&sql_format::format(&text));
+                    load_editor_text(0, &sql_format::format(&text));
                 }
             }
         });
@@ -5277,7 +5277,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 &st.mongo_filter,
                 &st.col_filters,
             );
-            load_editor_text(&text);
+            load_editor_text(0, &text);
             run_sql(text);
         })
     };
@@ -5930,7 +5930,7 @@ fn main() -> Result<(), slint::PlatformError> {
             set_workspace_tabs(&w, &tabs, Some(&id));
             save_query_tabs(&tabs, Some(&id));
             drop(tabs);
-            load_editor_text("");
+            load_editor_text(0, "");
             // Fresh query tab starts with no result tabs.
             results.lock().unwrap().clear();
             *active_result.lock().unwrap() = 0;
@@ -6137,7 +6137,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 set_workspace_tabs(&w, &tabs, None);
                 save_query_tabs(&tabs, None);
                 drop(tabs);
-                load_editor_text("");
+                load_editor_text(0, "");
                 let limit = browse.lock().unwrap().limit;
                 *browse.lock().unwrap() = BrowseState {
                     limit,

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1305,6 +1305,51 @@ fn set_p_query_running(w: &MainWindow, pane: usize, b: bool) {
         w.set_p1_query_running(b);
     }
 }
+fn set_p_find_open(w: &MainWindow, pane: usize, b: bool) {
+    if pane == 0 {
+        w.set_find_open(b);
+    } else {
+        w.set_p1_find_open(b);
+    }
+}
+fn get_p_find_open(w: &MainWindow, pane: usize) -> bool {
+    if pane == 0 {
+        w.get_find_open()
+    } else {
+        w.get_p1_find_open()
+    }
+}
+fn set_p_find_text(w: &MainWindow, pane: usize, s: SharedString) {
+    if pane == 0 {
+        w.set_find_text(s);
+    } else {
+        w.set_p1_find_text(s);
+    }
+}
+fn get_p_find_text(w: &MainWindow, pane: usize) -> String {
+    if pane == 0 {
+        w.get_find_text().to_string()
+    } else {
+        w.get_p1_find_text().to_string()
+    }
+}
+fn set_p_find_status(w: &MainWindow, pane: usize, s: SharedString) {
+    if pane == 0 {
+        w.set_find_status(s);
+    } else {
+        w.set_p1_find_status(s);
+    }
+}
+fn get_p_cursor(w: &MainWindow, pane: usize) -> (usize, usize) {
+    if pane == 0 {
+        (w.get_cursor_line() as usize, w.get_cursor_col() as usize)
+    } else {
+        (
+            w.get_p1_cursor_line() as usize,
+            w.get_p1_cursor_col() as usize,
+        )
+    }
+}
 
 /// Return a copy of `g` keeping only rows where some cell matches `needle`
 /// (already lowercased). An empty needle keeps every row.
@@ -2420,6 +2465,17 @@ fn main() -> Result<(), slint::PlatformError> {
                         }
                         return true;
                     }
+                    // ⌘F opens find in the pane the caret is in.
+                    if text.as_str() == "f" {
+                        if let Some(w) = weak.upgrade() {
+                            if pane == 0 {
+                                w.invoke_toggle_find();
+                            } else {
+                                w.invoke_p1_toggle_find();
+                            }
+                        }
+                        return true;
+                    }
                     // Editor-owned cmd combos; everything else bubbles up to the
                     // window shortcut scope (⌘S commit, ⌘R refresh, …).
                     let handled = {
@@ -2623,129 +2679,138 @@ fn main() -> Result<(), slint::PlatformError> {
         });
     }
 
-    // ----- find-in-editor (⌘F) -----
-    let find_hits = panes[0].find_hits.clone();
-    // Select the find hit at `idx` and refresh the "n / total" readout.
+    // ----- find-in-editor (⌘F), per pane -----
+    // Select the find hit at `idx` in `pane` and refresh the "n / total" readout.
     #[allow(clippy::type_complexity)]
-    let show_find: Rc<dyn Fn(&MainWindow, usize)> = {
-        let ed_state = ed_state.clone();
+    let show_find: Rc<dyn Fn(&MainWindow, usize, usize)> = {
+        let panes = panes.clone();
         let sync_editor = sync_editor.clone();
-        let find_hits = find_hits.clone();
-        Rc::new(move |w: &MainWindow, idx: usize| {
-            let hits = find_hits.borrow();
+        Rc::new(move |w: &MainWindow, pane: usize, idx: usize| {
+            let hits = panes[pane].find_hits.borrow();
             if let Some(&(l, s, e)) = hits.get(idx) {
-                ed_state.borrow_mut().set_selection((l, s), (l, e));
-                sync_editor(0);
-                w.set_find_status(SharedString::from(format!("{} / {}", idx + 1, hits.len())));
-            } else if w.get_find_text().is_empty() {
-                w.set_find_status(SharedString::default());
+                panes[pane]
+                    .ed_state
+                    .borrow_mut()
+                    .set_selection((l, s), (l, e));
+                sync_editor(pane);
+                set_p_find_status(
+                    w,
+                    pane,
+                    SharedString::from(format!("{} / {}", idx + 1, hits.len())),
+                );
+            } else if get_p_find_text(w, pane).is_empty() {
+                set_p_find_status(w, pane, SharedString::default());
             } else {
-                w.set_find_status(SharedString::from("no matches"));
+                set_p_find_status(w, pane, SharedString::from("no matches"));
             }
         })
     };
     // Recompute matches for `needle`, jump to the first at/after the cursor.
     #[allow(clippy::type_complexity)]
-    let recompute_find: Rc<dyn Fn(&MainWindow, &str)> = {
-        let ed_state = ed_state.clone();
-        let find_hits = find_hits.clone();
+    let recompute_find: Rc<dyn Fn(&MainWindow, usize, &str)> = {
+        let panes = panes.clone();
         let show_find = show_find.clone();
-        Rc::new(move |w: &MainWindow, needle: &str| {
+        Rc::new(move |w: &MainWindow, pane: usize, needle: &str| {
             let (cur, hits) = {
-                let ed = ed_state.borrow();
+                let ed = panes[pane].ed_state.borrow();
                 ((ed.line, ed.col), editor::find_matches(&ed.lines, needle))
             };
             let idx = hits
                 .iter()
                 .position(|&(l, s, _)| (l, s) >= cur)
                 .unwrap_or(0);
-            *find_hits.borrow_mut() = hits;
-            show_find(w, idx);
+            *panes[pane].find_hits.borrow_mut() = hits;
+            show_find(w, pane, idx);
         })
     };
-    {
-        let weak = window.as_weak();
-        let ed_state = ed_state.clone();
+    // ⌘F: open/close the find bar for a pane; seed from the selection.
+    #[allow(clippy::type_complexity)]
+    let toggle_find: Rc<dyn Fn(&MainWindow, usize)> = {
+        let panes = panes.clone();
         let recompute_find = recompute_find.clone();
-        window.on_toggle_find(move || {
-            let Some(w) = weak.upgrade() else { return };
-            let opening = !w.get_find_open();
-            w.set_find_open(opening);
+        Rc::new(move |w: &MainWindow, pane: usize| {
+            let opening = !get_p_find_open(w, pane);
+            set_p_find_open(w, pane, opening);
             if opening {
-                // Seed with the current single-line selection, if any.
-                if let Some(sel) = ed_state.borrow().selected_text() {
+                if let Some(sel) = panes[pane].ed_state.borrow().selected_text() {
                     if !sel.contains('\n') && !sel.is_empty() {
-                        w.set_find_text(SharedString::from(sel));
+                        set_p_find_text(w, pane, SharedString::from(sel));
                     }
                 }
-                let needle = w.get_find_text().to_string();
-                recompute_find(&w, &needle);
+                let needle = get_p_find_text(w, pane);
+                recompute_find(w, pane, &needle);
             }
-        });
-    }
-    {
-        let weak = window.as_weak();
-        let recompute_find = recompute_find.clone();
-        window.on_find_changed(move |text| {
-            if let Some(w) = weak.upgrade() {
-                recompute_find(&w, &text);
-            }
-        });
-    }
-    {
-        let weak = window.as_weak();
-        let find_hits = find_hits.clone();
+        })
+    };
+    // Step to the next/previous hit in a pane.
+    #[allow(clippy::type_complexity)]
+    let find_step: Rc<dyn Fn(&MainWindow, usize, i32)> = {
+        let panes = panes.clone();
         let show_find = show_find.clone();
-        let step = |w: &MainWindow, find_hits: &RefCell<Vec<(usize, usize, usize)>>, dir: i32| {
-            let n = find_hits.borrow().len();
-            if n == 0 {
-                return None;
-            }
-            // Where are we now? The current caret sits at a hit's end.
-            let cur = (w.get_cursor_line() as usize, w.get_cursor_col() as usize);
-            let hits = find_hits.borrow();
-            let here = hits
-                .iter()
-                .position(|&(l, _, e)| (l, e) == cur)
-                .unwrap_or(0);
-            Some(((here as i32 + dir).rem_euclid(n as i32)) as usize)
-        };
-        let show_find2 = show_find.clone();
-        window.on_find_next(move || {
-            if let Some(w) = weak.upgrade() {
-                if let Some(i) = step(&w, &find_hits, 1) {
-                    show_find2(&w, i);
-                }
-            }
-        });
-    }
-    {
-        let weak = window.as_weak();
-        let find_hits = find_hits.clone();
-        let show_find = show_find.clone();
-        window.on_find_prev(move || {
-            let Some(w) = weak.upgrade() else { return };
-            let n = find_hits.borrow().len();
+        Rc::new(move |w: &MainWindow, pane: usize, dir: i32| {
+            let n = panes[pane].find_hits.borrow().len();
             if n == 0 {
                 return;
             }
-            let cur = (w.get_cursor_line() as usize, w.get_cursor_col() as usize);
-            let here = find_hits
+            let cur = get_p_cursor(w, pane);
+            let here = panes[pane]
+                .find_hits
                 .borrow()
                 .iter()
                 .position(|&(l, _, e)| (l, e) == cur)
                 .unwrap_or(0);
-            let i = ((here as i32 - 1).rem_euclid(n as i32)) as usize;
-            show_find(&w, i);
-        });
-    }
-    {
+            let i = ((here as i32 + dir).rem_euclid(n as i32)) as usize;
+            show_find(w, pane, i);
+        })
+    };
+    for pane in [0usize, 1usize] {
         let weak = window.as_weak();
-        window.on_find_close(move || {
+        let toggle_find = toggle_find.clone();
+        let recompute_find = recompute_find.clone();
+        let find_step = find_step.clone();
+        let toggle = move || {
             if let Some(w) = weak.upgrade() {
-                w.set_find_open(false);
+                toggle_find(&w, pane);
             }
-        });
+        };
+        let weak_c = window.as_weak();
+        let changed = move |text: SharedString| {
+            if let Some(w) = weak_c.upgrade() {
+                recompute_find(&w, pane, &text);
+            }
+        };
+        let weak_n = window.as_weak();
+        let fs_n = find_step.clone();
+        let next = move || {
+            if let Some(w) = weak_n.upgrade() {
+                fs_n(&w, pane, 1);
+            }
+        };
+        let weak_p = window.as_weak();
+        let prev = move || {
+            if let Some(w) = weak_p.upgrade() {
+                find_step(&w, pane, -1);
+            }
+        };
+        let weak_x = window.as_weak();
+        let close = move || {
+            if let Some(w) = weak_x.upgrade() {
+                set_p_find_open(&w, pane, false);
+            }
+        };
+        if pane == 0 {
+            window.on_toggle_find(toggle);
+            window.on_find_changed(changed);
+            window.on_find_next(next);
+            window.on_find_prev(prev);
+            window.on_find_close(close);
+        } else {
+            window.on_p1_toggle_find(toggle);
+            window.on_p1_find_changed(changed);
+            window.on_p1_find_next(next);
+            window.on_p1_find_prev(prev);
+            window.on_p1_find_close(close);
+        }
     }
 
     // ----- saved/recent queries (sidebar Queries tab) -----

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -469,6 +469,55 @@ struct StoredResult {
     latency: String,
 }
 
+/// The live editor + result state a single query pane owns independently. A SQL
+/// tab can show up to two of these side by side (dual-pane split), so everything
+/// that must not be shared between panes — the editor buffer, folds, completion,
+/// find hits, result set, grid view/sort/filter, and streaming — lives here.
+struct PaneRuntime {
+    ed_state: Rc<RefCell<editor::EditorState>>,
+    folded_heads: Rc<RefCell<HashSet<usize>>>,
+    completion_ctx: Rc<RefCell<(usize, Vec<String>)>>,
+    find_hits: Rc<RefCell<Vec<(usize, usize, usize)>>>,
+    edit_buf: Arc<std::sync::Mutex<model::EditBuffer>>,
+    results: Arc<std::sync::Mutex<Vec<StoredResult>>>,
+    active_result: Arc<std::sync::Mutex<usize>>,
+    result_new_tab: Arc<std::sync::atomic::AtomicBool>,
+    displayed_grid: Arc<std::sync::Mutex<Option<model::GridModel>>>,
+    browse: Arc<std::sync::Mutex<BrowseState>>,
+    hidden_cols: Arc<std::sync::Mutex<HashSet<usize>>>,
+    sort_state: Arc<std::sync::Mutex<(i32, bool)>>,
+    col_order: Arc<std::sync::Mutex<Vec<usize>>>,
+    col_filters: Arc<std::sync::Mutex<Vec<String>>>,
+    stream_cancel: Rc<RefCell<Option<Arc<std::sync::atomic::AtomicBool>>>>,
+    stream_timer: Rc<RefCell<Option<slint::Timer>>>,
+}
+
+impl PaneRuntime {
+    fn new() -> Self {
+        Self {
+            ed_state: Rc::new(RefCell::new(editor::EditorState::from_text(""))),
+            folded_heads: Rc::new(RefCell::new(HashSet::new())),
+            completion_ctx: Rc::new(RefCell::new((0, Vec::new()))),
+            find_hits: Rc::new(RefCell::new(Vec::new())),
+            edit_buf: Arc::new(std::sync::Mutex::new(model::EditBuffer::default())),
+            results: Arc::new(std::sync::Mutex::new(Vec::new())),
+            active_result: Arc::new(std::sync::Mutex::new(0)),
+            result_new_tab: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            displayed_grid: Arc::new(std::sync::Mutex::new(None)),
+            browse: Arc::new(std::sync::Mutex::new(BrowseState {
+                limit: 300,
+                ..Default::default()
+            })),
+            hidden_cols: Arc::new(std::sync::Mutex::new(HashSet::new())),
+            sort_state: Arc::new(std::sync::Mutex::new((-1, true))),
+            col_order: Arc::new(std::sync::Mutex::new(Vec::new())),
+            col_filters: Arc::new(std::sync::Mutex::new(Vec::new())),
+            stream_cancel: Rc::new(RefCell::new(None)),
+            stream_timer: Rc::new(RefCell::new(None)),
+        }
+    }
+}
+
 /// Rust-owned document state. Slint only renders this list; an empty list and
 /// `active_tab_id == None` are a real empty workspace, not a synthetic query.
 #[derive(Clone)]
@@ -1818,44 +1867,37 @@ fn main() -> Result<(), slint::PlatformError> {
     // Sidebar tree filter text. Arc<Mutex> so lazy-load tasks can read it.
     let sidebar_filter: Arc<std::sync::Mutex<String>> =
         Arc::new(std::sync::Mutex::new(String::new()));
+    // Up to two independent editor+result panes per SQL tab (dual-pane split).
+    // Only pane 0 is wired for now; the alias bindings below bind the existing
+    // single-pane code to pane 0 so behavior is unchanged.
+    let panes: Rc<[PaneRuntime; 2]> = Rc::new([PaneRuntime::new(), PaneRuntime::new()]);
     // Browse-mode pagination state (open container + page window + pk).
-    let browse: Arc<std::sync::Mutex<BrowseState>> = Arc::new(std::sync::Mutex::new(BrowseState {
-        limit: 300,
-        ..Default::default()
-    }));
+    let browse = panes[0].browse.clone();
     // Streaming ("No limit") state, UI-thread only. `stream_cancel` is the flag
     // the Cancel button (and a new run) flips to stop the producer; `stream_timer`
     // is the UI-thread drain timer that appends batches to the grid.
-    let stream_cancel: Rc<std::cell::RefCell<Option<Arc<std::sync::atomic::AtomicBool>>>> =
-        Rc::new(std::cell::RefCell::new(None));
-    let stream_timer: Rc<std::cell::RefCell<Option<slint::Timer>>> =
-        Rc::new(std::cell::RefCell::new(None));
+    let stream_cancel = panes[0].stream_cancel.clone();
+    let stream_timer = panes[0].stream_timer.clone();
     // Buffered, uncommitted grid edits (⌘S commits, Esc/Discard drops).
-    let edit_buf: Arc<std::sync::Mutex<model::EditBuffer>> =
-        Arc::new(std::sync::Mutex::new(model::EditBuffer::default()));
+    let edit_buf = panes[0].edit_buf.clone();
     // The grid currently on screen (post client-side filter): edit-buffer row
     // indices refer to THIS grid, and its cells carry the pre-edit pk values.
-    let displayed_grid: Arc<std::sync::Mutex<Option<model::GridModel>>> =
-        Arc::new(std::sync::Mutex::new(None));
+    let displayed_grid = panes[0].displayed_grid.clone();
     // Column indices (into the last result) hidden via the Columns popup.
-    let hidden_cols: Arc<std::sync::Mutex<HashSet<usize>>> =
-        Arc::new(std::sync::Mutex::new(HashSet::new()));
+    let hidden_cols = panes[0].hidden_cols.clone();
     // Client-side sort: ORIGINAL column index (-1 = none) + ascending flag.
-    let sort_state: Arc<std::sync::Mutex<(i32, bool)>> =
-        Arc::new(std::sync::Mutex::new((-1, true)));
+    let sort_state = panes[0].sort_state.clone();
     // Display order of columns as ORIGINAL indices (drag-to-reorder). Reset to
     // 0..ncols on every fresh result.
-    let col_order: Arc<std::sync::Mutex<Vec<usize>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let col_order = panes[0].col_order.clone();
     // Per-column filter boxes, raw text indexed by ORIGINAL column. Empty =
     // no filter. Reset to blanks on every fresh result.
-    let col_filters: Arc<std::sync::Mutex<Vec<String>>> =
-        Arc::new(std::sync::Mutex::new(Vec::new()));
+    let col_filters = panes[0].col_filters.clone();
     // Result tabs for the SQL editor: cached results + the active index. ⌘\
     // sets `result_new_tab` so the next run appends instead of replacing.
-    let results: Arc<std::sync::Mutex<Vec<StoredResult>>> =
-        Arc::new(std::sync::Mutex::new(Vec::new()));
-    let active_result: Arc<std::sync::Mutex<usize>> = Arc::new(std::sync::Mutex::new(0));
-    let result_new_tab = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let results = panes[0].results.clone();
+    let active_result = panes[0].active_result.clone();
+    let result_new_tab = panes[0].result_new_tab.clone();
     // One Rust source of truth for document identity and state. The UI index is
     // derived from `active_tab_id`; it is -1 while this Option is None.
     let workspace_tabs: Arc<std::sync::Mutex<Vec<WorkspaceTab>>> =
@@ -1909,12 +1951,11 @@ fn main() -> Result<(), slint::PlatformError> {
     window.set_schema_tree(ModelRc::from(Rc::new(VecModel::<TreeNode>::default())));
 
     // ----- SQL editor: Rust-owned buffer + lexer feeding the span model -----
-    let ed_state: Rc<RefCell<editor::EditorState>> =
-        Rc::new(RefCell::new(editor::EditorState::from_text("")));
+    let ed_state = panes[0].ed_state.clone();
     // Statement head lines the user has folded closed. Kept by line index and
     // re-validated against the current statement spans on every render, so an
     // edit that shifts lines can only unfold — never hide the wrong lines.
-    let folded_heads: Rc<RefCell<HashSet<usize>>> = Rc::new(RefCell::new(HashSet::new()));
+    let folded_heads = panes[0].folded_heads.clone();
     let sync_editor = {
         let weak = window.as_weak();
         let ed_state = ed_state.clone();
@@ -2020,7 +2061,7 @@ fn main() -> Result<(), slint::PlatformError> {
 
     // ----- SQL autocomplete: recompute popup, accept a choice -----
     // completion_ctx = (word char length to replace, candidate labels).
-    let completion_ctx: Rc<RefCell<(usize, Vec<String>)>> = Rc::new(RefCell::new((0, Vec::new())));
+    let completion_ctx = panes[0].completion_ctx.clone();
     let refresh_completion: Rc<dyn Fn()> = {
         let weak = window.as_weak();
         let ed_state = ed_state.clone();
@@ -2330,7 +2371,7 @@ fn main() -> Result<(), slint::PlatformError> {
     }
 
     // ----- find-in-editor (⌘F) -----
-    let find_hits: Rc<RefCell<Vec<(usize, usize, usize)>>> = Rc::new(RefCell::new(Vec::new()));
+    let find_hits = panes[0].find_hits.clone();
     // Select the find hit at `idx` and refresh the "n / total" readout.
     #[allow(clippy::type_complexity)]
     let show_find: Rc<dyn Fn(&MainWindow, usize)> = {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -590,7 +590,8 @@ fn replaceable_table_tab_index(tabs: &[WorkspaceTab], active_id: Option<&str>) -
 }
 
 fn set_workspace_tabs(w: &MainWindow, tabs: &[WorkspaceTab], active_id: Option<&str>) {
-    let items: Vec<TabItem> = tabs
+    let left: Vec<&WorkspaceTab> = tabs.iter().filter(|tab| tab.group == 0).collect();
+    let items: Vec<TabItem> = left
         .iter()
         .map(|tab| TabItem {
             kind: tab.kind.clone().into(),
@@ -600,10 +601,24 @@ fn set_workspace_tabs(w: &MainWindow, tabs: &[WorkspaceTab], active_id: Option<&
         .collect();
     w.set_tabs(ModelRc::from(Rc::new(VecModel::from(items))));
     w.set_active_tab(
-        workspace_tab_index(tabs, active_id)
+        active_id
+            .and_then(|id| left.iter().position(|tab| tab.id == id))
             .map(|i| i as i32)
             .unwrap_or(-1),
     );
+    let right: Vec<&WorkspaceTab> = tabs.iter().filter(|tab| tab.group == 1).collect();
+    let p1_items: Vec<TabItem> = right
+        .iter()
+        .map(|tab| TabItem {
+            kind: tab.kind.clone().into(),
+            title: tab.title.clone().into(),
+            preview: tab.is_preview(),
+        })
+        .collect();
+    w.set_p1_tabs(ModelRc::from(Rc::new(VecModel::from(p1_items))));
+    if right.is_empty() {
+        w.set_p1_active_tab(-1);
+    }
 }
 
 const QUERY_CONSOLE_CAP: usize = 200;
@@ -2169,6 +2184,8 @@ fn main() -> Result<(), slint::PlatformError> {
     let workspace_tabs: Arc<std::sync::Mutex<Vec<WorkspaceTab>>> =
         Arc::new(std::sync::Mutex::new(Vec::new()));
     let active_tab_id: Arc<std::sync::Mutex<Option<String>>> =
+        Arc::new(std::sync::Mutex::new(None));
+    let active_p1_tab_id: Arc<std::sync::Mutex<Option<String>>> =
         Arc::new(std::sync::Mutex::new(None));
     let current_connection_id: Arc<std::sync::Mutex<Option<String>>> =
         Arc::new(std::sync::Mutex::new(None));
@@ -3945,6 +3962,115 @@ fn main() -> Result<(), slint::PlatformError> {
             }
         })
     };
+
+    let restore_p1_tab: Rc<dyn Fn(&MainWindow, usize)> = {
+        let tabs = workspace_tabs.clone();
+        let active_id = active_p1_tab_id.clone();
+        let load_editor_text = load_editor_text.clone();
+        let panes = panes.clone();
+        let last_view = last_view.clone();
+        Rc::new(move |w, group_index| {
+            let tab = {
+                let tabs = tabs.lock().unwrap();
+                tabs.iter()
+                    .filter(|tab| tab.group == 1)
+                    .nth(group_index)
+                    .cloned()
+            };
+            let Some(tab) = tab else {
+                return;
+            };
+            *active_id.lock().unwrap() = Some(tab.id.clone());
+            load_editor_text(1, &tab.query_text);
+            *panes[1].results.lock().unwrap() = tab.results.clone();
+            *panes[1].active_result.lock().unwrap() = tab.active_result;
+            set_result_tabs(w, 1, tab.results.len(), tab.active_result);
+            w.set_p1_active_tab(group_index as i32);
+            w.set_split(true);
+            let selected = if tab.kind == "sql" {
+                tab.results.get(tab.active_result).cloned().or(tab.view)
+            } else {
+                tab.view
+            };
+            if let Some(stored) = selected {
+                present_view(
+                    w,
+                    1,
+                    stored.view,
+                    &stored.meta,
+                    &stored.latency,
+                    &last_view,
+                    &panes[1].displayed_grid,
+                    &panes[1].hidden_cols,
+                    &panes[1].sort_state,
+                    &panes[1].col_order,
+                    &panes[1].col_filters,
+                    &panes[1].edit_buf,
+                    &panes[1].browse,
+                );
+            } else {
+                clear_grid(w, 1);
+                set_p_results_meta(w, 1, SharedString::default());
+                set_p_result_status(w, 1, SharedString::default());
+            }
+        })
+    };
+
+    {
+        let restore_p1_tab = restore_p1_tab.clone();
+        let weak = window.as_weak();
+        window.on_select_p1_tab(move |index| {
+            if let Some(w) = weak.upgrade() {
+                restore_p1_tab(&w, index.max(0) as usize);
+            }
+        });
+    }
+    {
+        let weak = window.as_weak();
+        let tabs = workspace_tabs.clone();
+        let save_active_tab = save_active_tab.clone();
+        let restore_tab = restore_tab.clone();
+        let restore_p1_tab = restore_p1_tab.clone();
+        let active_p1_tab_id = active_p1_tab_id.clone();
+        window.on_move_tab_group(move |index, target| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let target = target.clamp(0, 1) as usize;
+            save_active_tab(&w);
+            let source = if target == 1 { 0 } else { 1 };
+            let moved_id = {
+                let mut tabs = tabs.lock().unwrap();
+                let Some(tab) = tabs
+                    .iter_mut()
+                    .filter(|tab| tab.group == source)
+                    .nth(index.max(0) as usize)
+                else {
+                    return;
+                };
+                tab.group = target;
+                tab.id.clone()
+            };
+            let tabs_guard = tabs.lock().unwrap();
+            set_workspace_tabs(&w, &tabs_guard, Some(&moved_id));
+            drop(tabs_guard);
+            if target == 1 {
+                restore_p1_tab(&w, 0);
+            } else {
+                *active_p1_tab_id.lock().unwrap() = None;
+                let tabs_guard = tabs.lock().unwrap();
+                let index = workspace_tab_index(&tabs_guard, Some(&moved_id));
+                drop(tabs_guard);
+                if let Some(index) = index {
+                    restore_tab(&w, index);
+                }
+                if !tabs.lock().unwrap().iter().any(|tab| tab.group == 1) {
+                    w.set_split(false);
+                    w.set_p1_active_tab(-1);
+                }
+            }
+        });
+    }
 
     // ----- toggle a sidebar group's collapsed state (Feature A) -----
     {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -770,11 +770,17 @@ fn default_split_ratio() -> f32 {
 struct PersistedTabs {
     tabs: Vec<PersistedTab>,
     active: Option<String>,
+    // Active tab in the right group and which group was focused last session.
+    #[serde(default)]
+    active_p1: Option<String>,
+    #[serde(default)]
+    active_group: usize,
 }
 
-/// Persist the SQL tabs (kind == "sql") and the active tab id. Best-effort;
-/// I/O errors are ignored. Skipped in mock mode.
-fn save_query_tabs(tabs: &[WorkspaceTab], active: Option<&str>) {
+/// Persist the SQL tabs (kind == "sql") plus each group's active tab and the
+/// focused group (read from the window). Best-effort; I/O errors are ignored.
+/// Skipped in mock mode.
+fn save_query_tabs(w: &MainWindow, tabs: &[WorkspaceTab], active: Option<&str>) {
     if mock::mock_mode() {
         return;
     }
@@ -797,7 +803,19 @@ fn save_query_tabs(tabs: &[WorkspaceTab], active: Option<&str>) {
     let active = active
         .filter(|id| sql.iter().any(|t| t.id == *id))
         .map(|s| s.to_string());
-    let payload = PersistedTabs { tabs: sql, active };
+    // Right-group active tab: map the p1 strip index back to a tab id.
+    let active_p1 = tabs
+        .iter()
+        .filter(|t| t.group == 1)
+        .nth(w.get_p1_active_tab().max(0) as usize)
+        .filter(|t| t.kind == "sql")
+        .map(|t| t.id.clone());
+    let payload = PersistedTabs {
+        tabs: sql,
+        active,
+        active_p1,
+        active_group: (w.get_active_pane().max(0) as usize).min(1),
+    };
     if let Some(dir) = path.parent() {
         let _ = std::fs::create_dir_all(dir);
     }
@@ -807,16 +825,17 @@ fn save_query_tabs(tabs: &[WorkspaceTab], active: Option<&str>) {
 }
 
 /// Load persisted SQL tabs into fresh `WorkspaceTab`s (empty results/browse).
-/// Returns the tabs and the active tab id (if it still exists).
-fn load_query_tabs() -> (Vec<WorkspaceTab>, Option<String>) {
+/// Returns the tabs, each group's active tab id (if it still exists), and the
+/// focused group.
+fn load_query_tabs() -> (Vec<WorkspaceTab>, Option<String>, Option<String>, usize) {
     let Ok(path) = rdb_connstore::ConnStore::query_tabs_path() else {
-        return (Vec::new(), None);
+        return (Vec::new(), None, None, 0);
     };
     let Some(payload): Option<PersistedTabs> = std::fs::read_to_string(path)
         .ok()
         .and_then(|s| serde_json::from_str(&s).ok())
     else {
-        return (Vec::new(), None);
+        return (Vec::new(), None, None, 0);
     };
     let tabs: Vec<WorkspaceTab> = payload
         .tabs
@@ -832,8 +851,10 @@ fn load_query_tabs() -> (Vec<WorkspaceTab>, Option<String>) {
             t
         })
         .collect();
-    let active = payload.active.filter(|id| tabs.iter().any(|t| t.id == *id));
-    (tabs, active)
+    let exists = |id: &String| tabs.iter().any(|t| t.id == *id);
+    let active = payload.active.filter(|id| exists(id));
+    let active_p1 = payload.active_p1.filter(|id| exists(id));
+    (tabs, active, active_p1, payload.active_group.min(1))
 }
 
 fn page_bounds(page: u64, limit: u64, total: Option<u64>, shown: u64) -> (u64, u64, bool, bool) {
@@ -3792,7 +3813,7 @@ fn main() -> Result<(), slint::PlatformError> {
             }
             // Persist SQL scratch tabs so they survive a restart. Cheap JSON
             // write; fires on switch/new/close/run, which is when text changes.
-            save_query_tabs(&tabs, Some(&id));
+            save_query_tabs(w, &tabs, Some(&id));
         })
     };
 
@@ -3817,7 +3838,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 tab.results = panes[1].results.lock().unwrap().clone();
                 tab.active_result = *panes[1].active_result.lock().unwrap();
             }
-            save_query_tabs(&tabs, None);
+            save_query_tabs(w, &tabs, None);
         })
     };
 
@@ -4010,7 +4031,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 tabs.push(tab);
                 let left = active_tab_id.lock().unwrap().clone();
                 set_workspace_tabs(&w, &tabs, left.as_deref());
-                save_query_tabs(&tabs, left.as_deref());
+                save_query_tabs(&w, &tabs, left.as_deref());
                 tabs.iter().filter(|tab| tab.group == 1).count() - 1
             };
             *active_p1_tab_id.lock().unwrap() = Some(id);
@@ -4656,6 +4677,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let browse = browse.clone();
         let workspace_tabs = workspace_tabs.clone();
         let active_tab_id = active_tab_id.clone();
+        let active_p1_tab_id = active_p1_tab_id.clone();
         let current_connection_id = current_connection_id.clone();
         let query_console = query_console.clone();
         let results = results.clone();
@@ -4689,7 +4711,7 @@ fn main() -> Result<(), slint::PlatformError> {
             // without losing their queries.
             let restore = !tabs_restored.get() || db_ovr.is_some();
             tabs_restored.set(true);
-            let (init_tabs, init_active) = if restore {
+            let (init_tabs, init_active, init_active_p1, init_active_group) = if restore {
                 load_query_tabs()
             } else {
                 // Retain the SQL scratch tabs (with their results) so switching
@@ -4711,10 +4733,17 @@ fn main() -> Result<(), slint::PlatformError> {
                     .clone()
                     .filter(|id| kept.iter().any(|t| t.id == *id))
                     .or_else(|| kept.first().map(|t| t.id.clone()));
-                (kept, active)
+                // Connection switch keeps the in-memory focus + right-group tab.
+                let active_p1 = active_p1_tab_id
+                    .lock()
+                    .unwrap()
+                    .clone()
+                    .filter(|id| kept.iter().any(|t| t.id == *id));
+                (kept, active, active_p1, 0usize)
             };
             *workspace_tabs.lock().unwrap() = init_tabs;
             *active_tab_id.lock().unwrap() = init_active.clone();
+            *active_p1_tab_id.lock().unwrap() = init_active_p1.clone();
             results.lock().unwrap().clear();
             *last_view.lock().unwrap() = None;
             edit_buf.lock().unwrap().clear();
@@ -4793,6 +4822,19 @@ fn main() -> Result<(), slint::PlatformError> {
                 if let Some(idx) = active_idx {
                     restore_tab(&w, idx);
                 }
+                // Restore the right group's active tab, then land on the group
+                // that was focused last session.
+                if let Some(p1_id) = init_active_p1.as_deref() {
+                    let p1_idx = workspace_tabs
+                        .lock()
+                        .unwrap()
+                        .iter()
+                        .position(|t| t.id == p1_id);
+                    if let Some(idx) = p1_idx {
+                        restore_tab(&w, idx);
+                    }
+                }
+                w.set_active_pane(init_active_group as i32);
             }
             // Fresh connection: nothing browsed, nothing expanded.
             *cur_engine.borrow_mut() = Some(sc.engine);
@@ -6967,7 +7009,7 @@ fn main() -> Result<(), slint::PlatformError> {
             tabs.push(WorkspaceTab::sql(id.clone(), number));
             *active_tab_id.lock().unwrap() = Some(id.clone());
             set_workspace_tabs(&w, &tabs, Some(&id));
-            save_query_tabs(&tabs, Some(&id));
+            save_query_tabs(&w, &tabs, Some(&id));
             drop(tabs);
             load_editor_text(0, "");
             // Fresh query tab starts with no result tabs.
@@ -7294,7 +7336,7 @@ fn main() -> Result<(), slint::PlatformError> {
             if tabs.is_empty() {
                 *active_tab_id.lock().unwrap() = None;
                 set_workspace_tabs(&w, &tabs, None);
-                save_query_tabs(&tabs, None);
+                save_query_tabs(&w, &tabs, None);
                 drop(tabs);
                 load_editor_text(0, "");
                 let limit = browse.lock().unwrap().limit;
@@ -7334,6 +7376,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 set_workspace_tabs(&w, &tabs, active.as_deref());
             }
             save_query_tabs(
+                &w,
                 &workspace_tabs.lock().unwrap(),
                 active_tab_id.lock().unwrap().as_deref(),
             );
@@ -7373,7 +7416,7 @@ fn main() -> Result<(), slint::PlatformError> {
             let remaining = tabs.iter().filter(|tab| tab.group == 1).count();
             let active = active_tab_id.lock().unwrap().clone();
             set_workspace_tabs(&w, &tabs, active.as_deref());
-            save_query_tabs(&tabs, active.as_deref());
+            save_query_tabs(&w, &tabs, active.as_deref());
             drop(tabs);
             if remaining == 0 {
                 *active_p1_tab_id.lock().unwrap() = None;
@@ -7422,7 +7465,7 @@ fn main() -> Result<(), slint::PlatformError> {
             }
             let active = active_tab_id.lock().unwrap().clone();
             set_workspace_tabs(&w, &tabs, active.as_deref());
-            save_query_tabs(&tabs, active.as_deref());
+            save_query_tabs(&w, &tabs, active.as_deref());
         });
     }
 
@@ -8587,6 +8630,8 @@ mod tests {
                 },
             ],
             active: Some("query:c:2".into()),
+            active_p1: Some("query:c:1".into()),
+            active_group: 1,
         };
         let json = serde_json::to_string(&payload).unwrap();
         let back: PersistedTabs = serde_json::from_str(&json).unwrap();

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1325,6 +1325,13 @@ fn set_p_query_running(w: &MainWindow, pane: usize, b: bool) {
         w.set_p1_query_running(b);
     }
 }
+fn set_p_streaming(w: &MainWindow, pane: usize, b: bool) {
+    if pane == 0 {
+        w.set_streaming(b);
+    } else {
+        w.set_p1_streaming(b);
+    }
+}
 fn set_p_completion_items(w: &MainWindow, pane: usize, m: ModelRc<PaletteItem>) {
     if pane == 0 {
         w.set_completion_items(m);
@@ -2128,11 +2135,6 @@ fn main() -> Result<(), slint::PlatformError> {
     let panes: Rc<[PaneRuntime; 2]> = Rc::new([PaneRuntime::new(), PaneRuntime::new()]);
     // Browse-mode pagination state (open container + page window + pk).
     let browse = panes[0].browse.clone();
-    // Streaming ("No limit") state, UI-thread only. `stream_cancel` is the flag
-    // the Cancel button (and a new run) flips to stop the producer; `stream_timer`
-    // is the UI-thread drain timer that appends batches to the grid.
-    let stream_cancel = panes[0].stream_cancel.clone();
-    let stream_timer = panes[0].stream_timer.clone();
     // Buffered, uncommitted grid edits (⌘S commits, Esc/Discard drops).
     let edit_buf = panes[0].edit_buf.clone();
     // The grid currently on screen (post client-side filter): edit-buffer row
@@ -5143,29 +5145,30 @@ fn main() -> Result<(), slint::PlatformError> {
     // progressively and stays cancelable instead of freezing. The query text
     // reaches the driver verbatim — clean log, no injected LIMIT. A UI-thread
     // timer drains batches into the grid; an off-thread task does the fetch. -----
-    let run_stream: Rc<dyn Fn(String)> = {
+    let run_stream: Rc<dyn Fn(usize, String)> = {
         let weak = window.as_weak();
         let rt = rt.clone();
         let current = current.clone();
         let query_console = query_console.clone();
         let workspace_tabs = workspace_tabs.clone();
         let active_tab_id = active_tab_id.clone();
-        let results = results.clone();
-        let active_result = active_result.clone();
+        let panes = panes.clone();
         let last_view = last_view.clone();
-        let displayed_grid = displayed_grid.clone();
-        let hidden_cols = hidden_cols.clone();
-        let sort_state = sort_state.clone();
-        let col_order = col_order.clone();
-        let col_filters = col_filters.clone();
-        let edit_buf = edit_buf.clone();
-        let browse = browse.clone();
-        let stream_cancel = stream_cancel.clone();
-        let stream_timer = stream_timer.clone();
-        Rc::new(move |sql: String| {
+        Rc::new(move |pane, sql: String| {
             let Some(w) = weak.upgrade() else {
                 return;
             };
+            let results = panes[pane].results.clone();
+            let active_result = panes[pane].active_result.clone();
+            let displayed_grid = panes[pane].displayed_grid.clone();
+            let hidden_cols = panes[pane].hidden_cols.clone();
+            let sort_state = panes[pane].sort_state.clone();
+            let col_order = panes[pane].col_order.clone();
+            let col_filters = panes[pane].col_filters.clone();
+            let edit_buf = panes[pane].edit_buf.clone();
+            let browse = panes[pane].browse.clone();
+            let stream_cancel = panes[pane].stream_cancel.clone();
+            let stream_timer = panes[pane].stream_timer.clone();
             let Some(target_id) = active_tab_id.lock().unwrap().clone() else {
                 return;
             };
@@ -5186,14 +5189,18 @@ fn main() -> Result<(), slint::PlatformError> {
                 .find(|t| t.id == target_id)
             {
                 tab.loading = true;
-                tab.query_text = sql.clone();
+                if pane == 0 {
+                    tab.query_text = sql.clone();
+                } else {
+                    tab.pane1_query = sql.clone();
+                }
             }
-            w.set_query_running(true);
-            w.set_streaming(true);
+            set_p_query_running(&w, pane, true);
+            set_p_streaming(&w, pane, true);
             w.set_grid_read_only(true);
-            clear_grid(&w, 0);
-            w.set_result_status(SharedString::from("streaming…"));
-            w.set_results_meta(SharedString::default());
+            clear_grid(&w, pane);
+            set_p_result_status(&w, pane, SharedString::from("streaming…"));
+            set_p_results_meta(&w, pane, SharedString::default());
 
             // UI-thread accumulator (for filter/sort/export after the stream) and
             // the live cell model we push each batch into.
@@ -5223,6 +5230,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 let active_tab_id = active_tab_id.clone();
                 let stream_timer_stop = stream_timer.clone();
                 let target_id = target_id.clone();
+                let pane = pane;
                 timer.start(
                     slint::TimerMode::Repeated,
                     std::time::Duration::from_millis(50),
@@ -5240,12 +5248,14 @@ fn main() -> Result<(), slint::PlatformError> {
                                             type_name: c.type_name.clone().into(),
                                         })
                                         .collect();
-                                    w.set_grid_col_count(gcols.len() as i32);
-                                    w.set_grid_columns(ModelRc::from(Rc::new(VecModel::from(
-                                        gcols,
-                                    ))));
+                                    set_p_col_count(&w, pane, gcols.len() as i32);
+                                    set_p_columns(
+                                        &w,
+                                        pane,
+                                        ModelRc::from(Rc::new(VecModel::from(gcols))),
+                                    );
                                     let vm = Rc::new(VecModel::<GridCell>::default());
-                                    w.set_grid_cells(ModelRc::from(vm.clone()));
+                                    set_p_cells(&w, pane, ModelRc::from(vm.clone()));
                                     *cells_model.borrow_mut() = Some(vm);
                                     *accum.borrow_mut() = model::GridModel {
                                         columns: cols,
@@ -5270,10 +5280,14 @@ fn main() -> Result<(), slint::PlatformError> {
                                             }
                                             acc.rows.push(vmrow);
                                         }
-                                        w.set_result_status(SharedString::from(format!(
-                                            "loaded {}",
-                                            acc.rows.len()
-                                        )));
+                                        set_p_result_status(
+                                            &w,
+                                            pane,
+                                            SharedString::from(format!(
+                                                "loaded {}",
+                                                acc.rows.len()
+                                            )),
+                                        );
                                     }
                                 }
                                 Ok(StreamMsg::Done { capped, elapsed_ms }) => {
@@ -5297,18 +5311,22 @@ fn main() -> Result<(), slint::PlatformError> {
                                         .find(|t| t.id == target_id)
                                     {
                                         tab.loading = false;
-                                        tab.view = Some(sr.clone());
-                                        tab.results = vec![sr.clone()];
-                                        tab.active_result = 0;
+                                        if pane == 0 {
+                                            tab.view = Some(sr.clone());
+                                            tab.results = vec![sr.clone()];
+                                            tab.active_result = 0;
+                                        } else {
+                                            tab.pane1_view = Some(sr.clone());
+                                        }
                                     }
                                     if active_tab_id.lock().unwrap().as_deref() == Some(&target_id)
                                     {
                                         *results.lock().unwrap() = vec![sr];
                                         *active_result.lock().unwrap() = 0;
-                                        set_result_tabs(&w, 0, 1, 0);
+                                        set_result_tabs(&w, pane, 1, 0);
                                         present_view(
                                             &w,
-                                            0,
+                                            pane,
                                             view,
                                             &meta,
                                             &latency,
@@ -5321,8 +5339,8 @@ fn main() -> Result<(), slint::PlatformError> {
                                             &edit_buf,
                                             &browse,
                                         );
-                                        w.set_query_running(false);
-                                        w.set_streaming(false);
+                                        set_p_query_running(&w, pane, false);
+                                        set_p_streaming(&w, pane, false);
                                     }
                                     if let Some(t) = stream_timer_stop.borrow().as_ref() {
                                         t.stop();
@@ -5342,11 +5360,11 @@ fn main() -> Result<(), slint::PlatformError> {
                                     {
                                         apply_result(
                                             &w,
-                                            0,
+                                            pane,
                                             model::ResultView::Affected(format!("error: {e}")),
                                         );
-                                        w.set_query_running(false);
-                                        w.set_streaming(false);
+                                        set_p_query_running(&w, pane, false);
+                                        set_p_streaming(&w, pane, false);
                                     }
                                     if let Some(t) = stream_timer_stop.borrow().as_ref() {
                                         t.stop();
@@ -5355,8 +5373,8 @@ fn main() -> Result<(), slint::PlatformError> {
                                 }
                                 Err(std::sync::mpsc::TryRecvError::Empty) => break,
                                 Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                                    w.set_query_running(false);
-                                    w.set_streaming(false);
+                                    set_p_query_running(&w, pane, false);
+                                    set_p_streaming(&w, pane, false);
                                     if let Some(t) = stream_timer_stop.borrow().as_ref() {
                                         t.stop();
                                     }
@@ -5480,7 +5498,7 @@ fn main() -> Result<(), slint::PlatformError> {
                         .map(|e| is_bare_select(e, &text))
                         .unwrap_or(false);
                 if stream {
-                    run_stream(text);
+                    run_stream(0, text);
                 } else {
                     run_sql(0, text);
                 }
@@ -5491,10 +5509,13 @@ fn main() -> Result<(), slint::PlatformError> {
         });
     }
 
-    // ----- run query in the right split pane (buffered; streaming is pane-0) --
+    // ----- run query in the right split pane -----
     {
         let run_sql = run_sql.clone();
+        let run_stream = run_stream.clone();
         let panes = panes.clone();
+        let cur_engine = cur_engine.clone();
+        let weak = window.as_weak();
         let recent_queries = recent_queries.clone();
         let run_p1 = move || {
             let text = {
@@ -5508,7 +5529,22 @@ fn main() -> Result<(), slint::PlatformError> {
                 return;
             }
             record_recent(&recent_queries, &text);
-            run_sql(1, text);
+            let stream = weak
+                .upgrade()
+                .map(|w| {
+                    panes[1].browse.lock().unwrap().limit == 0
+                        && cur_engine
+                            .borrow()
+                            .map(|e| is_bare_select(e, &text))
+                            .unwrap_or(false)
+                        && active_tab_kind(&w) != "table"
+                })
+                .unwrap_or(false);
+            if stream {
+                run_stream(1, text);
+            } else {
+                run_sql(1, text);
+            }
         };
         window.on_p1_run(run_p1.clone());
         window.on_p1_run_selection(run_p1);
@@ -5622,7 +5658,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 }
                 record_recent(&recent_queries, &stmt);
                 if stream {
-                    run_stream(stmt);
+                    run_stream(0, stmt);
                 } else {
                     run_sql(0, stmt);
                 }
@@ -5633,13 +5669,25 @@ fn main() -> Result<(), slint::PlatformError> {
     // ----- Cancel a running stream ("No limit" fetch) -----
     {
         let weak = window.as_weak();
-        let stream_cancel = stream_cancel.clone();
+        let panes = panes.clone();
         window.on_cancel_stream(move || {
-            if let Some(c) = stream_cancel.borrow().as_ref() {
+            if let Some(c) = panes[0].stream_cancel.borrow().as_ref() {
                 c.store(true, std::sync::atomic::Ordering::SeqCst);
             }
             if let Some(w) = weak.upgrade() {
-                w.set_streaming(false);
+                set_p_streaming(&w, 0, false);
+            }
+        });
+    }
+    {
+        let weak = window.as_weak();
+        let panes = panes.clone();
+        window.on_p1_cancel_stream(move || {
+            if let Some(c) = panes[1].stream_cancel.borrow().as_ref() {
+                c.store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+            if let Some(w) = weak.upgrade() {
+                set_p_streaming(&w, 1, false);
             }
         });
     }
@@ -5670,6 +5718,33 @@ fn main() -> Result<(), slint::PlatformError> {
             }
         });
     }
+    {
+        let weak = window.as_weak();
+        let run_sql = run_sql.clone();
+        let panes = panes.clone();
+        window.on_p1_explain_query(move || {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            if !w.get_sql_capable() {
+                return;
+            }
+            let text = panes[1].ed_state.borrow().text();
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                return;
+            }
+            w.set_grid_read_only(true);
+            run_sql(
+                1,
+                if trimmed.to_uppercase().starts_with("EXPLAIN") {
+                    trimmed.to_string()
+                } else {
+                    format!("EXPLAIN {trimmed}")
+                },
+            );
+        });
+    }
 
     // ----- Format button: tidy the editor SQL in place -----
     {
@@ -5681,6 +5756,16 @@ fn main() -> Result<(), slint::PlatformError> {
                 if !text.trim().is_empty() {
                     load_editor_text(0, &sql_format::format(&text));
                 }
+            }
+        });
+    }
+    {
+        let load_editor_text = load_editor_text.clone();
+        let panes = panes.clone();
+        window.on_p1_format_sql(move || {
+            let text = panes[1].ed_state.borrow().text();
+            if !text.trim().is_empty() {
+                load_editor_text(1, &sql_format::format(&text));
             }
         });
     }
@@ -6081,6 +6166,28 @@ fn main() -> Result<(), slint::PlatformError> {
             }
             echo(&w, l);
             run_browse();
+        });
+    }
+
+    {
+        let panes = panes.clone();
+        window.on_p1_set_limit(move |text| {
+            let lower = text.trim().to_ascii_lowercase();
+            let limit = if lower.is_empty()
+                || lower == "0"
+                || lower == "all"
+                || lower == "none"
+                || lower.contains("no limit")
+            {
+                0
+            } else {
+                let digits: String = text.chars().filter(|c| c.is_ascii_digit()).collect();
+                let Some(limit) = digits.parse::<u64>().ok().map(|n| n.clamp(1, 10_000)) else {
+                    return;
+                };
+                limit
+            };
+            panes[1].browse.lock().unwrap().limit = limit;
         });
     }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -5305,6 +5305,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let query_console = query_console.clone();
         let workspace_tabs = workspace_tabs.clone();
         let active_tab_id = active_tab_id.clone();
+        let active_p1_tab_id = active_p1_tab_id.clone();
         let panes = panes.clone();
         let last_view = last_view.clone();
         Rc::new(move |pane, sql: String| {
@@ -5322,7 +5323,12 @@ fn main() -> Result<(), slint::PlatformError> {
             let browse = panes[pane].browse.clone();
             let stream_cancel = panes[pane].stream_cancel.clone();
             let stream_timer = panes[pane].stream_timer.clone();
-            let Some(target_id) = active_tab_id.lock().unwrap().clone() else {
+            let active_id = if pane == 1 {
+                &active_p1_tab_id
+            } else {
+                &active_tab_id
+            };
+            let Some(target_id) = active_id.lock().unwrap().clone() else {
                 return;
             };
             // Stop any in-flight stream, then arm a fresh cancel flag.
@@ -5342,11 +5348,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 .find(|t| t.id == target_id)
             {
                 tab.loading = true;
-                if pane == 0 {
-                    tab.query_text = sql.clone();
-                } else {
-                    tab.pane1_query = sql.clone();
-                }
+                tab.query_text = sql.clone();
             }
             set_p_query_running(&w, pane, true);
             set_p_streaming(&w, pane, true);
@@ -5464,17 +5466,16 @@ fn main() -> Result<(), slint::PlatformError> {
                                         .find(|t| t.id == target_id)
                                     {
                                         tab.loading = false;
-                                        if pane == 0 {
-                                            tab.view = Some(sr.clone());
-                                            tab.results = vec![sr.clone()];
-                                            tab.active_result = 0;
-                                        } else {
-                                            tab.pane1_results = vec![sr.clone()];
-                                            tab.pane1_active_result = 0;
-                                        }
+                                        tab.view = Some(sr.clone());
+                                        tab.results = vec![sr.clone()];
+                                        tab.active_result = 0;
                                     }
-                                    if active_tab_id.lock().unwrap().as_deref() == Some(&target_id)
-                                    {
+                                    let active_id = if pane == 1 {
+                                        &active_p1_tab_id
+                                    } else {
+                                        &active_tab_id
+                                    };
+                                    if active_id.lock().unwrap().as_deref() == Some(&target_id) {
                                         *results.lock().unwrap() = vec![sr];
                                         *active_result.lock().unwrap() = 0;
                                         set_result_tabs(&w, pane, 1, 0);
@@ -5510,8 +5511,12 @@ fn main() -> Result<(), slint::PlatformError> {
                                     {
                                         tab.loading = false;
                                     }
-                                    if active_tab_id.lock().unwrap().as_deref() == Some(&target_id)
-                                    {
+                                    let active_id = if pane == 1 {
+                                        &active_p1_tab_id
+                                    } else {
+                                        &active_tab_id
+                                    };
+                                    if active_id.lock().unwrap().as_deref() == Some(&target_id) {
                                         apply_result(
                                             &w,
                                             pane,
@@ -7151,7 +7156,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let panes = panes.clone();
         let last_view = last_view.clone();
         let workspace_tabs = workspace_tabs.clone();
-        let active_tab_id = active_tab_id.clone();
+        let active_p1_tab_id = active_p1_tab_id.clone();
         window.on_p1_select_result_tab(move |i| {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -7162,14 +7167,14 @@ fn main() -> Result<(), slint::PlatformError> {
                 return;
             };
             *panes[1].active_result.lock().unwrap() = i;
-            if let Some(id) = active_tab_id.lock().unwrap().clone() {
+            if let Some(id) = active_p1_tab_id.lock().unwrap().clone() {
                 if let Some(tab) = workspace_tabs
                     .lock()
                     .unwrap()
                     .iter_mut()
                     .find(|tab| tab.id == id)
                 {
-                    tab.pane1_active_result = i;
+                    tab.active_result = i;
                 }
             }
             w.set_p1_active_result(i as i32);
@@ -7195,7 +7200,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let panes = panes.clone();
         let last_view = last_view.clone();
         let workspace_tabs = workspace_tabs.clone();
-        let active_tab_id = active_tab_id.clone();
+        let active_p1_tab_id = active_p1_tab_id.clone();
         window.on_p1_close_result_tab(move |i| {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -7214,15 +7219,15 @@ fn main() -> Result<(), slint::PlatformError> {
                 (rv.len(), *ar, rv.get(*ar).cloned())
             };
             set_result_tabs(&w, 1, count, active);
-            if let Some(id) = active_tab_id.lock().unwrap().clone() {
+            if let Some(id) = active_p1_tab_id.lock().unwrap().clone() {
                 if let Some(tab) = workspace_tabs
                     .lock()
                     .unwrap()
                     .iter_mut()
                     .find(|tab| tab.id == id)
                 {
-                    tab.pane1_results = panes[1].results.lock().unwrap().clone();
-                    tab.pane1_active_result = active;
+                    tab.results = panes[1].results.lock().unwrap().clone();
+                    tab.active_result = active;
                 }
             }
             match sr {
@@ -7395,6 +7400,7 @@ fn main() -> Result<(), slint::PlatformError> {
         window.on_open_rename(move |idx, title| {
             if let Some(w) = weak.upgrade() {
                 w.set_rename_target(idx);
+                w.set_rename_group(0);
                 w.set_rename_text(title);
                 w.set_rename_modal_open(true);
             }
@@ -7409,9 +7415,16 @@ fn main() -> Result<(), slint::PlatformError> {
                 return;
             };
             let i = w.get_rename_target().max(0) as usize;
+            let group = w.get_rename_group().clamp(0, 1) as usize;
             let name = w.get_rename_text().trim().to_string();
             let mut tabs = workspace_tabs.lock().unwrap();
-            if let Some(tab) = tabs.get_mut(i) {
+            let index = tabs
+                .iter()
+                .enumerate()
+                .filter(|(_, tab)| tab.group == group)
+                .nth(i)
+                .map(|(index, _)| index);
+            if let Some(tab) = index.and_then(|index| tabs.get_mut(index)) {
                 if !name.is_empty() {
                     tab.title = name;
                 }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -541,8 +541,6 @@ struct WorkspaceTab {
     split: bool,
     split_ratio: f32,
     pane1_query: String,
-    pane1_results: Vec<StoredResult>,
-    pane1_active_result: usize,
 }
 
 impl WorkspaceTab {
@@ -564,8 +562,6 @@ impl WorkspaceTab {
             split: false,
             split_ratio: 0.5,
             pane1_query: String::new(),
-            pane1_results: Vec::new(),
-            pane1_active_result: 0,
         }
     }
 
@@ -3085,8 +3081,6 @@ fn main() -> Result<(), slint::PlatformError> {
                     split: false,
                     split_ratio: 0.5,
                     pane1_query: String::new(),
-                    pane1_results: Vec::new(),
-                    pane1_active_result: 0,
                 });
                 *active_tab_id.lock().unwrap() = Some(id.clone());
                 set_workspace_tabs(&w, &tabs, Some(&id));
@@ -5383,6 +5377,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 let results = results.clone();
                 let active_result = active_result.clone();
                 let active_tab_id = active_tab_id.clone();
+                let active_p1_tab_id = active_p1_tab_id.clone();
                 let stream_timer_stop = stream_timer.clone();
                 let target_id = target_id.clone();
                 let pane = pane;
@@ -6372,8 +6367,6 @@ fn main() -> Result<(), slint::PlatformError> {
                     split: false,
                     split_ratio: 0.5,
                     pane1_query: String::new(),
-                    pane1_results: Vec::new(),
-                    pane1_active_result: 0,
                 };
                 let active_id = active_tab_id.lock().unwrap().clone();
                 let mut tabs = workspace_tabs.lock().unwrap();

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -3915,6 +3915,7 @@ fn main() -> Result<(), slint::PlatformError> {
         })
     };
 
+    #[allow(clippy::type_complexity)]
     let restore_p1_tab: Rc<dyn Fn(&MainWindow, usize)> = {
         let tabs = workspace_tabs.clone();
         let active_id = active_p1_tab_id.clone();
@@ -5380,7 +5381,6 @@ fn main() -> Result<(), slint::PlatformError> {
                 let active_p1_tab_id = active_p1_tab_id.clone();
                 let stream_timer_stop = stream_timer.clone();
                 let target_id = target_id.clone();
-                let pane = pane;
                 timer.start(
                     slint::TimerMode::Repeated,
                     std::time::Duration::from_millis(50),

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2179,7 +2179,6 @@ fn main() -> Result<(), slint::PlatformError> {
     // sets `result_new_tab` so the next run appends instead of replacing.
     let results = panes[0].results.clone();
     let active_result = panes[0].active_result.clone();
-    let result_new_tab = panes[0].result_new_tab.clone();
     // One Rust source of truth for document identity and state. The UI index is
     // derived from `active_tab_id`; it is -1 while this Option is None.
     let workspace_tabs: Arc<std::sync::Mutex<Vec<WorkspaceTab>>> =
@@ -5058,6 +5057,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let panes = panes.clone();
         let workspace_tabs = workspace_tabs.clone();
         let active_tab_id = active_tab_id.clone();
+        let active_p1_tab_id = active_p1_tab_id.clone();
         let query_console = query_console.clone();
         Rc::new(move |pane: usize, sql: String| {
             // Per-pane live state; pane 1 (right split) uses its own buffers so a
@@ -5072,7 +5072,12 @@ fn main() -> Result<(), slint::PlatformError> {
             let results = panes[pane].results.clone();
             let active_result = panes[pane].active_result.clone();
             let result_new_tab = panes[pane].result_new_tab.clone();
-            let Some(target_id) = active_tab_id.lock().unwrap().clone() else {
+            let active_id = if pane == 1 {
+                &active_p1_tab_id
+            } else {
+                &active_tab_id
+            };
+            let Some(target_id) = active_id.lock().unwrap().clone() else {
                 return;
             };
             if let Some(tab) = workspace_tabs
@@ -5082,11 +5087,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 .find(|tab| tab.id == target_id)
             {
                 tab.loading = true;
-                if pane == 0 {
-                    tab.query_text = sql.clone();
-                } else {
-                    tab.pane1_query = sql.clone();
-                }
+                tab.query_text = sql.clone();
             }
             let weak2 = weak.clone();
             let current = current.clone();
@@ -5102,6 +5103,7 @@ fn main() -> Result<(), slint::PlatformError> {
             let active_result = active_result.clone();
             let workspace_tabs = workspace_tabs.clone();
             let active_tab_id = active_tab_id.clone();
+            let active_p1_tab_id = active_p1_tab_id.clone();
             let query_console = query_console.clone();
             // ⌘\ set this; consume it so the next plain run replaces again.
             let new_tab = result_new_tab.swap(false, std::sync::atomic::Ordering::SeqCst);
@@ -5184,8 +5186,12 @@ fn main() -> Result<(), slint::PlatformError> {
                 let _ = slint::invoke_from_event_loop(move || {
                     if let Some(w) = weak2.upgrade() {
                         sync_query_console(&w, &query_console);
-                        let is_active =
-                            active_tab_id.lock().unwrap().as_deref() == Some(&target_id);
+                        let active_id = if pane == 1 {
+                            &active_p1_tab_id
+                        } else {
+                            &active_tab_id
+                        };
+                        let is_active = active_id.lock().unwrap().as_deref() == Some(&target_id);
                         if is_active {
                             set_p_query_running(&w, pane, false);
                         }
@@ -5207,46 +5213,28 @@ fn main() -> Result<(), slint::PlatformError> {
                                     meta: meta.clone(),
                                     latency: latency.clone(),
                                 };
-                                let (tab_results, tab_active, is_browse) = if pane == 0 {
-                                    let mut tabs = workspace_tabs.lock().unwrap();
-                                    let Some(tab) = tabs.iter_mut().find(|tab| tab.id == target_id)
-                                    else {
-                                        return;
-                                    };
-                                    tab.loading = false;
-                                    tab.view = Some(sr.clone());
-                                    let is_browse = tab.kind == "table";
-                                    if is_browse {
-                                        tab.results.clear();
-                                        tab.active_result = 0;
-                                    } else if new_tab || tab.results.is_empty() {
-                                        tab.results.push(sr);
-                                        tab.active_result = tab.results.len() - 1;
-                                    } else {
-                                        if tab.active_result >= tab.results.len() {
-                                            tab.active_result = 0;
-                                        }
-                                        tab.results[tab.active_result] = sr;
-                                    }
-                                    (tab.results.clone(), tab.active_result, is_browse)
-                                } else {
-                                    let mut tabs = workspace_tabs.lock().unwrap();
-                                    let Some(tab) = tabs.iter_mut().find(|tab| tab.id == target_id)
-                                    else {
-                                        return;
-                                    };
-                                    tab.loading = false;
-                                    if new_tab || tab.pane1_results.is_empty() {
-                                        tab.pane1_results.push(sr);
-                                        tab.pane1_active_result = tab.pane1_results.len() - 1;
-                                    } else {
-                                        if tab.pane1_active_result >= tab.pane1_results.len() {
-                                            tab.pane1_active_result = 0;
-                                        }
-                                        tab.pane1_results[tab.pane1_active_result] = sr;
-                                    }
-                                    (tab.pane1_results.clone(), tab.pane1_active_result, false)
+                                let mut tabs = workspace_tabs.lock().unwrap();
+                                let Some(tab) = tabs.iter_mut().find(|tab| tab.id == target_id)
+                                else {
+                                    return;
                                 };
+                                tab.loading = false;
+                                tab.view = Some(sr.clone());
+                                let is_browse = tab.kind == "table";
+                                if is_browse {
+                                    tab.results.clear();
+                                    tab.active_result = 0;
+                                } else if new_tab || tab.results.is_empty() {
+                                    tab.results.push(sr);
+                                    tab.active_result = tab.results.len() - 1;
+                                } else {
+                                    if tab.active_result >= tab.results.len() {
+                                        tab.active_result = 0;
+                                    }
+                                    tab.results[tab.active_result] = sr;
+                                }
+                                let tab_results = tab.results.clone();
+                                let tab_active = tab.active_result;
                                 if !is_active {
                                     return;
                                 }
@@ -7008,16 +6996,16 @@ fn main() -> Result<(), slint::PlatformError> {
     // ----- ⌘\: run the current statement into a NEW result tab -----
     {
         let weak = window.as_weak();
-        let ed_state = ed_state.clone();
+        let panes = panes.clone();
         let run_sql = run_sql.clone();
         let recent_queries = recent_queries.clone();
-        let result_new_tab = result_new_tab.clone();
         window.on_run_new_tab(move || {
             let Some(w) = weak.upgrade() else {
                 return;
             };
+            let pane = w.get_active_pane().clamp(0, 1) as usize;
             let stmt = {
-                let ed = ed_state.borrow();
+                let ed = panes[pane].ed_state.borrow();
                 ed.selected_text()
                     .map(|s| s.trim().to_string())
                     .filter(|s| !s.is_empty())
@@ -7027,10 +7015,14 @@ fn main() -> Result<(), slint::PlatformError> {
                 return;
             }
             // Same editor; the run lands in an appended result tab.
-            result_new_tab.store(true, std::sync::atomic::Ordering::SeqCst);
-            w.set_grid_read_only(true);
+            panes[pane]
+                .result_new_tab
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            if pane == 0 {
+                w.set_grid_read_only(true);
+            }
             record_recent(&recent_queries, &stmt);
-            run_sql(0, stmt);
+            run_sql(pane, stmt);
         });
     }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -616,6 +616,7 @@ fn set_workspace_tabs(w: &MainWindow, tabs: &[WorkspaceTab], active_id: Option<&
         })
         .collect();
     w.set_p1_tabs(ModelRc::from(Rc::new(VecModel::from(p1_items))));
+    w.set_split(!right.is_empty());
     if right.is_empty() {
         w.set_p1_active_tab(-1);
     }
@@ -2323,26 +2324,6 @@ fn main() -> Result<(), slint::PlatformError> {
     };
     load_editor_text(0, "");
 
-    // ----- toggle the dual-pane split for the active SQL tab -----
-    {
-        let weak = window.as_weak();
-        let sync_editor = sync_editor.clone();
-        window.on_toggle_split(move || {
-            let Some(w) = weak.upgrade() else {
-                return;
-            };
-            let now = !w.get_split();
-            w.set_split(now);
-            if now {
-                // Render the right pane's (initially empty) editor + result.
-                sync_editor(1);
-                clear_grid(&w, 1);
-                set_p_result_status(&w, 1, SharedString::default());
-                set_p_results_meta(&w, 1, SharedString::default());
-            }
-        });
-    }
-
     // ----- toggle a statement fold from the gutter arrow -----
     {
         let panes = panes.clone();
@@ -3789,7 +3770,6 @@ fn main() -> Result<(), slint::PlatformError> {
         let tabs = workspace_tabs.clone();
         let active_id = active_tab_id.clone();
         let ed_state = ed_state.clone();
-        let panes = panes.clone();
         let browse = browse.clone();
         let results = results.clone();
         let active_result = active_result.clone();
@@ -3804,20 +3784,6 @@ fn main() -> Result<(), slint::PlatformError> {
             };
             tab.query_text = ed_state.borrow().text();
             tab.loading = w.get_query_running();
-            // Dual-pane split rides with SQL tabs (right-pane text only).
-            tab.split = tab.kind == "sql" && w.get_split();
-            tab.split_ratio = w.get_split_ratio().clamp(0.2, 0.8);
-            tab.pane1_query = if tab.kind == "sql" {
-                panes[1].ed_state.borrow().text()
-            } else {
-                String::new()
-            };
-            tab.pane1_results = if tab.kind == "sql" {
-                panes[1].results.lock().unwrap().clone()
-            } else {
-                Vec::new()
-            };
-            tab.pane1_active_result = *panes[1].active_result.lock().unwrap();
             if tab.kind == "table" {
                 tab.browse = browse.lock().unwrap().clone();
             } else if tab.kind == "sql" {
@@ -3837,12 +3803,36 @@ fn main() -> Result<(), slint::PlatformError> {
         })
     };
 
+    // The second workspace group has its own live editor/result runtime. Save
+    // it before selecting, closing, or moving one of its tabs just like the
+    // left group; otherwise a drag could move an older snapshot.
+    let save_p1_tab: Rc<dyn Fn(&MainWindow)> = {
+        let tabs = workspace_tabs.clone();
+        let active_id = active_p1_tab_id.clone();
+        let panes = panes.clone();
+        Rc::new(move |w| {
+            let Some(id) = active_id.lock().unwrap().clone() else {
+                return;
+            };
+            let mut tabs = tabs.lock().unwrap();
+            let Some(tab) = tabs.iter_mut().find(|tab| tab.id == id) else {
+                return;
+            };
+            tab.query_text = panes[1].ed_state.borrow().text();
+            tab.loading = w.get_p1_query_running();
+            if tab.kind == "sql" {
+                tab.results = panes[1].results.lock().unwrap().clone();
+                tab.active_result = *panes[1].active_result.lock().unwrap();
+            }
+            save_query_tabs(&tabs, None);
+        })
+    };
+
     #[allow(clippy::type_complexity)]
     let restore_tab: Rc<dyn Fn(&MainWindow, usize)> = {
         let tabs = workspace_tabs.clone();
         let active_id = active_tab_id.clone();
         let load_editor_text = load_editor_text.clone();
-        let panes = panes.clone();
         let browse = browse.clone();
         let results = results.clone();
         let active_result = active_result.clone();
@@ -3867,38 +3857,7 @@ fn main() -> Result<(), slint::PlatformError> {
             drop(tabs_guard);
 
             load_editor_text(0, &tab.query_text);
-            // Restore this tab's dual-pane split, right-pane editor text and its
-            // last result so the split survives a tab switch intact.
-            w.set_split(tab.split);
-            w.set_split_ratio(tab.split_ratio.clamp(0.2, 0.8));
             w.set_active_pane(0);
-            load_editor_text(1, &tab.pane1_query);
-            if let Some(stored) = tab.pane1_results.get(tab.pane1_active_result).cloned() {
-                *panes[1].results.lock().unwrap() = tab.pane1_results.clone();
-                *panes[1].active_result.lock().unwrap() = tab.pane1_active_result;
-                set_result_tabs(w, 1, tab.pane1_results.len(), tab.pane1_active_result);
-                present_view(
-                    w,
-                    1,
-                    stored.view,
-                    &stored.meta,
-                    &stored.latency,
-                    &last_view,
-                    &panes[1].displayed_grid,
-                    &panes[1].hidden_cols,
-                    &panes[1].sort_state,
-                    &panes[1].col_order,
-                    &panes[1].col_filters,
-                    &panes[1].edit_buf,
-                    &panes[1].browse,
-                );
-            } else {
-                *panes[1].results.lock().unwrap() = Vec::new();
-                set_result_tabs(w, 1, 0, 0);
-                clear_grid(w, 1);
-                set_p_result_status(w, 1, SharedString::default());
-                set_p_results_meta(w, 1, SharedString::default());
-            }
             w.set_fn_mode(tab.kind == "function");
             w.set_query_running(tab.loading);
             w.set_active_table(
@@ -3986,7 +3945,7 @@ fn main() -> Result<(), slint::PlatformError> {
             *panes[1].active_result.lock().unwrap() = tab.active_result;
             set_result_tabs(w, 1, tab.results.len(), tab.active_result);
             w.set_p1_active_tab(group_index as i32);
-            w.set_split(true);
+            w.set_active_pane(1);
             let selected = if tab.kind == "sql" {
                 tab.results.get(tab.active_result).cloned().or(tab.view)
             } else {
@@ -4018,9 +3977,11 @@ fn main() -> Result<(), slint::PlatformError> {
 
     {
         let restore_p1_tab = restore_p1_tab.clone();
+        let save_p1_tab = save_p1_tab.clone();
         let weak = window.as_weak();
         window.on_select_p1_tab(move |index| {
             if let Some(w) = weak.upgrade() {
+                save_p1_tab(&w);
                 restore_p1_tab(&w, index.max(0) as usize);
             }
         });
@@ -4029,18 +3990,24 @@ fn main() -> Result<(), slint::PlatformError> {
         let weak = window.as_weak();
         let tabs = workspace_tabs.clone();
         let save_active_tab = save_active_tab.clone();
+        let save_p1_tab = save_p1_tab.clone();
         let restore_tab = restore_tab.clone();
         let restore_p1_tab = restore_p1_tab.clone();
         let active_p1_tab_id = active_p1_tab_id.clone();
+        let active_tab_id = active_tab_id.clone();
         window.on_move_tab_group(move |index, target| {
             let Some(w) = weak.upgrade() else {
                 return;
             };
             let target = target.clamp(0, 1) as usize;
             save_active_tab(&w);
+            save_p1_tab(&w);
             let source = if target == 1 { 0 } else { 1 };
             let moved_id = {
                 let mut tabs = tabs.lock().unwrap();
+                if source == 0 && tabs.iter().filter(|tab| tab.group == 0).count() == 1 {
+                    return;
+                }
                 let Some(tab) = tabs
                     .iter_mut()
                     .filter(|tab| tab.group == source)
@@ -4051,23 +4018,27 @@ fn main() -> Result<(), slint::PlatformError> {
                 tab.group = target;
                 tab.id.clone()
             };
-            let tabs_guard = tabs.lock().unwrap();
-            set_workspace_tabs(&w, &tabs_guard, Some(&moved_id));
-            drop(tabs_guard);
-            if target == 1 {
-                restore_p1_tab(&w, 0);
+            let (left_index, right_index, left_id) = {
+                let tabs = tabs.lock().unwrap();
+                let left_index = tabs.iter().position(|tab| tab.group == 0);
+                let left_id = left_index.map(|index| tabs[index].id.clone());
+                let right_index = tabs
+                    .iter()
+                    .filter(|tab| tab.group == 1)
+                    .position(|tab| tab.id == moved_id)
+                    .or_else(|| tabs.iter().filter(|tab| tab.group == 1).position(|_| true));
+                set_workspace_tabs(&w, &tabs, left_id.as_deref());
+                (left_index, right_index, left_id)
+            };
+            *active_tab_id.lock().unwrap() = left_id;
+            if let Some(index) = left_index {
+                restore_tab(&w, index);
+            }
+            if let Some(index) = right_index {
+                restore_p1_tab(&w, index);
             } else {
                 *active_p1_tab_id.lock().unwrap() = None;
-                let tabs_guard = tabs.lock().unwrap();
-                let index = workspace_tab_index(&tabs_guard, Some(&moved_id));
-                drop(tabs_guard);
-                if let Some(index) = index {
-                    restore_tab(&w, index);
-                }
-                if !tabs.lock().unwrap().iter().any(|tab| tab.group == 1) {
-                    w.set_split(false);
-                    w.set_p1_active_tab(-1);
-                }
+                w.set_p1_active_tab(-1);
             }
         });
     }
@@ -6495,7 +6466,13 @@ fn main() -> Result<(), slint::PlatformError> {
         window.on_pin_tab(move |index| {
             let active = active_tab_id.lock().unwrap().clone();
             let mut tabs = workspace_tabs.lock().unwrap();
-            if let Some(tab) = tabs.get_mut(index as usize) {
+            let index = tabs
+                .iter()
+                .enumerate()
+                .filter(|(_, tab)| tab.group == 0)
+                .nth(index.max(0) as usize)
+                .map(|(index, _)| index);
+            if let Some(tab) = index.and_then(|index| tabs.get_mut(index)) {
                 tab.pinned = true;
                 if let Some(w) = weak.upgrade() {
                     set_workspace_tabs(&w, &tabs, active.as_deref());
@@ -6981,14 +6958,7 @@ fn main() -> Result<(), slint::PlatformError> {
             *last_view.lock().unwrap() = None;
             set_result_tabs(&w, 0, 0, 0);
             clear_grid(&w, 0);
-            // A fresh tab is never split; clear the right pane too.
-            w.set_split(false);
-            w.set_split_ratio(0.5);
             w.set_active_pane(0);
-            load_editor_text(1, "");
-            clear_grid(&w, 1);
-            set_p_result_status(&w, 1, SharedString::default());
-            set_p_results_meta(&w, 1, SharedString::default());
             w.set_active_table(SharedString::default());
             w.set_fn_mode(false);
             w.set_query_running(false);
@@ -7274,11 +7244,21 @@ fn main() -> Result<(), slint::PlatformError> {
                 return;
             }
             let remove_at = if requested >= 0 {
-                requested as usize
+                tabs.iter()
+                    .enumerate()
+                    .filter(|(_, tab)| tab.group == 0)
+                    .nth(requested as usize)
+                    .map(|(index, _)| index)
+                    .unwrap_or(tabs.len())
             } else {
                 workspace_tab_index(&tabs, active_tab_id.lock().unwrap().as_deref()).unwrap_or(0)
             };
             if remove_at >= tabs.len() {
+                return;
+            }
+            if tabs.iter().filter(|tab| tab.group == 0).count() == 1
+                && tabs.iter().any(|tab| tab.group == 1)
+            {
                 return;
             }
             let removed_active =
@@ -7306,9 +7286,22 @@ fn main() -> Result<(), slint::PlatformError> {
                 return;
             }
             if removed_active {
-                let next = remove_at.min(tabs.len() - 1);
+                let next = tabs
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, tab)| tab.group == 0)
+                    .nth(requested.max(0) as usize)
+                    .map(|(index, _)| index)
+                    .or_else(|| {
+                        tabs.iter()
+                            .enumerate()
+                            .find(|(_, tab)| tab.group == 0)
+                            .map(|(index, _)| index)
+                    });
                 drop(tabs);
-                restore_tab(&w, next);
+                if let Some(next) = next {
+                    restore_tab(&w, next);
+                }
             } else {
                 let active = active_tab_id.lock().unwrap().clone();
                 set_workspace_tabs(&w, &tabs, active.as_deref());
@@ -7317,6 +7310,51 @@ fn main() -> Result<(), slint::PlatformError> {
                 &workspace_tabs.lock().unwrap(),
                 active_tab_id.lock().unwrap().as_deref(),
             );
+        });
+    }
+
+    // Closing a right-group tab uses the right group's filtered index. When its
+    // last tab closes, `set_workspace_tabs` removes the whole second group.
+    {
+        let weak = window.as_weak();
+        let workspace_tabs = workspace_tabs.clone();
+        let active_p1_tab_id = active_p1_tab_id.clone();
+        let save_p1_tab = save_p1_tab.clone();
+        let restore_p1_tab = restore_p1_tab.clone();
+        let active_tab_id = active_tab_id.clone();
+        window.on_close_p1_tab(move |requested| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            if requested < 0 {
+                return;
+            }
+            save_p1_tab(&w);
+            let remove_at = {
+                let tabs = workspace_tabs.lock().unwrap();
+                tabs.iter()
+                    .enumerate()
+                    .filter(|(_, tab)| tab.group == 1)
+                    .nth(requested as usize)
+                    .map(|(index, _)| index)
+            };
+            let Some(remove_at) = remove_at else {
+                return;
+            };
+            let mut tabs = workspace_tabs.lock().unwrap();
+            tabs.remove(remove_at);
+            let remaining = tabs.iter().filter(|tab| tab.group == 1).count();
+            let active = active_tab_id.lock().unwrap().clone();
+            set_workspace_tabs(&w, &tabs, active.as_deref());
+            save_query_tabs(&tabs, active.as_deref());
+            drop(tabs);
+            if remaining == 0 {
+                *active_p1_tab_id.lock().unwrap() = None;
+                load_editor_text(1, "");
+                clear_grid(&w, 1);
+            } else {
+                restore_p1_tab(&w, requested.min((remaining - 1) as i32) as usize);
+            }
         });
     }
 
@@ -7364,14 +7402,24 @@ fn main() -> Result<(), slint::PlatformError> {
             let Some(w) = weak.upgrade() else {
                 return;
             };
-            if idx < 0 || idx as usize >= workspace_tabs.lock().unwrap().len() {
+            if idx < 0 {
                 return;
             }
             if guard_pending(&w) {
                 return;
             }
             save_active_tab(&w);
-            restore_tab(&w, idx as usize);
+            let index = workspace_tabs
+                .lock()
+                .unwrap()
+                .iter()
+                .enumerate()
+                .filter(|(_, tab)| tab.group == 0)
+                .nth(idx as usize)
+                .map(|(index, _)| index);
+            if let Some(index) = index {
+                restore_tab(&w, index);
+            }
         });
     }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1307,6 +1307,48 @@ fn set_p_query_running(w: &MainWindow, pane: usize, b: bool) {
         w.set_p1_query_running(b);
     }
 }
+fn set_p_completion_items(w: &MainWindow, pane: usize, m: ModelRc<PaletteItem>) {
+    if pane == 0 {
+        w.set_completion_items(m);
+    } else {
+        w.set_p1_completion_items(m);
+    }
+}
+fn set_p_completion_visible(w: &MainWindow, pane: usize, b: bool) {
+    if pane == 0 {
+        w.set_completion_visible(b);
+    } else {
+        w.set_p1_completion_visible(b);
+    }
+}
+fn get_p_completion_visible(w: &MainWindow, pane: usize) -> bool {
+    if pane == 0 {
+        w.get_completion_visible()
+    } else {
+        w.get_p1_completion_visible()
+    }
+}
+fn set_p_completion_selected(w: &MainWindow, pane: usize, i: i32) {
+    if pane == 0 {
+        w.set_completion_selected(i);
+    } else {
+        w.set_p1_completion_selected(i);
+    }
+}
+fn get_p_completion_selected(w: &MainWindow, pane: usize) -> i32 {
+    if pane == 0 {
+        w.get_completion_selected()
+    } else {
+        w.get_p1_completion_selected()
+    }
+}
+fn p_completion_count(w: &MainWindow, pane: usize) -> i32 {
+    if pane == 0 {
+        w.get_completion_items().row_count() as i32
+    } else {
+        w.get_p1_completion_items().row_count() as i32
+    }
+}
 fn set_p_find_open(w: &MainWindow, pane: usize, b: bool) {
     if pane == 0 {
         w.set_find_open(b);
@@ -2299,23 +2341,21 @@ fn main() -> Result<(), slint::PlatformError> {
 
     // ----- SQL autocomplete: recompute popup, accept a choice -----
     // completion_ctx = (word char length to replace, candidate labels).
-    let completion_ctx = panes[0].completion_ctx.clone();
-    let refresh_completion: Rc<dyn Fn()> = {
+    let refresh_completion: Rc<dyn Fn(usize)> = {
         let weak = window.as_weak();
-        let ed_state = ed_state.clone();
+        let panes = panes.clone();
         let completion_nodes = completion_nodes.clone();
-        let completion_ctx = completion_ctx.clone();
-        Rc::new(move || {
+        Rc::new(move |pane| {
             let Some(w) = weak.upgrade() else {
                 return;
             };
-            let before = ed_state.borrow().before_cursor_doc();
+            let before = panes[pane].ed_state.borrow().before_cursor_doc();
             let schema = w.get_schema_name().to_string();
             let (word_len, cands) =
                 completion::suggest(&before, &completion_nodes.lock().unwrap(), &schema);
             if cands.is_empty() {
-                w.set_completion_visible(false);
-                *completion_ctx.borrow_mut() = (0, Vec::new());
+                set_p_completion_visible(&w, pane, false);
+                *panes[pane].completion_ctx.borrow_mut() = (0, Vec::new());
                 return;
             }
             let items: Vec<PaletteItem> = cands
@@ -2327,41 +2367,44 @@ fn main() -> Result<(), slint::PlatformError> {
                     local: false,
                 })
                 .collect();
-            *completion_ctx.borrow_mut() =
+            *panes[pane].completion_ctx.borrow_mut() =
                 (word_len, cands.iter().map(|c| c.label.clone()).collect());
-            w.set_completion_items(ModelRc::from(Rc::new(VecModel::from(items))));
-            w.set_completion_selected(0);
-            w.set_completion_visible(true);
+            set_p_completion_items(&w, pane, ModelRc::from(Rc::new(VecModel::from(items))));
+            set_p_completion_selected(&w, pane, 0);
+            set_p_completion_visible(&w, pane, true);
         })
     };
-    let accept_completion: Rc<dyn Fn(i32)> = {
+    let accept_completion: Rc<dyn Fn(usize, i32)> = {
         let weak = window.as_weak();
-        let ed_state = ed_state.clone();
+        let panes = panes.clone();
         let sync_editor = sync_editor.clone();
-        let completion_ctx = completion_ctx.clone();
-        Rc::new(move |idx: i32| {
+        Rc::new(move |pane, idx| {
             let Some(w) = weak.upgrade() else {
                 return;
             };
-            let (word_len, labels) = completion_ctx.borrow().clone();
+            let (word_len, labels) = panes[pane].completion_ctx.borrow().clone();
             let Some(label) = labels.get(idx.max(0) as usize).cloned() else {
                 return;
             };
             {
-                let mut ed = ed_state.borrow_mut();
+                let mut ed = panes[pane].ed_state.borrow_mut();
                 for _ in 0..word_len {
                     ed.backspace();
                 }
                 ed.insert(&label);
             }
-            w.set_completion_visible(false);
-            *completion_ctx.borrow_mut() = (0, Vec::new());
-            sync_editor(0);
+            set_p_completion_visible(&w, pane, false);
+            *panes[pane].completion_ctx.borrow_mut() = (0, Vec::new());
+            sync_editor(pane);
         })
     };
     {
         let accept = accept_completion.clone();
-        window.on_completion_choose(move |i| accept(i));
+        window.on_completion_choose(move |i| accept(0, i));
+    }
+    {
+        let accept = accept_completion.clone();
+        window.on_p1_completion_choose(move |i| accept(1, i));
     }
     {
         let panes = panes.clone();
@@ -2371,32 +2414,45 @@ fn main() -> Result<(), slint::PlatformError> {
         let accept_completion = accept_completion.clone();
         let cur_engine = cur_engine.clone();
         // Shared editor-key handler for both split panes; `pane` selects which
-        // editor buffer it drives. Autocomplete is pane-0 only for now.
+        // editor buffer and completion popup it drives.
         #[allow(clippy::type_complexity)]
         let edit_key: Rc<dyn Fn(usize, SharedString, bool, bool, bool) -> bool> = Rc::new(
             move |pane: usize, text: SharedString, meta: bool, alt: bool, shift: bool| {
                 let ed_state = panes[pane].ed_state.clone();
+                // Typing in a pane focuses it, so global shortcuts (⌘F/⌘⏎) land
+                // on the pane the caret is really in.
+                if let Some(w) = weak.upgrade() {
+                    if w.get_active_pane() != pane as i32 {
+                        w.set_active_pane(pane as i32);
+                    }
+                }
                 // While the autocomplete popup is open it owns nav / accept / close.
                 if let Some(w) = weak.upgrade() {
-                    if pane == 0 && w.get_completion_visible() {
-                        let n = w.get_completion_items().row_count() as i32;
+                    if get_p_completion_visible(&w, pane) {
+                        let n = p_completion_count(&w, pane);
                         match text.as_str() {
                             "\u{f700}" if n > 0 => {
-                                w.set_completion_selected(
-                                    (w.get_completion_selected() - 1 + n) % n,
+                                set_p_completion_selected(
+                                    &w,
+                                    pane,
+                                    (get_p_completion_selected(&w, pane) - 1 + n) % n,
                                 );
                                 return true;
                             }
                             "\u{f701}" if n > 0 => {
-                                w.set_completion_selected((w.get_completion_selected() + 1) % n);
+                                set_p_completion_selected(
+                                    &w,
+                                    pane,
+                                    (get_p_completion_selected(&w, pane) + 1) % n,
+                                );
                                 return true;
                             }
                             "\t" | "\n" | "\r" => {
-                                accept_completion(w.get_completion_selected());
+                                accept_completion(pane, get_p_completion_selected(&w, pane));
                                 return true;
                             }
                             "\u{1b}" => {
-                                w.set_completion_visible(false);
+                                set_p_completion_visible(&w, pane, false);
                                 return true;
                             }
                             _ => {}
@@ -2594,11 +2650,8 @@ fn main() -> Result<(), slint::PlatformError> {
                 };
                 if handled {
                     sync_editor(pane);
-                    // Typing/deleting shifts the completion context — recompute
-                    // (pane-0 only for now).
-                    if pane == 0 {
-                        refresh_completion();
-                    }
+                    // Typing/deleting shifts this pane's completion context.
+                    refresh_completion(pane);
                 }
                 handled
             },
@@ -2621,9 +2674,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 // Clicking a pane focuses it: drives the accent + which pane
                 // global shortcuts fall back to.
                 w.set_active_pane(pane as i32);
-                if pane == 0 {
-                    w.set_completion_visible(false);
-                }
+                set_p_completion_visible(&w, pane, false);
             }
             panes[pane].ed_state.borrow_mut().move_to(line, col, false);
             sync_editor(pane);

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -469,11 +469,16 @@ struct StoredResult {
     latency: String,
 }
 
-/// The live editor + result state a single query pane owns independently. A SQL
-/// tab can show up to two of these side by side (dual-pane split), so everything
-/// that must not be shared between panes — the editor buffer, folds, completion,
-/// find hits, result set, grid view/sort/filter, and streaming — lives here.
-struct PaneRuntime {
+/// The live editor + result state a single **workspace tab group** owns
+/// independently. The workspace has two groups (left = 0, right = 1); each holds
+/// its own editor buffer, folds, completion, find hits, result set, grid
+/// view/sort/filter, and streaming. Held as `groups[0/1]` (the local binding is
+/// still named `panes` in some places for historical reasons).
+///
+/// Naming note: the Slint side still uses `p1-*` property/callback names for
+/// group 1 (e.g. `p1-cells`, `on_p1_run`). Those are compatibility plumbing —
+/// "p1" means "group 1" — kept to avoid renaming ~170 UI bindings in one pass.
+struct GroupRuntime {
     ed_state: Rc<RefCell<editor::EditorState>>,
     folded_heads: Rc<RefCell<HashSet<usize>>>,
     completion_ctx: Rc<RefCell<(usize, Vec<String>)>>,
@@ -492,7 +497,7 @@ struct PaneRuntime {
     stream_timer: Rc<RefCell<Option<slint::Timer>>>,
 }
 
-impl PaneRuntime {
+impl GroupRuntime {
     fn new() -> Self {
         Self {
             ed_state: Rc::new(RefCell::new(editor::EditorState::from_text(""))),
@@ -2250,7 +2255,7 @@ fn main() -> Result<(), slint::PlatformError> {
     // Up to two independent editor+result panes per SQL tab (dual-pane split).
     // Only pane 0 is wired for now; the alias bindings below bind the existing
     // single-pane code to pane 0 so behavior is unchanged.
-    let panes: Rc<[PaneRuntime; 2]> = Rc::new([PaneRuntime::new(), PaneRuntime::new()]);
+    let panes: Rc<[GroupRuntime; 2]> = Rc::new([GroupRuntime::new(), GroupRuntime::new()]);
     // Browse-mode pagination state (open container + page window + pk).
     let browse = panes[0].browse.clone();
     // Buffered, uncommitted grid edits (⌘S commits, Esc/Discard drops).
@@ -2278,7 +2283,7 @@ fn main() -> Result<(), slint::PlatformError> {
         Arc::new(std::sync::Mutex::new(Vec::new()));
     let active_tab_id: Arc<std::sync::Mutex<Option<String>>> =
         Arc::new(std::sync::Mutex::new(None));
-    let active_p1_tab_id: Arc<std::sync::Mutex<Option<String>>> =
+    let active_group1_tab_id: Arc<std::sync::Mutex<Option<String>>> =
         Arc::new(std::sync::Mutex::new(None));
     let current_connection_id: Arc<std::sync::Mutex<Option<String>>> =
         Arc::new(std::sync::Mutex::new(None));
@@ -3898,7 +3903,7 @@ fn main() -> Result<(), slint::PlatformError> {
     // left group; otherwise a drag could move an older snapshot.
     let save_p1_tab: Rc<dyn Fn(&MainWindow)> = {
         let tabs = workspace_tabs.clone();
-        let active_id = active_p1_tab_id.clone();
+        let active_id = active_group1_tab_id.clone();
         let panes = panes.clone();
         Rc::new(move |w| {
             let Some(id) = active_id.lock().unwrap().clone() else {
@@ -3932,7 +3937,7 @@ fn main() -> Result<(), slint::PlatformError> {
     let restore_tab_for_pane: Rc<dyn Fn(&MainWindow, usize)> = {
         let tabs = workspace_tabs.clone();
         let active_tab_id = active_tab_id.clone();
-        let active_p1_tab_id = active_p1_tab_id.clone();
+        let active_group1_tab_id = active_group1_tab_id.clone();
         let load_editor_text = load_editor_text.clone();
         let panes = panes.clone();
         let last_view = last_view.clone();
@@ -3949,7 +3954,7 @@ fn main() -> Result<(), slint::PlatformError> {
             if pane == 0 {
                 *active_tab_id.lock().unwrap() = Some(tab.id.clone());
             } else {
-                *active_p1_tab_id.lock().unwrap() = Some(tab.id.clone());
+                *active_group1_tab_id.lock().unwrap() = Some(tab.id.clone());
             }
             {
                 // Keep the group-0 selection stable when restoring the right group.
@@ -4075,7 +4080,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let weak = window.as_weak();
         let workspace_tabs = workspace_tabs.clone();
         let active_tab_id = active_tab_id.clone();
-        let active_p1_tab_id = active_p1_tab_id.clone();
+        let active_group1_tab_id = active_group1_tab_id.clone();
         let current_connection_id = current_connection_id.clone();
         let query_number = query_number.clone();
         let save_p1_tab = save_p1_tab.clone();
@@ -4106,7 +4111,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 save_query_tabs(&w, &tabs, left.as_deref());
                 tabs.iter().filter(|tab| tab.group == 1).count() - 1
             };
-            *active_p1_tab_id.lock().unwrap() = Some(id);
+            *active_group1_tab_id.lock().unwrap() = Some(id);
             restore_p1_tab(&w, right_index);
         });
     }
@@ -4117,7 +4122,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let save_p1_tab = save_p1_tab.clone();
         let restore_tab = restore_tab.clone();
         let restore_p1_tab = restore_p1_tab.clone();
-        let active_p1_tab_id = active_p1_tab_id.clone();
+        let active_group1_tab_id = active_group1_tab_id.clone();
         let active_tab_id = active_tab_id.clone();
         window.on_move_tab_group(move |index, target| {
             let Some(w) = weak.upgrade() else {
@@ -4161,7 +4166,7 @@ fn main() -> Result<(), slint::PlatformError> {
             if let Some(index) = right_index {
                 restore_p1_tab(&w, index);
             } else {
-                *active_p1_tab_id.lock().unwrap() = None;
+                *active_group1_tab_id.lock().unwrap() = None;
                 w.set_p1_active_tab(-1);
             }
         });
@@ -4749,7 +4754,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let browse = browse.clone();
         let workspace_tabs = workspace_tabs.clone();
         let active_tab_id = active_tab_id.clone();
-        let active_p1_tab_id = active_p1_tab_id.clone();
+        let active_group1_tab_id = active_group1_tab_id.clone();
         let current_connection_id = current_connection_id.clone();
         let query_console = query_console.clone();
         let results = results.clone();
@@ -4806,7 +4811,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     .filter(|id| kept.iter().any(|t| t.id == *id))
                     .or_else(|| kept.first().map(|t| t.id.clone()));
                 // Connection switch keeps the in-memory focus + right-group tab.
-                let active_p1 = active_p1_tab_id
+                let active_p1 = active_group1_tab_id
                     .lock()
                     .unwrap()
                     .clone()
@@ -4815,7 +4820,7 @@ fn main() -> Result<(), slint::PlatformError> {
             };
             *workspace_tabs.lock().unwrap() = init_tabs;
             *active_tab_id.lock().unwrap() = init_active.clone();
-            *active_p1_tab_id.lock().unwrap() = init_active_p1.clone();
+            *active_group1_tab_id.lock().unwrap() = init_active_p1.clone();
             results.lock().unwrap().clear();
             *last_view.lock().unwrap() = None;
             edit_buf.lock().unwrap().clear();
@@ -5164,7 +5169,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let panes = panes.clone();
         let workspace_tabs = workspace_tabs.clone();
         let active_tab_id = active_tab_id.clone();
-        let active_p1_tab_id = active_p1_tab_id.clone();
+        let active_group1_tab_id = active_group1_tab_id.clone();
         let query_console = query_console.clone();
         Rc::new(move |pane: usize, sql: String| {
             // Per-pane live state; pane 1 (right split) uses its own buffers so a
@@ -5180,7 +5185,7 @@ fn main() -> Result<(), slint::PlatformError> {
             let active_result = panes[pane].active_result.clone();
             let result_new_tab = panes[pane].result_new_tab.clone();
             let active_id = if pane == 1 {
-                &active_p1_tab_id
+                &active_group1_tab_id
             } else {
                 &active_tab_id
             };
@@ -5210,7 +5215,7 @@ fn main() -> Result<(), slint::PlatformError> {
             let active_result = active_result.clone();
             let workspace_tabs = workspace_tabs.clone();
             let active_tab_id = active_tab_id.clone();
-            let active_p1_tab_id = active_p1_tab_id.clone();
+            let active_group1_tab_id = active_group1_tab_id.clone();
             let query_console = query_console.clone();
             // ⌘\ set this; consume it so the next plain run replaces again.
             let new_tab = result_new_tab.swap(false, std::sync::atomic::Ordering::SeqCst);
@@ -5294,7 +5299,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     if let Some(w) = weak2.upgrade() {
                         sync_query_console(&w, &query_console);
                         let active_id = if pane == 1 {
-                            &active_p1_tab_id
+                            &active_group1_tab_id
                         } else {
                             &active_tab_id
                         };
@@ -5412,7 +5417,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let query_console = query_console.clone();
         let workspace_tabs = workspace_tabs.clone();
         let active_tab_id = active_tab_id.clone();
-        let active_p1_tab_id = active_p1_tab_id.clone();
+        let active_group1_tab_id = active_group1_tab_id.clone();
         let panes = panes.clone();
         let last_view = last_view.clone();
         Rc::new(move |pane, sql: String| {
@@ -5431,7 +5436,7 @@ fn main() -> Result<(), slint::PlatformError> {
             let stream_cancel = panes[pane].stream_cancel.clone();
             let stream_timer = panes[pane].stream_timer.clone();
             let active_id = if pane == 1 {
-                &active_p1_tab_id
+                &active_group1_tab_id
             } else {
                 &active_tab_id
             };
@@ -5490,7 +5495,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 let results = results.clone();
                 let active_result = active_result.clone();
                 let active_tab_id = active_tab_id.clone();
-                let active_p1_tab_id = active_p1_tab_id.clone();
+                let active_group1_tab_id = active_group1_tab_id.clone();
                 let stream_timer_stop = stream_timer.clone();
                 let target_id = target_id.clone();
                 timer.start(
@@ -5578,7 +5583,7 @@ fn main() -> Result<(), slint::PlatformError> {
                                         tab.active_result = 0;
                                     }
                                     let active_id = if pane == 1 {
-                                        &active_p1_tab_id
+                                        &active_group1_tab_id
                                     } else {
                                         &active_tab_id
                                     };
@@ -5619,7 +5624,7 @@ fn main() -> Result<(), slint::PlatformError> {
                                         tab.loading = false;
                                     }
                                     let active_id = if pane == 1 {
-                                        &active_p1_tab_id
+                                        &active_group1_tab_id
                                     } else {
                                         &active_tab_id
                                     };
@@ -7261,7 +7266,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let panes = panes.clone();
         let last_view = last_view.clone();
         let workspace_tabs = workspace_tabs.clone();
-        let active_p1_tab_id = active_p1_tab_id.clone();
+        let active_group1_tab_id = active_group1_tab_id.clone();
         window.on_p1_select_result_tab(move |i| {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -7272,7 +7277,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 return;
             };
             *panes[1].active_result.lock().unwrap() = i;
-            if let Some(id) = active_p1_tab_id.lock().unwrap().clone() {
+            if let Some(id) = active_group1_tab_id.lock().unwrap().clone() {
                 if let Some(tab) = workspace_tabs
                     .lock()
                     .unwrap()
@@ -7305,7 +7310,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let panes = panes.clone();
         let last_view = last_view.clone();
         let workspace_tabs = workspace_tabs.clone();
-        let active_p1_tab_id = active_p1_tab_id.clone();
+        let active_group1_tab_id = active_group1_tab_id.clone();
         window.on_p1_close_result_tab(move |i| {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -7324,7 +7329,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 (rv.len(), *ar, rv.get(*ar).cloned())
             };
             set_result_tabs(&w, 1, count, active);
-            if let Some(id) = active_p1_tab_id.lock().unwrap().clone() {
+            if let Some(id) = active_group1_tab_id.lock().unwrap().clone() {
                 if let Some(tab) = workspace_tabs
                     .lock()
                     .unwrap()
@@ -7460,7 +7465,7 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let weak = window.as_weak();
         let workspace_tabs = workspace_tabs.clone();
-        let active_p1_tab_id = active_p1_tab_id.clone();
+        let active_group1_tab_id = active_group1_tab_id.clone();
         let save_p1_tab = save_p1_tab.clone();
         let restore_p1_tab = restore_p1_tab.clone();
         let active_tab_id = active_tab_id.clone();
@@ -7491,7 +7496,7 @@ fn main() -> Result<(), slint::PlatformError> {
             save_query_tabs(&w, &tabs, active.as_deref());
             drop(tabs);
             if remaining == 0 {
-                *active_p1_tab_id.lock().unwrap() = None;
+                *active_group1_tab_id.lock().unwrap() = None;
                 load_editor_text(1, "");
                 clear_grid(&w, 1);
             } else {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -534,6 +534,10 @@ struct WorkspaceTab {
     indexes: Vec<(String, String)>,
     loading: bool,
     pinned: bool,
+    // Dual-pane split state for this tab: whether the right pane is open and its
+    // editor text. Results in the right pane are not persisted (re-run to fill).
+    split: bool,
+    pane1_query: String,
 }
 
 impl WorkspaceTab {
@@ -551,6 +555,8 @@ impl WorkspaceTab {
             indexes: Vec::new(),
             loading: false,
             pinned: true,
+            split: false,
+            pane1_query: String::new(),
         }
     }
 
@@ -2942,6 +2948,8 @@ fn main() -> Result<(), slint::PlatformError> {
                     indexes: Vec::new(),
                     loading: false,
                     pinned: true,
+                    split: false,
+                    pane1_query: String::new(),
                 });
                 *active_tab_id.lock().unwrap() = Some(id.clone());
                 set_workspace_tabs(&w, &tabs, Some(&id));
@@ -3624,6 +3632,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let tabs = workspace_tabs.clone();
         let active_id = active_tab_id.clone();
         let ed_state = ed_state.clone();
+        let panes = panes.clone();
         let browse = browse.clone();
         let results = results.clone();
         let active_result = active_result.clone();
@@ -3638,6 +3647,13 @@ fn main() -> Result<(), slint::PlatformError> {
             };
             tab.query_text = ed_state.borrow().text();
             tab.loading = w.get_query_running();
+            // Dual-pane split rides with SQL tabs (right-pane text only).
+            tab.split = tab.kind == "sql" && w.get_split();
+            tab.pane1_query = if tab.kind == "sql" {
+                panes[1].ed_state.borrow().text()
+            } else {
+                String::new()
+            };
             if tab.kind == "table" {
                 tab.browse = browse.lock().unwrap().clone();
             } else if tab.kind == "sql" {
@@ -3686,6 +3702,14 @@ fn main() -> Result<(), slint::PlatformError> {
             drop(tabs_guard);
 
             load_editor_text(0, &tab.query_text);
+            // Restore this tab's dual-pane split + right-pane editor text; the
+            // right pane's result is not persisted, so clear it (re-run fills it).
+            w.set_split(tab.split);
+            w.set_active_pane(0);
+            load_editor_text(1, &tab.pane1_query);
+            clear_grid(w, 1);
+            set_p_result_status(w, 1, SharedString::default());
+            set_p_results_meta(w, 1, SharedString::default());
             w.set_fn_mode(tab.kind == "function");
             w.set_query_running(tab.loading);
             w.set_active_table(
@@ -5644,6 +5668,8 @@ fn main() -> Result<(), slint::PlatformError> {
                     indexes: Vec::new(),
                     loading: true,
                     pinned: false,
+                    split: false,
+                    pane1_query: String::new(),
                 };
                 let active_id = active_tab_id.lock().unwrap().clone();
                 let mut tabs = workspace_tabs.lock().unwrap();

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -6241,6 +6241,13 @@ fn main() -> Result<(), slint::PlatformError> {
             *last_view.lock().unwrap() = None;
             set_result_tabs(&w, 0, 0, 0);
             clear_grid(&w, 0);
+            // A fresh tab is never split; clear the right pane too.
+            w.set_split(false);
+            w.set_active_pane(0);
+            load_editor_text(1, "");
+            clear_grid(&w, 1);
+            set_p_result_status(&w, 1, SharedString::default());
+            set_p_results_meta(&w, 1, SharedString::default());
             w.set_active_table(SharedString::default());
             w.set_fn_mode(false);
             w.set_query_running(false);

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -3822,43 +3822,53 @@ fn main() -> Result<(), slint::PlatformError> {
     };
 
     #[allow(clippy::type_complexity)]
-    let restore_tab: Rc<dyn Fn(&MainWindow, usize)> = {
+    // Restore a tab into a group's runtime (`pane` 0 left / 1 right). `group_index`
+    // is the position within that group's tab strip. Both groups share this path;
+    // per-group runtime state lives in `panes[pane]`. Chrome that is still a shared
+    // MainWindow property (fn-mode/active-table/pagination footer/indexes) is only
+    // painted for the left group until it is mirrored per-group.
+    // Restore the tab at absolute index `abs_index` into ITS group's runtime
+    // (`pane` = tab.group). `group_index` (position within that group's strip) is
+    // derived. Per-group runtime state lives in `panes[pane]`; chrome that is still
+    // a shared MainWindow property is only painted for the left group for now.
+    #[allow(clippy::type_complexity)]
+    let restore_tab_for_pane: Rc<dyn Fn(&MainWindow, usize)> = {
         let tabs = workspace_tabs.clone();
-        let active_id = active_tab_id.clone();
+        let active_tab_id = active_tab_id.clone();
+        let active_p1_tab_id = active_p1_tab_id.clone();
         let load_editor_text = load_editor_text.clone();
-        let browse = browse.clone();
-        let results = results.clone();
-        let active_result = active_result.clone();
+        let panes = panes.clone();
         let last_view = last_view.clone();
-        let displayed_grid = displayed_grid.clone();
-        let hidden_cols = hidden_cols.clone();
-        let sort_state = sort_state.clone();
-        let col_order = col_order.clone();
-        let col_filters = col_filters.clone();
-        let edit_buf = edit_buf.clone();
-        Rc::new(move |w, index| {
-            let tab = {
+        Rc::new(move |w, abs_index| {
+            let (tab, pane, group_index) = {
                 let tabs = tabs.lock().unwrap();
-                let Some(tab) = tabs.get(index).cloned() else {
+                let Some(tab) = tabs.get(abs_index).cloned() else {
                     return;
                 };
-                tab
+                let pane = tab.group.min(1);
+                let group_index = tabs[..abs_index].iter().filter(|t| t.group == pane).count();
+                (tab, pane, group_index)
             };
-            *active_id.lock().unwrap() = Some(tab.id.clone());
-            let tabs_guard = tabs.lock().unwrap();
-            set_workspace_tabs(w, &tabs_guard, Some(&tab.id));
-            drop(tabs_guard);
+            if pane == 0 {
+                *active_tab_id.lock().unwrap() = Some(tab.id.clone());
+            } else {
+                *active_p1_tab_id.lock().unwrap() = Some(tab.id.clone());
+            }
+            {
+                // Keep the group-0 selection stable when restoring the right group.
+                let tabs_guard = tabs.lock().unwrap();
+                let left_active = active_tab_id.lock().unwrap().clone();
+                set_workspace_tabs(w, &tabs_guard, left_active.as_deref());
+            }
+            w.set_active_pane(pane as i32);
+            if pane == 1 {
+                w.set_p1_active_tab(group_index as i32);
+            }
 
-            load_editor_text(0, &tab.query_text);
-            w.set_active_pane(0);
-            w.set_fn_mode(tab.kind == "function");
-            w.set_query_running(tab.loading);
-            w.set_active_table(
-                tab.table
-                    .as_ref()
-                    .map(|table| SharedString::from(table.name.clone()))
-                    .unwrap_or_default(),
-            );
+            load_editor_text(pane, &tab.query_text);
+
+            // Per-group browse state (drives that group's pagination + edits).
+            let browse = &panes[pane].browse;
             if tab.kind == "table" {
                 *browse.lock().unwrap() = tab.browse.clone();
             } else {
@@ -3868,103 +3878,91 @@ fn main() -> Result<(), slint::PlatformError> {
                     ..Default::default()
                 };
             }
-            w.set_total_rows(tab.browse.total.map(|n| n as i32).unwrap_or(-1));
-            w.set_grid_read_only(tab.browse.pk_cols.is_empty());
-            let index_rows: Vec<IndexRow> = tab
-                .indexes
-                .iter()
-                .cloned()
-                .map(|(name, definition)| IndexRow {
-                    name: name.into(),
-                    definition: definition.into(),
-                })
-                .collect();
-            w.set_index_rows(ModelRc::from(Rc::new(VecModel::from(index_rows))));
 
-            *results.lock().unwrap() = tab.results.clone();
-            *active_result.lock().unwrap() = tab.active_result;
-            set_result_tabs(w, 0, tab.results.len(), tab.active_result);
+            // Shared MainWindow chrome — left group only for now.
+            if pane == 0 {
+                w.set_fn_mode(tab.kind == "function");
+                w.set_query_running(tab.loading);
+                w.set_active_table(
+                    tab.table
+                        .as_ref()
+                        .map(|table| SharedString::from(table.name.clone()))
+                        .unwrap_or_default(),
+                );
+                w.set_total_rows(tab.browse.total.map(|n| n as i32).unwrap_or(-1));
+                w.set_grid_read_only(tab.browse.pk_cols.is_empty());
+                let index_rows: Vec<IndexRow> = tab
+                    .indexes
+                    .iter()
+                    .cloned()
+                    .map(|(name, definition)| IndexRow {
+                        name: name.into(),
+                        definition: definition.into(),
+                    })
+                    .collect();
+                w.set_index_rows(ModelRc::from(Rc::new(VecModel::from(index_rows))));
+            }
+
+            *panes[pane].results.lock().unwrap() = tab.results.clone();
+            *panes[pane].active_result.lock().unwrap() = tab.active_result;
+            set_result_tabs(w, pane, tab.results.len(), tab.active_result);
             let selected = if tab.kind == "sql" {
-                tab.results.get(tab.active_result).cloned().or(tab.view)
+                tab.results
+                    .get(tab.active_result)
+                    .cloned()
+                    .or(tab.view.clone())
             } else {
-                tab.view
+                tab.view.clone()
             };
             if let Some(stored) = selected {
                 present_view(
                     w,
-                    0,
+                    pane,
                     stored.view,
                     &stored.meta,
                     &stored.latency,
                     &last_view,
-                    &displayed_grid,
-                    &hidden_cols,
-                    &sort_state,
-                    &col_order,
-                    &col_filters,
-                    &edit_buf,
-                    &browse,
+                    &panes[pane].displayed_grid,
+                    &panes[pane].hidden_cols,
+                    &panes[pane].sort_state,
+                    &panes[pane].col_order,
+                    &panes[pane].col_filters,
+                    &panes[pane].edit_buf,
+                    &panes[pane].browse,
                 );
             } else {
                 *last_view.lock().unwrap() = None;
-                *displayed_grid.lock().unwrap() = None;
-                clear_grid(w, 0);
-                w.set_results_meta(SharedString::default());
-                w.set_result_status(SharedString::default());
+                *panes[pane].displayed_grid.lock().unwrap() = None;
+                clear_grid(w, pane);
+                set_p_results_meta(w, pane, SharedString::default());
+                set_p_result_status(w, pane, SharedString::default());
             }
         })
     };
 
+    // `restore_tab` takes an absolute `workspace_tabs` index (what most callers
+    // already compute). The UI select handlers pass a group-relative strip index
+    // and convert it before calling.
+    #[allow(clippy::type_complexity)]
+    let restore_tab: Rc<dyn Fn(&MainWindow, usize)> = restore_tab_for_pane.clone();
+
+    // `restore_p1_tab` takes a group-1 strip index and maps it to the absolute
+    // index the shared restore expects.
     #[allow(clippy::type_complexity)]
     let restore_p1_tab: Rc<dyn Fn(&MainWindow, usize)> = {
+        let f = restore_tab_for_pane.clone();
         let tabs = workspace_tabs.clone();
-        let active_id = active_p1_tab_id.clone();
-        let load_editor_text = load_editor_text.clone();
-        let panes = panes.clone();
-        let last_view = last_view.clone();
-        Rc::new(move |w, group_index| {
-            let tab = {
+        Rc::new(move |w, group1_index| {
+            let abs = {
                 let tabs = tabs.lock().unwrap();
                 tabs.iter()
-                    .filter(|tab| tab.group == 1)
-                    .nth(group_index)
-                    .cloned()
+                    .enumerate()
+                    .filter(|(_, t)| t.group == 1)
+                    .nth(group1_index)
+                    .map(|(abs, _)| abs)
             };
-            let Some(tab) = tab else {
-                return;
-            };
-            *active_id.lock().unwrap() = Some(tab.id.clone());
-            load_editor_text(1, &tab.query_text);
-            *panes[1].results.lock().unwrap() = tab.results.clone();
-            *panes[1].active_result.lock().unwrap() = tab.active_result;
-            set_result_tabs(w, 1, tab.results.len(), tab.active_result);
-            w.set_p1_active_tab(group_index as i32);
-            w.set_active_pane(1);
-            let selected = if tab.kind == "sql" {
-                tab.results.get(tab.active_result).cloned().or(tab.view)
-            } else {
-                tab.view
-            };
-            if let Some(stored) = selected {
-                present_view(
-                    w,
-                    1,
-                    stored.view,
-                    &stored.meta,
-                    &stored.latency,
-                    &last_view,
-                    &panes[1].displayed_grid,
-                    &panes[1].hidden_cols,
-                    &panes[1].sort_state,
-                    &panes[1].col_order,
-                    &panes[1].col_filters,
-                    &panes[1].edit_buf,
-                    &panes[1].browse,
-                );
-            } else {
-                clear_grid(w, 1);
-                set_p_results_meta(w, 1, SharedString::default());
-                set_p_result_status(w, 1, SharedString::default());
+            if let Some(abs) = abs {
+                f(w, abs);
             }
         })
     };

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1344,8 +1344,7 @@ fn clear_grid(w: &MainWindow, pane: usize) {
 }
 
 // ----- per-pane result setters: pane 0 writes the base properties, pane 1 the
-// p1-* mirror. Only genuinely per-pane props are routed; tab-global props
-// (browse paging, filter chrome, status latency) always use the base setter.
+// p1-* mirror. Workspace groups render independently, including table chrome.
 fn set_p_cells(w: &MainWindow, pane: usize, m: ModelRc<GridCell>) {
     if pane == 0 {
         w.set_grid_cells(m);
@@ -1393,6 +1392,47 @@ fn set_p_status_error(w: &MainWindow, pane: usize, b: bool) {
         w.set_status_error(b);
     } else {
         w.set_p1_status_error(b);
+    }
+}
+fn set_p_active_table(w: &MainWindow, pane: usize, table: SharedString) {
+    if pane == 0 {
+        w.set_active_table(table);
+    } else {
+        w.set_p1_active_table(table);
+    }
+}
+fn set_p_total_rows(w: &MainWindow, pane: usize, total: i32) {
+    if pane == 0 {
+        w.set_total_rows(total);
+    } else {
+        w.set_p1_total_rows(total);
+    }
+}
+fn set_p_page_bounds(w: &MainWindow, pane: usize, start: i32, end: i32, prev: bool, next: bool) {
+    if pane == 0 {
+        w.set_page_start(start);
+        w.set_page_end(end);
+        w.set_can_prev(prev);
+        w.set_can_next(next);
+    } else {
+        w.set_p1_page_start(start);
+        w.set_p1_page_end(end);
+        w.set_p1_can_prev(prev);
+        w.set_p1_can_next(next);
+    }
+}
+fn set_p_read_only(w: &MainWindow, pane: usize, read_only: bool) {
+    if pane == 0 {
+        w.set_grid_read_only(read_only);
+    } else {
+        w.set_p1_grid_read_only(read_only);
+    }
+}
+fn set_p_index_rows(w: &MainWindow, pane: usize, rows: ModelRc<IndexRow>) {
+    if pane == 0 {
+        w.set_index_rows(rows);
+    } else {
+        w.set_p1_index_rows(rows);
     }
 }
 fn set_p_results_meta(w: &MainWindow, pane: usize, s: SharedString) {
@@ -1998,7 +2038,9 @@ fn present_view(
         b.table = st.table.clone();
         b.pk_cols = st.pk_cols.clone();
     }
-    w.set_pending_count(0);
+    if pane == 0 {
+        w.set_pending_count(0);
+    }
     set_p_editing(w, pane, -1, -1);
     set_p_status_error(w, pane, false);
     w.set_status_latency(SharedString::from(latency));
@@ -2028,11 +2070,8 @@ fn present_view(
     let st = browse.lock().unwrap().clone();
     if st.table.is_some() {
         let (start, end, prev, next) = page_bounds(st.page, st.limit, st.total, shown);
-        w.set_page_start(start as i32);
-        w.set_page_end(end as i32);
-        w.set_total_rows(st.total.map(|t| t as i32).unwrap_or(-1));
-        w.set_can_prev(prev);
-        w.set_can_next(next);
+        set_p_page_bounds(w, pane, start as i32, end as i32, prev, next);
+        set_p_total_rows(w, pane, st.total.map(|t| t as i32).unwrap_or(-1));
     }
 }
 
@@ -3981,29 +4020,32 @@ fn main() -> Result<(), slint::PlatformError> {
                 };
             }
 
-            // Shared MainWindow chrome — left group only for now.
+            // Function source is still a left-group view; table chrome is fully
+            // group-local so moving a table keeps its toolbar and footer.
             if pane == 0 {
                 w.set_fn_mode(tab.kind == "function");
                 w.set_query_running(tab.loading);
-                w.set_active_table(
-                    tab.table
-                        .as_ref()
-                        .map(|table| SharedString::from(table.name.clone()))
-                        .unwrap_or_default(),
-                );
-                w.set_total_rows(tab.browse.total.map(|n| n as i32).unwrap_or(-1));
-                w.set_grid_read_only(tab.browse.pk_cols.is_empty());
-                let index_rows: Vec<IndexRow> = tab
-                    .indexes
-                    .iter()
-                    .cloned()
-                    .map(|(name, definition)| IndexRow {
-                        name: name.into(),
-                        definition: definition.into(),
-                    })
-                    .collect();
-                w.set_index_rows(ModelRc::from(Rc::new(VecModel::from(index_rows))));
             }
+            set_p_active_table(
+                w,
+                pane,
+                tab.table
+                    .as_ref()
+                    .map(|table| SharedString::from(table.name.clone()))
+                    .unwrap_or_default(),
+            );
+            set_p_total_rows(w, pane, tab.browse.total.map(|n| n as i32).unwrap_or(-1));
+            set_p_read_only(w, pane, tab.browse.pk_cols.is_empty());
+            let index_rows: Vec<IndexRow> = tab
+                .indexes
+                .iter()
+                .cloned()
+                .map(|(name, definition)| IndexRow {
+                    name: name.into(),
+                    definition: definition.into(),
+                })
+                .collect();
+            set_p_index_rows(w, pane, ModelRc::from(Rc::new(VecModel::from(index_rows))));
 
             *panes[pane].results.lock().unwrap() = tab.results.clone();
             *panes[pane].active_result.lock().unwrap() = tab.active_result;
@@ -6358,16 +6400,17 @@ fn main() -> Result<(), slint::PlatformError> {
         Rc::new(move |w: &MainWindow| guard_pending_edits(w, &edit_buf))
     };
 
-    let run_browse: Rc<dyn Fn()> = {
+    let run_browse: Rc<dyn Fn(usize)> = {
         let cur_engine = cur_engine.clone();
-        let browse = browse.clone();
+        let panes = panes.clone();
         let run_sql = run_sql.clone();
         let load_editor_text = load_editor_text.clone();
-        Rc::new(move || {
+        Rc::new(move |pane| {
             let Some(engine) = *cur_engine.borrow() else {
                 return;
             };
-            let st = browse.lock().unwrap().clone();
+            let pane = pane.min(1);
+            let st = panes[pane].browse.lock().unwrap().clone();
             let Some(table) = st.table else {
                 return;
             };
@@ -6386,12 +6429,15 @@ fn main() -> Result<(), slint::PlatformError> {
                 &st.mongo_filter,
                 &st.col_filters,
             );
-            load_editor_text(0, &text);
-            run_sql(0, text);
+            load_editor_text(pane, &text);
+            run_sql(pane, text);
         })
     };
     // Wire the deferred handle so per-column browse filters can re-query.
-    *browse_trigger.borrow_mut() = Some(run_browse.clone());
+    *browse_trigger.borrow_mut() = Some(Rc::new({
+        let run_browse = run_browse.clone();
+        move || run_browse(0)
+    }));
 
     {
         let weak = window.as_weak();
@@ -6507,7 +6553,7 @@ fn main() -> Result<(), slint::PlatformError> {
             results.lock().unwrap().clear();
             set_result_tabs(&w, 0, 0, 0);
             clear_grid(&w, 0);
-            run_browse();
+            run_browse(0);
 
             // Fetch total + primary key off-thread; footer updates when done.
             let weak2 = weak.clone();
@@ -6640,7 +6686,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 }
                 st.page -= 1;
             }
-            run_browse();
+            run_browse(0);
         });
     }
     {
@@ -6653,7 +6699,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 return;
             }
             browse.lock().unwrap().page += 1;
-            run_browse();
+            run_browse(0);
         });
     }
     {
@@ -6667,7 +6713,7 @@ fn main() -> Result<(), slint::PlatformError> {
             if weak.upgrade().is_some_and(|w| guard_pending(&w)) {
                 return;
             }
-            run_browse();
+            run_browse(0);
             // Re-count in the background so the total tracks external writes.
             let table = browse.lock().unwrap().table.clone();
             let Some(table) = table else { return };
@@ -6725,7 +6771,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     st.page = 0;
                 }
                 echo(&w, 0);
-                run_browse();
+                run_browse(0);
                 return;
             }
             // The manual field may contain dot separators — keep digits only.
@@ -6740,12 +6786,13 @@ fn main() -> Result<(), slint::PlatformError> {
                 st.page = 0;
             }
             echo(&w, l);
-            run_browse();
+            run_browse(0);
         });
     }
 
     {
         let panes = panes.clone();
+        let run_browse = run_browse.clone();
         window.on_p1_set_limit(move |text| {
             let lower = text.trim().to_ascii_lowercase();
             let limit = if lower.is_empty()
@@ -6762,8 +6809,37 @@ fn main() -> Result<(), slint::PlatformError> {
                 };
                 limit
             };
-            panes[1].browse.lock().unwrap().limit = limit;
+            let mut browse = panes[1].browse.lock().unwrap();
+            browse.limit = limit;
+            browse.page = 0;
+            drop(browse);
+            run_browse(1);
         });
+    }
+    {
+        let panes = panes.clone();
+        let run_browse = run_browse.clone();
+        window.on_p1_prev_page(move || {
+            let mut browse = panes[1].browse.lock().unwrap();
+            if browse.page == 0 {
+                return;
+            }
+            browse.page -= 1;
+            drop(browse);
+            run_browse(1);
+        });
+    }
+    {
+        let panes = panes.clone();
+        let run_browse = run_browse.clone();
+        window.on_p1_next_page(move || {
+            panes[1].browse.lock().unwrap().page += 1;
+            run_browse(1);
+        });
+    }
+    {
+        let run_browse = run_browse.clone();
+        window.on_p1_refresh_page(move || run_browse(1));
     }
 
     // ----- Mongo browse filter bar (Compass-style filter document) -----
@@ -6794,7 +6870,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 st.mongo_filter = trimmed.to_string();
                 st.page = 0;
             }
-            run_browse();
+            run_browse(0);
         });
     }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -534,10 +534,11 @@ struct WorkspaceTab {
     indexes: Vec<(String, String)>,
     loading: bool,
     pinned: bool,
-    // Dual-pane split state for this tab: whether the right pane is open and its
-    // editor text. Results in the right pane are not persisted (re-run to fill).
+    // Dual-pane split state for this tab: whether the right pane is open, its
+    // editor text, and its last result (single result, no result-tab strip).
     split: bool,
     pane1_query: String,
+    pane1_view: Option<StoredResult>,
 }
 
 impl WorkspaceTab {
@@ -557,6 +558,7 @@ impl WorkspaceTab {
             pinned: true,
             split: false,
             pane1_query: String::new(),
+            pane1_view: None,
         }
     }
 
@@ -2465,17 +2467,6 @@ fn main() -> Result<(), slint::PlatformError> {
                         }
                         return true;
                     }
-                    // ⌘F opens find in the pane the caret is in.
-                    if text.as_str() == "f" {
-                        if let Some(w) = weak.upgrade() {
-                            if pane == 0 {
-                                w.invoke_toggle_find();
-                            } else {
-                                w.invoke_p1_toggle_find();
-                            }
-                        }
-                        return true;
-                    }
                     // Editor-owned cmd combos; everything else bubbles up to the
                     // window shortcut scope (⌘S commit, ⌘R refresh, …).
                     let handled = {
@@ -3015,6 +3006,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     pinned: true,
                     split: false,
                     pane1_query: String::new(),
+                    pane1_view: None,
                 });
                 *active_tab_id.lock().unwrap() = Some(id.clone());
                 set_workspace_tabs(&w, &tabs, Some(&id));
@@ -3719,6 +3711,11 @@ fn main() -> Result<(), slint::PlatformError> {
             } else {
                 String::new()
             };
+            tab.pane1_view = if tab.kind == "sql" {
+                panes[1].results.lock().unwrap().first().cloned()
+            } else {
+                None
+            };
             if tab.kind == "table" {
                 tab.browse = browse.lock().unwrap().clone();
             } else if tab.kind == "sql" {
@@ -3743,6 +3740,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let tabs = workspace_tabs.clone();
         let active_id = active_tab_id.clone();
         let load_editor_text = load_editor_text.clone();
+        let panes = panes.clone();
         let browse = browse.clone();
         let results = results.clone();
         let active_result = active_result.clone();
@@ -3767,14 +3765,37 @@ fn main() -> Result<(), slint::PlatformError> {
             drop(tabs_guard);
 
             load_editor_text(0, &tab.query_text);
-            // Restore this tab's dual-pane split + right-pane editor text; the
-            // right pane's result is not persisted, so clear it (re-run fills it).
+            // Restore this tab's dual-pane split, right-pane editor text and its
+            // last result so the split survives a tab switch intact.
             w.set_split(tab.split);
             w.set_active_pane(0);
             load_editor_text(1, &tab.pane1_query);
-            clear_grid(w, 1);
-            set_p_result_status(w, 1, SharedString::default());
-            set_p_results_meta(w, 1, SharedString::default());
+            if let Some(stored) = tab.pane1_view.clone() {
+                *panes[1].results.lock().unwrap() = vec![stored.clone()];
+                *panes[1].active_result.lock().unwrap() = 0;
+                set_result_tabs(w, 1, 1, 0);
+                present_view(
+                    w,
+                    1,
+                    stored.view,
+                    &stored.meta,
+                    &stored.latency,
+                    &last_view,
+                    &panes[1].displayed_grid,
+                    &panes[1].hidden_cols,
+                    &panes[1].sort_state,
+                    &panes[1].col_order,
+                    &panes[1].col_filters,
+                    &panes[1].edit_buf,
+                    &panes[1].browse,
+                );
+            } else {
+                *panes[1].results.lock().unwrap() = Vec::new();
+                set_result_tabs(w, 1, 0, 0);
+                clear_grid(w, 1);
+                set_p_result_status(w, 1, SharedString::default());
+                set_p_results_meta(w, 1, SharedString::default());
+            }
             w.set_fn_mode(tab.kind == "function");
             w.set_query_running(tab.loading);
             w.set_active_table(
@@ -5735,6 +5756,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     pinned: false,
                     split: false,
                     pane1_query: String::new(),
+                    pane1_view: None,
                 };
                 let active_id = active_tab_id.lock().unwrap().clone();
                 let mut tabs = workspace_tabs.lock().unwrap();

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -534,6 +534,8 @@ struct WorkspaceTab {
     indexes: Vec<(String, String)>,
     loading: bool,
     pinned: bool,
+    // Workspace group that owns this tab: 0 is left, 1 is right.
+    group: usize,
     // Dual-pane split state for this tab. Right-pane results stay in memory
     // like the left pane; only the SQL text is persisted to disk.
     split: bool,
@@ -558,6 +560,7 @@ impl WorkspaceTab {
             indexes: Vec::new(),
             loading: false,
             pinned: true,
+            group: 0,
             split: false,
             split_ratio: 0.5,
             pane1_query: String::new(),
@@ -738,6 +741,8 @@ struct PersistedTab {
     title: String,
     query_text: String,
     #[serde(default)]
+    group: usize,
+    #[serde(default)]
     split: bool,
     #[serde(default)]
     pane1_query: String,
@@ -771,6 +776,7 @@ fn save_query_tabs(tabs: &[WorkspaceTab], active: Option<&str>) {
             id: t.id.clone(),
             title: t.title.clone(),
             query_text: t.query_text.clone(),
+            group: t.group.min(1),
             split: t.split,
             pane1_query: t.pane1_query.clone(),
             split_ratio: t.split_ratio,
@@ -807,6 +813,7 @@ fn load_query_tabs() -> (Vec<WorkspaceTab>, Option<String>) {
             let mut t = WorkspaceTab::sql(p.id, 0);
             t.title = p.title;
             t.query_text = p.query_text;
+            t.group = p.group.min(1);
             t.split = p.split;
             t.pane1_query = p.pane1_query;
             t.split_ratio = p.split_ratio.clamp(0.2, 0.8);
@@ -3077,6 +3084,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     indexes: Vec::new(),
                     loading: false,
                     pinned: true,
+                    group: 0,
                     split: false,
                     split_ratio: 0.5,
                     pane1_query: String::new(),
@@ -6231,6 +6239,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     indexes: Vec::new(),
                     loading: true,
                     pinned: false,
+                    group: 0,
                     split: false,
                     split_ratio: 0.5,
                     pane1_query: String::new(),
@@ -8353,6 +8362,7 @@ mod tests {
                     id: "query:c:1".into(),
                     title: "Query 1".into(),
                     query_text: "select * from users;".into(),
+                    group: 1,
                     split: true,
                     pane1_query: "select * from orders;".into(),
                     split_ratio: 0.35,
@@ -8361,6 +8371,7 @@ mod tests {
                     id: "query:c:2".into(),
                     title: "scratch".into(),
                     query_text: String::new(),
+                    group: 0,
                     split: false,
                     pane1_query: String::new(),
                     split_ratio: 0.5,
@@ -8372,6 +8383,7 @@ mod tests {
         let back: PersistedTabs = serde_json::from_str(&json).unwrap();
         assert_eq!(back.tabs.len(), 2);
         assert_eq!(back.tabs[0].query_text, "select * from users;");
+        assert_eq!(back.tabs[0].group, 1);
         assert!(back.tabs[0].split);
         assert_eq!(back.tabs[0].pane1_query, "select * from orders;");
         assert_eq!(back.tabs[0].split_ratio, 0.35);
@@ -8385,6 +8397,7 @@ mod tests {
         )
         .unwrap();
         assert!(!payload.tabs[0].split);
+        assert_eq!(payload.tabs[0].group, 0);
         assert!(payload.tabs[0].pane1_query.is_empty());
         assert_eq!(payload.tabs[0].split_ratio, 0.5);
     }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2087,10 +2087,8 @@ fn main() -> Result<(), slint::PlatformError> {
 
     // ----- SQL editor: Rust-owned buffer + lexer feeding the span model -----
     let ed_state = panes[0].ed_state.clone();
-    // Statement head lines the user has folded closed. Kept by line index and
-    // re-validated against the current statement spans on every render, so an
-    // edit that shifts lines can only unfold — never hide the wrong lines.
-    let folded_heads = panes[0].folded_heads.clone();
+    // Statement head lines the user has folded closed live per-pane in
+    // `panes[*].folded_heads`; sync_editor + the fold toggle read them by pane.
     let sync_editor = {
         let weak = window.as_weak();
         let panes = panes.clone();
@@ -2199,10 +2197,11 @@ fn main() -> Result<(), slint::PlatformError> {
 
     // ----- toggle a statement fold from the gutter arrow -----
     {
-        let ed_state = ed_state.clone();
-        let folded_heads = folded_heads.clone();
+        let panes = panes.clone();
         let sync_editor = sync_editor.clone();
-        window.on_toggle_fold(move |line| {
+        let fold: Rc<dyn Fn(usize, i32)> = Rc::new(move |pane: usize, line: i32| {
+            let ed_state = panes[pane].ed_state.clone();
+            let folded_heads = panes[pane].folded_heads.clone();
             let head = line.max(0) as usize;
             let now_closed = {
                 let mut f = folded_heads.borrow_mut();
@@ -2226,7 +2225,15 @@ fn main() -> Result<(), slint::PlatformError> {
                     }
                 }
             }
-            sync_editor(0);
+            sync_editor(pane);
+        });
+        window.on_toggle_fold({
+            let fold = fold.clone();
+            move |line| fold(0, line)
+        });
+        window.on_p1_toggle_fold({
+            let fold = fold.clone();
+            move |line| fold(1, line)
         });
     }
 
@@ -2297,247 +2304,293 @@ fn main() -> Result<(), slint::PlatformError> {
         window.on_completion_choose(move |i| accept(i));
     }
     {
-        let ed_state = ed_state.clone();
+        let panes = panes.clone();
         let sync_editor = sync_editor.clone();
         let weak = window.as_weak();
         let refresh_completion = refresh_completion.clone();
         let accept_completion = accept_completion.clone();
         let cur_engine = cur_engine.clone();
-        window.on_editor_key(move |text, meta, alt, shift| {
-            // While the autocomplete popup is open it owns nav / accept / close.
-            if let Some(w) = weak.upgrade() {
-                if w.get_completion_visible() {
-                    let n = w.get_completion_items().row_count() as i32;
-                    match text.as_str() {
-                        "\u{f700}" if n > 0 => {
-                            w.set_completion_selected((w.get_completion_selected() - 1 + n) % n);
-                            return true;
+        // Shared editor-key handler for both split panes; `pane` selects which
+        // editor buffer it drives. Autocomplete is pane-0 only for now.
+        #[allow(clippy::type_complexity)]
+        let edit_key: Rc<dyn Fn(usize, SharedString, bool, bool, bool) -> bool> = Rc::new(
+            move |pane: usize, text: SharedString, meta: bool, alt: bool, shift: bool| {
+                let ed_state = panes[pane].ed_state.clone();
+                // While the autocomplete popup is open it owns nav / accept / close.
+                if let Some(w) = weak.upgrade() {
+                    if pane == 0 && w.get_completion_visible() {
+                        let n = w.get_completion_items().row_count() as i32;
+                        match text.as_str() {
+                            "\u{f700}" if n > 0 => {
+                                w.set_completion_selected(
+                                    (w.get_completion_selected() - 1 + n) % n,
+                                );
+                                return true;
+                            }
+                            "\u{f701}" if n > 0 => {
+                                w.set_completion_selected((w.get_completion_selected() + 1) % n);
+                                return true;
+                            }
+                            "\t" | "\n" | "\r" => {
+                                accept_completion(w.get_completion_selected());
+                                return true;
+                            }
+                            "\u{1b}" => {
+                                w.set_completion_visible(false);
+                                return true;
+                            }
+                            _ => {}
                         }
-                        "\u{f701}" if n > 0 => {
-                            w.set_completion_selected((w.get_completion_selected() + 1) % n);
-                            return true;
-                        }
-                        "\t" | "\n" | "\r" => {
-                            accept_completion(w.get_completion_selected());
-                            return true;
-                        }
-                        "\u{1b}" => {
-                            w.set_completion_visible(false);
-                            return true;
-                        }
-                        _ => {}
                     }
                 }
-            }
-            // Cursor motion first: arrows / home / end, with macOS ⌘ (line &
-            // document) and ⌥ (word) semantics. shift extends the selection.
-            if matches!(
-                text.as_str(),
-                "\u{f700}" | "\u{f701}" | "\u{f702}" | "\u{f703}" | "\u{f729}" | "\u{f72b}"
-            ) {
-                {
-                    let mut ed = ed_state.borrow_mut();
-                    ed.set_selecting(shift);
-                    match text.as_str() {
-                        "\u{f702}" => {
-                            if alt {
-                                ed.move_word(-1)
-                            } else if meta {
-                                ed.home()
-                            } else {
-                                ed.move_cursor(0, -1)
+                // Cursor motion first: arrows / home / end, with macOS ⌘ (line &
+                // document) and ⌥ (word) semantics. shift extends the selection.
+                if matches!(
+                    text.as_str(),
+                    "\u{f700}" | "\u{f701}" | "\u{f702}" | "\u{f703}" | "\u{f729}" | "\u{f72b}"
+                ) {
+                    {
+                        let mut ed = ed_state.borrow_mut();
+                        ed.set_selecting(shift);
+                        match text.as_str() {
+                            "\u{f702}" => {
+                                if alt {
+                                    ed.move_word(-1)
+                                } else if meta {
+                                    ed.home()
+                                } else {
+                                    ed.move_cursor(0, -1)
+                                }
                             }
-                        }
-                        "\u{f703}" => {
-                            if alt {
-                                ed.move_word(1)
-                            } else if meta {
-                                ed.end()
-                            } else {
-                                ed.move_cursor(0, 1)
+                            "\u{f703}" => {
+                                if alt {
+                                    ed.move_word(1)
+                                } else if meta {
+                                    ed.end()
+                                } else {
+                                    ed.move_cursor(0, 1)
+                                }
                             }
-                        }
-                        "\u{f700}" => {
-                            if meta {
-                                ed.move_doc_start()
-                            } else {
-                                ed.move_cursor(-1, 0)
+                            "\u{f700}" => {
+                                if meta {
+                                    ed.move_doc_start()
+                                } else {
+                                    ed.move_cursor(-1, 0)
+                                }
                             }
-                        }
-                        "\u{f701}" => {
-                            if meta {
-                                ed.move_doc_end()
-                            } else {
-                                ed.move_cursor(1, 0)
+                            "\u{f701}" => {
+                                if meta {
+                                    ed.move_doc_end()
+                                } else {
+                                    ed.move_cursor(1, 0)
+                                }
                             }
+                            "\u{f729}" => ed.home(),
+                            "\u{f72b}" => ed.end(),
+                            _ => {}
                         }
-                        "\u{f729}" => ed.home(),
-                        "\u{f72b}" => ed.end(),
-                        _ => {}
                     }
+                    sync_editor(pane);
+                    return true;
                 }
-                sync_editor(0);
-                return true;
-            }
-            if meta {
-                // Editor-owned cmd combos; everything else bubbles up to the
-                // window shortcut scope (⌘⏎ run, ⌘S commit, ⌘R refresh, …).
+                if meta {
+                    // Editor-owned cmd combos; everything else bubbles up to the
+                    // window shortcut scope (⌘⏎ run, ⌘S commit, ⌘R refresh, …).
+                    let handled = {
+                        let mut ed = ed_state.borrow_mut();
+                        match text.as_str() {
+                            "a" => {
+                                ed.select_all();
+                                true
+                            }
+                            "c" => {
+                                // no selection → copy the statement under the cursor
+                                let t =
+                                    ed.selected_text().unwrap_or_else(|| ed.current_statement());
+                                clip_set(&t);
+                                true
+                            }
+                            "x" => {
+                                if let Some(t) = ed.selected_text() {
+                                    clip_set(&t);
+                                    ed.cut_selection();
+                                }
+                                true
+                            }
+                            "v" => {
+                                if let Some(t) = clip_get() {
+                                    ed.insert(&t.replace("\r\n", "\n"));
+                                }
+                                true
+                            }
+                            "z" if shift => {
+                                ed.redo();
+                                true
+                            }
+                            "z" => {
+                                ed.undo();
+                                true
+                            }
+                            "/" => {
+                                // Comment marker follows the connected engine's query
+                                // language; default to SQL when not yet connected.
+                                let engine = cur_engine
+                                    .borrow()
+                                    .unwrap_or(rdb_connstore::Engine::Postgres);
+                                ed.toggle_comment(crate::query_parse::comment_prefix(engine));
+                                true
+                            }
+                            _ => false,
+                        }
+                    };
+                    if handled {
+                        sync_editor(pane);
+                    }
+                    return handled;
+                }
                 let handled = {
                     let mut ed = ed_state.borrow_mut();
-                    match text.as_str() {
-                        "a" => {
-                            ed.select_all();
-                            true
-                        }
-                        "c" => {
-                            // no selection → copy the statement under the cursor
-                            let t = ed.selected_text().unwrap_or_else(|| ed.current_statement());
-                            clip_set(&t);
-                            true
-                        }
-                        "x" => {
-                            if let Some(t) = ed.selected_text() {
-                                clip_set(&t);
-                                ed.cut_selection();
+                    // movement keys: shift extends the selection, plain drops it
+                    if matches!(
+                        text.as_str(),
+                        "\u{f700}" | "\u{f701}" | "\u{f702}" | "\u{f703}" | "\u{f729}" | "\u{f72b}"
+                    ) {
+                        ed.set_selecting(shift);
+                    }
+                    let mut it = text.chars();
+                    match (it.next(), it.next()) {
+                        (Some(c), None) => match c {
+                            '\u{8}' => {
+                                ed.backspace();
+                                true
                             }
-                            true
-                        }
-                        "v" => {
-                            if let Some(t) = clip_get() {
-                                ed.insert(&t.replace("\r\n", "\n"));
+                            '\u{7f}' => {
+                                ed.delete();
+                                true
                             }
-                            true
-                        }
-                        "z" if shift => {
-                            ed.redo();
-                            true
-                        }
-                        "z" => {
-                            ed.undo();
-                            true
-                        }
-                        "/" => {
-                            // Comment marker follows the connected engine's query
-                            // language; default to SQL when not yet connected.
-                            let engine = cur_engine
-                                .borrow()
-                                .unwrap_or(rdb_connstore::Engine::Postgres);
-                            ed.toggle_comment(crate::query_parse::comment_prefix(engine));
+                            '\n' | '\r' => {
+                                ed.newline();
+                                true
+                            }
+                            '\t' => {
+                                ed.insert("  ");
+                                true
+                            }
+                            // Esc clears the selection; without one it bubbles
+                            // up (modal close).
+                            '\u{1b}' if ed.selection().is_some() => {
+                                ed.set_selecting(false);
+                                true
+                            }
+                            '\u{f700}' => {
+                                ed.move_cursor(-1, 0);
+                                true
+                            }
+                            '\u{f701}' => {
+                                ed.move_cursor(1, 0);
+                                true
+                            }
+                            '\u{f702}' => {
+                                ed.move_cursor(0, -1);
+                                true
+                            }
+                            '\u{f703}' => {
+                                ed.move_cursor(0, 1);
+                                true
+                            }
+                            '\u{f729}' => {
+                                ed.home();
+                                true
+                            }
+                            '\u{f72b}' => {
+                                ed.end();
+                                true
+                            }
+                            c if !c.is_control() => {
+                                ed.insert(&c.to_string());
+                                true
+                            }
+                            _ => false,
+                        },
+                        (Some(_), Some(_)) if !text.starts_with('\u{f700}') => {
+                            ed.insert(&text);
                             true
                         }
                         _ => false,
                     }
                 };
                 if handled {
-                    sync_editor(0);
-                }
-                return handled;
-            }
-            let handled = {
-                let mut ed = ed_state.borrow_mut();
-                // movement keys: shift extends the selection, plain drops it
-                if matches!(
-                    text.as_str(),
-                    "\u{f700}" | "\u{f701}" | "\u{f702}" | "\u{f703}" | "\u{f729}" | "\u{f72b}"
-                ) {
-                    ed.set_selecting(shift);
-                }
-                let mut it = text.chars();
-                match (it.next(), it.next()) {
-                    (Some(c), None) => match c {
-                        '\u{8}' => {
-                            ed.backspace();
-                            true
-                        }
-                        '\u{7f}' => {
-                            ed.delete();
-                            true
-                        }
-                        '\n' | '\r' => {
-                            ed.newline();
-                            true
-                        }
-                        '\t' => {
-                            ed.insert("  ");
-                            true
-                        }
-                        // Esc clears the selection; without one it bubbles
-                        // up (modal close).
-                        '\u{1b}' if ed.selection().is_some() => {
-                            ed.set_selecting(false);
-                            true
-                        }
-                        '\u{f700}' => {
-                            ed.move_cursor(-1, 0);
-                            true
-                        }
-                        '\u{f701}' => {
-                            ed.move_cursor(1, 0);
-                            true
-                        }
-                        '\u{f702}' => {
-                            ed.move_cursor(0, -1);
-                            true
-                        }
-                        '\u{f703}' => {
-                            ed.move_cursor(0, 1);
-                            true
-                        }
-                        '\u{f729}' => {
-                            ed.home();
-                            true
-                        }
-                        '\u{f72b}' => {
-                            ed.end();
-                            true
-                        }
-                        c if !c.is_control() => {
-                            ed.insert(&c.to_string());
-                            true
-                        }
-                        _ => false,
-                    },
-                    (Some(_), Some(_)) if !text.starts_with('\u{f700}') => {
-                        ed.insert(&text);
-                        true
+                    sync_editor(pane);
+                    // Typing/deleting shifts the completion context — recompute
+                    // (pane-0 only for now).
+                    if pane == 0 {
+                        refresh_completion();
                     }
-                    _ => false,
                 }
-            };
-            if handled {
-                sync_editor(0);
-                // Typing/deleting shifts the completion context — recompute.
-                refresh_completion();
-            }
-            handled
+                handled
+            },
+        );
+        window.on_editor_key({
+            let edit_key = edit_key.clone();
+            move |text, meta, alt, shift| edit_key(0, text, meta, alt, shift)
+        });
+        window.on_p1_editor_key({
+            let edit_key = edit_key.clone();
+            move |text, meta, alt, shift| edit_key(1, text, meta, alt, shift)
         });
     }
     {
-        let ed_state = ed_state.clone();
+        let panes = panes.clone();
         let sync_editor = sync_editor.clone();
         let weak = window.as_weak();
-        window.on_editor_press(move |line, col| {
-            if let Some(w) = weak.upgrade() {
-                w.set_completion_visible(false);
+        let press: Rc<dyn Fn(usize, i32, i32)> = Rc::new(move |pane, line, col| {
+            if pane == 0 {
+                if let Some(w) = weak.upgrade() {
+                    w.set_completion_visible(false);
+                }
             }
-            ed_state.borrow_mut().move_to(line, col, false);
-            sync_editor(0);
+            panes[pane].ed_state.borrow_mut().move_to(line, col, false);
+            sync_editor(pane);
+        });
+        window.on_editor_press({
+            let press = press.clone();
+            move |line, col| press(0, line, col)
+        });
+        window.on_p1_editor_press({
+            let press = press.clone();
+            move |line, col| press(1, line, col)
         });
     }
     {
-        let ed_state = ed_state.clone();
+        let panes = panes.clone();
         let sync_editor = sync_editor.clone();
-        window.on_editor_drag(move |line, col| {
-            ed_state.borrow_mut().move_to(line, col, true);
-            sync_editor(0);
+        let drag: Rc<dyn Fn(usize, i32, i32)> = Rc::new(move |pane, line, col| {
+            panes[pane].ed_state.borrow_mut().move_to(line, col, true);
+            sync_editor(pane);
+        });
+        window.on_editor_drag({
+            let drag = drag.clone();
+            move |line, col| drag(0, line, col)
+        });
+        window.on_p1_editor_drag({
+            let drag = drag.clone();
+            move |line, col| drag(1, line, col)
         });
     }
     {
-        let ed_state = ed_state.clone();
+        let panes = panes.clone();
         let sync_editor = sync_editor.clone();
-        window.on_editor_select_word(move |line, col| {
-            ed_state.borrow_mut().select_word_at(line, col);
-            sync_editor(0);
+        let select_word: Rc<dyn Fn(usize, i32, i32)> = Rc::new(move |pane, line, col| {
+            panes[pane].ed_state.borrow_mut().select_word_at(line, col);
+            sync_editor(pane);
+        });
+        window.on_editor_select_word({
+            let select_word = select_word.clone();
+            move |line, col| select_word(0, line, col)
+        });
+        window.on_p1_editor_select_word({
+            let select_word = select_word.clone();
+            move |line, col| select_word(1, line, col)
         });
     }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1292,6 +1292,13 @@ fn set_p_doc_tree(w: &MainWindow, pane: usize, m: ModelRc<DocRow>) {
         w.set_p1_doc_tree(m);
     }
 }
+fn set_p_query_running(w: &MainWindow, pane: usize, b: bool) {
+    if pane == 0 {
+        w.set_query_running(b);
+    } else {
+        w.set_p1_query_running(b);
+    }
+}
 
 /// Return a copy of `g` keeping only rows where some cell matches `needle`
 /// (already lowercased). An empty needle keeps every row.
@@ -4694,25 +4701,29 @@ fn main() -> Result<(), slint::PlatformError> {
     // ----- shared query runner: parse text for the live engine, run it, push
     // the result (grid / documents / error) back to the UI. Used by both the
     // Run button and table clicks. -----
-    let run_sql: Rc<dyn Fn(String)> = {
+    #[allow(clippy::type_complexity)]
+    let run_sql: Rc<dyn Fn(usize, String)> = {
         let weak = window.as_weak();
         let rt = rt.clone();
         let current = current.clone();
         let last_view = last_view.clone();
-        let browse = browse.clone();
-        let edit_buf = edit_buf.clone();
-        let displayed_grid = displayed_grid.clone();
-        let hidden_cols = hidden_cols.clone();
-        let sort_state = sort_state.clone();
-        let col_order = col_order.clone();
-        let col_filters = col_filters.clone();
-        let results = results.clone();
-        let active_result = active_result.clone();
-        let result_new_tab = result_new_tab.clone();
+        let panes = panes.clone();
         let workspace_tabs = workspace_tabs.clone();
         let active_tab_id = active_tab_id.clone();
         let query_console = query_console.clone();
-        Rc::new(move |sql: String| {
+        Rc::new(move |pane: usize, sql: String| {
+            // Per-pane live state; pane 1 (right split) uses its own buffers so a
+            // run in one pane never disturbs the other.
+            let browse = panes[pane].browse.clone();
+            let edit_buf = panes[pane].edit_buf.clone();
+            let displayed_grid = panes[pane].displayed_grid.clone();
+            let hidden_cols = panes[pane].hidden_cols.clone();
+            let sort_state = panes[pane].sort_state.clone();
+            let col_order = panes[pane].col_order.clone();
+            let col_filters = panes[pane].col_filters.clone();
+            let results = panes[pane].results.clone();
+            let active_result = panes[pane].active_result.clone();
+            let result_new_tab = panes[pane].result_new_tab.clone();
             let Some(target_id) = active_tab_id.lock().unwrap().clone() else {
                 return;
             };
@@ -4746,7 +4757,7 @@ fn main() -> Result<(), slint::PlatformError> {
             // no `use(...)` run against it, matching what the user sees browsing.
             let mut cur_db = String::new();
             if let Some(w) = weak.upgrade() {
-                w.set_query_running(true);
+                set_p_query_running(&w, pane, true);
                 // Don't force the SQL console open on every run — the eye toggle
                 // owns its visibility. Re-opening it here ignored a user who just
                 // hid it. The console still updates in place when it is open.
@@ -4824,7 +4835,7 @@ fn main() -> Result<(), slint::PlatformError> {
                         let is_active =
                             active_tab_id.lock().unwrap().as_deref() == Some(&target_id);
                         if is_active {
-                            w.set_query_running(false);
+                            set_p_query_running(&w, pane, false);
                         }
                         match (view, err) {
                             (Some(v), _) => {
@@ -4844,7 +4855,7 @@ fn main() -> Result<(), slint::PlatformError> {
                                     meta: meta.clone(),
                                     latency: latency.clone(),
                                 };
-                                let (tab_results, tab_active, is_browse) = {
+                                let (tab_results, tab_active, is_browse) = if pane == 0 {
                                     let mut tabs = workspace_tabs.lock().unwrap();
                                     let Some(tab) = tabs.iter_mut().find(|tab| tab.id == target_id)
                                     else {
@@ -4866,6 +4877,10 @@ fn main() -> Result<(), slint::PlatformError> {
                                         tab.results[tab.active_result] = sr;
                                     }
                                     (tab.results.clone(), tab.active_result, is_browse)
+                                } else {
+                                    // Pane 1 (right split) keeps a single result and
+                                    // is not persisted into the tab's result tabs.
+                                    (vec![sr.clone()], 0, false)
                                 };
                                 if !is_active {
                                     return;
@@ -4873,18 +4888,18 @@ fn main() -> Result<(), slint::PlatformError> {
                                 *results.lock().unwrap() = tab_results;
                                 *active_result.lock().unwrap() = tab_active;
                                 if is_browse {
-                                    set_result_tabs(&w, 0, 0, 0);
+                                    set_result_tabs(&w, pane, 0, 0);
                                 } else {
                                     set_result_tabs(
                                         &w,
-                                        0,
+                                        pane,
                                         results.lock().unwrap().len(),
                                         tab_active,
                                     );
                                 }
                                 present_view(
                                     &w,
-                                    0,
+                                    pane,
                                     v,
                                     &meta,
                                     &latency,
@@ -4913,7 +4928,7 @@ fn main() -> Result<(), slint::PlatformError> {
                                 *last_view.lock().unwrap() = None;
                                 apply_result(
                                     &w,
-                                    0,
+                                    pane,
                                     model::ResultView::Affected(format!("error: {e}")),
                                 );
                             }
@@ -5269,13 +5284,36 @@ fn main() -> Result<(), slint::PlatformError> {
                 if stream {
                     run_stream(text);
                 } else {
-                    run_sql(text);
+                    run_sql(0, text);
                 }
                 if w.get_sidebar_mode() != 0 {
                     rebuild_query_tree("");
                 }
             }
         });
+    }
+
+    // ----- run query in the right split pane (buffered; streaming is pane-0) --
+    {
+        let run_sql = run_sql.clone();
+        let panes = panes.clone();
+        let recent_queries = recent_queries.clone();
+        let run_p1 = move || {
+            let text = {
+                let ed = panes[1].ed_state.borrow();
+                ed.selected_text()
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or_else(|| ed.current_statement())
+            };
+            if text.is_empty() {
+                return;
+            }
+            record_recent(&recent_queries, &text);
+            run_sql(1, text);
+        };
+        window.on_p1_run(run_p1.clone());
+        window.on_p1_run_selection(run_p1);
     }
 
     // ----- Copy results (TSV → clipboard) / Export CSV (~/Downloads) -----
@@ -5388,7 +5426,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 if stream {
                     run_stream(stmt);
                 } else {
-                    run_sql(stmt);
+                    run_sql(0, stmt);
                 }
             }
         });
@@ -5428,9 +5466,9 @@ fn main() -> Result<(), slint::PlatformError> {
                 w.set_grid_read_only(true);
             }
             if trimmed.to_uppercase().starts_with("EXPLAIN") {
-                run_sql(trimmed.to_string());
+                run_sql(0, trimmed.to_string());
             } else {
-                run_sql(format!("EXPLAIN {trimmed}"));
+                run_sql(0, format!("EXPLAIN {trimmed}"));
             }
         });
     }
@@ -5497,7 +5535,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 &st.col_filters,
             );
             load_editor_text(0, &text);
-            run_sql(text);
+            run_sql(0, text);
         })
     };
     // Wire the deferred handle so per-column browse filters can re-query.
@@ -6193,7 +6231,7 @@ fn main() -> Result<(), slint::PlatformError> {
             result_new_tab.store(true, std::sync::atomic::Ordering::SeqCst);
             w.set_grid_read_only(true);
             record_recent(&recent_queries, &stmt);
-            run_sql(stmt);
+            run_sql(0, stmt);
         });
     }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -585,6 +585,82 @@ fn replaceable_table_tab_index(tabs: &[WorkspaceTab], active_id: Option<&str>) -
     tab.is_preview().then_some(index)
 }
 
+/// Absolute `tabs` index of the `group_index`-th tab in `group` (i.e. that
+/// group's tab-strip position → the underlying vector index). None if out of
+/// range. Inverse of [`group_relative_index`].
+fn abs_index_for_group(tabs: &[WorkspaceTab], group: usize, group_index: usize) -> Option<usize> {
+    tabs.iter()
+        .enumerate()
+        .filter(|(_, t)| t.group == group)
+        .nth(group_index)
+        .map(|(abs, _)| abs)
+}
+
+/// Position of the tab at absolute index `abs` within its own group's tab strip.
+fn group_relative_index(tabs: &[WorkspaceTab], abs: usize) -> usize {
+    let group = tabs[abs].group;
+    tabs[..abs].iter().filter(|t| t.group == group).count()
+}
+
+#[cfg(test)]
+mod group_tests {
+    use super::{
+        abs_index_for_group, group_relative_index, replaceable_table_tab_index,
+        workspace_tab_index, WorkspaceTab,
+    };
+
+    fn tab(id: &str, group: usize) -> WorkspaceTab {
+        let mut t = WorkspaceTab::sql(id.into(), 0);
+        t.group = group;
+        t
+    }
+
+    #[test]
+    fn abs_and_relative_index_are_inverse() {
+        // Interleaved groups: L R L R L.
+        let tabs = vec![
+            tab("a", 0),
+            tab("b", 1),
+            tab("c", 0),
+            tab("d", 1),
+            tab("e", 0),
+        ];
+        // Left strip = a(0), c(2), e(4); right strip = b(1), d(3).
+        assert_eq!(abs_index_for_group(&tabs, 0, 0), Some(0));
+        assert_eq!(abs_index_for_group(&tabs, 0, 1), Some(2));
+        assert_eq!(abs_index_for_group(&tabs, 0, 2), Some(4));
+        assert_eq!(abs_index_for_group(&tabs, 0, 3), None);
+        assert_eq!(abs_index_for_group(&tabs, 1, 0), Some(1));
+        assert_eq!(abs_index_for_group(&tabs, 1, 1), Some(3));
+        assert_eq!(abs_index_for_group(&tabs, 1, 2), None);
+        assert_eq!(group_relative_index(&tabs, 4), 2);
+        assert_eq!(group_relative_index(&tabs, 3), 1);
+        // Round-trip: every absolute index maps back to itself.
+        for (abs, t) in tabs.iter().enumerate() {
+            let gi = group_relative_index(&tabs, abs);
+            assert_eq!(abs_index_for_group(&tabs, t.group, gi), Some(abs));
+        }
+    }
+
+    #[test]
+    fn workspace_tab_index_finds_by_id() {
+        let tabs = vec![tab("a", 0), tab("b", 1)];
+        assert_eq!(workspace_tab_index(&tabs, Some("b")), Some(1));
+        assert_eq!(workspace_tab_index(&tabs, Some("x")), None);
+        assert_eq!(workspace_tab_index(&tabs, None), None);
+    }
+
+    #[test]
+    fn replaceable_table_tab_only_for_unpinned_table() {
+        let mut t = WorkspaceTab::sql("t".into(), 0);
+        t.kind = "table".into();
+        t.pinned = false; // an unpinned table tab is a "preview"
+        assert_eq!(replaceable_table_tab_index(&[t], Some("t")), Some(0));
+        // A SQL tab is never replaceable.
+        assert_eq!(replaceable_table_tab_index(&[tab("s", 0)], Some("s")), None);
+    }
+}
+
 fn set_workspace_tabs(w: &MainWindow, tabs: &[WorkspaceTab], active_id: Option<&str>) {
     let left: Vec<&WorkspaceTab> = tabs.iter().filter(|tab| tab.group == 0).collect();
     let items: Vec<TabItem> = left
@@ -3867,7 +3943,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     return;
                 };
                 let pane = tab.group.min(1);
-                let group_index = tabs[..abs_index].iter().filter(|t| t.group == pane).count();
+                let group_index = group_relative_index(&tabs, abs_index);
                 (tab, pane, group_index)
             };
             if pane == 0 {
@@ -3976,11 +4052,7 @@ fn main() -> Result<(), slint::PlatformError> {
         Rc::new(move |w, group1_index| {
             let abs = {
                 let tabs = tabs.lock().unwrap();
-                tabs.iter()
-                    .enumerate()
-                    .filter(|(_, t)| t.group == 1)
-                    .nth(group1_index)
-                    .map(|(abs, _)| abs)
+                abs_index_for_group(&tabs, 1, group1_index)
             };
             if let Some(abs) = abs {
                 f(w, abs);

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2564,8 +2564,11 @@ fn main() -> Result<(), slint::PlatformError> {
         let sync_editor = sync_editor.clone();
         let weak = window.as_weak();
         let press: Rc<dyn Fn(usize, i32, i32)> = Rc::new(move |pane, line, col| {
-            if pane == 0 {
-                if let Some(w) = weak.upgrade() {
+            if let Some(w) = weak.upgrade() {
+                // Clicking a pane focuses it: drives the accent + which pane
+                // global shortcuts fall back to.
+                w.set_active_pane(pane as i32);
+                if pane == 0 {
                     w.set_completion_visible(false);
                 }
             }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -534,12 +534,13 @@ struct WorkspaceTab {
     indexes: Vec<(String, String)>,
     loading: bool,
     pinned: bool,
-    // Dual-pane split state for this tab: whether the right pane is open, its
-    // editor text, and its last result (single result, no result-tab strip).
+    // Dual-pane split state for this tab. Right-pane results stay in memory
+    // like the left pane; only the SQL text is persisted to disk.
     split: bool,
     split_ratio: f32,
     pane1_query: String,
-    pane1_view: Option<StoredResult>,
+    pane1_results: Vec<StoredResult>,
+    pane1_active_result: usize,
 }
 
 impl WorkspaceTab {
@@ -560,7 +561,8 @@ impl WorkspaceTab {
             split: false,
             split_ratio: 0.5,
             pane1_query: String::new(),
-            pane1_view: None,
+            pane1_results: Vec::new(),
+            pane1_active_result: 0,
         }
     }
 
@@ -1732,8 +1734,8 @@ thread_local! {
     /// Full JSON-tree nodes + collapsed paths for the currently displayed Mongo
     /// document result. The Slint event loop is single-threaded, so a
     /// thread_local suffices; no cross-tab persistence is needed.
-    static DOC_TREE: std::cell::RefCell<(Vec<model::DocNode>, HashSet<String>)> =
-        std::cell::RefCell::new((Vec::new(), HashSet::new()));
+    static DOC_TREES: std::cell::RefCell<[(Vec<model::DocNode>, HashSet<String>); 2]> =
+        std::cell::RefCell::new(Default::default());
 }
 
 /// Compute the visible JSON-tree rows for the current collapse state and push
@@ -1783,7 +1785,7 @@ fn apply_result(w: &MainWindow, pane: usize, view: model::ResultView) {
             );
             let collapsed = model::default_doc_collapsed(&d.tree);
             push_doc_tree(w, pane, &d.tree, &collapsed);
-            DOC_TREE.with(|s| *s.borrow_mut() = (d.tree, collapsed));
+            DOC_TREES.with(|s| s.borrow_mut()[pane] = (d.tree, collapsed));
         }
         model::ResultView::Affected(status) => {
             set_p_result_kind(w, pane, 3);
@@ -3078,7 +3080,8 @@ fn main() -> Result<(), slint::PlatformError> {
                     split: false,
                     split_ratio: 0.5,
                     pane1_query: String::new(),
-                    pane1_view: None,
+                    pane1_results: Vec::new(),
+                    pane1_active_result: 0,
                 });
                 *active_tab_id.lock().unwrap() = Some(id.clone());
                 set_workspace_tabs(&w, &tabs, Some(&id));
@@ -3784,11 +3787,12 @@ fn main() -> Result<(), slint::PlatformError> {
             } else {
                 String::new()
             };
-            tab.pane1_view = if tab.kind == "sql" {
-                panes[1].results.lock().unwrap().first().cloned()
+            tab.pane1_results = if tab.kind == "sql" {
+                panes[1].results.lock().unwrap().clone()
             } else {
-                None
+                Vec::new()
             };
+            tab.pane1_active_result = *panes[1].active_result.lock().unwrap();
             if tab.kind == "table" {
                 tab.browse = browse.lock().unwrap().clone();
             } else if tab.kind == "sql" {
@@ -3844,10 +3848,10 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_split_ratio(tab.split_ratio.clamp(0.2, 0.8));
             w.set_active_pane(0);
             load_editor_text(1, &tab.pane1_query);
-            if let Some(stored) = tab.pane1_view.clone() {
-                *panes[1].results.lock().unwrap() = vec![stored.clone()];
-                *panes[1].active_result.lock().unwrap() = 0;
-                set_result_tabs(w, 1, 1, 0);
+            if let Some(stored) = tab.pane1_results.get(tab.pane1_active_result).cloned() {
+                *panes[1].results.lock().unwrap() = tab.pane1_results.clone();
+                *panes[1].active_result.lock().unwrap() = tab.pane1_active_result;
+                set_result_tabs(w, 1, tab.pane1_results.len(), tab.pane1_active_result);
                 present_view(
                     w,
                     1,
@@ -4934,7 +4938,11 @@ fn main() -> Result<(), slint::PlatformError> {
                 .find(|tab| tab.id == target_id)
             {
                 tab.loading = true;
-                tab.query_text = sql.clone();
+                if pane == 0 {
+                    tab.query_text = sql.clone();
+                } else {
+                    tab.pane1_query = sql.clone();
+                }
             }
             let weak2 = weak.clone();
             let current = current.clone();
@@ -5078,9 +5086,22 @@ fn main() -> Result<(), slint::PlatformError> {
                                     }
                                     (tab.results.clone(), tab.active_result, is_browse)
                                 } else {
-                                    // Pane 1 (right split) keeps a single result and
-                                    // is not persisted into the tab's result tabs.
-                                    (vec![sr.clone()], 0, false)
+                                    let mut tabs = workspace_tabs.lock().unwrap();
+                                    let Some(tab) = tabs.iter_mut().find(|tab| tab.id == target_id)
+                                    else {
+                                        return;
+                                    };
+                                    tab.loading = false;
+                                    if new_tab || tab.pane1_results.is_empty() {
+                                        tab.pane1_results.push(sr);
+                                        tab.pane1_active_result = tab.pane1_results.len() - 1;
+                                    } else {
+                                        if tab.pane1_active_result >= tab.pane1_results.len() {
+                                            tab.pane1_active_result = 0;
+                                        }
+                                        tab.pane1_results[tab.pane1_active_result] = sr;
+                                    }
+                                    (tab.pane1_results.clone(), tab.pane1_active_result, false)
                                 };
                                 if !is_active {
                                     return;
@@ -5316,7 +5337,8 @@ fn main() -> Result<(), slint::PlatformError> {
                                             tab.results = vec![sr.clone()];
                                             tab.active_result = 0;
                                         } else {
-                                            tab.pane1_view = Some(sr.clone());
+                                            tab.pane1_results = vec![sr.clone()];
+                                            tab.pane1_active_result = 0;
                                         }
                                     }
                                     if active_tab_id.lock().unwrap().as_deref() == Some(&target_id)
@@ -5682,6 +5704,304 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let weak = window.as_weak();
         let panes = panes.clone();
+        window.on_p1_reorder_col(move |from, local_x| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let from = from.max(0) as usize;
+            let mut widths: Vec<f32> = w.get_p1_col_widths().iter().collect();
+            if from >= widths.len() {
+                return;
+            }
+            let drop = widths.iter().take(from).sum::<f32>() + local_x;
+            let mut acc = 0.0;
+            let mut target = widths.len() - 1;
+            for (index, width) in widths.iter().enumerate() {
+                if drop < acc + width {
+                    target = index;
+                    break;
+                }
+                acc += width;
+            }
+            if target == from {
+                return;
+            }
+            let hidden = panes[1].hidden_cols.lock().unwrap().clone();
+            {
+                let mut order = panes[1].col_order.lock().unwrap();
+                let visible: Vec<usize> = order
+                    .iter()
+                    .copied()
+                    .enumerate()
+                    .filter(|(_, index)| !hidden.contains(index))
+                    .map(|(position, _)| position)
+                    .collect();
+                let (Some(&from_position), Some(&to_position)) =
+                    (visible.get(from), visible.get(target))
+                else {
+                    return;
+                };
+                let value = order.remove(from_position);
+                order.insert(
+                    if to_position > from_position {
+                        to_position - 1
+                    } else {
+                        to_position
+                    },
+                    value,
+                );
+            }
+            let width = widths.remove(from);
+            widths.insert(if target > from { target - 1 } else { target }, width);
+            set_p_col_widths(&w, 1, ModelRc::from(Rc::new(VecModel::from(widths))));
+            let view = {
+                let results = panes[1].results.lock().unwrap();
+                let active = *panes[1].active_result.lock().unwrap();
+                results.get(active).map(|result| result.view.clone())
+            };
+            let Some(view) = view else {
+                return;
+            };
+            let order = panes[1].col_order.lock().unwrap().clone();
+            let filters = panes[1].col_filters.lock().unwrap().clone();
+            let (sort_col, ascending) = *panes[1].sort_state.lock().unwrap();
+            let reordered = compute_view(
+                &view, "", "", "", &filters, &hidden, &order, sort_col, ascending,
+            );
+            *panes[1].displayed_grid.lock().unwrap() = view_grid(&reordered);
+            apply_result(&w, 1, reordered);
+        });
+    }
+
+    // ----- right-pane grid interactions -----
+    {
+        let weak = window.as_weak();
+        window.on_p1_select_cell(move |row, col| {
+            if let Some(w) = weak.upgrade() {
+                w.set_p1_selected_row(row);
+                w.set_p1_selected_col(col);
+            }
+        });
+    }
+    {
+        let weak = window.as_weak();
+        window.on_p1_edit_cell(move |row, col| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            if w.get_grid_read_only() || row < 0 || col < 0 {
+                set_p_result_status(&w, 1, SharedString::from("read-only result"));
+                return;
+            }
+            let count = w.get_p1_col_count();
+            let value = if count > 0 {
+                w.get_p1_cells()
+                    .row_data((row * count + col) as usize)
+                    .filter(|cell| !cell.is_null)
+                    .map(|cell| cell.text)
+                    .unwrap_or_default()
+            } else {
+                SharedString::default()
+            };
+            w.set_p1_editing_value(value);
+            set_p_editing(&w, 1, row, col);
+        });
+    }
+    {
+        let weak = window.as_weak();
+        let panes = panes.clone();
+        window.on_p1_stage_cell(move |row, col, text| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            if w.get_grid_read_only() || row < 0 || col < 0 {
+                return;
+            }
+            let base = panes[1]
+                .displayed_grid
+                .lock()
+                .unwrap()
+                .as_ref()
+                .map(|grid| grid.rows.len())
+                .unwrap_or(0);
+            panes[1].edit_buf.lock().unwrap().set_cell(
+                base,
+                row as usize,
+                col as usize,
+                text.to_string(),
+            );
+            let count = w.get_p1_col_count();
+            if count > 0 {
+                let index = (row * count + col) as usize;
+                let cells = w.get_p1_cells();
+                if let Some(mut cell) = cells.row_data(index) {
+                    cell.text = text;
+                    cell.is_null = false;
+                    cell.state = 1;
+                    cells.set_row_data(index, cell);
+                }
+            }
+        });
+    }
+    {
+        let weak = window.as_weak();
+        let panes = panes.clone();
+        window.on_p1_cell_edited(move |row, col, text| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let base = panes[1]
+                .displayed_grid
+                .lock()
+                .unwrap()
+                .as_ref()
+                .map(|grid| grid.rows.len())
+                .unwrap_or(0);
+            panes[1].edit_buf.lock().unwrap().set_cell(
+                base,
+                row.max(0) as usize,
+                col.max(0) as usize,
+                text.to_string(),
+            );
+            set_p_editing(&w, 1, -1, -1);
+            if let Some(grid) = panes[1].displayed_grid.lock().unwrap().as_ref() {
+                let edits = panes[1].edit_buf.lock().unwrap();
+                paint_grid_with_edits(&w, 1, grid, &edits);
+            }
+        });
+    }
+    {
+        let weak = window.as_weak();
+        window.on_p1_edit_cancelled(move || {
+            if let Some(w) = weak.upgrade() {
+                set_p_editing(&w, 1, -1, -1);
+            }
+        });
+    }
+    {
+        let weak = window.as_weak();
+        window.on_p1_cell_advance(move |row, col, text, forward| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let count = w.get_p1_col_count();
+            if count <= 0 {
+                set_p_editing(&w, 1, -1, -1);
+                return;
+            }
+            w.invoke_p1_cell_edited(row, col, text);
+            let next = if forward { col + 1 } else { col - 1 };
+            let (next_row, next_col) = if next >= count {
+                (row + 1, 0)
+            } else if next < 0 {
+                (row - 1, count - 1)
+            } else {
+                (row, next)
+            };
+            w.set_p1_selected_row(next_row);
+            w.set_p1_selected_col(next_col);
+            set_p_editing(&w, 1, next_row, next_col);
+        });
+    }
+    {
+        let weak = window.as_weak();
+        window.on_p1_resize_col(move |i, delta| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let mut widths: Vec<f32> = w.get_p1_col_widths().iter().collect();
+            if let Some(width) = widths.get_mut(i.max(0) as usize) {
+                *width = (*width + delta).clamp(60.0, 1000.0);
+                w.set_p1_col_widths(ModelRc::from(Rc::new(VecModel::from(widths))));
+            }
+        });
+    }
+    {
+        let weak = window.as_weak();
+        let panes = panes.clone();
+        window.on_p1_sort_col(move |display_col| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let view = {
+                let results = panes[1].results.lock().unwrap();
+                let active = *panes[1].active_result.lock().unwrap();
+                results.get(active).map(|result| result.view.clone())
+            };
+            let Some(view) = view else {
+                return;
+            };
+            let hidden = panes[1].hidden_cols.lock().unwrap().clone();
+            let order = panes[1].col_order.lock().unwrap().clone();
+            let visible: Vec<usize> = order
+                .iter()
+                .copied()
+                .filter(|index| !hidden.contains(index))
+                .collect();
+            let Some(&original) = visible.get(display_col.max(0) as usize) else {
+                return;
+            };
+            let (sort_col, ascending) = {
+                let mut sort = panes[1].sort_state.lock().unwrap();
+                if sort.0 == original as i32 {
+                    sort.1 = !sort.1;
+                } else {
+                    *sort = (original as i32, true);
+                }
+                *sort
+            };
+            let filters = panes[1].col_filters.lock().unwrap().clone();
+            let sorted = compute_view(
+                &view, "", "", "", &filters, &hidden, &order, sort_col, ascending,
+            );
+            *panes[1].displayed_grid.lock().unwrap() = view_grid(&sorted);
+            set_p_grid_sort(&w, 1, display_col, ascending);
+            apply_result(&w, 1, sorted);
+        });
+    }
+    {
+        let weak = window.as_weak();
+        let panes = panes.clone();
+        window.on_p1_set_col_filter(move |display_col, text| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let view = {
+                let results = panes[1].results.lock().unwrap();
+                let active = *panes[1].active_result.lock().unwrap();
+                results.get(active).map(|result| result.view.clone())
+            };
+            let Some(view) = view else {
+                return;
+            };
+            let hidden = panes[1].hidden_cols.lock().unwrap().clone();
+            let order = panes[1].col_order.lock().unwrap().clone();
+            let visible: Vec<usize> = order
+                .iter()
+                .copied()
+                .filter(|index| !hidden.contains(index))
+                .collect();
+            let Some(&original) = visible.get(display_col.max(0) as usize) else {
+                return;
+            };
+            let filters = {
+                let mut filters = panes[1].col_filters.lock().unwrap();
+                if let Some(filter) = filters.get_mut(original) {
+                    *filter = text.to_string();
+                }
+                filters.clone()
+            };
+            let (sort_col, ascending) = *panes[1].sort_state.lock().unwrap();
+            let filtered = compute_view(
+                &view, "", "", "", &filters, &hidden, &order, sort_col, ascending,
+            );
+            *panes[1].displayed_grid.lock().unwrap() = view_grid(&filtered);
+            apply_result(&w, 1, filtered);
+        });
+    }
+    {
+        let weak = window.as_weak();
+        let panes = panes.clone();
         window.on_p1_cancel_stream(move || {
             if let Some(c) = panes[1].stream_cancel.borrow().as_ref() {
                 c.store(true, std::sync::atomic::Ordering::SeqCst);
@@ -5914,7 +6234,8 @@ fn main() -> Result<(), slint::PlatformError> {
                     split: false,
                     split_ratio: 0.5,
                     pane1_query: String::new(),
-                    pane1_view: None,
+                    pane1_results: Vec::new(),
+                    pane1_active_result: 0,
                 };
                 let active_id = active_tab_id.lock().unwrap().clone();
                 let mut tabs = workspace_tabs.lock().unwrap();
@@ -6230,14 +6551,31 @@ fn main() -> Result<(), slint::PlatformError> {
             let Some(w) = weak.upgrade() else {
                 return;
             };
-            DOC_TREE.with(|s| {
+            DOC_TREES.with(|s| {
                 let mut st = s.borrow_mut();
-                let (full, collapsed) = &mut *st;
+                let (full, collapsed) = &mut st[0];
                 let p = path.to_string();
                 if !collapsed.remove(&p) {
                     collapsed.insert(p);
                 }
                 push_doc_tree(&w, 0, full, collapsed);
+            });
+        });
+    }
+    {
+        let weak = window.as_weak();
+        window.on_p1_toggle_doc_node(move |path| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            DOC_TREES.with(|s| {
+                let mut st = s.borrow_mut();
+                let (full, collapsed) = &mut st[1];
+                let p = path.to_string();
+                if !collapsed.remove(&p) {
+                    collapsed.insert(p);
+                }
+                push_doc_tree(&w, 1, full, collapsed);
             });
         });
     }
@@ -6667,6 +7005,109 @@ fn main() -> Result<(), slint::PlatformError> {
                 None => {
                     clear_grid(&w, 0);
                     *last_view.lock().unwrap() = None;
+                }
+            }
+        });
+    }
+
+    {
+        let weak = window.as_weak();
+        let panes = panes.clone();
+        let last_view = last_view.clone();
+        let workspace_tabs = workspace_tabs.clone();
+        let active_tab_id = active_tab_id.clone();
+        window.on_p1_select_result_tab(move |i| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let i = i.max(0) as usize;
+            let sr = panes[1].results.lock().unwrap().get(i).cloned();
+            let Some(sr) = sr else {
+                return;
+            };
+            *panes[1].active_result.lock().unwrap() = i;
+            if let Some(id) = active_tab_id.lock().unwrap().clone() {
+                if let Some(tab) = workspace_tabs
+                    .lock()
+                    .unwrap()
+                    .iter_mut()
+                    .find(|tab| tab.id == id)
+                {
+                    tab.pane1_active_result = i;
+                }
+            }
+            w.set_p1_active_result(i as i32);
+            present_view(
+                &w,
+                1,
+                sr.view,
+                &sr.meta,
+                &sr.latency,
+                &last_view,
+                &panes[1].displayed_grid,
+                &panes[1].hidden_cols,
+                &panes[1].sort_state,
+                &panes[1].col_order,
+                &panes[1].col_filters,
+                &panes[1].edit_buf,
+                &panes[1].browse,
+            );
+        });
+    }
+    {
+        let weak = window.as_weak();
+        let panes = panes.clone();
+        let last_view = last_view.clone();
+        let workspace_tabs = workspace_tabs.clone();
+        let active_tab_id = active_tab_id.clone();
+        window.on_p1_close_result_tab(move |i| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let i = i.max(0) as usize;
+            let (count, active, sr) = {
+                let mut rv = panes[1].results.lock().unwrap();
+                if i >= rv.len() {
+                    return;
+                }
+                rv.remove(i);
+                let mut ar = panes[1].active_result.lock().unwrap();
+                if *ar >= rv.len() {
+                    *ar = rv.len().saturating_sub(1);
+                }
+                (rv.len(), *ar, rv.get(*ar).cloned())
+            };
+            set_result_tabs(&w, 1, count, active);
+            if let Some(id) = active_tab_id.lock().unwrap().clone() {
+                if let Some(tab) = workspace_tabs
+                    .lock()
+                    .unwrap()
+                    .iter_mut()
+                    .find(|tab| tab.id == id)
+                {
+                    tab.pane1_results = panes[1].results.lock().unwrap().clone();
+                    tab.pane1_active_result = active;
+                }
+            }
+            match sr {
+                Some(sr) => present_view(
+                    &w,
+                    1,
+                    sr.view,
+                    &sr.meta,
+                    &sr.latency,
+                    &last_view,
+                    &panes[1].displayed_grid,
+                    &panes[1].hidden_cols,
+                    &panes[1].sort_state,
+                    &panes[1].col_order,
+                    &panes[1].col_filters,
+                    &panes[1].edit_buf,
+                    &panes[1].browse,
+                ),
+                None => {
+                    clear_grid(&w, 1);
+                    set_p_results_meta(&w, 1, SharedString::default());
                 }
             }
         });

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2177,6 +2177,26 @@ fn main() -> Result<(), slint::PlatformError> {
     };
     load_editor_text(0, "");
 
+    // ----- toggle the dual-pane split for the active SQL tab -----
+    {
+        let weak = window.as_weak();
+        let sync_editor = sync_editor.clone();
+        window.on_toggle_split(move || {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let now = !w.get_split();
+            w.set_split(now);
+            if now {
+                // Render the right pane's (initially empty) editor + result.
+                sync_editor(1);
+                clear_grid(&w, 1);
+                set_p_result_status(&w, 1, SharedString::default());
+                set_p_results_meta(&w, 1, SharedString::default());
+            }
+        });
+    }
+
     // ----- toggle a statement fold from the gutter arrow -----
     {
         let ed_state = ed_state.clone();

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2401,8 +2401,21 @@ fn main() -> Result<(), slint::PlatformError> {
                     return true;
                 }
                 if meta {
+                    // ⌘⏎ runs the pane the caret is in. The global window shortcut
+                    // always targets pane 0, so intercept it here (outside the ed
+                    // borrow) and dispatch to the firing pane instead.
+                    if text.as_str() == "\r" || text.as_str() == "\n" {
+                        if let Some(w) = weak.upgrade() {
+                            if pane == 0 {
+                                w.invoke_run_query();
+                            } else {
+                                w.invoke_p1_run();
+                            }
+                        }
+                        return true;
+                    }
                     // Editor-owned cmd combos; everything else bubbles up to the
-                    // window shortcut scope (⌘⏎ run, ⌘S commit, ⌘R refresh, …).
+                    // window shortcut scope (⌘S commit, ⌘R refresh, …).
                     let handled = {
                         let mut ed = ed_state.borrow_mut();
                         match text.as_str() {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -3988,6 +3988,45 @@ fn main() -> Result<(), slint::PlatformError> {
     }
     {
         let weak = window.as_weak();
+        let workspace_tabs = workspace_tabs.clone();
+        let active_tab_id = active_tab_id.clone();
+        let active_p1_tab_id = active_p1_tab_id.clone();
+        let current_connection_id = current_connection_id.clone();
+        let query_number = query_number.clone();
+        let save_p1_tab = save_p1_tab.clone();
+        let restore_p1_tab = restore_p1_tab.clone();
+        window.on_new_tab_in_group(move |group| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            if group == 0 {
+                w.invoke_new_tab();
+                return;
+            }
+            save_p1_tab(&w);
+            let number = query_number.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+            let connection = current_connection_id
+                .lock()
+                .unwrap()
+                .clone()
+                .unwrap_or_default();
+            let id = format!("query:{connection}:{number}");
+            let right_index = {
+                let mut tabs = workspace_tabs.lock().unwrap();
+                let mut tab = WorkspaceTab::sql(id.clone(), number);
+                tab.group = 1;
+                tabs.push(tab);
+                let left = active_tab_id.lock().unwrap().clone();
+                set_workspace_tabs(&w, &tabs, left.as_deref());
+                save_query_tabs(&tabs, left.as_deref());
+                tabs.iter().filter(|tab| tab.group == 1).count() - 1
+            };
+            *active_p1_tab_id.lock().unwrap() = Some(id);
+            restore_p1_tab(&w, right_index);
+        });
+    }
+    {
+        let weak = window.as_weak();
         let tabs = workspace_tabs.clone();
         let save_active_tab = save_active_tab.clone();
         let save_p1_tab = save_p1_tab.clone();

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -337,6 +337,9 @@ in-out property <string> rename-text;
     // ----- tabs + palette -----
     in property <[TabItem]> tabs;
     in-out property <int> active-tab: -1;
+    // Dual-pane split for the active SQL tab (right pane + focused pane index).
+    in-out property <bool> split: false;
+    in-out property <int> active-pane: 0;
     in property <bool> palette-open;
     in property <[PaletteItem]> palette-items;
     callback new-tab();
@@ -968,6 +971,8 @@ in-out property <string> rename-text;
 
                     if root.tabs.length > 0: WorkArea {
                         vertical-stretch: 1;
+                        split: root.split;
+                        active-pane: root.active-pane;
                         detail-visible <=> root.detail-visible;
                         detail-left: root.sidebar-right;
                         results-collapsed <=> root.results-collapsed;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -85,6 +85,8 @@ export component MainWindow inherits Window {
                     if (root.active-table != "") {
                         root.data-filter-open = true;
                         root.focus-data-filter-tick += 1;
+                    } else if (root.active-pane == 1) {
+                        root.p1-toggle-find();
                     } else {
                         root.toggle-find();
                     }
@@ -522,11 +524,16 @@ in-out property <string> rename-text;
                     return accept;
                 }
                 if (e.text == Key.Return) {
-                    root.run-query();
+                    if (root.active-pane == 1) { root.p1-run(); } else { root.run-query(); }
                     return accept;
                 }
                 if (e.text == "\\") {
                     root.run-new-tab();
+                    return accept;
+                }
+                // ⌘D splits / unsplits the SQL editor into two panes.
+                if (e.text == "d" && root.active-table == "") {
+                    root.toggle-split();
                     return accept;
                 }
                 if (e.text == "s") {
@@ -541,6 +548,8 @@ in-out property <string> rename-text;
                     if (root.active-table != "") {
                         root.data-filter-open = true;
                         root.focus-data-filter-tick += 1;
+                    } else if (root.active-pane == 1) {
+                        root.p1-toggle-find();
                     } else {
                         root.toggle-find();
                     }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -340,6 +340,82 @@ in-out property <string> rename-text;
     // Dual-pane split for the active SQL tab (right pane + focused pane index).
     in-out property <bool> split: false;
     in-out property <int> active-pane: 0;
+    // Pane 1 (right split pane) mirror state, filled by Rust while split is on.
+    in property <[[Span]]> p1-editor-lines;
+    in property <[int]> p1-editor-fold-state;
+    in property <[bool]> p1-editor-line-hidden;
+    in property <string> p1-editor-placeholder;
+    in property <int> p1-cursor-line;
+    in property <int> p1-cursor-col;
+    in-out property <bool> p1-editor-collapsed;
+    in-out property <length> p1-editor-h: 340px;
+    in property <[PaletteItem]> p1-completion-items;
+    in property <bool> p1-completion-visible;
+    in property <int> p1-completion-selected;
+    in property <bool> p1-find-open;
+    in property <string> p1-find-text;
+    in property <string> p1-find-status;
+    in property <bool> p1-query-running;
+    in property <bool> p1-streaming;
+    in-out property <string> p1-limit-text;
+    in property <string> p1-query-label;
+    in property <string> p1-results-meta;
+    in property <[string]> p1-result-tabs;
+    in property <int> p1-active-result;
+    in-out property <int> p1-sql-view-mode;
+    in-out property <bool> p1-filter-open;
+    in property <[GridColumn]> p1-columns;
+    in property <[GridCell]> p1-cells;
+    in property <int> p1-col-count;
+    in property <[length]> p1-col-widths;
+    in property <int> p1-result-kind;
+    in property <string> p1-result-status;
+    in property <bool> p1-status-error;
+    in property <int> p1-grid-sort-col: -1;
+    in property <bool> p1-grid-sort-asc: true;
+    in property <[string]> p1-grid-col-filters;
+    in-out property <int> p1-selected-row;
+    in-out property <int> p1-selected-col: -1;
+    in property <int> p1-editing-row: -1;
+    in property <int> p1-editing-col: -1;
+    in-out property <string> p1-editing-value;
+    in property <int> p1-scroll-grid-tick;
+    in property <int> p1-doc-view;
+    in property <[DocRow]> p1-doc-tree;
+    in property <[StructField]> p1-structure-columns;
+    in property <[IndexRow]> p1-index-rows;
+    in property <[ChartBar]> p1-chart-bars;
+    callback p1-run();
+    callback p1-run-selection();
+    callback p1-format-sql();
+    callback p1-explain-query();
+    callback p1-cancel-stream();
+    callback p1-set-limit(string);
+    callback p1-find-changed(string);
+    callback p1-find-next();
+    callback p1-find-prev();
+    callback p1-find-close();
+    callback p1-toggle-fold(int);
+    callback p1-editor-key(string, bool, bool, bool) -> bool;
+    callback p1-editor-press(int, int);
+    callback p1-editor-drag(int, int);
+    callback p1-editor-select-word(int, int);
+    callback p1-completion-choose(int);
+    callback p1-select-result-tab(int);
+    callback p1-close-result-tab(int);
+    callback p1-copy-results();
+    callback p1-export-results(int);
+    callback p1-sort-col(int);
+    callback p1-reorder-col(int, length);
+    callback p1-set-col-filter(int, string);
+    callback p1-resize-col(int, length);
+    callback p1-select-cell(int, int);
+    callback p1-edit-cell(int, int);
+    callback p1-cell-edited(int, int, string);
+    callback p1-cell-advance(int, int, string, bool);
+    callback p1-stage-cell(int, int, string);
+    callback p1-edit-cancelled();
+    callback p1-toggle-doc-node(string);
     in property <bool> palette-open;
     in property <[PaletteItem]> palette-items;
     callback new-tab();
@@ -973,6 +1049,81 @@ in-out property <string> rename-text;
                         vertical-stretch: 1;
                         split: root.split;
                         active-pane: root.active-pane;
+                        p1-editor-lines: root.p1-editor-lines;
+                        p1-editor-fold-state: root.p1-editor-fold-state;
+                        p1-editor-line-hidden: root.p1-editor-line-hidden;
+                        p1-editor-placeholder: root.p1-editor-placeholder;
+                        p1-cursor-line: root.p1-cursor-line;
+                        p1-cursor-col: root.p1-cursor-col;
+                        p1-editor-collapsed <=> root.p1-editor-collapsed;
+                        p1-editor-h <=> root.p1-editor-h;
+                        p1-completion-items: root.p1-completion-items;
+                        p1-completion-visible: root.p1-completion-visible;
+                        p1-completion-selected: root.p1-completion-selected;
+                        p1-find-open: root.p1-find-open;
+                        p1-find-text: root.p1-find-text;
+                        p1-find-status: root.p1-find-status;
+                        p1-query-running: root.p1-query-running;
+                        p1-streaming: root.p1-streaming;
+                        p1-limit-text <=> root.p1-limit-text;
+                        p1-query-label: root.p1-query-label;
+                        p1-results-meta: root.p1-results-meta;
+                        p1-result-tabs: root.p1-result-tabs;
+                        p1-active-result: root.p1-active-result;
+                        p1-sql-view-mode <=> root.p1-sql-view-mode;
+                        p1-filter-open <=> root.p1-filter-open;
+                        p1-columns: root.p1-columns;
+                        p1-cells: root.p1-cells;
+                        p1-col-count: root.p1-col-count;
+                        p1-col-widths: root.p1-col-widths;
+                        p1-result-kind: root.p1-result-kind;
+                        p1-result-status: root.p1-result-status;
+                        p1-status-error: root.p1-status-error;
+                        p1-grid-sort-col: root.p1-grid-sort-col;
+                        p1-grid-sort-asc: root.p1-grid-sort-asc;
+                        p1-grid-col-filters: root.p1-grid-col-filters;
+                        p1-selected-row <=> root.p1-selected-row;
+                        p1-selected-col <=> root.p1-selected-col;
+                        p1-editing-row: root.p1-editing-row;
+                        p1-editing-col: root.p1-editing-col;
+                        p1-editing-value <=> root.p1-editing-value;
+                        p1-scroll-grid-tick: root.p1-scroll-grid-tick;
+                        p1-doc-view: root.p1-doc-view;
+                        p1-doc-tree: root.p1-doc-tree;
+                        p1-structure-columns: root.p1-structure-columns;
+                        p1-index-rows: root.p1-index-rows;
+                        p1-chart-bars: root.p1-chart-bars;
+                        p1-run() => { root.p1-run(); }
+                        p1-run-selection() => { root.p1-run-selection(); }
+                        p1-format-sql() => { root.p1-format-sql(); }
+                        p1-explain-query() => { root.p1-explain-query(); }
+                        p1-cancel-stream() => { root.p1-cancel-stream(); }
+                        p1-set-limit(t) => { root.p1-set-limit(t); }
+                        p1-find-changed(t) => { root.p1-find-changed(t); }
+                        p1-find-next() => { root.p1-find-next(); }
+                        p1-find-prev() => { root.p1-find-prev(); }
+                        p1-find-close() => { root.p1-find-close(); }
+                        p1-toggle-fold(l) => { root.p1-toggle-fold(l); }
+                        p1-editor-key(t, cmd, alt, shift) => { root.p1-editor-key(t, cmd, alt, shift) }
+                        p1-editor-press(l, c) => { root.p1-editor-press(l, c); }
+                        p1-editor-drag(l, c) => { root.p1-editor-drag(l, c); }
+                        p1-editor-select-word(l, c) => { root.p1-editor-select-word(l, c); }
+                        p1-completion-choose(i) => { root.p1-completion-choose(i); }
+                        p1-select-result-tab(i) => { root.p1-select-result-tab(i); }
+                        p1-close-result-tab(i) => { root.p1-close-result-tab(i); }
+                        p1-copy-results() => { root.p1-copy-results(); }
+                        p1-export-results(i) => { root.p1-export-results(i); }
+                        p1-sort-col(i) => { root.p1-sort-col(i); }
+                        p1-reorder-col(i, x) => { root.p1-reorder-col(i, x); }
+                        p1-set-col-filter(i, t) => { root.p1-set-col-filter(i, t); }
+                        p1-resize-col(i, d) => { root.p1-resize-col(i, d); }
+                        p1-select-cell(r, c) => { root.p1-select-cell(r, c); }
+                        p1-edit-cell(r, c) => { root.p1-edit-cell(r, c); }
+                        p1-cell-edited(r, c, t) => { root.p1-cell-edited(r, c, t); }
+                        p1-cell-advance(r, c, t, fwd) => { root.p1-cell-advance(r, c, t, fwd); }
+                        p1-stage-cell(r, c, t) => { root.p1-stage-cell(r, c, t); }
+                        p1-edit-cancelled() => { root.p1-edit-cancelled(); }
+                        p1-toggle-doc-node(p) => { root.p1-toggle-doc-node(p); }
                         detail-visible <=> root.detail-visible;
                         detail-left: root.sidebar-right;
                         results-collapsed <=> root.results-collapsed;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -160,6 +160,7 @@ callback open-rename(int, string);
 callback rename-commit();
 in-out property <bool> rename-modal-open: false;
 in-out property <int> rename-target: -1;
+in-out property <int> rename-group: 0;
 in-out property <string> rename-text;
     callback toggle-group(string);
     callback toggle-favorite(int);          // star/unstar a saved connection
@@ -968,12 +969,14 @@ in-out property <string> rename-text;
                                     moved => {
                                         if (abs(self.mouse-x - self.pressed-x) > 8px) {
                                             self.dragging = true;
+                                            root.tab-drag-source = 0;
                                         }
                                     }
                                     pointer-event(e) => {
                                         if (e.kind == PointerEventKind.down) {
                                             self.dragging = false;
-                                            root.tab-drag-source = 0;
+                                            root.active-tab = i;
+                                            root.active-pane = 0;
                                         }
                                         if (e.kind == PointerEventKind.up && self.dragging
                                             && self.mouse-x - self.pressed-x > 48px) {
@@ -1036,6 +1039,27 @@ in-out property <string> rename-text;
                                         font-weight: i == root.active-tab ? Tokens.weight-emphasis : 400;
                                         font-italic: tab.preview;
                                         overflow: elide;
+                                    }
+                                    Rectangle {
+                                        width: 18px;
+                                        height: 18px;
+                                        y: (parent.height - self.height) / 2;
+                                        border-radius: 4px;
+                                        background: rename-ta.has-hover ? Tokens.card : transparent;
+                                        visible: i == root.active-tab || tab-ta.has-hover;
+                                        rename-ta := TouchArea {
+                                            clicked => {
+                                                root.rename-target = i;
+                                                root.rename-group = 0;
+                                                root.rename-text = tab.title;
+                                                root.rename-modal-open = true;
+                                            }
+                                        }
+                                        AppIcon {
+                                            name: "pencil";
+                                            size: 11px;
+                                            color: rename-ta.has-hover ? Tokens.text : Tokens.text-dim;
+                                        }
                                     }
                                     Rectangle {
                                         width: 18px;
@@ -1113,12 +1137,14 @@ in-out property <string> rename-text;
                                     moved => {
                                         if (abs(self.mouse-x - self.pressed-x) > 8px) {
                                             self.dragging = true;
+                                            root.tab-drag-source = 1;
                                         }
                                     }
                                     pointer-event(e) => {
                                         if (e.kind == PointerEventKind.down) {
                                             self.dragging = false;
-                                            root.tab-drag-source = 1;
+                                            root.p1-active-tab = i;
+                                            root.active-pane = 1;
                                         }
                                         if (e.kind == PointerEventKind.up && self.dragging
                                             && self.pressed-x - self.mouse-x > 48px) {
@@ -1156,6 +1182,27 @@ in-out property <string> rename-text;
                                         font-size: Tokens.font-sm;
                                         font-weight: i == root.p1-active-tab ? Tokens.weight-emphasis : 400;
                                         overflow: elide;
+                                    }
+                                    Rectangle {
+                                        width: 18px;
+                                        height: 18px;
+                                        y: (parent.height - self.height) / 2;
+                                        border-radius: 4px;
+                                        background: p1-rename-ta.has-hover ? Tokens.card : transparent;
+                                        visible: i == root.p1-active-tab || p1-tab-ta.has-hover;
+                                        p1-rename-ta := TouchArea {
+                                            clicked => {
+                                                root.rename-target = i;
+                                                root.rename-group = 1;
+                                                root.rename-text = tab.title;
+                                                root.rename-modal-open = true;
+                                            }
+                                        }
+                                        AppIcon {
+                                            name: "pencil";
+                                            size: 11px;
+                                            color: p1-rename-ta.has-hover ? Tokens.text : Tokens.text-dim;
+                                        }
                                     }
                                     Rectangle {
                                         width: 18px;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -339,6 +339,10 @@ in-out property <string> rename-text;
     // ----- tabs + palette -----
     in property <[TabItem]> tabs;
     in-out property <int> active-tab: -1;
+    in property <[TabItem]> p1-tabs;
+    in-out property <int> p1-active-tab: -1;
+    callback select-p1-tab(int);
+    callback move-tab-group(int, int);
     // Dual-pane split for the active SQL tab (right pane + focused pane index).
     in-out property <bool> split: false;
     in-out property <int> active-pane: 0;
@@ -950,6 +954,19 @@ in-out property <string> rename-text;
                                     : (tab-ta.has-hover ? Tokens.card.with-alpha(0.5) : transparent);
                                 border-radius: 0;
                                 tab-ta := TouchArea {
+                                    property <bool> dragging: false;
+                                    moved => {
+                                        if (abs(self.mouse-x - self.pressed-x) > 8px) {
+                                            self.dragging = true;
+                                        }
+                                    }
+                                    pointer-event(e) => {
+                                        if (e.kind == PointerEventKind.down) { self.dragging = false; }
+                                        if (e.kind == PointerEventKind.up && self.dragging
+                                            && self.mouse-x - self.pressed-x > 48px) {
+                                            root.move-tab-group(i, 1);
+                                        }
+                                    }
                                     clicked => {
                                         root.select-tab(i);
                                     }
@@ -1041,6 +1058,57 @@ in-out property <string> rename-text;
                                             size: 11px;
                                             color: close-ta.has-hover ? white : Tokens.text-dim;
                                         }
+                                    }
+                                }
+                            }
+                            if root.p1-tabs.length > 0: Rectangle {
+                                width: 1px;
+                                height: parent.height - Tokens.sp2;
+                                background: Tokens.border-strong;
+                            }
+                            for tab[i] in root.p1-tabs: Rectangle {
+                                width: min(170px, p1-tab-content.preferred-width + 2 * Tokens.sp3);
+                                height: Tokens.doc-tab-h;
+                                background: i == root.p1-active-tab ? Tokens.card
+                                    : (p1-tab-ta.has-hover ? Tokens.card.with-alpha(0.5) : transparent);
+                                p1-tab-ta := TouchArea {
+                                    property <bool> dragging: false;
+                                    moved => {
+                                        if (abs(self.mouse-x - self.pressed-x) > 8px) {
+                                            self.dragging = true;
+                                        }
+                                    }
+                                    pointer-event(e) => {
+                                        if (e.kind == PointerEventKind.down) { self.dragging = false; }
+                                        if (e.kind == PointerEventKind.up && self.dragging
+                                            && self.pressed-x - self.mouse-x > 48px) {
+                                            root.move-tab-group(i, 0);
+                                        }
+                                    }
+                                    clicked => { root.select-p1-tab(i); }
+                                }
+                                if i == root.p1-active-tab: Rectangle {
+                                    y: 0;
+                                    height: 2px;
+                                    width: parent.width;
+                                    background: Tokens.accent;
+                                }
+                                p1-tab-content := HorizontalLayout {
+                                    padding-left: Tokens.sp3;
+                                    padding-right: Tokens.sp2;
+                                    Text {
+                                        vertical-alignment: center;
+                                        text: tab.kind == "sql" ? ">_" : tab.kind == "function" ? "ƒ" : "▦";
+                                        color: Tokens.text-faint;
+                                        font-size: Tokens.font-sm;
+                                    }
+                                    Text {
+                                        vertical-alignment: center;
+                                        text: tab.title;
+                                        color: i == root.p1-active-tab ? Tokens.text : Tokens.text-dim;
+                                        font-size: Tokens.font-sm;
+                                        font-weight: i == root.p1-active-tab ? Tokens.weight-emphasis : 400;
+                                        overflow: elide;
                                     }
                                 }
                             }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -536,11 +536,6 @@ in-out property <string> rename-text;
                     root.run-new-tab();
                     return accept;
                 }
-                // ⌘D splits / unsplits the SQL editor into two panes.
-                if (e.text == "d" && root.active-table == "") {
-                    root.toggle-split();
-                    return accept;
-                }
                 if (e.text == "s") {
                     root.commit-edits();
                     return accept;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -370,6 +370,14 @@ in-out property <string> rename-text;
     in property <bool> p1-query-running;
     in property <bool> p1-streaming;
     in-out property <string> p1-limit-text;
+    in property <string> p1-active-table;
+    in property <int> p1-page-start;
+    in property <int> p1-page-end;
+    in property <int> p1-total-rows: -1;
+    in property <bool> p1-can-prev;
+    in property <bool> p1-can-next;
+    in property <bool> p1-grid-read-only: true;
+    in-out property <bool> p1-show-structure: false;
     in property <string> p1-query-label;
     in property <string> p1-results-meta;
     in property <[string]> p1-result-tabs;
@@ -403,6 +411,9 @@ in-out property <string> rename-text;
     callback p1-explain-query();
     callback p1-cancel-stream();
     callback p1-set-limit(string);
+    callback p1-prev-page();
+    callback p1-next-page();
+    callback p1-refresh-page();
     callback p1-toggle-find();
     callback p1-find-changed(string);
     callback p1-find-next();
@@ -1279,6 +1290,14 @@ in-out property <string> rename-text;
                         p1-query-running: root.p1-query-running;
                         p1-streaming: root.p1-streaming;
                         p1-limit-text <=> root.p1-limit-text;
+                        p1-active-table: root.p1-active-table;
+                        p1-page-start: root.p1-page-start;
+                        p1-page-end: root.p1-page-end;
+                        p1-total-rows: root.p1-total-rows;
+                        p1-can-prev: root.p1-can-prev;
+                        p1-can-next: root.p1-can-next;
+                        p1-read-only: root.p1-grid-read-only;
+                        p1-show-structure <=> root.p1-show-structure;
                         p1-query-label: root.p1-query-label;
                         p1-results-meta: root.p1-results-meta;
                         p1-result-tabs: root.p1-result-tabs;
@@ -1312,6 +1331,9 @@ in-out property <string> rename-text;
                         p1-explain-query() => { root.p1-explain-query(); }
                         p1-cancel-stream() => { root.p1-cancel-stream(); }
                         p1-set-limit(t) => { root.p1-set-limit(t); }
+                        p1-prev-page() => { root.p1-prev-page(); }
+                        p1-next-page() => { root.p1-next-page(); }
+                        p1-refresh-page() => { root.p1-refresh-page(); }
                         p1-find-changed(t) => { root.p1-find-changed(t); }
                         p1-find-next() => { root.p1-find-next(); }
                         p1-find-prev() => { root.p1-find-prev(); }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -559,11 +559,15 @@ in-out property <string> rename-text;
                     return accept;
                 }
                 if (e.text == "t") {
-                    root.new-tab();
+                    root.new-tab-in-group(root.active-pane);
                     return accept;
                 }
                 if (e.text == "w") {
-                    root.close-tab(root.active-tab);
+                    if (root.active-pane == 1) {
+                        root.close-p1-tab(root.p1-active-tab);
+                    } else {
+                        root.close-tab(root.active-tab);
+                    }
                     return accept;
                 }
                 if (e.text == "1") {

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -343,7 +343,9 @@ in-out property <string> rename-text;
     in-out property <int> p1-active-tab: -1;
     callback select-p1-tab(int);
     callback close-p1-tab(int);
+    callback new-tab-in-group(int);
     callback move-tab-group(int, int);
+    in-out property <int> tab-drag-source: -1;
     // Dual-pane split for the active SQL tab (right pane + focused pane index).
     in-out property <bool> split: false;
     in-out property <int> active-pane: 0;
@@ -943,7 +945,8 @@ in-out property <string> rename-text;
                         background: Tokens.chrome;
                         left-group := Rectangle {
                             x: 0;
-                            width: root.split ? (parent.width - 6px) * root.split-ratio : parent.width;
+                            width: (root.split || root.tab-drag-source == 0)
+                                ? (parent.width - 6px) * root.split-ratio : parent.width;
                             height: parent.height;
                             clip: true;
                             HorizontalLayout {
@@ -964,14 +967,22 @@ in-out property <string> rename-text;
                                         }
                                     }
                                     pointer-event(e) => {
-                                        if (e.kind == PointerEventKind.down) { self.dragging = false; }
+                                        if (e.kind == PointerEventKind.down) {
+                                            self.dragging = false;
+                                            root.tab-drag-source = 0;
+                                        }
                                         if (e.kind == PointerEventKind.up && self.dragging
                                             && self.mouse-x - self.pressed-x > 48px) {
                                             root.move-tab-group(i, 1);
                                         }
+                                        if (e.kind == PointerEventKind.up) { root.tab-drag-source = -1; }
                                     }
                                     clicked => {
-                                        if !self.dragging { root.select-tab(i); }
+                                        if !self.dragging {
+                                            root.active-tab = i;
+                                            root.active-pane = 0;
+                                            root.select-tab(i);
+                                        }
                                     }
                                     double-clicked => {
                                         root.pin-tab(i);
@@ -1022,6 +1033,21 @@ in-out property <string> rename-text;
                                         font-italic: tab.preview;
                                         overflow: elide;
                                     }
+                                    Rectangle {
+                                        width: 18px;
+                                        height: 18px;
+                                        y: (parent.height - self.height) / 2;
+                                        border-radius: 4px;
+                                        background: move-ta.has-hover ? Tokens.accent-tint : transparent;
+                                        visible: i == root.active-tab || tab-ta.has-hover;
+                                        move-ta := TouchArea { clicked => { root.move-tab-group(i, 1); } }
+                                        Text {
+                                            text: "⇥";
+                                            color: move-ta.has-hover ? Tokens.accent : Tokens.text-dim;
+                                            horizontal-alignment: center;
+                                            vertical-alignment: center;
+                                        }
+                                    }
                                     // close affordance (active or hovered tab)
                                     Rectangle {
                                         width: 18px;
@@ -1044,15 +1070,31 @@ in-out property <string> rename-text;
                                     }
                                 }
                             }
+                                Rectangle {
+                                    width: 26px;
+                                    height: 26px;
+                                    y: (parent.height - self.height) / 2;
+                                    border-radius: Tokens.radius;
+                                    background: add-ta.has-hover ? Tokens.accent-tint : transparent;
+                                    Text { text: "+"; color: add-ta.has-hover ? Tokens.accent : Tokens.text-dim; horizontal-alignment: center; vertical-alignment: center; font-size: 16px; }
+                                    add-ta := TouchArea { clicked => { root.new-tab-in-group(0); } }
+                                }
                                 Rectangle { horizontal-stretch: 1; }
                             }
                         }
-                        if root.split: Rectangle {
+                        if root.split || root.tab-drag-source == 0: Rectangle {
                             x: (parent.width - 6px) * root.split-ratio + 6px;
                             width: (parent.width - 6px) * (1 - root.split-ratio);
                             height: parent.height;
                             clip: true;
-                            background: Tokens.chrome;
+                            background: root.tab-drag-source == 0 ? Tokens.accent-tint : Tokens.chrome;
+                            if !root.split: Text {
+                                text: "Drop tab here";
+                                color: Tokens.accent;
+                                horizontal-alignment: center;
+                                vertical-alignment: center;
+                                font-size: Tokens.font-sm;
+                            }
                             HorizontalLayout {
                                 padding-left: Tokens.sp2;
                                 padding-top: Tokens.doc-tab-row-h - Tokens.doc-tab-h;
@@ -1070,14 +1112,22 @@ in-out property <string> rename-text;
                                         }
                                     }
                                     pointer-event(e) => {
-                                        if (e.kind == PointerEventKind.down) { self.dragging = false; }
+                                        if (e.kind == PointerEventKind.down) {
+                                            self.dragging = false;
+                                            root.tab-drag-source = 1;
+                                        }
                                         if (e.kind == PointerEventKind.up && self.dragging
                                             && self.pressed-x - self.mouse-x > 48px) {
                                             root.move-tab-group(i, 0);
                                         }
+                                        if (e.kind == PointerEventKind.up) { root.tab-drag-source = -1; }
                                     }
                                     clicked => {
-                                        if !self.dragging { root.select-p1-tab(i); }
+                                        if !self.dragging {
+                                            root.p1-active-tab = i;
+                                            root.active-pane = 1;
+                                            root.select-p1-tab(i);
+                                        }
                                     }
                                 }
                                 if i == root.p1-active-tab: Rectangle {
@@ -1108,6 +1158,21 @@ in-out property <string> rename-text;
                                         height: 18px;
                                         y: (parent.height - self.height) / 2;
                                         border-radius: 4px;
+                                        background: p1-move-ta.has-hover ? Tokens.accent-tint : transparent;
+                                        visible: i == root.p1-active-tab || p1-tab-ta.has-hover;
+                                        p1-move-ta := TouchArea { clicked => { root.move-tab-group(i, 0); } }
+                                        Text {
+                                            text: "⇤";
+                                            color: p1-move-ta.has-hover ? Tokens.accent : Tokens.text-dim;
+                                            horizontal-alignment: center;
+                                            vertical-alignment: center;
+                                        }
+                                    }
+                                    Rectangle {
+                                        width: 18px;
+                                        height: 18px;
+                                        y: (parent.height - self.height) / 2;
+                                        border-radius: 4px;
                                         background: p1-close-ta.has-hover ? Tokens.error : transparent;
                                         visible: i == root.p1-active-tab || p1-tab-ta.has-hover;
                                         p1-close-ta := TouchArea {
@@ -1121,6 +1186,15 @@ in-out property <string> rename-text;
                                     }
                                 }
                             }
+                                if root.split: Rectangle {
+                                    width: 26px;
+                                    height: 26px;
+                                    y: (parent.height - self.height) / 2;
+                                    border-radius: Tokens.radius;
+                                    background: p1-add-ta.has-hover ? Tokens.accent-tint : transparent;
+                                    Text { text: "+"; color: p1-add-ta.has-hover ? Tokens.accent : Tokens.text-dim; horizontal-alignment: center; vertical-alignment: center; font-size: 16px; }
+                                    p1-add-ta := TouchArea { clicked => { root.new-tab-in-group(1); } }
+                                }
                                 Rectangle { horizontal-stretch: 1; }
                             }
                         }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -342,6 +342,7 @@ in-out property <string> rename-text;
     in property <[TabItem]> p1-tabs;
     in-out property <int> p1-active-tab: -1;
     callback select-p1-tab(int);
+    callback close-p1-tab(int);
     callback move-tab-group(int, int);
     // Dual-pane split for the active SQL tab (right pane + focused pane index).
     in-out property <bool> split: false;
@@ -934,14 +935,21 @@ in-out property <string> rename-text;
                     min-width: 340px;
                     max-width: 100000px;
                     spacing: 0px;
-                    // ----- doc-tab row (36px, tabs h30, active = card + accent top inset) -----
+                    // Each workspace group owns a tab strip directly above its
+                    // preview. `split` here means a second tab group exists;
+                    // it is no longer a second editor inside one document tab.
                     if root.tabs.length > 0: tabbar := Rectangle {
                         height: Tokens.doc-tab-row-h;
                         background: Tokens.chrome;
-                        HorizontalLayout {
-                            padding-left: Tokens.sp2;
-                            padding-top: Tokens.doc-tab-row-h - Tokens.doc-tab-h;
-                            spacing: Tokens.sp1;
+                        left-group := Rectangle {
+                            x: 0;
+                            width: root.split ? (parent.width - 6px) * root.split-ratio : parent.width;
+                            height: parent.height;
+                            clip: true;
+                            HorizontalLayout {
+                                padding-left: Tokens.sp2;
+                                padding-top: Tokens.doc-tab-row-h - Tokens.doc-tab-h;
+                                spacing: Tokens.sp1;
                             for tab[i] in root.tabs: Rectangle {
                                 width: min(170px, tab-content.preferred-width + 2 * Tokens.sp3);
                                 height: Tokens.doc-tab-h;
@@ -963,7 +971,7 @@ in-out property <string> rename-text;
                                         }
                                     }
                                     clicked => {
-                                        root.select-tab(i);
+                                        if !self.dragging { root.select-tab(i); }
                                     }
                                     double-clicked => {
                                         root.pin-tab(i);
@@ -1014,26 +1022,6 @@ in-out property <string> rename-text;
                                         font-italic: tab.preview;
                                         overflow: elide;
                                     }
-                                    // rename affordance (active or hovered tab)
-                                    Rectangle {
-                                        width: 18px;
-                                        height: 18px;
-                                        y: (parent.height - self.height) / 2;
-                                        border-radius: 4px;
-                                        background: rename-ta.has-hover ? Tokens.card : transparent;
-                                        visible: i == root.active-tab || tab-ta.has-hover;
-                                        rename-ta := TouchArea {
-                                            clicked => {
-                                                root.open-rename(i, tab.title);
-                                            }
-                                        }
-
-                                        AppIcon {
-                                            name: "pencil";
-                                            size: 11px;
-                                            color: rename-ta.has-hover ? Tokens.text : Tokens.text-dim;
-                                        }
-                                    }
                                     // close affordance (active or hovered tab)
                                     Rectangle {
                                         width: 18px;
@@ -1056,11 +1044,19 @@ in-out property <string> rename-text;
                                     }
                                 }
                             }
-                            if root.p1-tabs.length > 0: Rectangle {
-                                width: 1px;
-                                height: parent.height - Tokens.sp2;
-                                background: Tokens.border-strong;
+                                Rectangle { horizontal-stretch: 1; }
                             }
+                        }
+                        if root.split: Rectangle {
+                            x: (parent.width - 6px) * root.split-ratio + 6px;
+                            width: (parent.width - 6px) * (1 - root.split-ratio);
+                            height: parent.height;
+                            clip: true;
+                            background: Tokens.chrome;
+                            HorizontalLayout {
+                                padding-left: Tokens.sp2;
+                                padding-top: Tokens.doc-tab-row-h - Tokens.doc-tab-h;
+                                spacing: Tokens.sp1;
                             for tab[i] in root.p1-tabs: Rectangle {
                                 width: min(170px, p1-tab-content.preferred-width + 2 * Tokens.sp3);
                                 height: Tokens.doc-tab-h;
@@ -1080,7 +1076,9 @@ in-out property <string> rename-text;
                                             root.move-tab-group(i, 0);
                                         }
                                     }
-                                    clicked => { root.select-p1-tab(i); }
+                                    clicked => {
+                                        if !self.dragging { root.select-p1-tab(i); }
+                                    }
                                 }
                                 if i == root.p1-active-tab: Rectangle {
                                     y: 0;
@@ -1105,12 +1103,25 @@ in-out property <string> rename-text;
                                         font-weight: i == root.p1-active-tab ? Tokens.weight-emphasis : 400;
                                         overflow: elide;
                                     }
+                                    Rectangle {
+                                        width: 18px;
+                                        height: 18px;
+                                        y: (parent.height - self.height) / 2;
+                                        border-radius: 4px;
+                                        background: p1-close-ta.has-hover ? Tokens.error : transparent;
+                                        visible: i == root.p1-active-tab || p1-tab-ta.has-hover;
+                                        p1-close-ta := TouchArea {
+                                            clicked => { root.close-p1-tab(i); }
+                                        }
+                                        AppIcon {
+                                            name: "close";
+                                            size: 11px;
+                                            color: p1-close-ta.has-hover ? white : Tokens.text-dim;
+                                        }
+                                    }
                                 }
                             }
-                            // trailing filler: gives the tab bar an infinite max-width
-                            // so the work column (and the window) can stretch full-width
-                            Rectangle {
-                                horizontal-stretch: 1;
+                                Rectangle { horizontal-stretch: 1; }
                             }
                         }
                     }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -342,6 +342,7 @@ in-out property <string> rename-text;
     // Dual-pane split for the active SQL tab (right pane + focused pane index).
     in-out property <bool> split: false;
     in-out property <int> active-pane: 0;
+    in-out property <float> split-ratio: 0.5;
     callback toggle-split();
     // Pane 1 (right split pane) mirror state, filled by Rust while split is on.
     in property <[[Span]]> p1-editor-lines;
@@ -1060,6 +1061,7 @@ in-out property <string> rename-text;
                         vertical-stretch: 1;
                         split: root.split;
                         active-pane: root.active-pane;
+                        split-ratio <=> root.split-ratio;
                         toggle-split() => { root.toggle-split(); }
                         p1-editor-lines: root.p1-editor-lines;
                         p1-editor-fold-state: root.p1-editor-fold-state;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -392,6 +392,7 @@ in-out property <string> rename-text;
     callback p1-explain-query();
     callback p1-cancel-stream();
     callback p1-set-limit(string);
+    callback p1-toggle-find();
     callback p1-find-changed(string);
     callback p1-find-next();
     callback p1-find-prev();

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -340,6 +340,7 @@ in-out property <string> rename-text;
     // Dual-pane split for the active SQL tab (right pane + focused pane index).
     in-out property <bool> split: false;
     in-out property <int> active-pane: 0;
+    callback toggle-split();
     // Pane 1 (right split pane) mirror state, filled by Rust while split is on.
     in property <[[Span]]> p1-editor-lines;
     in property <[int]> p1-editor-fold-state;
@@ -1049,6 +1050,7 @@ in-out property <string> rename-text;
                         vertical-stretch: 1;
                         split: root.split;
                         active-pane: root.active-pane;
+                        toggle-split() => { root.toggle-split(); }
                         p1-editor-lines: root.p1-editor-lines;
                         p1-editor-fold-state: root.p1-editor-fold-state;
                         p1-editor-line-hidden: root.p1-editor-line-hidden;

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -1,0 +1,732 @@
+// One query pane: the SQL editor (toolbar + find bar + CodeEditor + results
+// header/tabs), the editor/results splitter, and the result body (grid, detail
+// panel, Mongo docs, structure, indexes, message, chart). A SQL tab can show two
+// of these side by side (dual-pane split); browse/function chrome stays in
+// WorkArea. Lifted verbatim from workarea.slint — property names match 1:1 so
+// the moved markup's `root.<prop>` references resolve to this component.
+import { Tokens } from "tokens.slint";
+import { GridColumn, GridCell, StructField, Span, ChartBar, IndexRow, DocRow } from "structs.slint";
+import { CodeEditor } from "code-editor.slint";
+import { TabularGrid } from "tabular-grid.slint";
+import { PaletteItem } from "palette.slint";
+import { SecondaryButton, PrimaryButton, TextButton, ExportButton } from "components.slint";
+import { ScrollView } from "std-widgets.slint";
+
+export component QueryPane inherits Rectangle {
+    // ----- tab-global context (forwarded from WorkArea) -----
+    in property <bool> browse-mode: false;
+    in property <bool> browse-editor-open: false;
+    in property <bool> fn-mode: false;
+    in property <bool> results-collapsed: false;
+    in property <bool> detail-visible: true;
+    in property <bool> detail-left: false;
+    in property <int> view-mode: 0;
+    in property <bool> sql-capable: true;
+    in property <bool> read-only: true;
+
+    // ----- editor toolbar -----
+    in-out property <length> editor-h: 340px;
+    in property <bool> query-running;
+    in property <bool> streaming;
+    in-out property <string> limit-text;
+    in property <string> query-label;
+    callback run();
+    callback run-selection();
+    callback format-sql();
+    callback explain-query();
+    callback cancel-stream();
+    callback set-limit(string);
+
+    // ----- find bar -----
+    in property <bool> find-open;
+    in property <string> find-text;
+    in property <string> find-status;
+    callback find-changed(string);
+    callback find-next();
+    callback find-prev();
+    callback find-close();
+
+    // ----- editor model -----
+    in-out property <bool> editor-collapsed: false;
+    in property <[[Span]]> editor-lines;
+    in property <[int]> editor-fold-state;
+    in property <[bool]> editor-line-hidden;
+    in property <string> editor-placeholder;
+    in property <int> cursor-line;
+    in property <int> cursor-col;
+    callback toggle-fold(int);
+    callback editor-key(string, bool, bool, bool) -> bool;
+    callback editor-press(int, int);
+    callback editor-drag(int, int);
+    callback editor-select-word(int, int);
+
+    // ----- autocomplete -----
+    in property <[PaletteItem]> completion-items;
+    in property <bool> completion-visible;
+    in property <int> completion-selected;
+    callback completion-choose(int);
+
+    // ----- results header + tabs -----
+    in property <string> results-meta;
+    in-out property <bool> filter-open: false;
+    in-out property <int> sql-view-mode: 0;
+    in property <[string]> result-tabs;
+    in property <int> active-result;
+    callback select-result-tab(int);
+    callback close-result-tab(int);
+    callback copy-results();
+    callback export-results(int);
+
+    // ----- result grid -----
+    in property <[GridColumn]> columns;
+    in property <[GridCell]> cells;
+    in property <int> col-count;
+    in property <[length]> col-widths;
+    in property <int> result-kind: 0;
+    in property <string> result-status;
+    in property <bool> status-error;
+    in property <int> grid-sort-col: -1;
+    in property <bool> grid-sort-asc: true;
+    in property <[string]> grid-col-filters;
+    in-out property <int> selected-row: 0;
+    in-out property <int> selected-col: -1;
+    in property <int> editing-row: -1;
+    in property <int> editing-col: -1;
+    in-out property <string> editing-value;
+    in property <int> scroll-grid-tick;
+    callback sort-col(int);
+    callback reorder-col(int, length);
+    callback set-col-filter(int, string);
+    callback resize-col(int, length);
+    callback select-cell(int, int);
+    callback edit-cell(int, int);
+    callback cell-edited(int, int, string);
+    callback cell-advance(int, int, string, bool);
+    callback stage-cell(int, int, string);
+    callback edit-cancelled();
+
+    // ----- other result views -----
+    in property <int> doc-view: 0;
+    in property <[DocRow]> doc-tree;
+    callback toggle-doc-node(string);
+    in property <[StructField]> structure-columns;
+    in property <[IndexRow]> index-rows;
+    in property <[ChartBar]> chart-bars;
+
+    background: transparent;
+
+    VerticalLayout {
+        width: 100%;
+        height: 100%;
+        spacing: 0;
+
+        // ================= SQL editor (non-browse tabs) =================
+        // Also shown over a browse grid when the user opens "Query ▸".
+        if (!root.browse-mode || root.browse-editor-open) && !root.fn-mode: Rectangle {
+            vertical-stretch: 0.0;
+            preferred-height: root.editor-h;
+            background: Tokens.canvas;
+            VerticalLayout {
+                width: 100%;
+                height: 100%;
+                spacing: 0;
+                HorizontalLayout {
+                    height: 44px;
+                    padding-left: Tokens.sp3;
+                    padding-right: Tokens.sp3;
+                    spacing: Tokens.sp2;
+                    VerticalLayout {
+                        alignment: center;
+                        PrimaryButton {
+                            text: root.query-running ? "Running…" : "▶ Run  ⌘⏎";
+                            height: 28px;
+                            enabled: !root.query-running;
+                            clicked => { root.run(); }
+                        }
+                    }
+                    VerticalLayout {
+                        alignment: center;
+                        SecondaryButton { text: "Run Selection"; height: 28px; clicked => { root.run-selection(); } }
+                    }
+                    VerticalLayout {
+                        alignment: center;
+                        visible: root.sql-capable;
+                        SecondaryButton { text: "Format"; height: 28px; clicked => { root.format-sql(); } }
+                    }
+                    VerticalLayout {
+                        alignment: center;
+                        visible: root.sql-capable;
+                        SecondaryButton {
+                            text: "Explain";
+                            height: 28px;
+                            clicked => { root.explain-query(); }
+                        }
+                    }
+                    // Row limit for manual queries: a number caps the result;
+                    // "No limit" streams the whole table in progressively.
+                    VerticalLayout {
+                        alignment: center;
+                        visible: root.sql-capable;
+                        HorizontalLayout {
+                            spacing: Tokens.sp1;
+                            VerticalLayout {
+                                alignment: center;
+                                Text {
+                                    text: "Limit";
+                                    color: Tokens.text-faint;
+                                    font-size: Tokens.font-sm;
+                                }
+                            }
+                            Rectangle {
+                                width: 78px;
+                                height: 28px;
+                                border-radius: Tokens.radius;
+                                border-width: 1px;
+                                border-color: Tokens.border-strong;
+                                background: Tokens.card;
+                                TextInput {
+                                    width: parent.width;
+                                    text <=> root.limit-text;
+                                    horizontal-alignment: center;
+                                    vertical-alignment: center;
+                                    single-line: true;
+                                    color: Tokens.text;
+                                    font-family: Tokens.mono;
+                                    font-size: Tokens.font-sm;
+                                    accepted => { root.set-limit(self.text); }
+                                }
+                            }
+                        }
+                    }
+                    if root.streaming: VerticalLayout {
+                        alignment: center;
+                        SecondaryButton {
+                            text: "✕ Cancel";
+                            height: 28px;
+                            clicked => { root.cancel-stream(); }
+                        }
+                    }
+                    Rectangle { horizontal-stretch: 1; }
+                    Text {
+                        text: root.query-label;
+                        color: Tokens.text-faint;
+                        font-size: Tokens.font-sm;
+                        vertical-alignment: center;
+                    }
+                }
+                // find bar (⌘F): input + match count + prev/next + close
+                if root.find-open: Rectangle {
+                    height: 36px;
+                    background: Tokens.chrome;
+                    // Focus the input one tick after the bar mounts. Calling
+                    // .focus() from the input's own `init` recurses through the
+                    // layout geometry solver (Slint 1.16); a deferred Timer
+                    // avoids it. `did-focus` resets on every reopen because the
+                    // conditional recreates this element.
+                    property <bool> did-focus;
+                    Timer {
+                        interval: 16ms;
+                        running: !parent.did-focus;
+                        triggered => { find-input.focus(); parent.did-focus = true; }
+                    }
+                    HorizontalLayout {
+                        padding-left: Tokens.sp3;
+                        padding-right: Tokens.sp3;
+                        spacing: Tokens.sp2;
+                        VerticalLayout {
+                            alignment: center;
+                            Rectangle {
+                                width: 240px;
+                                height: 26px;
+                                border-radius: Tokens.radius;
+                                border-width: 1px;
+                                border-color: Tokens.border-strong;
+                                background: Tokens.card;
+                                find-input := TextInput {
+                                    x: Tokens.sp2;
+                                    width: parent.width - 2 * Tokens.sp2;
+                                    vertical-alignment: center;
+                                    text: root.find-text;
+                                    color: Tokens.text;
+                                    font-family: Tokens.mono;
+                                    font-size: Tokens.font-sm;
+                                    single-line: true;
+                                    edited => { root.find-changed(self.text); }
+                                    accepted => { root.find-next(); }
+                                    key-pressed(e) => {
+                                        if (e.text == Key.Escape) { root.find-close(); return accept; }
+                                        return reject;
+                                    }
+                                }
+                            }
+                        }
+                        Text {
+                            text: root.find-status;
+                            color: Tokens.text-faint;
+                            font-size: Tokens.font-sm;
+                            font-family: Tokens.mono;
+                            vertical-alignment: center;
+                        }
+                        Rectangle { horizontal-stretch: 1; }
+                        VerticalLayout {
+                            alignment: center;
+                            SecondaryButton { text: "‹ Prev"; height: 26px; clicked => { root.find-prev(); } }
+                        }
+                        VerticalLayout {
+                            alignment: center;
+                            SecondaryButton { text: "Next ›"; height: 26px; clicked => { root.find-next(); } }
+                        }
+                        VerticalLayout {
+                            alignment: center;
+                            SecondaryButton { text: "✕"; height: 26px; clicked => { root.find-close(); } }
+                        }
+                    }
+                }
+                if !root.editor-collapsed: CodeEditor {
+                    vertical-stretch: 1;
+                    lines: root.editor-lines;
+                    fold-state: root.editor-fold-state;
+                    line-hidden: root.editor-line-hidden;
+                    toggle-fold(l) => { root.toggle-fold(l); }
+                    placeholder: root.editor-placeholder;
+                    cursor-line: root.cursor-line;
+                    cursor-col: root.cursor-col;
+                    completion-items: root.completion-items;
+                    completion-visible: root.completion-visible;
+                    completion-selected: root.completion-selected;
+                    completion-choose(i) => { root.completion-choose(i); }
+                    edit-key(t, cmd, alt, shift) => { root.editor-key(t, cmd, alt, shift) }
+                    press-pos(l, c) => { root.editor-press(l, c); }
+                    drag-pos(l, c) => { root.editor-drag(l, c); }
+                    select-word(l, c) => { root.editor-select-word(l, c); }
+                }
+                Rectangle { height: 1px; background: Tokens.border; }
+                // results header strip
+                HorizontalLayout {
+                    height: 34px;
+                    padding-left: Tokens.sp3;
+                    padding-right: Tokens.sp3;
+                    spacing: Tokens.sp2;
+                    Text {
+                        text: "Results";
+                        color: Tokens.text;
+                        font-size: Tokens.font-sm;
+                        font-weight: Tokens.weight-emphasis;
+                        vertical-alignment: center;
+                    }
+                    Text {
+                        text: root.results-meta;
+                        color: Tokens.text-faint;
+                        font-size: Tokens.font-sm;
+                        font-family: Tokens.mono;
+                        vertical-alignment: center;
+                    }
+                    Rectangle { horizontal-stretch: 1; }
+                    TextButton { text: root.editor-collapsed ? "Editor ▸" : "Editor ▾"; clicked => { root.editor-collapsed = !root.editor-collapsed; } }
+                    if !root.browse-mode: TextButton { text: root.filter-open ? "Filter ▲" : "Filter ▼"; clicked => { root.filter-open = !root.filter-open; } }
+                    TextButton { text: "Copy"; clicked => { root.copy-results(); } }
+                    ExportButton { export(i) => { root.export-results(i); } }
+                    TextButton { text: "Chart"; clicked => { root.sql-view-mode = 2; } }
+                }
+                // result tabs — appear once ⌘\ has spawned a second result
+                if root.result-tabs.length > 1: HorizontalLayout {
+                    height: 30px;
+                    padding-left: Tokens.sp3;
+                    padding-right: Tokens.sp3;
+                    spacing: Tokens.sp1;
+                    alignment: start;
+                    for name[i] in root.result-tabs: Rectangle {
+                        height: 24px;
+                        width: rl.preferred-width + 2 * Tokens.sp2 + 18px;
+                        border-radius: Tokens.radius;
+                        background: i == root.active-result ? Tokens.accent-tint
+                            : rta.has-hover ? Tokens.chrome : transparent;
+                        rta := TouchArea { clicked => { root.select-result-tab(i); } }
+                        HorizontalLayout {
+                            padding-left: Tokens.sp2;
+                            padding-right: Tokens.sp1;
+                            spacing: Tokens.sp1;
+                            rl := Text {
+                                text: name;
+                                color: i == root.active-result ? Tokens.on-tint : Tokens.text-dim;
+                                font-size: Tokens.font-sm;
+                                vertical-alignment: center;
+                            }
+                            Rectangle {
+                                width: 16px;
+                                Text {
+                                    text: "×";
+                                    color: Tokens.text-faint;
+                                    vertical-alignment: center;
+                                    horizontal-alignment: center;
+                                }
+                                TouchArea { clicked => { root.close-result-tab(i); } }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // draggable splitter: grow/shrink the editor vs the results (SQL tabs)
+        if (!root.browse-mode || root.browse-editor-open) && !root.fn-mode && !root.results-collapsed: Rectangle {
+            height: 6px;
+            background: split-ta.has-hover || split-ta.pressed ? Tokens.accent : Tokens.chrome;
+            split-ta := TouchArea {
+                mouse-cursor: row-resize;
+                moved => {
+                    root.editor-h = clamp(
+                        root.editor-h + (self.mouse-y - self.pressed-y),
+                        120px, root.height - 200px);
+                }
+            }
+        }
+
+        // The per-column filter inputs live inside TabularGrid (aligned to the
+        // columns) and are toggled by `filter-open`; see the "Filter" button.
+
+        // ================= result body =================
+        if !root.fn-mode && !root.results-collapsed: body := Rectangle {
+            property <bool> detail-shown: root.detail-visible && root.view-mode == 0
+                && root.result-kind == 0 && root.col-count > 0 && root.selected-row >= 0
+                && (root.selected-row + 1) * root.col-count <= root.cells.length;
+            property <length> detail-w: min(320px, max(240px, self.width * 0.32));
+            vertical-stretch: 1;
+            background: Tokens.canvas;
+
+            // Data grid — SQL/KeyValue, and Mongo documents in grid view.
+            if root.view-mode == 0 && (root.browse-mode || root.sql-view-mode == 0) && (root.result-kind == 0 || root.result-kind == 2 || (root.result-kind == 1 && root.doc-view == 0)): TabularGrid {
+                x: (body.detail-shown && root.detail-left) ? body.detail-w + 1px : 0;
+                width: body.detail-shown ? body.width - body.detail-w - 1px : body.width;
+                height: 100%;
+                columns: root.columns;
+                cells: root.cells;
+                col-count: root.col-count;
+                col-widths: root.col-widths;
+                sorted-col: root.grid-sort-col;
+                sort-asc: root.grid-sort-asc;
+                sort-col(i) => { root.sort-col(i); }
+                reorder-col(i, x) => { root.reorder-col(i, x); }
+                filter-open: root.filter-open;
+                col-filter-values: root.grid-col-filters;
+                set-col-filter(i, t) => { root.set-col-filter(i, t); }
+                selected-row <=> root.selected-row;
+                selected-col <=> root.selected-col;
+                editing-row: root.editing-row;
+                editing-col: root.editing-col;
+                editing-value <=> root.editing-value;
+                resize-col(i, d) => { root.resize-col(i, d); }
+                select-cell(r, c) => { root.select-cell(r, c); }
+                edit-cell(r, c) => { root.edit-cell(r, c); }
+                cell-edited(r, c, t) => { root.cell-edited(r, c, t); }
+                cell-advance(r, c, t, fwd) => { root.cell-advance(r, c, t, fwd); }
+                edit-cancelled() => { root.edit-cancelled(); }
+                scroll-grid-tick: root.scroll-grid-tick;
+            }
+
+            if body.detail-shown: Rectangle {
+                x: root.detail-left ? 0 : body.width - body.detail-w;
+                width: body.detail-w;
+                height: 100%;
+                background: Tokens.card;
+                border-width: 1px;
+                border-color: Tokens.border;
+
+                VerticalLayout {
+                    spacing: 0;
+                    Rectangle {
+                        height: 40px;
+                        background: Tokens.chrome;
+                        HorizontalLayout {
+                            padding-left: Tokens.sp3;
+                            padding-right: Tokens.sp3;
+                            Text {
+                                text: "Details";
+                                color: Tokens.text;
+                                font-size: Tokens.font-sm;
+                                font-weight: 600;
+                                vertical-alignment: center;
+                            }
+                            Rectangle { horizontal-stretch: 1; }
+                            Text {
+                                text: "Row " + (root.selected-row + 1);
+                                color: Tokens.text-faint;
+                                font-family: Tokens.mono;
+                                font-size: Tokens.font-xs;
+                                vertical-alignment: center;
+                            }
+                        }
+                    }
+                    Rectangle { height: 1px; background: Tokens.border; }
+                    ScrollView {
+                        vertical-stretch: 1;
+                        VerticalLayout {
+                            padding: Tokens.sp3;
+                            spacing: Tokens.sp3;
+                            for c in root.col-count: Rectangle {
+                                property <GridCell> detail-cell: root.cells[root.selected-row * root.col-count + c];
+                                height: 96px;
+                                VerticalLayout {
+                                    spacing: Tokens.sp1;
+                                    HorizontalLayout {
+                                        Text {
+                                            text: root.columns[c].name;
+                                            color: Tokens.text-dim;
+                                            font-family: Tokens.mono;
+                                            font-size: Tokens.font-xs;
+                                            overflow: elide;
+                                        }
+                                        Rectangle { horizontal-stretch: 1; }
+                                        Text {
+                                            text: root.columns[c].type-name;
+                                            color: Tokens.text-faint;
+                                            font-family: Tokens.mono;
+                                            font-size: Tokens.font-xs;
+                                        }
+                                    }
+                                    Rectangle {
+                                        vertical-stretch: 1;
+                                        clip: true;
+                                        border-radius: Tokens.radius;
+                                        border-width: 1px;
+                                        border-color: detail-input.has-focus ? Tokens.accent : Tokens.border-strong;
+                                        background: Tokens.canvas;
+                                        detail-input := TextInput {
+                                            x: Tokens.sp2;
+                                            y: Tokens.sp2;
+                                            width: parent.width - 2 * Tokens.sp2;
+                                            height: parent.height - 2 * Tokens.sp2;
+                                            text: detail-cell.is-null ? "" : detail-cell.text;
+                                            enabled: !root.read-only;
+                                            single-line: false;
+                                            wrap: word-wrap;
+                                            vertical-alignment: top;
+                                            color: root.read-only ? Tokens.text-dim : Tokens.text;
+                                            font-family: Tokens.mono;
+                                            font-size: Tokens.font-sm;
+                                            edited => { root.stage-cell(root.selected-row, c, self.text); }
+                                        }
+                                        if detail-cell.is-null && detail-input.text == "": Text {
+                                            x: Tokens.sp2;
+                                            y: Tokens.sp2;
+                                            text: "NULL";
+                                            color: Tokens.text-ghost;
+                                            font-family: Tokens.mono;
+                                            font-size: Tokens.font-sm;
+                                            font-italic: true;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // empty result: distinct from an error, distinct from loading
+            if root.view-mode == 0 && (root.browse-mode || root.sql-view-mode == 0)
+                && root.result-kind == 0 && root.cells.length == 0
+                && !root.status-error && !root.query-running: VerticalLayout {
+                alignment: center;
+                spacing: Tokens.sp2;
+                Text {
+                    text: "No rows";
+                    color: Tokens.text-dim;
+                    font-size: Tokens.font-md;
+                    horizontal-alignment: center;
+                }
+                Text {
+                    text: root.browse-mode && !root.read-only
+                        ? "Table is empty — “+ Row” inserts one"
+                        : "The query returned no rows";
+                    color: Tokens.text-faint;
+                    font-size: Tokens.font-sm;
+                    horizontal-alignment: center;
+                }
+            }
+
+            // in-flight query indicator
+            if root.query-running: VerticalLayout {
+                alignment: center;
+                Text {
+                    text: "Running…";
+                    color: Tokens.text-dim;
+                    font-size: Tokens.font-md;
+                    horizontal-alignment: center;
+                }
+            }
+
+            // Documents (Mongo) — JSON tree view (grid view uses TabularGrid above).
+            if root.view-mode == 0 && (root.browse-mode || root.sql-view-mode == 0) && root.result-kind == 1 && root.doc-view == 1: ScrollView {
+                width: 100%;
+                height: 100%;
+                VerticalLayout {
+                    padding: Tokens.sp3;
+                    spacing: 0;
+                    alignment: start;
+                    for row in root.doc-tree: Rectangle {
+                        height: 22px;
+                        // Whole branch row is clickable to fold/unfold; leaves inert.
+                        background: row-ta.has-hover && row.expandable ? Tokens.card : transparent;
+                        row-ta := TouchArea {
+                            enabled: row.expandable;
+                            clicked => { root.toggle-doc-node(row.path); }
+                        }
+                        HorizontalLayout {
+                            padding-left: row.depth * 16px;
+                            spacing: Tokens.sp1;
+                            alignment: start;
+                            // fold caret (branches only)
+                            Text {
+                                width: 14px;
+                                text: row.expandable ? (row.expanded ? "▾" : "▸") : "";
+                                color: Tokens.text-dim;
+                                font-size: Tokens.font-xs;
+                                vertical-alignment: center;
+                            }
+                            Text {
+                                width: 200px;
+                                text: row.key + ":";
+                                color: Tokens.accent;
+                                font-family: Tokens.mono;
+                                font-size: Tokens.font-sm;
+                                overflow: elide;
+                                vertical-alignment: center;
+                            }
+                            Text {
+                                text: row.preview;
+                                color: row.expandable ? Tokens.text-dim : Tokens.text;
+                                font-family: Tokens.mono;
+                                font-size: Tokens.font-sm;
+                                horizontal-alignment: left;
+                                overflow: elide;
+                                vertical-alignment: center;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Affected-rows toast
+            if root.view-mode == 0 && (root.browse-mode || root.sql-view-mode == 0) && root.result-kind == 3: Text {
+                text: root.result-status;
+                color: root.status-error ? Tokens.error : Tokens.text-dim;
+                font-size: Tokens.font-md;
+            }
+
+            // Structure view
+            if root.view-mode == 1: ScrollView {
+                width: 100%;
+                height: 100%;
+                VerticalLayout {
+                    width: parent.visible-width;
+                    padding: Tokens.sp3;
+                    spacing: 0;
+                    alignment: start;
+                    HorizontalLayout {
+                        height: Tokens.grid-header-h;
+                        Text { width: 220px; text: "column"; color: Tokens.text; font-family: Tokens.mono; font-size: Tokens.font-sm; font-weight: 600; vertical-alignment: center; }
+                        Text { width: 180px; text: "type"; color: Tokens.text; font-family: Tokens.mono; font-size: Tokens.font-sm; font-weight: 600; vertical-alignment: center; }
+                        Text { text: "nullable"; color: Tokens.text; font-family: Tokens.mono; font-size: Tokens.font-sm; font-weight: 600; vertical-alignment: center; }
+                    }
+                    Rectangle { height: 1px; background: Tokens.border-strong; }
+                    for f in root.structure-columns: HorizontalLayout {
+                        height: Tokens.grid-row-h;
+                        Text { width: 220px; text: f.name; color: Tokens.text; font-family: Tokens.mono; font-size: Tokens.font-sm; vertical-alignment: center; }
+                        Text { width: 180px; text: f.type-name; color: Tokens.text-dim; font-family: Tokens.mono; font-size: Tokens.font-sm; vertical-alignment: center; }
+                        Text { text: f.nullable ? "YES" : "NO"; color: f.nullable ? Tokens.text-faint : Tokens.text-dim; font-family: Tokens.mono; font-size: Tokens.font-sm; vertical-alignment: center; }
+                    }
+                }
+            }
+
+            // Indexes view (from engine catalogs; empty for engines without them)
+            if root.view-mode == 2 && root.index-rows.length == 0: Text {
+                text: "No indexes to show";
+                color: Tokens.text-faint;
+                font-size: Tokens.font-md;
+            }
+            if root.view-mode == 2 && root.index-rows.length > 0: ScrollView {
+                width: 100%;
+                height: 100%;
+                VerticalLayout {
+                    width: parent.visible-width;
+                    padding: Tokens.sp3;
+                    spacing: 0;
+                    alignment: start;
+                    HorizontalLayout {
+                        height: Tokens.grid-header-h;
+                        Text { width: 220px; text: "index"; color: Tokens.text; font-family: Tokens.mono; font-size: Tokens.font-sm; font-weight: 600; vertical-alignment: center; }
+                        Text { text: "definition"; color: Tokens.text; font-family: Tokens.mono; font-size: Tokens.font-sm; font-weight: 600; vertical-alignment: center; }
+                    }
+                    Rectangle { height: 1px; background: Tokens.border-strong; }
+                    for ix in root.index-rows: HorizontalLayout {
+                        height: Tokens.grid-row-h;
+                        Text { width: 220px; text: ix.name; color: Tokens.text; font-family: Tokens.mono; font-size: Tokens.font-sm; vertical-alignment: center; overflow: elide; }
+                        Text { text: ix.definition; color: Tokens.text-dim; font-family: Tokens.mono; font-size: Tokens.font-sm; vertical-alignment: center; overflow: elide; }
+                    }
+                }
+            }
+
+            // Message view (SQL footer segment)
+            if !root.browse-mode && root.view-mode == 0 && root.sql-view-mode == 1: VerticalLayout {
+                padding: Tokens.sp3;
+                alignment: start;
+                Text {
+                    text: root.result-status == "" ? "No messages" : root.result-status;
+                    color: root.status-error ? Tokens.error : Tokens.text-dim;
+                    font-size: Tokens.font-md;
+                }
+            }
+
+            // Chart view: horizontal bars, first text column vs first numeric column
+            if !root.browse-mode && root.view-mode == 0 && root.sql-view-mode == 2: ScrollView {
+                width: 100%;
+                height: 100%;
+                VerticalLayout {
+                    width: parent.visible-width;
+                    padding: Tokens.sp3;
+                    spacing: Tokens.sp1;
+                    alignment: start;
+                    if root.chart-bars.length == 0: Text {
+                        text: "Nothing to chart — the result needs a numeric column";
+                        color: Tokens.text-faint;
+                        font-size: Tokens.font-md;
+                    }
+                    for bar in root.chart-bars: HorizontalLayout {
+                        height: 20px;
+                        spacing: Tokens.sp2;
+                        Text {
+                            width: 160px;
+                            text: bar.label;
+                            color: Tokens.text-dim;
+                            font-size: Tokens.font-sm;
+                            font-family: Tokens.mono;
+                            overflow: elide;
+                            vertical-alignment: center;
+                        }
+                        Rectangle {
+                            horizontal-stretch: 1;
+                            Rectangle {
+                                x: 0;
+                                width: parent.width * bar.frac;
+                                height: 14px;
+                                y: (parent.height - self.height) / 2;
+                                border-radius: 3px;
+                                background: Tokens.accent;
+                            }
+                        }
+                        Text {
+                            width: 100px;
+                            text: bar.value;
+                            color: Tokens.text;
+                            font-size: Tokens.font-sm;
+                            font-family: Tokens.mono;
+                            horizontal-alignment: right;
+                            vertical-alignment: center;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -25,6 +25,8 @@ export component QueryPane inherits Rectangle {
     in property <bool> read-only: true;
     // Whether the tab is currently split (drives the toggle button label).
     in property <bool> split: false;
+    // This pane has editor focus (shows an accent bar while split).
+    in property <bool> active: false;
     callback toggle-split();
 
     // ----- editor toolbar -----
@@ -733,5 +735,13 @@ export component QueryPane inherits Rectangle {
                 }
             }
         }
+    }
+
+    // Accent bar marks the focused pane while split.
+    if root.active: Rectangle {
+        y: 0;
+        height: 2px;
+        width: 100%;
+        background: Tokens.accent;
     }
 }

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -15,6 +15,7 @@ import { ScrollView } from "std-widgets.slint";
 export component QueryPane inherits Rectangle {
     // ----- tab-global context (forwarded from WorkArea) -----
     in property <bool> browse-mode: false;
+    in property <string> table-name;
     in property <bool> browse-editor-open: false;
     in property <bool> fn-mode: false;
     in property <bool> results-collapsed: false;
@@ -28,6 +29,7 @@ export component QueryPane inherits Rectangle {
     // This pane has editor focus (shows an accent bar while split).
     in property <bool> active: false;
     callback toggle-split();
+    callback refresh-page();
 
     // ----- editor toolbar -----
     in-out property <length> editor-h: 340px;
@@ -124,6 +126,19 @@ export component QueryPane inherits Rectangle {
         width: 100%;
         height: 100%;
         spacing: 0;
+
+        if root.browse-mode && root.split: Rectangle {
+            height: 42px;
+            background: Tokens.canvas;
+            HorizontalLayout {
+                padding-left: Tokens.sp3;
+                padding-right: Tokens.sp3;
+                spacing: Tokens.sp3;
+                Text { text: root.table-name; color: Tokens.text; font-size: Tokens.font-sm; font-weight: 600; vertical-alignment: center; }
+                Rectangle { horizontal-stretch: 1; }
+                TextButton { text: "Refresh"; clicked => { root.refresh-page(); } }
+            }
+        }
 
         // ================= SQL editor (non-browse tabs) =================
         // Also shown over a browse grid when the user opens "Query ▸".

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -328,8 +328,6 @@ export component QueryPane inherits Rectangle {
                     }
                     Rectangle { horizontal-stretch: 1; }
                     TextButton { text: root.editor-collapsed ? "Editor ▸" : "Editor ▾"; clicked => { root.editor-collapsed = !root.editor-collapsed; } }
-                    // Split the SQL tab into two panes (or merge back).
-                    if !root.browse-mode: TextButton { text: root.split ? "Unsplit" : "Split ⇆"; clicked => { root.toggle-split(); } }
                     if !root.browse-mode: TextButton { text: root.filter-open ? "Filter ▲" : "Filter ▼"; clicked => { root.filter-open = !root.filter-open; } }
                     TextButton { text: "Copy"; clicked => { root.copy-results(); } }
                     ExportButton { export(i) => { root.export-results(i); } }

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -23,6 +23,9 @@ export component QueryPane inherits Rectangle {
     in property <int> view-mode: 0;
     in property <bool> sql-capable: true;
     in property <bool> read-only: true;
+    // Whether the tab is currently split (drives the toggle button label).
+    in property <bool> split: false;
+    callback toggle-split();
 
     // ----- editor toolbar -----
     in-out property <length> editor-h: 340px;
@@ -323,6 +326,8 @@ export component QueryPane inherits Rectangle {
                     }
                     Rectangle { horizontal-stretch: 1; }
                     TextButton { text: root.editor-collapsed ? "Editor ▸" : "Editor ▾"; clicked => { root.editor-collapsed = !root.editor-collapsed; } }
+                    // Split the SQL tab into two panes (or merge back).
+                    if !root.browse-mode: TextButton { text: root.split ? "Unsplit" : "Split ⇆"; clicked => { root.toggle-split(); } }
                     if !root.browse-mode: TextButton { text: root.filter-open ? "Filter ▲" : "Filter ▼"; clicked => { root.filter-open = !root.filter-open; } }
                     TextButton { text: "Copy"; clicked => { root.copy-results(); } }
                     ExportButton { export(i) => { root.export-results(i); } }

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -117,6 +117,7 @@ export component WorkArea inherits Rectangle {
     // right. `active-pane` is the focused pane (0 left / 1 right).
     in property <bool> split: false;
     in property <int> active-pane: 0;
+    callback toggle-split();
 
     // ----- pane 1 (right split pane) mirror of the per-pane state above -----
     // Pane 0 uses the base properties; Rust fills these only while `split` is on.
@@ -470,11 +471,14 @@ export component WorkArea inherits Rectangle {
         // Browse and SQL tabs render the left pane; function tabs use the view
         // above. A SQL tab can split into two panes side by side; the right pane
         // shows only when `split` is set (wired in a later step).
-        if !root.fn-mode: HorizontalLayout {
+        if !root.fn-mode: Rectangle {
             vertical-stretch: 1;
-            spacing: 0;
             QueryPane {
-            horizontal-stretch: 1;
+            x: 0;
+            width: root.split ? (parent.width - 6px) / 2 : parent.width;
+            height: 100%;
+            split: root.split;
+            toggle-split() => { root.toggle-split(); }
             browse-mode: root.browse-mode;
             browse-editor-open: root.browse-editor-open;
             fn-mode: root.fn-mode;
@@ -563,13 +567,19 @@ export component WorkArea inherits Rectangle {
 
             // vertical divider between the two panes (SQL split)
             if root.split: Rectangle {
+                x: (parent.width - 6px) / 2;
                 width: 6px;
-                background: Tokens.chrome;
+                height: 100%;
+                background: Tokens.border-strong;
             }
 
             // right pane (pane 1) — driven by the p1-* mirror state.
             if root.split: QueryPane {
-                horizontal-stretch: 1;
+                x: (parent.width + 6px) / 2;
+                width: (parent.width - 6px) / 2;
+                height: 100%;
+                split: root.split;
+                toggle-split() => { root.toggle-split(); }
                 // tab-global context shared with the left pane
                 browse-mode: root.browse-mode;
                 browse-editor-open: root.browse-editor-open;

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -478,6 +478,7 @@ export component WorkArea inherits Rectangle {
             width: root.split ? (parent.width - 6px) / 2 : parent.width;
             height: 100%;
             split: root.split;
+            active: root.split && root.active-pane == 0;
             toggle-split() => { root.toggle-split(); }
             browse-mode: root.browse-mode;
             browse-editor-open: root.browse-editor-open;
@@ -579,6 +580,7 @@ export component WorkArea inherits Rectangle {
                 width: (parent.width - 6px) / 2;
                 height: 100%;
                 split: root.split;
+                active: root.split && root.active-pane == 1;
                 toggle-split() => { root.toggle-split(); }
                 // tab-global context shared with the left pane
                 browse-mode: root.browse-mode;

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -117,6 +117,7 @@ export component WorkArea inherits Rectangle {
     // right. `active-pane` is the focused pane (0 left / 1 right).
     in property <bool> split: false;
     in property <int> active-pane: 0;
+    in-out property <float> split-ratio: 0.5;
     callback toggle-split();
 
     // ----- pane 1 (right split pane) mirror of the per-pane state above -----
@@ -475,7 +476,7 @@ export component WorkArea inherits Rectangle {
             vertical-stretch: 1;
             QueryPane {
             x: 0;
-            width: root.split ? (parent.width - 6px) / 2 : parent.width;
+            width: root.split ? (parent.width - 6px) * root.split-ratio : parent.width;
             height: 100%;
             split: root.split;
             active: root.split && root.active-pane == 0;
@@ -568,16 +569,24 @@ export component WorkArea inherits Rectangle {
 
             // vertical divider between the two panes (SQL split)
             if root.split: Rectangle {
-                x: (parent.width - 6px) / 2;
+                x: (parent.width - 6px) * root.split-ratio;
                 width: 6px;
                 height: 100%;
-                background: Tokens.border-strong;
+                background: divider.has-hover || divider.pressed ? Tokens.accent : Tokens.border-strong;
+                divider := TouchArea {
+                    mouse-cursor: col-resize;
+                    moved => {
+                        root.split-ratio = clamp(
+                            root.split-ratio + (self.mouse-x - self.pressed-x) / root.width,
+                            0.2, 0.8);
+                    }
+                }
             }
 
             // right pane (pane 1) — driven by the p1-* mirror state.
             if root.split: QueryPane {
-                x: (parent.width + 6px) / 2;
-                width: (parent.width - 6px) / 2;
+                x: (parent.width - 6px) * root.split-ratio + 6px;
+                width: (parent.width - 6px) * (1 - root.split-ratio);
                 height: 100%;
                 split: root.split;
                 active: root.split && root.active-pane == 1;

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -705,8 +705,8 @@ export component WorkArea inherits Rectangle {
         }
 
         // ================= footer strip (34px) =================
-        Rectangle { height: 1px; background: Tokens.border; }
-        Rectangle {
+        if !root.split: Rectangle { height: 1px; background: Tokens.border; }
+        if !root.split: Rectangle {
             height: Tokens.status-bar-h;
             background: Tokens.chrome;
             HorizontalLayout {
@@ -873,6 +873,52 @@ export component WorkArea inherits Rectangle {
                         font-family: Tokens.mono;
                         vertical-alignment: center;
                     }
+                }
+            }
+        }
+        if root.split: Rectangle {
+            height: 1px;
+            background: Tokens.border;
+        }
+        if root.split: Rectangle {
+            height: Tokens.status-bar-h;
+            background: Tokens.chrome;
+            left-footer := Rectangle {
+                x: 0;
+                width: (parent.width - 6px) * root.split-ratio;
+                height: parent.height;
+                background: Tokens.chrome;
+                HorizontalLayout {
+                    padding-left: Tokens.sp3;
+                    padding-right: Tokens.sp3;
+                    spacing: Tokens.sp3;
+                    UnderlineSegment { text: "Data"; active: root.sql-view-mode == 0; clicked => { root.sql-view-mode = 0; } }
+                    UnderlineSegment { text: "Message"; active: root.sql-view-mode == 1; clicked => { root.sql-view-mode = 1; } }
+                    UnderlineSegment { text: "Chart"; active: root.sql-view-mode == 2; clicked => { root.sql-view-mode = 2; } }
+                    Rectangle { horizontal-stretch: 1; }
+                    Text { text: root.result-status; color: root.status-error ? Tokens.error : Tokens.text-dim; font-size: Tokens.font-sm; vertical-alignment: center; overflow: elide; }
+                }
+            }
+            Rectangle {
+                x: (parent.width - 6px) * root.split-ratio;
+                width: 6px;
+                height: parent.height;
+                background: Tokens.border-strong;
+            }
+            right-footer := Rectangle {
+                x: (parent.width - 6px) * root.split-ratio + 6px;
+                width: (parent.width - 6px) * (1 - root.split-ratio);
+                height: parent.height;
+                background: Tokens.chrome;
+                HorizontalLayout {
+                    padding-left: Tokens.sp3;
+                    padding-right: Tokens.sp3;
+                    spacing: Tokens.sp3;
+                    UnderlineSegment { text: "Data"; active: root.p1-sql-view-mode == 0; clicked => { root.p1-sql-view-mode = 0; } }
+                    UnderlineSegment { text: "Message"; active: root.p1-sql-view-mode == 1; clicked => { root.p1-sql-view-mode = 1; } }
+                    UnderlineSegment { text: "Chart"; active: root.p1-sql-view-mode == 2; clicked => { root.p1-sql-view-mode = 2; } }
+                    Rectangle { horizontal-stretch: 1; }
+                    Text { text: root.p1-result-status; color: root.p1-status-error ? Tokens.error : Tokens.text-dim; font-size: Tokens.font-sm; vertical-alignment: center; overflow: elide; }
                 }
             }
         }

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -11,6 +11,7 @@ import {
 } from "components.slint";
 import { ScrollView, ComboBox } from "std-widgets.slint";
 import { AppIcon } from "icons.slint";
+import { QueryPane } from "query-pane.slint";
 
 export component WorkArea inherits Rectangle {
     // ----- editor / results state (wired 1:1 from MainWindow) -----
@@ -381,614 +382,95 @@ export component WorkArea inherits Rectangle {
             }
         }
 
-        // ================= empty state (nothing open) =================
-        // ================= SQL editor (non-browse tabs) =================
-        // Also shown over a browse grid when the user opens "Query ▸".
-        if (!root.browse-mode || root.browse-editor-open) && !root.fn-mode: Rectangle {
-            vertical-stretch: 0.0;
-            preferred-height: root.editor-h;
-            background: Tokens.canvas;
-            VerticalLayout {
-                width: 100%;
-                height: 100%;
-                spacing: 0;
-                HorizontalLayout {
-                    height: 44px;
-                    padding-left: Tokens.sp3;
-                    padding-right: Tokens.sp3;
-                    spacing: Tokens.sp2;
-                    VerticalLayout {
-                        alignment: center;
-                        PrimaryButton {
-                            text: root.query-running ? "Running…" : "▶ Run  ⌘⏎";
-                            height: 28px;
-                            enabled: !root.query-running;
-                            clicked => { root.run(); }
-                        }
-                    }
-                    VerticalLayout {
-                        alignment: center;
-                        SecondaryButton { text: "Run Selection"; height: 28px; clicked => { root.run-selection(); } }
-                    }
-                    VerticalLayout {
-                        alignment: center;
-                        visible: root.sql-capable;
-                        SecondaryButton { text: "Format"; height: 28px; clicked => { root.format-sql(); } }
-                    }
-                    VerticalLayout {
-                        alignment: center;
-                        visible: root.sql-capable;
-                        SecondaryButton {
-                            text: "Explain";
-                            height: 28px;
-                            clicked => { root.explain-query(); }
-                        }
-                    }
-                    // Row limit for manual queries: a number caps the result;
-                    // "No limit" streams the whole table in progressively.
-                    VerticalLayout {
-                        alignment: center;
-                        visible: root.sql-capable;
-                        HorizontalLayout {
-                            spacing: Tokens.sp1;
-                            VerticalLayout {
-                                alignment: center;
-                                Text {
-                                    text: "Limit";
-                                    color: Tokens.text-faint;
-                                    font-size: Tokens.font-sm;
-                                }
-                            }
-                            Rectangle {
-                                width: 78px;
-                                height: 28px;
-                                border-radius: Tokens.radius;
-                                border-width: 1px;
-                                border-color: Tokens.border-strong;
-                                background: Tokens.card;
-                                TextInput {
-                                    width: parent.width;
-                                    text <=> root.limit-text;
-                                    horizontal-alignment: center;
-                                    vertical-alignment: center;
-                                    single-line: true;
-                                    color: Tokens.text;
-                                    font-family: Tokens.mono;
-                                    font-size: Tokens.font-sm;
-                                    accepted => { root.set-limit(self.text); }
-                                }
-                            }
-                        }
-                    }
-                    if root.streaming: VerticalLayout {
-                        alignment: center;
-                        SecondaryButton {
-                            text: "✕ Cancel";
-                            height: 28px;
-                            clicked => { root.cancel-stream(); }
-                        }
-                    }
-                    Rectangle { horizontal-stretch: 1; }
-                    Text {
-                        text: root.query-label;
-                        color: Tokens.text-faint;
-                        font-size: Tokens.font-sm;
-                        vertical-alignment: center;
-                    }
-                }
-                // find bar (⌘F): input + match count + prev/next + close
-                if root.find-open: Rectangle {
-                    height: 36px;
-                    background: Tokens.chrome;
-                    // Focus the input one tick after the bar mounts. Calling
-                    // .focus() from the input's own `init` recurses through the
-                    // layout geometry solver (Slint 1.16); a deferred Timer
-                    // avoids it. `did-focus` resets on every reopen because the
-                    // conditional recreates this element.
-                    property <bool> did-focus;
-                    Timer {
-                        interval: 16ms;
-                        running: !parent.did-focus;
-                        triggered => { find-input.focus(); parent.did-focus = true; }
-                    }
-                    HorizontalLayout {
-                        padding-left: Tokens.sp3;
-                        padding-right: Tokens.sp3;
-                        spacing: Tokens.sp2;
-                        VerticalLayout {
-                            alignment: center;
-                            Rectangle {
-                                width: 240px;
-                                height: 26px;
-                                border-radius: Tokens.radius;
-                                border-width: 1px;
-                                border-color: Tokens.border-strong;
-                                background: Tokens.card;
-                                find-input := TextInput {
-                                    x: Tokens.sp2;
-                                    width: parent.width - 2 * Tokens.sp2;
-                                    vertical-alignment: center;
-                                    text: root.find-text;
-                                    color: Tokens.text;
-                                    font-family: Tokens.mono;
-                                    font-size: Tokens.font-sm;
-                                    single-line: true;
-                                    edited => { root.find-changed(self.text); }
-                                    accepted => { root.find-next(); }
-                                    key-pressed(e) => {
-                                        if (e.text == Key.Escape) { root.find-close(); return accept; }
-                                        return reject;
-                                    }
-                                }
-                            }
-                        }
-                        Text {
-                            text: root.find-status;
-                            color: Tokens.text-faint;
-                            font-size: Tokens.font-sm;
-                            font-family: Tokens.mono;
-                            vertical-alignment: center;
-                        }
-                        Rectangle { horizontal-stretch: 1; }
-                        VerticalLayout {
-                            alignment: center;
-                            SecondaryButton { text: "‹ Prev"; height: 26px; clicked => { root.find-prev(); } }
-                        }
-                        VerticalLayout {
-                            alignment: center;
-                            SecondaryButton { text: "Next ›"; height: 26px; clicked => { root.find-next(); } }
-                        }
-                        VerticalLayout {
-                            alignment: center;
-                            SecondaryButton { text: "✕"; height: 26px; clicked => { root.find-close(); } }
-                        }
-                    }
-                }
-                if !root.editor-collapsed: CodeEditor {
-                    vertical-stretch: 1;
-                    lines: root.editor-lines;
-                    fold-state: root.editor-fold-state;
-                    line-hidden: root.editor-line-hidden;
-                    toggle-fold(l) => { root.toggle-fold(l); }
-                    placeholder: root.editor-placeholder;
-                    cursor-line: root.cursor-line;
-                    cursor-col: root.cursor-col;
-                    completion-items: root.completion-items;
-                    completion-visible: root.completion-visible;
-                    completion-selected: root.completion-selected;
-                    completion-choose(i) => { root.completion-choose(i); }
-                    edit-key(t, cmd, alt, shift) => { root.editor-key(t, cmd, alt, shift) }
-                    press-pos(l, c) => { root.editor-press(l, c); }
-                    drag-pos(l, c) => { root.editor-drag(l, c); }
-                    select-word(l, c) => { root.editor-select-word(l, c); }
-                }
-                Rectangle { height: 1px; background: Tokens.border; }
-                // results header strip
-                HorizontalLayout {
-                    height: 34px;
-                    padding-left: Tokens.sp3;
-                    padding-right: Tokens.sp3;
-                    spacing: Tokens.sp2;
-                    Text {
-                        text: "Results";
-                        color: Tokens.text;
-                        font-size: Tokens.font-sm;
-                        font-weight: Tokens.weight-emphasis;
-                        vertical-alignment: center;
-                    }
-                    Text {
-                        text: root.results-meta;
-                        color: Tokens.text-faint;
-                        font-size: Tokens.font-sm;
-                        font-family: Tokens.mono;
-                        vertical-alignment: center;
-                    }
-                    Rectangle { horizontal-stretch: 1; }
-                    TextButton { text: root.editor-collapsed ? "Editor ▸" : "Editor ▾"; clicked => { root.editor-collapsed = !root.editor-collapsed; } }
-                    if !root.browse-mode: TextButton { text: root.filter-open ? "Filter ▲" : "Filter ▼"; clicked => { root.filter-open = !root.filter-open; } }
-                    TextButton { text: "Copy"; clicked => { root.copy-results(); } }
-                    ExportButton { export(i) => { root.export-results(i); } }
-                    TextButton { text: "Chart"; clicked => { root.sql-view-mode = 2; } }
-                }
-                // result tabs — appear once ⌘\ has spawned a second result
-                if root.result-tabs.length > 1: HorizontalLayout {
-                    height: 30px;
-                    padding-left: Tokens.sp3;
-                    padding-right: Tokens.sp3;
-                    spacing: Tokens.sp1;
-                    alignment: start;
-                    for name[i] in root.result-tabs: Rectangle {
-                        height: 24px;
-                        width: rl.preferred-width + 2 * Tokens.sp2 + 18px;
-                        border-radius: Tokens.radius;
-                        background: i == root.active-result ? Tokens.accent-tint
-                            : rta.has-hover ? Tokens.chrome : transparent;
-                        rta := TouchArea { clicked => { root.select-result-tab(i); } }
-                        HorizontalLayout {
-                            padding-left: Tokens.sp2;
-                            padding-right: Tokens.sp1;
-                            spacing: Tokens.sp1;
-                            rl := Text {
-                                text: name;
-                                color: i == root.active-result ? Tokens.on-tint : Tokens.text-dim;
-                                font-size: Tokens.font-sm;
-                                vertical-alignment: center;
-                            }
-                            Rectangle {
-                                width: 16px;
-                                Text {
-                                    text: "×";
-                                    color: Tokens.text-faint;
-                                    vertical-alignment: center;
-                                    horizontal-alignment: center;
-                                }
-                                TouchArea { clicked => { root.close-result-tab(i); } }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // draggable splitter: grow/shrink the editor vs the results (SQL tabs)
-        if (!root.browse-mode || root.browse-editor-open) && !root.fn-mode && !root.results-collapsed: Rectangle {
-            height: 6px;
-            background: split-ta.has-hover || split-ta.pressed ? Tokens.accent : Tokens.chrome;
-            split-ta := TouchArea {
-                mouse-cursor: row-resize;
-                moved => {
-                    root.editor-h = clamp(
-                        root.editor-h + (self.mouse-y - self.pressed-y),
-                        120px, root.height - 200px);
-                }
-            }
-        }
-
-        // The per-column filter inputs live inside TabularGrid (aligned to the
-        // columns) and are toggled by `filter-open`; see the "Filter" button.
-
-        // ================= result body =================
-        if !root.fn-mode && !root.results-collapsed: body := Rectangle {
-            property <bool> detail-shown: root.detail-visible && root.view-mode == 0
-                && root.result-kind == 0 && root.col-count > 0 && root.selected-row >= 0
-                && (root.selected-row + 1) * root.col-count <= root.cells.length;
-            property <length> detail-w: min(320px, max(240px, self.width * 0.32));
+        // ================= query pane (editor + results) =================
+        // Browse and SQL tabs render this pane; function tabs use the view above.
+        // A SQL tab can later show two of these side by side (dual-pane split).
+        if !root.fn-mode: QueryPane {
             vertical-stretch: 1;
-            background: Tokens.canvas;
-
-            // Data grid — SQL/KeyValue, and Mongo documents in grid view.
-            if root.view-mode == 0 && (root.browse-mode || root.sql-view-mode == 0) && (root.result-kind == 0 || root.result-kind == 2 || (root.result-kind == 1 && root.doc-view == 0)): TabularGrid {
-                x: (body.detail-shown && root.detail-left) ? body.detail-w + 1px : 0;
-                width: body.detail-shown ? body.width - body.detail-w - 1px : body.width;
-                height: 100%;
-                columns: root.columns;
-                cells: root.cells;
-                col-count: root.col-count;
-                col-widths: root.col-widths;
-                sorted-col: root.grid-sort-col;
-                sort-asc: root.grid-sort-asc;
-                sort-col(i) => { root.sort-col(i); }
-                reorder-col(i, x) => { root.reorder-col(i, x); }
-                filter-open: root.filter-open;
-                col-filter-values: root.grid-col-filters;
-                set-col-filter(i, t) => { root.set-col-filter(i, t); }
-                selected-row <=> root.selected-row;
-                selected-col <=> root.selected-col;
-                editing-row: root.editing-row;
-                editing-col: root.editing-col;
-                editing-value <=> root.editing-value;
-                resize-col(i, d) => { root.resize-col(i, d); }
-                select-cell(r, c) => { root.select-cell(r, c); }
-                edit-cell(r, c) => { root.edit-cell(r, c); }
-                cell-edited(r, c, t) => { root.cell-edited(r, c, t); }
-                cell-advance(r, c, t, fwd) => { root.cell-advance(r, c, t, fwd); }
-                edit-cancelled() => { root.edit-cancelled(); }
-                scroll-grid-tick: root.scroll-grid-tick;
-            }
-
-            if body.detail-shown: Rectangle {
-                x: root.detail-left ? 0 : body.width - body.detail-w;
-                width: body.detail-w;
-                height: 100%;
-                background: Tokens.card;
-                border-width: 1px;
-                border-color: Tokens.border;
-
-                VerticalLayout {
-                    spacing: 0;
-                    Rectangle {
-                        height: 40px;
-                        background: Tokens.chrome;
-                        HorizontalLayout {
-                            padding-left: Tokens.sp3;
-                            padding-right: Tokens.sp3;
-                            Text {
-                                text: "Details";
-                                color: Tokens.text;
-                                font-size: Tokens.font-sm;
-                                font-weight: 600;
-                                vertical-alignment: center;
-                            }
-                            Rectangle { horizontal-stretch: 1; }
-                            Text {
-                                text: "Row " + (root.selected-row + 1);
-                                color: Tokens.text-faint;
-                                font-family: Tokens.mono;
-                                font-size: Tokens.font-xs;
-                                vertical-alignment: center;
-                            }
-                        }
-                    }
-                    Rectangle { height: 1px; background: Tokens.border; }
-                    ScrollView {
-                        vertical-stretch: 1;
-                        VerticalLayout {
-                            padding: Tokens.sp3;
-                            spacing: Tokens.sp3;
-                            for c in root.col-count: Rectangle {
-                                property <GridCell> detail-cell: root.cells[root.selected-row * root.col-count + c];
-                                height: 96px;
-                                VerticalLayout {
-                                    spacing: Tokens.sp1;
-                                    HorizontalLayout {
-                                        Text {
-                                            text: root.columns[c].name;
-                                            color: Tokens.text-dim;
-                                            font-family: Tokens.mono;
-                                            font-size: Tokens.font-xs;
-                                            overflow: elide;
-                                        }
-                                        Rectangle { horizontal-stretch: 1; }
-                                        Text {
-                                            text: root.columns[c].type-name;
-                                            color: Tokens.text-faint;
-                                            font-family: Tokens.mono;
-                                            font-size: Tokens.font-xs;
-                                        }
-                                    }
-                                    Rectangle {
-                                        vertical-stretch: 1;
-                                        clip: true;
-                                        border-radius: Tokens.radius;
-                                        border-width: 1px;
-                                        border-color: detail-input.has-focus ? Tokens.accent : Tokens.border-strong;
-                                        background: Tokens.canvas;
-                                        detail-input := TextInput {
-                                            x: Tokens.sp2;
-                                            y: Tokens.sp2;
-                                            width: parent.width - 2 * Tokens.sp2;
-                                            height: parent.height - 2 * Tokens.sp2;
-                                            text: detail-cell.is-null ? "" : detail-cell.text;
-                                            enabled: !root.read-only;
-                                            single-line: false;
-                                            wrap: word-wrap;
-                                            vertical-alignment: top;
-                                            color: root.read-only ? Tokens.text-dim : Tokens.text;
-                                            font-family: Tokens.mono;
-                                            font-size: Tokens.font-sm;
-                                            edited => { root.stage-cell(root.selected-row, c, self.text); }
-                                        }
-                                        if detail-cell.is-null && detail-input.text == "": Text {
-                                            x: Tokens.sp2;
-                                            y: Tokens.sp2;
-                                            text: "NULL";
-                                            color: Tokens.text-ghost;
-                                            font-family: Tokens.mono;
-                                            font-size: Tokens.font-sm;
-                                            font-italic: true;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // empty result: distinct from an error, distinct from loading
-            if root.view-mode == 0 && (root.browse-mode || root.sql-view-mode == 0)
-                && root.result-kind == 0 && root.cells.length == 0
-                && !root.status-error && !root.query-running: VerticalLayout {
-                alignment: center;
-                spacing: Tokens.sp2;
-                Text {
-                    text: "No rows";
-                    color: Tokens.text-dim;
-                    font-size: Tokens.font-md;
-                    horizontal-alignment: center;
-                }
-                Text {
-                    text: root.browse-mode && !root.read-only
-                        ? "Table is empty — “+ Row” inserts one"
-                        : "The query returned no rows";
-                    color: Tokens.text-faint;
-                    font-size: Tokens.font-sm;
-                    horizontal-alignment: center;
-                }
-            }
-
-            // in-flight query indicator
-            if root.query-running: VerticalLayout {
-                alignment: center;
-                Text {
-                    text: "Running…";
-                    color: Tokens.text-dim;
-                    font-size: Tokens.font-md;
-                    horizontal-alignment: center;
-                }
-            }
-
-            // Documents (Mongo) — JSON tree view (grid view uses TabularGrid above).
-            if root.view-mode == 0 && (root.browse-mode || root.sql-view-mode == 0) && root.result-kind == 1 && root.doc-view == 1: ScrollView {
-                width: 100%;
-                height: 100%;
-                VerticalLayout {
-                    padding: Tokens.sp3;
-                    spacing: 0;
-                    alignment: start;
-                    for row in root.doc-tree: Rectangle {
-                        height: 22px;
-                        // Whole branch row is clickable to fold/unfold; leaves inert.
-                        background: row-ta.has-hover && row.expandable ? Tokens.card : transparent;
-                        row-ta := TouchArea {
-                            enabled: row.expandable;
-                            clicked => { root.toggle-doc-node(row.path); }
-                        }
-                        HorizontalLayout {
-                            padding-left: row.depth * 16px;
-                            spacing: Tokens.sp1;
-                            alignment: start;
-                            // fold caret (branches only)
-                            Text {
-                                width: 14px;
-                                text: row.expandable ? (row.expanded ? "▾" : "▸") : "";
-                                color: Tokens.text-dim;
-                                font-size: Tokens.font-xs;
-                                vertical-alignment: center;
-                            }
-                            Text {
-                                width: 200px;
-                                text: row.key + ":";
-                                color: Tokens.accent;
-                                font-family: Tokens.mono;
-                                font-size: Tokens.font-sm;
-                                overflow: elide;
-                                vertical-alignment: center;
-                            }
-                            Text {
-                                text: row.preview;
-                                color: row.expandable ? Tokens.text-dim : Tokens.text;
-                                font-family: Tokens.mono;
-                                font-size: Tokens.font-sm;
-                                horizontal-alignment: left;
-                                overflow: elide;
-                                vertical-alignment: center;
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Affected-rows toast
-            if root.view-mode == 0 && (root.browse-mode || root.sql-view-mode == 0) && root.result-kind == 3: Text {
-                text: root.result-status;
-                color: root.status-error ? Tokens.error : Tokens.text-dim;
-                font-size: Tokens.font-md;
-            }
-
-            // Structure view
-            if root.view-mode == 1: ScrollView {
-                width: 100%;
-                height: 100%;
-                VerticalLayout {
-                    width: parent.visible-width;
-                    padding: Tokens.sp3;
-                    spacing: 0;
-                    alignment: start;
-                    HorizontalLayout {
-                        height: Tokens.grid-header-h;
-                        Text { width: 220px; text: "column"; color: Tokens.text; font-family: Tokens.mono; font-size: Tokens.font-sm; font-weight: 600; vertical-alignment: center; }
-                        Text { width: 180px; text: "type"; color: Tokens.text; font-family: Tokens.mono; font-size: Tokens.font-sm; font-weight: 600; vertical-alignment: center; }
-                        Text { text: "nullable"; color: Tokens.text; font-family: Tokens.mono; font-size: Tokens.font-sm; font-weight: 600; vertical-alignment: center; }
-                    }
-                    Rectangle { height: 1px; background: Tokens.border-strong; }
-                    for f in root.structure-columns: HorizontalLayout {
-                        height: Tokens.grid-row-h;
-                        Text { width: 220px; text: f.name; color: Tokens.text; font-family: Tokens.mono; font-size: Tokens.font-sm; vertical-alignment: center; }
-                        Text { width: 180px; text: f.type-name; color: Tokens.text-dim; font-family: Tokens.mono; font-size: Tokens.font-sm; vertical-alignment: center; }
-                        Text { text: f.nullable ? "YES" : "NO"; color: f.nullable ? Tokens.text-faint : Tokens.text-dim; font-family: Tokens.mono; font-size: Tokens.font-sm; vertical-alignment: center; }
-                    }
-                }
-            }
-
-            // Indexes view (from engine catalogs; empty for engines without them)
-            if root.view-mode == 2 && root.index-rows.length == 0: Text {
-                text: "No indexes to show";
-                color: Tokens.text-faint;
-                font-size: Tokens.font-md;
-            }
-            if root.view-mode == 2 && root.index-rows.length > 0: ScrollView {
-                width: 100%;
-                height: 100%;
-                VerticalLayout {
-                    width: parent.visible-width;
-                    padding: Tokens.sp3;
-                    spacing: 0;
-                    alignment: start;
-                    HorizontalLayout {
-                        height: Tokens.grid-header-h;
-                        Text { width: 220px; text: "index"; color: Tokens.text; font-family: Tokens.mono; font-size: Tokens.font-sm; font-weight: 600; vertical-alignment: center; }
-                        Text { text: "definition"; color: Tokens.text; font-family: Tokens.mono; font-size: Tokens.font-sm; font-weight: 600; vertical-alignment: center; }
-                    }
-                    Rectangle { height: 1px; background: Tokens.border-strong; }
-                    for ix in root.index-rows: HorizontalLayout {
-                        height: Tokens.grid-row-h;
-                        Text { width: 220px; text: ix.name; color: Tokens.text; font-family: Tokens.mono; font-size: Tokens.font-sm; vertical-alignment: center; overflow: elide; }
-                        Text { text: ix.definition; color: Tokens.text-dim; font-family: Tokens.mono; font-size: Tokens.font-sm; vertical-alignment: center; overflow: elide; }
-                    }
-                }
-            }
-
-            // Message view (SQL footer segment)
-            if !root.browse-mode && root.view-mode == 0 && root.sql-view-mode == 1: VerticalLayout {
-                padding: Tokens.sp3;
-                alignment: start;
-                Text {
-                    text: root.result-status == "" ? "No messages" : root.result-status;
-                    color: root.status-error ? Tokens.error : Tokens.text-dim;
-                    font-size: Tokens.font-md;
-                }
-            }
-
-            // Chart view: horizontal bars, first text column vs first numeric column
-            if !root.browse-mode && root.view-mode == 0 && root.sql-view-mode == 2: ScrollView {
-                width: 100%;
-                height: 100%;
-                VerticalLayout {
-                    width: parent.visible-width;
-                    padding: Tokens.sp3;
-                    spacing: Tokens.sp1;
-                    alignment: start;
-                    if root.chart-bars.length == 0: Text {
-                        text: "Nothing to chart — the result needs a numeric column";
-                        color: Tokens.text-faint;
-                        font-size: Tokens.font-md;
-                    }
-                    for bar in root.chart-bars: HorizontalLayout {
-                        height: 20px;
-                        spacing: Tokens.sp2;
-                        Text {
-                            width: 160px;
-                            text: bar.label;
-                            color: Tokens.text-dim;
-                            font-size: Tokens.font-sm;
-                            font-family: Tokens.mono;
-                            overflow: elide;
-                            vertical-alignment: center;
-                        }
-                        Rectangle {
-                            horizontal-stretch: 1;
-                            Rectangle {
-                                x: 0;
-                                width: parent.width * bar.frac;
-                                height: 14px;
-                                y: (parent.height - self.height) / 2;
-                                border-radius: 3px;
-                                background: Tokens.accent;
-                            }
-                        }
-                        Text {
-                            width: 100px;
-                            text: bar.value;
-                            color: Tokens.text;
-                            font-size: Tokens.font-sm;
-                            font-family: Tokens.mono;
-                            horizontal-alignment: right;
-                            vertical-alignment: center;
-                        }
-                    }
-                }
-            }
+            browse-mode: root.browse-mode;
+            browse-editor-open: root.browse-editor-open;
+            fn-mode: root.fn-mode;
+            results-collapsed: root.results-collapsed;
+            detail-visible: root.detail-visible;
+            detail-left: root.detail-left;
+            view-mode: root.view-mode;
+            sql-capable: root.sql-capable;
+            read-only: root.read-only;
+            editor-h <=> root.editor-h;
+            query-running: root.query-running;
+            streaming: root.streaming;
+            limit-text <=> root.limit-text;
+            query-label: root.query-label;
+            run() => { root.run(); }
+            run-selection() => { root.run-selection(); }
+            format-sql() => { root.format-sql(); }
+            explain-query() => { root.explain-query(); }
+            cancel-stream() => { root.cancel-stream(); }
+            set-limit(t) => { root.set-limit(t); }
+            find-open: root.find-open;
+            find-text: root.find-text;
+            find-status: root.find-status;
+            find-changed(t) => { root.find-changed(t); }
+            find-next() => { root.find-next(); }
+            find-prev() => { root.find-prev(); }
+            find-close() => { root.find-close(); }
+            editor-collapsed <=> root.editor-collapsed;
+            editor-lines: root.editor-lines;
+            editor-fold-state: root.editor-fold-state;
+            editor-line-hidden: root.editor-line-hidden;
+            editor-placeholder: root.editor-placeholder;
+            cursor-line: root.cursor-line;
+            cursor-col: root.cursor-col;
+            toggle-fold(l) => { root.toggle-fold(l); }
+            editor-key(t, cmd, alt, shift) => { root.editor-key(t, cmd, alt, shift) }
+            editor-press(l, c) => { root.editor-press(l, c); }
+            editor-drag(l, c) => { root.editor-drag(l, c); }
+            editor-select-word(l, c) => { root.editor-select-word(l, c); }
+            completion-items: root.completion-items;
+            completion-visible: root.completion-visible;
+            completion-selected: root.completion-selected;
+            completion-choose(i) => { root.completion-choose(i); }
+            results-meta: root.results-meta;
+            filter-open <=> root.filter-open;
+            sql-view-mode <=> root.sql-view-mode;
+            result-tabs: root.result-tabs;
+            active-result: root.active-result;
+            select-result-tab(i) => { root.select-result-tab(i); }
+            close-result-tab(i) => { root.close-result-tab(i); }
+            copy-results() => { root.copy-results(); }
+            export-results(i) => { root.export-results(i); }
+            columns: root.columns;
+            cells: root.cells;
+            col-count: root.col-count;
+            col-widths: root.col-widths;
+            result-kind: root.result-kind;
+            result-status: root.result-status;
+            status-error: root.status-error;
+            grid-sort-col: root.grid-sort-col;
+            grid-sort-asc: root.grid-sort-asc;
+            grid-col-filters: root.grid-col-filters;
+            selected-row <=> root.selected-row;
+            selected-col <=> root.selected-col;
+            editing-row: root.editing-row;
+            editing-col: root.editing-col;
+            editing-value <=> root.editing-value;
+            scroll-grid-tick: root.scroll-grid-tick;
+            sort-col(i) => { root.sort-col(i); }
+            reorder-col(i, x) => { root.reorder-col(i, x); }
+            set-col-filter(i, t) => { root.set-col-filter(i, t); }
+            resize-col(i, d) => { root.resize-col(i, d); }
+            select-cell(r, c) => { root.select-cell(r, c); }
+            edit-cell(r, c) => { root.edit-cell(r, c); }
+            cell-edited(r, c, t) => { root.cell-edited(r, c, t); }
+            cell-advance(r, c, t, fwd) => { root.cell-advance(r, c, t, fwd); }
+            stage-cell(r, c, t) => { root.stage-cell(r, c, t); }
+            edit-cancelled() => { root.edit-cancelled(); }
+            doc-view: root.doc-view;
+            doc-tree: root.doc-tree;
+            toggle-doc-node(p) => { root.toggle-doc-node(p); }
+            structure-columns: root.structure-columns;
+            index-rows: root.index-rows;
+            chart-bars: root.chart-bars;
         }
 
         // ================= pending-edits strip =================

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -113,6 +113,10 @@ export component WorkArea inherits Rectangle {
     in-out property <string> limit-text;
     // Draggable height of the SQL editor pane (session-local).
     in-out property <length> editor-h: 340px;
+    // Dual-pane split (SQL tabs only): show a second editor+result pane on the
+    // right. `active-pane` is the focused pane (0 left / 1 right).
+    in property <bool> split: false;
+    in property <int> active-pane: 0;
     // Browse chrome shows whenever a table is open in this tab.
     property <bool> browse-mode: root.active-table != "";
     // Footer view segments: 0 Data · 1 Structure · 2 Indexes
@@ -382,11 +386,15 @@ export component WorkArea inherits Rectangle {
             }
         }
 
-        // ================= query pane (editor + results) =================
-        // Browse and SQL tabs render this pane; function tabs use the view above.
-        // A SQL tab can later show two of these side by side (dual-pane split).
-        if !root.fn-mode: QueryPane {
+        // ================= query pane(s) (editor + results) =================
+        // Browse and SQL tabs render the left pane; function tabs use the view
+        // above. A SQL tab can split into two panes side by side; the right pane
+        // shows only when `split` is set (wired in a later step).
+        if !root.fn-mode: HorizontalLayout {
             vertical-stretch: 1;
+            spacing: 0;
+            QueryPane {
+            horizontal-stretch: 1;
             browse-mode: root.browse-mode;
             browse-editor-open: root.browse-editor-open;
             fn-mode: root.fn-mode;
@@ -471,6 +479,21 @@ export component WorkArea inherits Rectangle {
             structure-columns: root.structure-columns;
             index-rows: root.index-rows;
             chart-bars: root.chart-bars;
+            }
+
+            // vertical divider between the two panes (SQL split)
+            if root.split: Rectangle {
+                width: 6px;
+                background: Tokens.chrome;
+            }
+
+            // right pane — empty until its per-pane state is wired.
+            if root.split: QueryPane {
+                horizontal-stretch: 1;
+                fn-mode: root.fn-mode;
+                sql-capable: root.sql-capable;
+                read-only: root.read-only;
+            }
         }
 
         // ================= pending-edits strip =================

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -117,6 +117,86 @@ export component WorkArea inherits Rectangle {
     // right. `active-pane` is the focused pane (0 left / 1 right).
     in property <bool> split: false;
     in property <int> active-pane: 0;
+
+    // ----- pane 1 (right split pane) mirror of the per-pane state above -----
+    // Pane 0 uses the base properties; Rust fills these only while `split` is on.
+    in property <[[Span]]> p1-editor-lines;
+    in property <[int]> p1-editor-fold-state;
+    in property <[bool]> p1-editor-line-hidden;
+    in property <string> p1-editor-placeholder;
+    in property <int> p1-cursor-line;
+    in property <int> p1-cursor-col;
+    in-out property <bool> p1-editor-collapsed;
+    in-out property <length> p1-editor-h: 340px;
+    in property <[PaletteItem]> p1-completion-items;
+    in property <bool> p1-completion-visible;
+    in property <int> p1-completion-selected;
+    in property <bool> p1-find-open;
+    in property <string> p1-find-text;
+    in property <string> p1-find-status;
+    in property <bool> p1-query-running;
+    in property <bool> p1-streaming;
+    in-out property <string> p1-limit-text;
+    in property <string> p1-query-label;
+    in property <string> p1-results-meta;
+    in property <[string]> p1-result-tabs;
+    in property <int> p1-active-result;
+    in-out property <int> p1-sql-view-mode;
+    in-out property <bool> p1-filter-open;
+    in property <[GridColumn]> p1-columns;
+    in property <[GridCell]> p1-cells;
+    in property <int> p1-col-count;
+    in property <[length]> p1-col-widths;
+    in property <int> p1-result-kind;
+    in property <string> p1-result-status;
+    in property <bool> p1-status-error;
+    in property <int> p1-grid-sort-col: -1;
+    in property <bool> p1-grid-sort-asc: true;
+    in property <[string]> p1-grid-col-filters;
+    in-out property <int> p1-selected-row;
+    in-out property <int> p1-selected-col: -1;
+    in property <int> p1-editing-row: -1;
+    in property <int> p1-editing-col: -1;
+    in-out property <string> p1-editing-value;
+    in property <int> p1-scroll-grid-tick;
+    in property <int> p1-doc-view;
+    in property <[DocRow]> p1-doc-tree;
+    in property <[StructField]> p1-structure-columns;
+    in property <[IndexRow]> p1-index-rows;
+    in property <[ChartBar]> p1-chart-bars;
+    // Pane 1 callbacks carry no pane arg here; they are wired to pane-1 handlers
+    // on MainWindow (a later step). Left unhandled = no-op until then.
+    callback p1-run();
+    callback p1-run-selection();
+    callback p1-format-sql();
+    callback p1-explain-query();
+    callback p1-cancel-stream();
+    callback p1-set-limit(string);
+    callback p1-find-changed(string);
+    callback p1-find-next();
+    callback p1-find-prev();
+    callback p1-find-close();
+    callback p1-toggle-fold(int);
+    callback p1-editor-key(string, bool, bool, bool) -> bool;
+    callback p1-editor-press(int, int);
+    callback p1-editor-drag(int, int);
+    callback p1-editor-select-word(int, int);
+    callback p1-completion-choose(int);
+    callback p1-select-result-tab(int);
+    callback p1-close-result-tab(int);
+    callback p1-copy-results();
+    callback p1-export-results(int);
+    callback p1-sort-col(int);
+    callback p1-reorder-col(int, length);
+    callback p1-set-col-filter(int, string);
+    callback p1-resize-col(int, length);
+    callback p1-select-cell(int, int);
+    callback p1-edit-cell(int, int);
+    callback p1-cell-edited(int, int, string);
+    callback p1-cell-advance(int, int, string, bool);
+    callback p1-stage-cell(int, int, string);
+    callback p1-edit-cancelled();
+    callback p1-toggle-doc-node(string);
     // Browse chrome shows whenever a table is open in this tab.
     property <bool> browse-mode: root.active-table != "";
     // Footer view segments: 0 Data · 1 Structure · 2 Indexes
@@ -487,12 +567,95 @@ export component WorkArea inherits Rectangle {
                 background: Tokens.chrome;
             }
 
-            // right pane — empty until its per-pane state is wired.
+            // right pane (pane 1) — driven by the p1-* mirror state.
             if root.split: QueryPane {
                 horizontal-stretch: 1;
+                // tab-global context shared with the left pane
+                browse-mode: root.browse-mode;
+                browse-editor-open: root.browse-editor-open;
                 fn-mode: root.fn-mode;
+                results-collapsed: root.results-collapsed;
+                detail-visible: root.detail-visible;
+                detail-left: root.detail-left;
+                view-mode: root.view-mode;
                 sql-capable: root.sql-capable;
                 read-only: root.read-only;
+                // per-pane state
+                editor-h <=> root.p1-editor-h;
+                query-running: root.p1-query-running;
+                streaming: root.p1-streaming;
+                limit-text <=> root.p1-limit-text;
+                query-label: root.p1-query-label;
+                run() => { root.p1-run(); }
+                run-selection() => { root.p1-run-selection(); }
+                format-sql() => { root.p1-format-sql(); }
+                explain-query() => { root.p1-explain-query(); }
+                cancel-stream() => { root.p1-cancel-stream(); }
+                set-limit(t) => { root.p1-set-limit(t); }
+                find-open: root.p1-find-open;
+                find-text: root.p1-find-text;
+                find-status: root.p1-find-status;
+                find-changed(t) => { root.p1-find-changed(t); }
+                find-next() => { root.p1-find-next(); }
+                find-prev() => { root.p1-find-prev(); }
+                find-close() => { root.p1-find-close(); }
+                editor-collapsed <=> root.p1-editor-collapsed;
+                editor-lines: root.p1-editor-lines;
+                editor-fold-state: root.p1-editor-fold-state;
+                editor-line-hidden: root.p1-editor-line-hidden;
+                editor-placeholder: root.p1-editor-placeholder;
+                cursor-line: root.p1-cursor-line;
+                cursor-col: root.p1-cursor-col;
+                toggle-fold(l) => { root.p1-toggle-fold(l); }
+                editor-key(t, cmd, alt, shift) => { root.p1-editor-key(t, cmd, alt, shift) }
+                editor-press(l, c) => { root.p1-editor-press(l, c); }
+                editor-drag(l, c) => { root.p1-editor-drag(l, c); }
+                editor-select-word(l, c) => { root.p1-editor-select-word(l, c); }
+                completion-items: root.p1-completion-items;
+                completion-visible: root.p1-completion-visible;
+                completion-selected: root.p1-completion-selected;
+                completion-choose(i) => { root.p1-completion-choose(i); }
+                results-meta: root.p1-results-meta;
+                filter-open <=> root.p1-filter-open;
+                sql-view-mode <=> root.p1-sql-view-mode;
+                result-tabs: root.p1-result-tabs;
+                active-result: root.p1-active-result;
+                select-result-tab(i) => { root.p1-select-result-tab(i); }
+                close-result-tab(i) => { root.p1-close-result-tab(i); }
+                copy-results() => { root.p1-copy-results(); }
+                export-results(i) => { root.p1-export-results(i); }
+                columns: root.p1-columns;
+                cells: root.p1-cells;
+                col-count: root.p1-col-count;
+                col-widths: root.p1-col-widths;
+                result-kind: root.p1-result-kind;
+                result-status: root.p1-result-status;
+                status-error: root.p1-status-error;
+                grid-sort-col: root.p1-grid-sort-col;
+                grid-sort-asc: root.p1-grid-sort-asc;
+                grid-col-filters: root.p1-grid-col-filters;
+                selected-row <=> root.p1-selected-row;
+                selected-col <=> root.p1-selected-col;
+                editing-row: root.p1-editing-row;
+                editing-col: root.p1-editing-col;
+                editing-value <=> root.p1-editing-value;
+                scroll-grid-tick: root.p1-scroll-grid-tick;
+                sort-col(i) => { root.p1-sort-col(i); }
+                reorder-col(i, x) => { root.p1-reorder-col(i, x); }
+                set-col-filter(i, t) => { root.p1-set-col-filter(i, t); }
+                resize-col(i, d) => { root.p1-resize-col(i, d); }
+                select-cell(r, c) => { root.p1-select-cell(r, c); }
+                edit-cell(r, c) => { root.p1-edit-cell(r, c); }
+                cell-edited(r, c, t) => { root.p1-cell-edited(r, c, t); }
+                cell-advance(r, c, t, fwd) => { root.p1-cell-advance(r, c, t, fwd); }
+                stage-cell(r, c, t) => { root.p1-stage-cell(r, c, t); }
+                edit-cancelled() => { root.p1-edit-cancelled(); }
+                doc-view: root.p1-doc-view;
+                doc-tree: root.p1-doc-tree;
+                toggle-doc-node(p) => { root.p1-toggle-doc-node(p); }
+                structure-columns: root.p1-structure-columns;
+                index-rows: root.p1-index-rows;
+                chart-bars: root.p1-chart-bars;
             }
         }
 

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -139,6 +139,14 @@ export component WorkArea inherits Rectangle {
     in property <bool> p1-query-running;
     in property <bool> p1-streaming;
     in-out property <string> p1-limit-text;
+    in property <string> p1-active-table;
+    in property <int> p1-page-start;
+    in property <int> p1-page-end;
+    in property <int> p1-total-rows: -1;
+    in property <bool> p1-can-prev;
+    in property <bool> p1-can-next;
+    in property <bool> p1-read-only: true;
+    in-out property <bool> p1-show-structure: false;
     in property <string> p1-query-label;
     in property <string> p1-results-meta;
     in property <[string]> p1-result-tabs;
@@ -174,6 +182,9 @@ export component WorkArea inherits Rectangle {
     callback p1-explain-query();
     callback p1-cancel-stream();
     callback p1-set-limit(string);
+    callback p1-prev-page();
+    callback p1-next-page();
+    callback p1-refresh-page();
     callback p1-find-changed(string);
     callback p1-find-next();
     callback p1-find-prev();
@@ -258,7 +269,7 @@ export component WorkArea inherits Rectangle {
         spacing: 0;
 
         // ================= browse toolbar =================
-        if root.browse-mode: Rectangle {
+        if root.browse-mode && !root.split: Rectangle {
             height: 42px;
             background: Tokens.canvas;
             HorizontalLayout {
@@ -379,7 +390,7 @@ export component WorkArea inherits Rectangle {
 
         // One TablePlus-style condition row. Apply and Enter share the same
         // callback; the toolbar and footer no longer expose duplicate triggers.
-        if root.browse-mode && root.filter-open: Rectangle {
+        if root.browse-mode && !root.split && root.filter-open: Rectangle {
             property <int> focus-tick: root.focus-filter-tick;
             changed focus-tick => { filter-value.focus-input(); }
             height: 38px;
@@ -482,6 +493,8 @@ export component WorkArea inherits Rectangle {
             active: root.split && root.active-pane == 0;
             toggle-split() => { root.toggle-split(); }
             browse-mode: root.browse-mode;
+            table-name: root.active-table;
+            refresh-page() => { root.refresh-page(); }
             browse-editor-open: root.browse-editor-open;
             fn-mode: root.fn-mode;
             results-collapsed: root.results-collapsed;
@@ -591,16 +604,18 @@ export component WorkArea inherits Rectangle {
                 split: root.split;
                 active: root.split && root.active-pane == 1;
                 toggle-split() => { root.toggle-split(); }
-                // tab-global context shared with the left pane
-                browse-mode: root.browse-mode;
+                refresh-page() => { root.p1-refresh-page(); }
+                // Each workspace group owns its browse state.
+                browse-mode: root.p1-active-table != "";
+                table-name: root.p1-active-table;
                 browse-editor-open: root.browse-editor-open;
                 fn-mode: root.fn-mode;
                 results-collapsed: root.results-collapsed;
                 detail-visible: root.detail-visible;
                 detail-left: root.detail-left;
-                view-mode: root.view-mode;
+                view-mode: root.p1-show-structure ? 1 : 0;
                 sql-capable: root.sql-capable;
-                read-only: root.read-only;
+                read-only: root.p1-read-only;
                 // per-pane state
                 editor-h <=> root.p1-editor-h;
                 query-running: root.p1-query-running;
@@ -892,10 +907,15 @@ export component WorkArea inherits Rectangle {
                     padding-left: Tokens.sp3;
                     padding-right: Tokens.sp3;
                     spacing: Tokens.sp3;
-                    UnderlineSegment { text: "Data"; active: root.sql-view-mode == 0; clicked => { root.sql-view-mode = 0; } }
-                    UnderlineSegment { text: "Message"; active: root.sql-view-mode == 1; clicked => { root.sql-view-mode = 1; } }
-                    UnderlineSegment { text: "Chart"; active: root.sql-view-mode == 2; clicked => { root.sql-view-mode = 2; } }
+                    if root.browse-mode: UnderlineSegment { text: "Data"; active: !root.show-structure; clicked => { root.show-structure = false; } }
+                    if root.browse-mode: UnderlineSegment { text: "Structure"; active: root.show-structure; clicked => { root.show-structure = true; } }
+                    if !root.browse-mode: UnderlineSegment { text: "Data"; active: root.sql-view-mode == 0; clicked => { root.sql-view-mode = 0; } }
+                    if !root.browse-mode: UnderlineSegment { text: "Message"; active: root.sql-view-mode == 1; clicked => { root.sql-view-mode = 1; } }
+                    if !root.browse-mode: UnderlineSegment { text: "Chart"; active: root.sql-view-mode == 2; clicked => { root.sql-view-mode = 2; } }
                     Rectangle { horizontal-stretch: 1; }
+                    if root.browse-mode: Text { text: root.total-rows >= 0 ? root.page-start + "–" + root.page-end + " of " + root.total-rows : root.page-start + "–" + root.page-end; color: Tokens.text-dim; font-size: Tokens.font-sm; }
+                    if root.browse-mode: TextButton { text: "‹"; clicked => { root.prev-page(); } }
+                    if root.browse-mode: TextButton { text: "›"; clicked => { root.next-page(); } }
                     Text { text: root.result-status; color: root.status-error ? Tokens.error : Tokens.text-dim; font-size: Tokens.font-sm; vertical-alignment: center; overflow: elide; }
                 }
             }
@@ -914,10 +934,15 @@ export component WorkArea inherits Rectangle {
                     padding-left: Tokens.sp3;
                     padding-right: Tokens.sp3;
                     spacing: Tokens.sp3;
-                    UnderlineSegment { text: "Data"; active: root.p1-sql-view-mode == 0; clicked => { root.p1-sql-view-mode = 0; } }
-                    UnderlineSegment { text: "Message"; active: root.p1-sql-view-mode == 1; clicked => { root.p1-sql-view-mode = 1; } }
-                    UnderlineSegment { text: "Chart"; active: root.p1-sql-view-mode == 2; clicked => { root.p1-sql-view-mode = 2; } }
+                    if root.p1-active-table != "": UnderlineSegment { text: "Data"; active: !root.p1-show-structure; clicked => { root.p1-show-structure = false; } }
+                    if root.p1-active-table != "": UnderlineSegment { text: "Structure"; active: root.p1-show-structure; clicked => { root.p1-show-structure = true; } }
+                    if root.p1-active-table == "": UnderlineSegment { text: "Data"; active: root.p1-sql-view-mode == 0; clicked => { root.p1-sql-view-mode = 0; } }
+                    if root.p1-active-table == "": UnderlineSegment { text: "Message"; active: root.p1-sql-view-mode == 1; clicked => { root.p1-sql-view-mode = 1; } }
+                    if root.p1-active-table == "": UnderlineSegment { text: "Chart"; active: root.p1-sql-view-mode == 2; clicked => { root.p1-sql-view-mode = 2; } }
                     Rectangle { horizontal-stretch: 1; }
+                    if root.p1-active-table != "": Text { text: root.p1-total-rows >= 0 ? root.p1-page-start + "–" + root.p1-page-end + " of " + root.p1-total-rows : root.p1-page-start + "–" + root.p1-page-end; color: Tokens.text-dim; font-size: Tokens.font-sm; }
+                    if root.p1-active-table != "": TextButton { text: "‹"; clicked => { root.p1-prev-page(); } }
+                    if root.p1-active-table != "": TextButton { text: "›"; clicked => { root.p1-next-page(); } }
                     Text { text: root.p1-result-status; color: root.p1-status-error ? Tokens.error : Tokens.text-dim; font-size: Tokens.font-sm; vertical-alignment: center; overflow: elide; }
                 }
             }


### PR DESCRIPTION
## Summary

- Turns the query workspace into **VSCode-style tab groups**: the workspace can split into an independent left and right group, each with its own tab strip, editor, results, browse chrome, find, and streaming.
- Tabs belong to a group (`WorkspaceTab.group`) and move between groups by drag or ⇥/⇤; the right group appears when it holds a tab and closes when empty.
- Grew out of an in-tab dual-pane split (early commits) that was reworked into the group model — the commit history is kept intentionally to show the evolution.

## Changes

**Group model & runtime**
- `GroupRuntime` (per-group live editor/result/browse/stream state), held as two instances; `set_workspace_tabs` splits tabs into the left/right strips.
- Unified `restore_tab_for_pane` (merges the old left/right restore paths) — fixes a right-group table tab restoring without its browse/pk/read-only state; absolute-vs-group index handled by `abs_index_for_group` / `group_relative_index` (unit-tested).

**Per-group behavior**
- Editor input, completion, find, buffered runs, streaming, and `⌘Enter` route through the focused group; `⌘T` new tab, `⌘\` new result tab, `⌘W` close, `⌘F` find, `⌘D` split all target the focused group.
- Table browse chrome is group-local: per-group pagination/toolbar (`p1-*` mirror props + `set_p_*` facades), independent footers, and per-group `run_browse`.

**Persistence**
- Persists each group's active tab and the focused group; restores both groups on reconnect.

## Test plan

- [x] `make all` green (fmt-check + clippy `-D warnings` + tests + build).
- [x] Unit tests for the group index helpers.
- [x] Manual QA: move/add/close/rename tabs, ⌘T/⌘\/⌘W/⌘Enter, run in both groups, per-group browse pagination, and restart restoring the groups + focus.
