### PR TITLE
fix: export save dialog, connection URL, and tab/drag icons

### DIFF
--- a/app/src/export.rs
+++ b/app/src/export.rs
@@ -26,10 +26,47 @@ fn engine_label(e: Engine) -> &'static str {
     }
 }
 
+/// URI scheme for a connection-string URL. Distinct from `engine_label`:
+/// postgres/mongo use the canonical `postgresql`/`mongodb` schemes.
+fn engine_scheme(e: Engine) -> &'static str {
+    match e {
+        Engine::Postgres => "postgresql",
+        Engine::MySql => "mysql",
+        Engine::Redis => "redis",
+        Engine::Mongo => "mongodb",
+        Engine::Sqlite => "sqlite",
+        Engine::Cassandra => "cassandra",
+    }
+}
+
+/// Connection-string URL, e.g. `postgresql://user:***@host:5432/db`. The
+/// password is never stored in `SavedConnection` (it lives in the keychain),
+/// so a fixed `***` placeholder marks where it belongs. The user segment is
+/// omitted when empty and the `/database` when absent.
+pub fn conn_to_url(c: &SavedConnection) -> String {
+    let cred = if c.user.is_empty() {
+        String::new()
+    } else {
+        format!("{}:***@", c.user)
+    };
+    let db = c
+        .database
+        .as_deref()
+        .map(|d| format!("/{d}"))
+        .unwrap_or_default();
+    format!(
+        "{}://{cred}{}:{}{db}",
+        engine_scheme(c.engine),
+        c.host,
+        c.port
+    )
+}
+
 /// Saved connections as CSV. Non-secret fields only — passwords live in the
-/// keychain and are never part of `SavedConnection`, so the dump is safe.
+/// keychain and are never part of `SavedConnection`, so the dump is safe. The
+/// `url` column carries a `:***@` placeholder in place of the password.
 pub fn conns_to_csv(conns: &[SavedConnection]) -> String {
-    let mut out = String::from("name,engine,host,port,database,user\n");
+    let mut out = String::from("name,engine,host,port,database,user,url\n");
     for c in conns {
         let row = [
             csv_esc(&c.name),
@@ -38,11 +75,35 @@ pub fn conns_to_csv(conns: &[SavedConnection]) -> String {
             c.port.to_string(),
             csv_esc(c.database.as_deref().unwrap_or("")),
             csv_esc(&c.user),
+            csv_esc(&conn_to_url(c)),
         ];
         out.push_str(&row.join(","));
         out.push('\n');
     }
     out
+}
+
+/// Saved connections as a pretty JSON array. Mirrors `conns_to_csv`: non-secret
+/// fields plus a `url` with the `:***@` password placeholder. Built by hand
+/// (not via `Serialize` on `SavedConnection`) so the computed `url` is included
+/// and keychain secrets stay out.
+pub fn conns_to_json(conns: &[SavedConnection]) -> String {
+    use serde_json::{json, Value};
+    let arr: Vec<Value> = conns
+        .iter()
+        .map(|c| {
+            json!({
+                "name": c.name,
+                "engine": engine_label(c.engine),
+                "host": c.host,
+                "port": c.port,
+                "database": c.database,
+                "user": c.user,
+                "url": conn_to_url(c),
+            })
+        })
+        .collect();
+    serde_json::to_string_pretty(&arr).unwrap_or_else(|_| "[]".into())
 }
 
 /// RFC-4180-style CSV: fields quoted when they contain a comma, quote or
@@ -194,9 +255,37 @@ mod tests {
         let csv = conns_to_csv(&[c]);
         assert_eq!(
             csv,
-            "name,engine,host,port,database,user\n\"db, prod\",postgres,localhost,5432,app,postgres\n"
+            "name,engine,host,port,database,user,url\n\"db, prod\",postgres,localhost,5432,app,postgres,postgresql://postgres:***@localhost:5432/app\n"
         );
         assert!(!csv.to_lowercase().contains("password"));
+    }
+
+    #[test]
+    fn conn_url_scheme_and_placeholder_per_engine() {
+        let mut c = SavedConnection::new("c", Engine::Postgres, "10.2.238.22", 5432, "app");
+        c.database = Some("oss_rba".into());
+        assert_eq!(
+            conn_to_url(&c),
+            "postgresql://app:***@10.2.238.22:5432/oss_rba"
+        );
+
+        let m = SavedConnection::new("m", Engine::Mongo, "10.2.238.111", 27017, "root");
+        assert_eq!(conn_to_url(&m), "mongodb://root:***@10.2.238.111:27017");
+    }
+
+    #[test]
+    fn conn_url_omits_empty_user_and_missing_db() {
+        let c = SavedConnection::new("c", Engine::Redis, "localhost", 6379, "");
+        assert_eq!(conn_to_url(&c), "redis://localhost:6379");
+    }
+
+    #[test]
+    fn conns_json_has_url_and_no_secrets() {
+        let mut c = SavedConnection::new("prod", Engine::Postgres, "localhost", 5432, "app");
+        c.database = Some("db".into());
+        let json = conns_to_json(&[c]);
+        assert!(json.contains("\"url\": \"postgresql://app:***@localhost:5432/db\""));
+        assert!(!json.to_lowercase().contains("password"));
     }
 
     #[test]

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -5918,7 +5918,7 @@ fn main() -> Result<(), slint::PlatformError> {
             // process, so nothing appears and nothing is written).
             let parent = w.window().window_handle();
             let weak = w.as_weak();
-            let _ = slint::spawn_local(async move {
+            if slint::spawn_local(async move {
                 let Some(file) = rfd::AsyncFileDialog::new()
                     .set_parent(&parent)
                     .set_file_name(format!("rdb-export.{ext}"))
@@ -5935,7 +5935,11 @@ fn main() -> Result<(), slint::PlatformError> {
                 if let Some(w) = weak.upgrade() {
                     w.set_results_meta(SharedString::from(msg));
                 }
-            });
+            })
+            .is_err()
+            {
+                w.set_results_meta(SharedString::from("export failed: no UI event loop"));
+            }
         });
     }
 
@@ -8385,7 +8389,7 @@ fn main() -> Result<(), slint::PlatformError> {
             // process, so nothing appears and nothing is written).
             let parent = w.window().window_handle();
             let weak = w.as_weak();
-            let _ = slint::spawn_local(async move {
+            if slint::spawn_local(async move {
                 let Some(file) = rfd::AsyncFileDialog::new()
                     .set_parent(&parent)
                     .set_file_name(format!("rdb-connections.{ext}"))
@@ -8402,7 +8406,11 @@ fn main() -> Result<(), slint::PlatformError> {
                 if let Some(w) = weak.upgrade() {
                     w.set_sel_footer(SharedString::from(msg));
                 }
-            });
+            })
+            .is_err()
+            {
+                w.set_sel_footer(SharedString::from("export failed: no UI event loop"));
+            }
         });
     }
     // quick test from the picker detail pane: saved config, result in the

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -8373,23 +8373,21 @@ fn main() -> Result<(), slint::PlatformError> {
                 return;
             };
             let st = store.borrow();
-            let (ext, body) = if fmt == 1 {
-                ("csv", Ok(export::conns_to_csv(st.list())))
+            let (ext, contents) = if fmt == 1 {
+                ("csv", export::conns_to_csv(st.list()))
             } else {
-                ("json", serde_json::to_string_pretty(st.list()))
-            };
-            let contents = match body {
-                Ok(j) => j,
-                Err(e) => {
-                    w.set_sel_footer(SharedString::from(format!("export failed: {e}")));
-                    return;
-                }
+                ("json", export::conns_to_json(st.list()))
             };
             // Native save dialog via rfd's async API + Slint's local executor:
             // the sync dialog blocks the winit event loop and never surfaces.
+            // Parent it to our window so macOS presents the panel as a sheet
+            // (an unparented NSSavePanel silently no-ops for a non-foreground
+            // process, so nothing appears and nothing is written).
+            let parent = w.window().window_handle();
             let weak = w.as_weak();
             let _ = slint::spawn_local(async move {
                 let Some(file) = rfd::AsyncFileDialog::new()
+                    .set_parent(&parent)
                     .set_file_name(format!("rdb-connections.{ext}"))
                     .add_filter(ext.to_uppercase(), &[ext])
                     .save_file()

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -1080,11 +1080,10 @@ in-out property <string> rename-text;
                                         background: move-ta.has-hover ? Tokens.accent-tint : transparent;
                                         visible: i == root.active-tab || tab-ta.has-hover;
                                         move-ta := TouchArea { clicked => { root.move-tab-group(i, 1); } }
-                                        Text {
-                                            text: "⇥";
+                                        AppIcon {
+                                            name: "columns";
+                                            size: 11px;
                                             color: move-ta.has-hover ? Tokens.accent : Tokens.text-dim;
-                                            horizontal-alignment: center;
-                                            vertical-alignment: center;
                                         }
                                     }
                                     // close affordance (active or hovered tab)

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -1222,11 +1222,10 @@ in-out property <string> rename-text;
                                         background: p1-move-ta.has-hover ? Tokens.accent-tint : transparent;
                                         visible: i == root.p1-active-tab || p1-tab-ta.has-hover;
                                         p1-move-ta := TouchArea { clicked => { root.move-tab-group(i, 0); } }
-                                        Text {
-                                            text: "⇤";
+                                        AppIcon {
+                                            name: "columns";
+                                            size: 11px;
                                             color: p1-move-ta.has-hover ? Tokens.accent : Tokens.text-dim;
-                                            horizontal-alignment: center;
-                                            vertical-alignment: center;
                                         }
                                     }
                                     Rectangle {

--- a/app/src/ui/icons.slint
+++ b/app/src/ui/icons.slint
@@ -27,6 +27,7 @@ export component AppIcon inherits Image {
         name == "bolt"      ? @image-url("icons/bolt.svg")     :
         name == "filter"    ? @image-url("icons/filter.svg")   :
         name == "columns"   ? @image-url("icons/columns.svg")  :
+        name == "grip"      ? @image-url("icons/grip.svg")     :
         name == "rows"      ? @image-url("icons/rows.svg")     :
         name == "panel-right" ? @image-url("icons/panel-right.svg") :
         name == "panel-left" ? @image-url("icons/panel-left.svg") :

--- a/app/src/ui/icons/grip.svg
+++ b/app/src/ui/icons/grip.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000"><circle cx="9" cy="5" r="1.6"/><circle cx="9" cy="12" r="1.6"/><circle cx="9" cy="19" r="1.6"/><circle cx="15" cy="5" r="1.6"/><circle cx="15" cy="12" r="1.6"/><circle cx="15" cy="19" r="1.6"/></svg>

--- a/app/src/ui/picker.slint
+++ b/app/src/ui/picker.slint
@@ -6,6 +6,7 @@ import {
     DbBadge, OutlineChip, PrimaryButton, SecondaryButton, TextButton,
     TagChip, FilterField
 } from "components.slint";
+import { AppIcon } from "icons.slint";
 import { ConnItem, KvRow } from "structs.slint";
 import { ScrollView } from "std-widgets.slint";
 
@@ -181,12 +182,10 @@ export component ConnPicker inherits Rectangle {
                                         Rectangle {
                                             width: 12px;
                                             opacity: row-ta.has-hover || grip-ta.has-hover || grip-ta.pressed ? 1.0 : 0.0;
-                                            Text {
-                                                text: "⋮⋮";
+                                            AppIcon {
+                                                name: "grip";
+                                                size: 12px;
                                                 color: selected ? white.with-alpha(0.7) : Tokens.text-faint;
-                                                font-size: 13px;
-                                                horizontal-alignment: center;
-                                                vertical-alignment: center;
                                             }
                                             grip-ta := TouchArea {
                                                 mouse-cursor: grab;


### PR DESCRIPTION
## Summary

- Export (connections and query results) produced no save dialog and wrote no file; make both handlers parent the panel to the window and stop swallowing scheduling errors.
- Enrich the connections export with a connection-string URL so the dump carries the registered endpoint, not just plain fields.
- Replace missing-glyph tab/drag affordances (rendered as tofu boxes) with real icons.

## Changes

- **Connections export** (`app/src/main.rs`): parent the rfd save panel to the app window (an unparented `NSSavePanel` no-ops for a non-foreground macOS process). Route JSON through the new `conns_to_json`.
- **Export URL** (`app/src/export.rs`): new `conn_to_url` → `engine://user:***@host:port/db` (password lives in the keychain, so a fixed `***` placeholder marks its position). Added as a `url` CSV column and JSON field; unit tests for scheme-per-engine, placeholder, and empty user / missing db.
- **Error surfacing** (`app/src/main.rs`): both export handlers now report `export failed: no UI event loop` instead of silently discarding a failed `spawn_local`.
- **Drag handle** (`app/src/ui/picker.slint` + `icons.slint` + `icons/grip.svg`): swap the `⋮⋮` text glyph for a tintable 6-dot grip `AppIcon`.
- **Tab move button** (`app/src/ui/app-window.slint`): both the left-group (`⇥`) and right-pane (`⇤`) buttons rendered as empty boxes; point both at the existing `columns` `AppIcon`.

## Test plan

- [x] `cargo test -p rdb --bin rdb export` — export serializers pass (incl. new URL/JSON tests)
- [x] `make lint` + `make fmt-check`
- [x] `cargo build -p rdb`
- [x] `make fe-run`: connections + query-result Export → native save dialog appears, file written, status line shows path; exported connections file contains the `url` column/field
- [x] Drag handle shows the grip icon; drag-reorder still works
- [x] Both left and right pane tab move buttons show the columns icon (no box)