### PR TITLE
chore(website): rename RDBS to RDB

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,6 @@
-# RDBS website
+# RDB website
 
-Marketing site for RDBS, the open-source database manager in this repo.
+Marketing site for RDB, the open-source database manager in this repo.
 Static site built with [Astro](https://astro.build) and Tailwind CSS v4.
 
 ## Requirements
@@ -59,16 +59,16 @@ Then regenerate the social image: crop `workspace.png` to 1200x630 as
 ## Deployment
 
 Hosted on Cloudflare Workers (static assets); canonical home is
-`https://rdbs.suiflex.dev` (root base). Workers Builds runs from the repo
+`https://rdb.suiflex.dev` (root base). Workers Builds runs from the repo
 root, so the wrangler config and a build delegator live there
 (`../wrangler.jsonc`, `../package.json`), not in `website/`. Dashboard
-settings for the `rdbs` service:
+settings for the `rdb` service:
 
 - Git repository: `suiflex/rdb`, branch `develop`
 - Root directory: `/` (repo root)
 - Build command: `npm run build` (delegates into `website/`)
 - Deploy command: `npx wrangler deploy`
-- Domains & Routes: add `rdbs.suiflex.dev`
+- Domains & Routes: add `rdb.suiflex.dev`
 
 `.github/workflows/website.yml` runs build + tests as a CI check.
 `public/_headers` sets caching and security headers; 404s are served from

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -5,7 +5,7 @@ import tailwindcss from "@tailwindcss/vite";
 
 // Canonical home is the custom subdomain (public/CNAME points GitHub Pages
 // at it). SITE_URL / SITE_BASE override for previews or a different host.
-const site = process.env.SITE_URL ?? "https://rdbs.suiflex.dev";
+const site = process.env.SITE_URL ?? "https://rdb.suiflex.dev";
 const base = process.env.SITE_BASE ?? "/";
 
 export default defineConfig({

--- a/website/package.json
+++ b/website/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rdbs-website",
+  "name": "rdb-website",
   "private": true,
   "type": "module",
   "version": "0.0.0",

--- a/website/public/manifest.webmanifest
+++ b/website/public/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "RDBS",
-  "short_name": "RDBS",
+  "name": "RDB",
+  "short_name": "RDB",
   "description": "Fast, lightweight, open-source database management for everyone.",
   "start_url": "./",
   "display": "browser",

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -40,7 +40,7 @@ const year = new Date().getFullYear();
       }
     </div>
     <div class="mt-12 flex flex-col justify-between gap-3 border-t border-line pt-6 text-sm text-fg-3 sm:flex-row">
-      <p>MIT licensed. Copyright {year} the RDBS contributors.</p>
+      <p>MIT licensed. Copyright {year} the RDB contributors.</p>
       <p>
         Built in the open at
         <a href={GITHUB} rel="noopener" class="text-fg-2 underline decoration-line underline-offset-4 hover:text-fg">

--- a/website/src/components/Logo.astro
+++ b/website/src/components/Logo.astro
@@ -5,7 +5,7 @@ interface Props {
 const { class: className = "h-6 w-6" } = Astro.props;
 ---
 
-<!-- RDBS brand mark: database cylinder with a relation node (assets/brand/logo-mark.svg) -->
+<!-- RDB brand mark: database cylinder with a relation node (assets/brand/logo-mark.svg) -->
 <svg
   xmlns="http://www.w3.org/2000/svg"
   viewBox="0 0 32 32"

--- a/website/src/components/Screenshot.astro
+++ b/website/src/components/Screenshot.astro
@@ -3,7 +3,7 @@ import { Image } from "astro:assets";
 import type { ImageMetadata } from "astro";
 
 /**
- * Real application screenshot, captured from the RDBS mock harness
+ * Real application screenshot, captured from the RDB mock harness
  * (RDB_MOCK=1, seeded sample data, no credentials). No fake chrome is added:
  * the frame is a plain border so the pixels stay honest.
  */

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -1,5 +1,5 @@
 /** Single source of truth for names, links, and nav. */
-export const PRODUCT = "RDBS";
+export const PRODUCT = "RDB";
 export const TAGLINE = "Fast, lightweight, open-source database management for everyone.";
 
 export const GITHUB = "https://github.com/suiflex/rdb";

--- a/website/src/pages/404.astro
+++ b/website/src/pages/404.astro
@@ -4,8 +4,8 @@ import { url } from "../config";
 ---
 
 <Base
-  title="Page not found: RDBS"
-  description="This page does not exist. Head back to the RDBS homepage or the downloads page."
+  title="Page not found: RDB"
+  description="This page does not exist. Head back to the RDB homepage or the downloads page."
   path="/404"
 >
   <section class="mx-auto flex max-w-3xl flex-col items-start px-4 py-28 sm:px-6">

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -37,8 +37,8 @@ for (const block of blocks.slice(0, 5)) {
 ---
 
 <Base
-  title="RDBS changelog"
-  description="What changed in recent RDBS releases: new features, fixes, and improvements, generated from the project's conventional-commit history."
+  title="RDB changelog"
+  description="What changed in recent RDB releases: new features, fixes, and improvements, generated from the project's conventional-commit history."
   path="/changelog"
 >
   <section class="mx-auto max-w-3xl px-4 pt-16 pb-10 sm:px-6">

--- a/website/src/pages/docs.astro
+++ b/website/src/pages/docs.astro
@@ -24,8 +24,8 @@ const guides = [
 ---
 
 <Base
-  title="RDBS documentation"
-  description="Get started with RDBS: install it, add your first connection, run queries, and build from source. Full documentation lives in the GitHub repository."
+  title="RDB documentation"
+  description="Get started with RDB: install it, add your first connection, run queries, and build from source. Full documentation lives in the GitHub repository."
   path="/docs"
 >
   <section class="mx-auto max-w-4xl px-4 pt-16 pb-12 sm:px-6">

--- a/website/src/pages/download.astro
+++ b/website/src/pages/download.astro
@@ -31,7 +31,7 @@ const platforms: Platform[] = [
   {
     id: "macos",
     name: "macOS",
-    hint: "Open the .dmg and drag RDBS to Applications.",
+    hint: "Open the .dmg and drag RDB to Applications.",
     rows: [
       row("Disk image", "Apple Silicon", "rdb-aarch64-apple-darwin.dmg"),
       row("Disk image", "Intel", "rdb-x86_64-apple-darwin.dmg"),
@@ -65,13 +65,13 @@ const platforms: Platform[] = [
 ---
 
 <Base
-  title="Download RDBS for macOS, Windows, and Linux"
-  description={`Download RDBS ${release.tag}, the free open-source database client, for macOS, Windows, and Linux. Direct binaries with SHA-256 checksums, plus Homebrew, npm, and Scoop.`}
+  title="Download RDB for macOS, Windows, and Linux"
+  description={`Download RDB ${release.tag}, the free open-source database client, for macOS, Windows, and Linux. Direct binaries with SHA-256 checksums, plus Homebrew, npm, and Scoop.`}
   path="/download"
 >
   <section class="mx-auto max-w-4xl px-4 pt-16 pb-8 sm:px-6">
     <h1 class="font-display text-4xl font-semibold tracking-tight sm:text-5xl">
-      Download RDBS
+      Download RDB
     </h1>
     <p class="mt-4 text-lg text-fg-2">
       Latest stable release

--- a/website/src/pages/features.astro
+++ b/website/src/pages/features.astro
@@ -54,8 +54,8 @@ const groups = [
 ---
 
 <Base
-  title="RDBS features: editor, data grid, and six database engines"
-  description="What ships in RDBS today: a real SQL editor with split panes, a virtualized data grid with server-side filters, keychain-backed credentials, and support for six database engines."
+  title="RDB features: editor, data grid, and six database engines"
+  description="What ships in RDB today: a real SQL editor with split panes, a virtualized data grid with server-side filters, keychain-backed credentials, and support for six database engines."
   path="/features"
 >
   <section class="mx-auto max-w-6xl px-4 pt-16 pb-12 sm:px-6">
@@ -72,13 +72,13 @@ const groups = [
     <div class="grid gap-6 lg:grid-cols-2">
       <Screenshot
         src={shotConnections}
-        alt="RDBS connection picker with saved PostgreSQL, MySQL, and Redis connections organized in groups"
+        alt="RDB connection picker with saved PostgreSQL, MySQL, and Redis connections organized in groups"
         sizes="(min-width: 1024px) 560px, 94vw"
         priority
       />
       <Screenshot
         src={shotSql}
-        alt="RDBS SQL editor with a query and its results grid"
+        alt="RDB SQL editor with a query and its results grid"
         sizes="(min-width: 1024px) 560px, 94vw"
         priority
       />
@@ -134,7 +134,7 @@ const groups = [
           href={url("/download")}
           class="inline-block rounded-lg bg-accent px-5 py-3 font-semibold text-accent-ink transition-colors hover:bg-accent-soft"
         >
-          Download RDBS
+          Download RDB
         </a>
       </div>
     </div>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -15,7 +15,7 @@ const dmgMb = macDmg ? (macDmg.size / 1_000_000).toFixed(1) : null;
 const structuredData = {
   "@context": "https://schema.org",
   "@type": "SoftwareApplication",
-  name: "RDBS",
+  name: "RDB",
   applicationCategory: "DeveloperApplication",
   operatingSystem: "macOS, Windows, Linux",
   offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
@@ -26,8 +26,8 @@ const structuredData = {
 ---
 
 <Base
-  title="RDBS: fast, lightweight, open-source database management"
-  description="RDBS is a free, open-source desktop database client for PostgreSQL, MySQL, Redis, MongoDB, SQLite, and Cassandra. One native Rust binary for macOS, Windows, and Linux."
+  title="RDB: fast, lightweight, open-source database management"
+  description="RDB is a free, open-source desktop database client for PostgreSQL, MySQL, Redis, MongoDB, SQLite, and Cassandra. One native Rust binary for macOS, Windows, and Linux."
   path="/"
 >
   <script type="application/ld+json" set:html={JSON.stringify(structuredData)} slot="head" />
@@ -40,7 +40,7 @@ const structuredData = {
         <span class="text-accent">heavyweight</span> client.
       </h1>
       <p class="mt-5 max-w-xl text-lg leading-relaxed text-fg-2">
-        RDBS is a free, open-source desktop client for PostgreSQL, MySQL,
+        RDB is a free, open-source desktop client for PostgreSQL, MySQL,
         Redis, MongoDB, SQLite, and Cassandra. One native Rust binary.
       </p>
       <div class="mt-8 flex flex-wrap items-center gap-3">
@@ -48,7 +48,7 @@ const structuredData = {
           href={url("/download")}
           class="rounded-lg bg-accent px-5 py-3 font-semibold text-accent-ink transition-colors hover:bg-accent-soft"
         >
-          Download RDBS
+          Download RDB
         </a>
         <a
           href={GITHUB}
@@ -68,7 +68,7 @@ const structuredData = {
   <section class="mx-auto max-w-6xl px-4 pb-24 sm:px-6" aria-label="Product screenshot">
     <Screenshot
       src={shotWorkspace}
-      alt="RDBS workspace: schema sidebar on the left, a tabbed SQL editor, and a results grid showing rows from a PostgreSQL table"
+      alt="RDB workspace: schema sidebar on the left, a tabbed SQL editor, and a results grid showing rows from a PostgreSQL table"
       priority
     />
   </section>
@@ -82,7 +82,7 @@ const structuredData = {
             Six engines, one window.
           </h2>
           <p class="mt-4 leading-relaxed text-fg-2">
-            Stop juggling one client per database. RDBS speaks each engine's
+            Stop juggling one client per database. RDB speaks each engine's
             native protocol through its own Rust driver, so the same sidebar,
             editor, and grid work everywhere.
           </p>
@@ -128,7 +128,7 @@ const structuredData = {
     <div class="mx-auto grid max-w-6xl gap-10 px-4 py-20 sm:px-6 lg:grid-cols-[1.4fr_1fr] lg:items-center lg:gap-16">
       <Screenshot
         src={shotSql}
-        alt="RDBS SQL editor running a query, with syntax highlighting and a results grid below"
+        alt="RDB SQL editor running a query, with syntax highlighting and a results grid below"
         sizes="(min-width: 1024px) 640px, 94vw"
         class="order-last lg:order-first"
       />
@@ -159,7 +159,7 @@ const structuredData = {
         </h2>
         <p class="mt-4 leading-relaxed text-fg-2">
           Run <code class="rounded bg-code px-1.5 py-0.5 font-mono text-sm">SELECT * FROM huge_table</code>
-          and keep working. RDBS loads rows in batches as you scroll and
+          and keep working. RDB loads rows in batches as you scroll and
           virtualizes the grid, so a million-row result never lands in memory
           all at once.
         </p>
@@ -185,7 +185,7 @@ const structuredData = {
           </div>
           <Screenshot
             src={shotPalette}
-            alt="RDBS command palette open over the workspace, listing saved PostgreSQL, MySQL, Redis, and MongoDB connections"
+            alt="RDB command palette open over the workspace, listing saved PostgreSQL, MySQL, Redis, and MongoDB connections"
             sizes="(min-width: 1024px) 640px, 94vw"
             class="mx-6 mb-0 translate-y-2 rounded-b-none border-b-0"
           />
@@ -219,7 +219,7 @@ const structuredData = {
           Built in the open.
         </h2>
         <p class="mt-4 leading-relaxed text-fg-2">
-          RDBS is MIT licensed and developed entirely on GitHub. Read the
+          RDB is MIT licensed and developed entirely on GitHub. Read the
           code, report a bug, or help shape what comes next: every engine is
           a self-contained Rust crate behind one
           <code class="rounded bg-code px-1.5 py-0.5 font-mono text-sm">Driver</code>
@@ -239,7 +239,7 @@ const structuredData = {
             { label: "Good first issues", note: "a gentle place to start", href: REPO_LINKS.goodFirstIssues },
             { label: "Contributing guide", note: "setup, style, PR flow", href: REPO_LINKS.contributing },
             { label: "Discussions", note: "questions and ideas", href: REPO_LINKS.discussions },
-            { label: "Roadmap", note: "where RDBS is headed", href: REPO_LINKS.vision },
+            { label: "Roadmap", note: "where RDB is headed", href: REPO_LINKS.vision },
             { label: "Releases", note: "binaries and notes", href: REPO_LINKS.releases },
           ].map((item) => (
             <li>
@@ -266,7 +266,7 @@ const structuredData = {
           No account. No telemetry.
         </h2>
         <p class="mt-4 leading-relaxed text-fg-2">
-          RDBS is a local tool. Your queries travel between you and your
+          RDB is a local tool. Your queries travel between you and your
           database, and nowhere else.
         </p>
       </div>
@@ -286,14 +286,14 @@ const structuredData = {
   <section class="border-t border-line">
     <div class="mx-auto max-w-6xl px-4 py-24 text-center sm:px-6">
       <h2 class="font-display text-3xl font-semibold tracking-tight text-balance sm:text-4xl">
-        Download RDBS and connect to your first database.
+        Download RDB and connect to your first database.
       </h2>
       <div class="mt-8 flex flex-wrap items-center justify-center gap-3">
         <a
           href={url("/download")}
           class="rounded-lg bg-accent px-5 py-3 font-semibold text-accent-ink transition-colors hover:bg-accent-soft"
         >
-          Download RDBS
+          Download RDB
         </a>
         <a
           href={GITHUB}

--- a/website/src/pages/license.astro
+++ b/website/src/pages/license.astro
@@ -8,14 +8,14 @@ const licenseText = readFileSync(new URL("../../../LICENSE", import.meta.url), "
 ---
 
 <Base
-  title="RDBS license"
-  description="RDBS is released under the MIT license: free to use, modify, and redistribute, commercially or otherwise."
+  title="RDB license"
+  description="RDB is released under the MIT license: free to use, modify, and redistribute, commercially or otherwise."
   path="/license"
 >
   <section class="mx-auto max-w-3xl px-4 pt-16 pb-20 sm:px-6">
     <h1 class="font-display text-4xl font-semibold tracking-tight sm:text-5xl">License</h1>
     <p class="mt-4 text-lg leading-relaxed text-fg-2">
-      RDBS is released under the MIT license. In practice that means you can
+      RDB is released under the MIT license. In practice that means you can
       use it at work, modify it, and redistribute it, free of charge. The
       only condition is keeping the copyright notice.
     </p>

--- a/website/src/pages/open-source.astro
+++ b/website/src/pages/open-source.astro
@@ -17,8 +17,8 @@ const crates = [
 ---
 
 <Base
-  title="Contribute to RDBS"
-  description="RDBS is MIT-licensed and built in the open. Read the code, report a bug, pick up a good first issue, or add a driver for your favorite database."
+  title="Contribute to RDB"
+  description="RDB is MIT-licensed and built in the open. Read the code, report a bug, pick up a good first issue, or add a driver for your favorite database."
   path="/open-source"
 >
   <section class="mx-auto max-w-4xl px-4 pt-16 pb-12 sm:px-6">
@@ -26,7 +26,7 @@ const crates = [
       Built in the open. Yours to shape.
     </h1>
     <p class="mt-4 max-w-xl text-lg leading-relaxed text-fg-2">
-      Every line of RDBS is public and MIT licensed. Read the code, report a
+      Every line of RDB is public and MIT licensed. Read the code, report a
       bug, or help decide what comes next.
     </p>
     <div class="mt-8 flex flex-wrap gap-3">
@@ -69,7 +69,7 @@ const crates = [
             Engines are self-contained crates implementing one
             <code class="rounded bg-code px-1.5 py-0.5 font-mono text-xs">Driver</code>
             trait. If you know an engine's wire protocol or its Rust client
-            library, you can bring it to RDBS.
+            library, you can bring it to RDB.
           </li>
           <li>
             <strong class="text-fg">Join the discussion.</strong>

--- a/website/src/pages/privacy.astro
+++ b/website/src/pages/privacy.astro
@@ -4,22 +4,22 @@ import { REPO_LINKS } from "../config";
 ---
 
 <Base
-  title="RDBS privacy"
-  description="How RDBS handles your data: no account, no telemetry, credentials in your OS keychain, and a single optional update check you can turn off."
+  title="RDB privacy"
+  description="How RDB handles your data: no account, no telemetry, credentials in your OS keychain, and a single optional update check you can turn off."
   path="/privacy"
 >
   <section class="mx-auto max-w-3xl px-4 pt-16 pb-20 sm:px-6">
     <h1 class="font-display text-4xl font-semibold tracking-tight sm:text-5xl">Privacy</h1>
     <p class="mt-4 text-lg leading-relaxed text-fg-2">
-      RDBS is a local desktop application. This page describes everything it
+      RDB is a local desktop application. This page describes everything it
       does with your data. It is short because there is not much to describe.
     </p>
 
-    <div class="prose-rdbs mt-10 space-y-8 text-sm leading-relaxed text-fg-2">
+    <div class="prose-rdb mt-10 space-y-8 text-sm leading-relaxed text-fg-2">
       <section>
         <h2 class="font-display text-xl font-semibold text-fg">No account, no tracking</h2>
         <p class="mt-2">
-          RDBS requires no sign-up and has no cloud backend. It contains no
+          RDB requires no sign-up and has no cloud backend. It contains no
           analytics, no usage tracking, and no crash reporting. The
           application works fully offline.
         </p>
@@ -50,7 +50,7 @@ import { REPO_LINKS } from "../config";
       <section>
         <h2 class="font-display text-xl font-semibold text-fg">The one network call</h2>
         <p class="mt-2">
-          At most once a day, RDBS makes a single HTTPS request to the GitHub
+          At most once a day, RDB makes a single HTTPS request to the GitHub
           Releases API to check whether a newer version exists. No identifier
           or usage data is attached; it is a plain HTTP GET. You can disable
           this check in Settings, and the app never downloads or installs

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 /*
-  RDBS design tokens. One dark theme, locked for the whole site.
+  RDB design tokens. One dark theme, locked for the whole site.
   Accent is the product's brand green (see assets/brand/logo-mark.svg).
   Radius rule: interactive elements 8px, panels/media 12px. Nothing else.
 */

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,7 +3,7 @@
 //   build:  npm run build      (delegates to website/, see package.json)
 //   deploy: npx wrangler deploy
 {
-  "name": "rdbs",
+  "name": "rdb",
   "compatibility_date": "2026-07-20",
   "assets": {
     "directory": "./website/dist",


### PR DESCRIPTION
Renames the website brand from **RDBS** to **RDB** to match the product's real name (repo `suiflex/rdb`, binary `rdb`, package `@suiflex/rdb`).

## Changes

- Brand text across all 9 pages, `config.ts` (`PRODUCT`), titles, meta/OG, and `manifest.webmanifest`
- Canonical domain `rdbs.suiflex.dev` -> `rdb.suiflex.dev` (astro config default + README)
- Worker name `rdbs` -> `rdb` in `wrangler.jsonc`
- Internal names: `prose-rdbs` class, `rdbs-website` package name

## Cloudflare follow-up (dashboard)

Since the deploy identifiers changed, in the Cloudflare dashboard: rename the Workers service to `rdb` (or recreate it from the repo), and add `rdb.suiflex.dev` under Domains & Routes.

## Verified

`npm run build` (9 pages) + `npm run test` pass; canonical is `https://rdb.suiflex.dev/`, zero `rdbs` strings remain.