### PR TITLE
ci: guard website worker name

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -5,9 +5,9 @@ name: website
 on:
   push:
     branches: [develop]
-    paths: ["website/**"]
+    paths: ["website/**", "wrangler.jsonc"]
   pull_request:
-    paths: ["website/**"]
+    paths: ["website/**", "wrangler.jsonc"]
 
 jobs:
   build:
@@ -22,6 +22,16 @@ jobs:
           node-version: 22
           cache: npm
           cache-dependency-path: website/package-lock.json
+      - name: Verify Worker name
+        working-directory: .
+        run: |
+          node -e '
+            const config = require("fs").readFileSync("wrangler.jsonc", "utf8");
+            const name = config.match(/"name"\s*:\s*"([^"]+)"/)?.[1];
+            if (name !== "rdb") {
+              throw new Error(`wrangler.jsonc name must be rdb, got ${name}`);
+            }
+          '
       - run: npm ci
       - run: npm run build
       - run: SKIP_NETWORK=1 npm run test

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "rdbs-website",
+  "name": "rdb-website",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "rdbs-website",
+      "name": "rdb-website",
       "version": "0.0.0",
       "dependencies": {
         "@astrojs/sitemap": "^3.4.0",


### PR DESCRIPTION
## Summary

- Keep the website Worker config pinned to the RDB name.
- Prevent future Cloudflare-generated config changes from silently moving the repo back to rdbs.

## Changes

- Run the website workflow when `wrangler.jsonc` changes.
- Add a CI check that requires `wrangler.jsonc` to keep `name` as `rdb`.
- Rename the website package lock metadata from `rdbs-website` to `rdb-website`.

## Test plan

- [x] `rg -n "rdbs" .` returns no matches
- [x] Parse `.github/workflows/website.yml` with Ruby YAML
- [x] Verify `wrangler.jsonc` Worker name with Node
- [x] `npm --prefix website run build`
- [x] `SKIP_NETWORK=1 npm --prefix website run test`
- [x] `git diff --check`

Note: Cloudflare Dashboard should still point the deployed Worker/Build target to `rdb` so the bot stops opening rename PRs.