### PR TITLE
ci: update website release data

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -149,6 +149,37 @@ jobs:
   # A failure in one does NOT cancel the other (GitHub only cancels a job's own
   # dependents). Single shared PAT: secrets.TAP_PUBLISH_TOKEN.
 
+  update-website-release:
+    if: github.event_name == 'push'
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: develop
+          persist-credentials: false
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - name: Refresh website release data
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: npm --prefix website run fetch-release
+      - name: Commit website release data
+        env:
+          GH_TOKEN: ${{ secrets.TAP_PUBLISH_TOKEN }}
+        run: |
+          if git diff --quiet -- website/src/data/release.json; then
+            echo "website release data already current"
+            exit 0
+          fi
+          git config user.name "MULHAM"
+          git config user.email "mulhamna@gmail.com"
+          git add website/src/data/release.json
+          git commit -m "docs: update website release data"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git push origin HEAD:develop
+
   publish-homebrew:
     if: github.event_name == 'push'
     needs: [build]

--- a/website/scripts/fetch-release.mjs
+++ b/website/scripts/fetch-release.mjs
@@ -3,7 +3,10 @@
 // committed JSON stays in place, so the site always has valid data.
 import { writeFileSync } from "node:fs";
 
-const API = "https://api.github.com/repos/suiflex/rdb/releases/latest";
+const TAG = process.env.RELEASE_TAG?.trim();
+const API = TAG
+  ? `https://api.github.com/repos/suiflex/rdb/releases/tags/${encodeURIComponent(TAG)}`
+  : "https://api.github.com/repos/suiflex/rdb/releases/latest";
 const OUT = new URL("../src/data/release.json", import.meta.url);
 
 try {
@@ -15,18 +18,25 @@ try {
   const release = {
     tag: data.tag_name,
     published: data.published_at.split("T")[0],
-    assets: data.assets.map((a) => ({
-      name: a.name,
-      size: a.size,
-      sha256: (a.digest ?? "").replace(/^sha256:/, ""),
-      url: a.browser_download_url,
-    })),
+    assets: data.assets.map((a) => {
+      const asset = {
+        name: a.name,
+        size: a.size,
+        sha256: (a.digest ?? "").replace(/^sha256:/, ""),
+        url: a.browser_download_url,
+      };
+      if (!asset.name || !asset.size || !asset.sha256 || !asset.url) {
+        throw new Error(`release asset missing data: ${asset.name || "unknown"}`);
+      }
+      return asset;
+    }),
   };
-  if (!release.tag || release.assets.length === 0) {
+  if (!release.tag || !release.published || release.assets.length === 0) {
     throw new Error("release payload missing tag or assets");
   }
   writeFileSync(OUT, JSON.stringify(release, null, 2) + "\n");
   console.log(`release.json updated to ${release.tag} (${release.assets.length} assets)`);
 } catch (err) {
   console.warn(`fetch-release: keeping committed release.json (${err.message})`);
+  if (TAG) process.exitCode = 1;
 }


### PR DESCRIPTION
## Summary

- Keep website download metadata current after release assets are published.
- Avoid stale committed release data when a new version tag is built.

## Changes

- Allow the website release fetch script to target a specific release tag.
- Fail tagged fetches when required release asset data is missing.
- Add a release-build job that refreshes and commits website release data to develop.

## Test plan

- [x] `node --check website/scripts/fetch-release.mjs`
- [x] Parse `.github/workflows/release-build.yml` with Ruby YAML
- [x] `npm --prefix website run build`
- [x] `SKIP_NETWORK=1 npm --prefix website run test`
- [x] `git diff --check`
- [x] Verify release asset digest data with `gh api`