### PR TITLE
fix(website): build from repo root for Cloudflare Workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ docs/superpowers
 *.tmp
 *.swp
 *.swo
+
+# Node (root delegator + website build)
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "rdb-monorepo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rdb-monorepo"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "rdb-monorepo",
+  "private": true,
+  "description": "Root delegator so Cloudflare Workers Builds (which runs from the repo root) can build and deploy the marketing site in website/.",
+  "scripts": {
+    "build": "npm --prefix website ci && npm --prefix website run build",
+    "deploy": "wrangler deploy"
+  }
+}

--- a/website/README.md
+++ b/website/README.md
@@ -58,13 +58,15 @@ Then regenerate the social image: crop `workspace.png` to 1200x630 as
 
 ## Deployment
 
-Hosted on Cloudflare Workers (static assets, `wrangler.jsonc`); canonical
-home is `https://rdbs.suiflex.dev` (root base). Workers Builds settings for
-the `rdbs` service in the Cloudflare dashboard:
+Hosted on Cloudflare Workers (static assets); canonical home is
+`https://rdbs.suiflex.dev` (root base). Workers Builds runs from the repo
+root, so the wrangler config and a build delegator live there
+(`../wrangler.jsonc`, `../package.json`), not in `website/`. Dashboard
+settings for the `rdbs` service:
 
 - Git repository: `suiflex/rdb`, branch `develop`
-- Root directory: `website`
-- Build command: `npm ci && npm run build`
+- Root directory: `/` (repo root)
+- Build command: `npm run build` (delegates into `website/`)
 - Deploy command: `npx wrangler deploy`
 - Domains & Routes: add `rdbs.suiflex.dev`
 
@@ -72,7 +74,7 @@ the `rdbs` service in the Cloudflare dashboard:
 `public/_headers` sets caching and security headers; 404s are served from
 the built `404.html`.
 
-Manual deploy from a local checkout:
+Manual deploy from a local checkout (run at the repo root):
 
 ```bash
 npm run build && npx wrangler deploy

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,12 +1,12 @@
 // Cloudflare Workers (static assets) config for the marketing site.
-// Workers Builds runs from root directory `website`:
-//   build:  npm ci && npm run build
+// Lives at the repo root because Workers Builds runs from there:
+//   build:  npm run build      (delegates to website/, see package.json)
 //   deploy: npx wrangler deploy
 {
   "name": "rdbs",
   "compatibility_date": "2026-07-20",
   "assets": {
-    "directory": "./dist",
+    "directory": "./website/dist",
     "not_found_handling": "404-page"
   }
 }


### PR DESCRIPTION
## Problem

Cloudflare Workers Builds runs the build from the repository root (`/opt/buildhome/repo`), but `package.json` lives in `website/`, so `npm run build` fails with `ENOENT: package.json`. Changing the dashboard root directory would also fix it, but this makes the existing dashboard config work with no dashboard changes.

## Fix

- Root `package.json` delegates: `build` runs `npm --prefix website ci && npm --prefix website run build`
- Root `wrangler.jsonc` deploys `website/dist` as static assets, with `404-page` handling
- Move wrangler config from `website/` to the repo root (Workers Builds deploys from root)
- Ignore `node_modules/` at the repo root

## Verified locally (from repo root)

```
npm run build          # installs website deps + builds -> website/dist (9 pages)
npx wrangler deploy --dry-run   # reads 64 files from website/dist
```

After merge, Cloudflare just needs a **Retry build**; no dashboard edits. Dashboard settings that now work: root `/`, build `npm run build`, deploy `npx wrangler deploy`.