### PR TITLE
feat(macos): install RDB.app to Applications via curl/brew/npm

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -175,19 +175,30 @@ jobs:
           intel_sha="$(sha rdb-x86_64-apple-darwin.tar.gz)"
           linux_sha="$(sha rdb-x86_64-unknown-linux-gnu.tar.gz)"
 
+          # DMGs carry the signed RDB.app for the GUI cask.
+          dl "rdb-aarch64-apple-darwin.dmg"
+          dl "rdb-x86_64-apple-darwin.dmg"
+          arm_dmg_sha="$(sha rdb-aarch64-apple-darwin.dmg)"
+          intel_dmg_sha="$(sha rdb-x86_64-apple-darwin.dmg)"
+
           git clone "https://x-access-token:${GH_TOKEN}@github.com/suiflex/homebrew-tap.git" tap
-          mkdir -p tap/Formula
+          mkdir -p tap/Formula tap/Casks
           sed -e "s|@VERSION@|${VERSION}|g" \
               -e "s|@BASE@|${base}|g" \
               -e "s|@ARM_SHA@|${arm_sha}|g" \
               -e "s|@INTEL_SHA@|${intel_sha}|g" \
               -e "s|@LINUX_SHA@|${linux_sha}|g" \
               packaging/rdb.rb.tmpl > tap/Formula/rdb.rb
+          sed -e "s|@VERSION@|${VERSION}|g" \
+              -e "s|@BASE@|${base}|g" \
+              -e "s|@ARM_DMG_SHA@|${arm_dmg_sha}|g" \
+              -e "s|@INTEL_DMG_SHA@|${intel_dmg_sha}|g" \
+              packaging/rdb-cask.rb.tmpl > tap/Casks/rdb.rb
 
           cd tap
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Formula/rdb.rb
+          git add Formula/rdb.rb Casks/rdb.rb
           git commit -m "rdb ${VERSION}" || { echo "no change"; exit 0; }
           git push
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ npm i -g @suiflex/rdb
 ```
 
 The postinstall step downloads the prebuilt `rdb` binary for your platform from
-the matching GitHub Release, then `rdb` launches it.
+the matching GitHub Release, then `rdb` launches it. On macOS it also installs
+`RDB.app` into `~/Applications` so it shows up in Launchpad.
 
 ### macOS / Linux
 
@@ -117,9 +118,19 @@ Optional:
 curl -fsSL https://raw.githubusercontent.com/suiflex/rdb/develop/scripts/install.sh | RDB_VERSION=v0.1.0 INSTALL_DIR="$HOME/.local/bin" bash
 ```
 
-The script installs `rdb` into `/usr/local/bin` when writable, otherwise it falls back to `~/.local/bin`.
+On macOS the script installs `RDB.app` into Applications (Launchpad) and symlinks
+the `rdb` command into `~/.local/bin`. On Linux it installs the `rdb` binary into
+`/usr/local/bin` when writable, otherwise `~/.local/bin`.
 
 ### Homebrew (macOS / Linux)
+
+For the macOS app (Launchpad):
+
+```bash
+brew install --cask suiflex/tap/rdb
+```
+
+For the CLI binary only:
 
 ```bash
 brew install suiflex/tap/rdb

--- a/npm/install.js
+++ b/npm/install.js
@@ -53,15 +53,74 @@ function download(url, dest, redirects = 0) {
   });
 }
 
+// macOS: the .dmg carries the signed RDB.app. Its name mirrors the tarball's
+// target triple. Pure so it can be self-checked without touching the network.
+function macDmgAsset(arch) {
+  const target = resolveTarget("darwin", arch).target;
+  return `rdb-${target}.dmg`;
+}
+
+// macOS: fetch the .dmg, copy RDB.app into ~/Applications (Launchpad), and
+// vendor the inner binary so the `rdb` command still works. No sudo needed.
+async function installMacApp(version, vendor) {
+  const asset = macDmgAsset(process.arch);
+  const tag = `v${version}`;
+  const url = `https://github.com/${REPO}/releases/download/${tag}/${asset}`;
+  const dmg = path.join(vendor, asset);
+
+  process.stdout.write(`rdb: downloading ${asset} (${tag})…\n`);
+  await download(url, dmg);
+
+  const mnt = fs.mkdtempSync(path.join(require("os").tmpdir(), "rdb-dmg-"));
+  try {
+    execFileSync("hdiutil", ["attach", "-nobrowse", "-readonly", "-mountpoint", mnt, dmg], {
+      stdio: "inherit",
+    });
+    const appName = fs.readdirSync(mnt).find((n) => n.endsWith(".app"));
+    if (!appName) throw new Error("dmg did not contain a .app bundle");
+
+    const appsDir = path.join(require("os").homedir(), "Applications");
+    fs.mkdirSync(appsDir, { recursive: true });
+    const dest = path.join(appsDir, appName);
+    fs.rmSync(dest, { recursive: true, force: true });
+    execFileSync("cp", ["-R", path.join(mnt, appName), dest], { stdio: "inherit" });
+    // Clear quarantine so the ad-hoc-signed app opens without a Gatekeeper prompt.
+    try {
+      execFileSync("xattr", ["-dr", "com.apple.quarantine", dest], { stdio: "ignore" });
+    } catch {
+      /* xattr absent or nothing to clear */
+    }
+    process.stdout.write(`rdb: installed ${appName} to ${appsDir}\n`);
+
+    // Vendor the inner binary so bin/rdb.js keeps resolving the `rdb` command.
+    const binPath = path.join(vendor, "rdb");
+    fs.copyFileSync(path.join(dest, "Contents", "MacOS", "rdb"), binPath);
+    fs.chmodSync(binPath, 0o755);
+  } finally {
+    try {
+      execFileSync("hdiutil", ["detach", mnt], { stdio: "ignore" });
+    } catch {
+      /* already detached */
+    }
+    fs.rmSync(dmg, { force: true });
+  }
+}
+
 async function main() {
   const version = require("./package.json").version;
+
+  const vendor = path.join(__dirname, "vendor");
+  fs.mkdirSync(vendor, { recursive: true });
+
+  if (process.platform === "darwin") {
+    await installMacApp(version, vendor);
+    return;
+  }
+
   const { target, ext, bin } = resolveTarget(process.platform, process.arch);
   const asset = `rdb-${target}.${ext}`;
   const tag = `v${version}`;
   const url = `https://github.com/${REPO}/releases/download/${tag}/${asset}`;
-
-  const vendor = path.join(__dirname, "vendor");
-  fs.mkdirSync(vendor, { recursive: true });
   const archive = path.join(vendor, asset);
 
   process.stdout.write(`rdb: downloading ${asset} (${tag})…\n`);
@@ -86,6 +145,8 @@ if (process.argv.includes("--selftest")) {
   assert.strictEqual(resolveTarget("win32", "x64").bin, "rdb.exe");
   assert.strictEqual(resolveTarget("linux", "x64").ext, "tar.gz");
   assert.throws(() => resolveTarget("sunos", "sparc"));
+  assert.strictEqual(macDmgAsset("arm64"), "rdb-aarch64-apple-darwin.dmg");
+  assert.strictEqual(macDmgAsset("x64"), "rdb-x86_64-apple-darwin.dmg");
   console.log("selftest ok");
   process.exit(0);
 }

--- a/packaging/rdb-cask.rb.tmpl
+++ b/packaging/rdb-cask.rb.tmpl
@@ -1,0 +1,24 @@
+# Rendered by .github/workflows/release-build.yml into suiflex/homebrew-tap.
+# Placeholders (@VERSION@, @BASE@, @ARM_DMG_SHA@, @INTEL_DMG_SHA@) are filled in
+# via sed on each release. Edit the template, not the generated file.
+#
+# This cask installs the RDB.app GUI (from the release .dmg) into Applications.
+# The CLI-only binary is the separate `rdb` formula.
+cask "rdb" do
+  version "@VERSION@"
+
+  on_arm do
+    sha256 "@ARM_DMG_SHA@"
+    url "@BASE@/rdb-aarch64-apple-darwin.dmg"
+  end
+  on_intel do
+    sha256 "@INTEL_DMG_SHA@"
+    url "@BASE@/rdb-x86_64-apple-darwin.dmg"
+  end
+
+  name "RDB"
+  desc "Native cross-platform database manager (PostgreSQL, MySQL, Redis, MongoDB)"
+  homepage "https://github.com/suiflex/rdb"
+
+  app "RDB.app"
+end

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -56,6 +56,20 @@ ASSET_URLS="$(printf '%s' "$RELEASE_JSON" | grep -o '"browser_download_url": *"[
 
 pick_asset() {
   local url
+  # On macOS prefer the .dmg: it carries the signed RDB.app that installs to
+  # Applications (Launchpad). Other OSes take the tarball/zip (bare binary).
+  if [ "$OS_RAW" = "Darwin" ]; then
+    while IFS= read -r url; do
+      case "$url" in
+        *"$TARGET_TRIPLE"*.dmg|*apple-darwin*"$ARCH"*.dmg)
+          printf '%s\n' "$url"
+          return 0
+          ;;
+      esac
+    done <<EOF
+$ASSET_URLS
+EOF
+  fi
   while IFS= read -r url; do
     case "$url" in
       *"$TARGET_TRIPLE"*.tar.gz|*"$TARGET_TRIPLE"*.zip|*"$TARGET_HINT_1"*"$ARCH"*.tar.gz|*"$TARGET_HINT_1"*"$ARCH"*.zip|*"$TARGET_HINT_1"*"$TARGET_HINT_2"*.tar.gz|*"$TARGET_HINT_1"*"$TARGET_HINT_2"*.zip)
@@ -84,11 +98,26 @@ curl -fsSL "$ASSET_URL" -o "$ARCHIVE_PATH"
 case "$ASSET_NAME" in
   *.tar.gz) tar -xzf "$ARCHIVE_PATH" -C "$EXTRACT_DIR" ;;
   *.zip) unzip -q "$ARCHIVE_PATH" -d "$EXTRACT_DIR" ;;
+  *.dmg)
+    need_cmd hdiutil
+    MNT="$TMP_DIR/mnt"
+    mkdir -p "$MNT"
+    hdiutil attach -nobrowse -readonly -mountpoint "$MNT" "$ARCHIVE_PATH" >/dev/null
+    trap 'hdiutil detach "$MNT" >/dev/null 2>&1 || true; rm -rf "$TMP_DIR"' EXIT
+    cp -R "$MNT"/*.app "$EXTRACT_DIR"/
+    hdiutil detach "$MNT" >/dev/null
+    trap 'rm -rf "$TMP_DIR"' EXIT
+    ;;
   *) fail "unsupported asset format: $ASSET_NAME" ;;
 esac
 
-BIN_PATH="$(find "$EXTRACT_DIR" -type f -name "$BINARY" | head -n 1)"
 APP_PATH="$(find "$EXTRACT_DIR" -type d -name '*.app' | head -n 1)"
+# A .app bundle wins on macOS (Launchpad); otherwise install the bare binary.
+if [ -n "$APP_PATH" ]; then
+  BIN_PATH=""
+else
+  BIN_PATH="$(find "$EXTRACT_DIR" -type f -name "$BINARY" | head -n 1)"
+fi
 
 if [ -n "$BIN_PATH" ]; then
   DEFAULT_INSTALL_DIR="$HOME/.local/bin"
@@ -120,7 +149,22 @@ elif [ "$OS_RAW" = "Darwin" ] && [ -n "$APP_PATH" ]; then
   DEST_PATH="$APP_INSTALL_DIR/$(basename "$APP_PATH")"
   rm -rf "$DEST_PATH"
   cp -R "$APP_PATH" "$DEST_PATH"
+  # Clear quarantine so the ad-hoc-signed app opens without a Gatekeeper prompt.
+  xattr -dr com.apple.quarantine "$DEST_PATH" 2>/dev/null || true
   log "Installed app bundle to $DEST_PATH"
+
+  # Keep the `rdb` terminal command working via a symlink into ~/.local/bin.
+  CLI_DIR="$HOME/.local/bin"
+  mkdir -p "$CLI_DIR"
+  ln -sf "$DEST_PATH/Contents/MacOS/$BINARY" "$CLI_DIR/$BINARY"
+  log "Linked CLI to $CLI_DIR/$BINARY"
+  case ":$PATH:" in
+    *":$CLI_DIR:"*) ;;
+    *)
+      printf 'warning: %s is not on your PATH yet\n' "$CLI_DIR" >&2
+      printf 'add this to your shell profile: export PATH="%s:$PATH"\n' "$CLI_DIR" >&2
+      ;;
+  esac
 else
   fail "downloaded archive does not contain $BINARY or a macOS .app bundle"
 fi


### PR DESCRIPTION
## Summary

- On macOS, curl / brew / npm installed a bare CLI binary that never surfaced in Launchpad or Applications — the only artifact with a real `RDB.app` was the `.dmg`, which no installer consumed.
- Point every macOS channel at the already-built, signed `RDB.app` inside the `.dmg` so the app lands in Applications, while keeping the `rdb` terminal command working.
- No client-side icon/plist generation; Linux and Windows paths are untouched.

## Changes

- **curl** (`scripts/install.sh`): on macOS fetch and mount the `.dmg`, copy `RDB.app` into Applications, strip quarantine, and symlink the inner binary into `~/.local/bin` for the `rdb` command.
- **Homebrew** (`packaging/rdb-cask.rb.tmpl` + `release-build.yml`): new cask pointing at the release dmgs; `publish-homebrew` now renders and pushes `Casks/rdb.rb` alongside the CLI formula. Install the app with `brew install --cask suiflex/tap/rdb`.
- **npm** (`npm/install.js`): on macOS download the `.dmg`, copy `RDB.app` into `~/Applications`, and vendor the inner binary so `bin/rdb.js` still resolves `rdb`.
- **docs** (`README.md`): document the macOS app install path for all three channels.

## Test plan

- [x] `node npm/install.js --selftest` → `selftest ok`
- [x] `bash -n scripts/install.sh` syntax check
- [x] rendered cask passes `ruby -c`; workflow YAML validates
- [x] post-merge, on the next `vX.Y.Z` tag: confirm the cask is pushed to the tap and that curl/npm install `RDB.app` into Applications from the fresh dmgs
- [x] manual: `brew install --cask suiflex/tap/rdb` → RDB.app in Applications, launches from Launchpad

## Notes

- App is ad-hoc signed; first launch may need right-click → Open once (quarantine strip in curl/npm reduces this).
- `npm uninstall -g` / `brew uninstall` will not remove `~/Applications/RDB.app`.