### PR TITLE
fix: SQL editor UX batch — cancel, autocomplete, folding, cell copy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5565,7 +5565,7 @@ dependencies = [
 
 [[package]]
 name = "rdb"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "copypasta",

--- a/app/src/completion.rs
+++ b/app/src/completion.rs
@@ -172,7 +172,9 @@ fn columns_of(nodes: &[VmTreeNode], owner: &str) -> Vec<Candidate> {
                 .map(|f| Candidate {
                     label: field_name(&f.label).to_string(),
                     kind: "field".into(),
-                    sub: owner.to_string(),
+                    // Bare table name only — the schema prefix just crowds the
+                    // row and pushes the field label into an ellipsis.
+                    sub: owner.rsplit('.').next().unwrap_or(owner).to_string(),
                 })
                 .collect();
         }

--- a/app/src/editor.rs
+++ b/app/src/editor.rs
@@ -788,45 +788,48 @@ pub fn find_matches(lines: &[String], needle: &str) -> Vec<(usize, usize, usize)
     out
 }
 
-/// Inclusive `(first_line, last_line)` of each SQL statement, for the editor's
-/// gutter fold arrows. Uses the same string/comment rules as
-/// [`split_statements`] (a `;` inside a `'literal'` or after `--` doesn't end a
-/// statement), carrying string state across lines. Blank leading lines are
-/// skipped so a block starts at its first content line. A block is foldable
-/// only when `last_line > first_line`.
-pub fn statement_line_spans(lines: &[String]) -> Vec<(usize, usize)> {
-    let mut out: Vec<(usize, usize)> = Vec::new();
-    let mut in_str = false;
-    let mut start: Option<usize> = None;
-    for (li, line) in lines.iter().enumerate() {
-        if start.is_none() && !line.trim().is_empty() {
-            start = Some(li);
-        }
-        let chars: Vec<char> = line.chars().collect();
-        let mut i = 0;
-        let mut ends = false;
-        while i < chars.len() {
-            let c = chars[i];
-            if c == '\'' {
-                in_str = !in_str;
-            } else if !in_str && c == '-' && chars.get(i + 1) == Some(&'-') {
-                break; // rest of the line is a comment
-            } else if c == ';' && !in_str {
-                ends = true;
+/// Foldable `(head_line, last_line)` regions for the editor gutter, VSCode-style:
+/// any line whose following lines are more indented heads a fold that runs until
+/// the indent returns to its level or shallower. This nests naturally (a `select`
+/// heads its column list, a `from` its joins, an indented subquery its body), so
+/// a single statement gets several collapsible blocks instead of one arrow.
+/// Blank lines belong to the surrounding block and don't end a region.
+pub fn fold_regions(lines: &[String]) -> Vec<(usize, usize)> {
+    // Leading-whitespace width per line; `None` marks a blank line, which is
+    // transparent to indent (it neither heads nor closes a region).
+    let ind: Vec<Option<usize>> = lines
+        .iter()
+        .map(|l| {
+            if l.trim().is_empty() {
+                None
+            } else {
+                Some(l.chars().take_while(|c| c.is_whitespace()).count())
             }
-            i += 1;
-        }
-        if ends {
-            if let Some(s) = start.take() {
-                out.push((s, li));
+        })
+        .collect();
+    let n = lines.len();
+    let mut regions = Vec::new();
+    for i in 0..n {
+        let Some(di) = ind[i] else { continue };
+        // Walk forward while deeper-indented (skipping blanks); the last deeper
+        // line is the region end.
+        let mut end = i;
+        let mut k = i + 1;
+        while k < n {
+            match ind[k] {
+                None => k += 1,
+                Some(dk) if dk > di => {
+                    end = k;
+                    k += 1;
+                }
+                Some(_) => break,
             }
+        }
+        if end > i {
+            regions.push((i, end));
         }
     }
-    // Trailing statement without a terminating ';'.
-    if let (Some(s), false) = (start, lines.is_empty()) {
-        out.push((s, lines.len() - 1));
-    }
-    out
+    regions
 }
 
 /// True when a statement segment carries no executable SQL — only whitespace
@@ -848,22 +851,30 @@ mod tests {
             .collect()
     }
 
-    fn spans(text: &str) -> Vec<(usize, usize)> {
+    fn regions(text: &str) -> Vec<(usize, usize)> {
         let lines: Vec<String> = text.lines().map(str::to_string).collect();
-        statement_line_spans(&lines)
+        fold_regions(&lines)
     }
 
     #[test]
-    fn fold_spans_group_multiline_statements() {
-        // Two statements: lines 0-2 (ends with ;) and lines 3-4 (no ;).
+    fn fold_regions_by_indent() {
+        // Each clause heads its indented body: select→cols, from→joins, where.
         assert_eq!(
-            spans("select *\nfrom t\nwhere x=1;\nupdate t\nset a=1"),
-            vec![(0, 2), (3, 4)]
+            regions("select\n  a,\n  b\nfrom\n  t\nwhere\n  x = 1;"),
+            vec![(0, 2), (3, 4), (5, 6)]
         );
-        // Semicolon inside a literal does not split.
-        assert_eq!(spans("select 'a;b'\nfrom t;"), vec![(0, 1)]);
-        // A semicolon after `--` is a comment, not a terminator.
-        assert_eq!(spans("select 1 -- a;b\nfrom t;"), vec![(0, 1)]);
+        // Nested indent nests regions; the outer head covers the whole block.
+        assert_eq!(
+            regions("select\n  a,\n  case\n    when x then 1\n  end\nfrom t"),
+            vec![(0, 4), (2, 3)]
+        );
+        // Flat text with no deeper lines folds nothing.
+        assert_eq!(
+            regions("select a\nfrom t\nwhere x=1;"),
+            Vec::<(usize, usize)>::new()
+        );
+        // Blank lines stay inside the block instead of ending it.
+        assert_eq!(regions("select\n  a,\n\n  b\nfrom t"), vec![(0, 3)]);
     }
 
     #[test]

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -6246,8 +6246,9 @@ fn main() -> Result<(), slint::PlatformError> {
             let Some(w) = weak.upgrade() else {
                 return;
             };
-            if w.get_grid_read_only() || row < 0 || col < 0 {
-                set_p_result_status(&w, 1, SharedString::from("read-only result"));
+            // Open the cell overlay even when read-only — as a selectable viewer
+            // (the grid's read-only branch), so the value can be copied out.
+            if row < 0 || col < 0 {
                 return;
             }
             let count = w.get_p1_col_count();
@@ -7913,18 +7914,11 @@ fn main() -> Result<(), slint::PlatformError> {
             let Some(w) = weak.upgrade() else {
                 return;
             };
-            // Editable only in a tabular browse view with a known identity.
-            if w.get_grid_read_only() || w.get_show_structure() || w.get_result_kind() == 3 {
-                // Tell the user why the double-click did nothing.
-                if w.get_grid_read_only() && !w.get_show_structure() && w.get_result_kind() == 0 {
-                    let msg = if active_tab_kind(&w) == "table" {
-                        "read-only — table has no primary key"
-                    } else {
-                        "read-only result — open the table from the sidebar to edit"
-                    };
-                    w.set_status_error(false);
-                    w.set_result_status(SharedString::from(msg));
-                }
+            // Structure view and chart results have no cell to open. Everything
+            // else opens the cell overlay: an editor when the grid is writable,
+            // otherwise a read-only, selectable viewer so the value can be copied
+            // out (the read-only branch is driven by grid-read-only in the UI).
+            if w.get_show_structure() || w.get_result_kind() == 3 {
                 return;
             }
             let cols = w.get_grid_col_count();

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -602,6 +602,10 @@ struct GroupRuntime {
     col_filters: Arc<std::sync::Mutex<Vec<String>>>,
     stream_cancel: Rc<RefCell<Option<Arc<std::sync::atomic::AtomicBool>>>>,
     stream_timer: Rc<RefCell<Option<slint::Timer>>>,
+    // Abort handle for the in-flight buffered query task, so a slow query can be
+    // hard-cancelled. Overwritten on each run; aborting a finished task is a
+    // no-op, so no clearing on completion is needed.
+    query_abort: Rc<RefCell<Option<tokio::task::AbortHandle>>>,
 }
 
 impl GroupRuntime {
@@ -626,6 +630,7 @@ impl GroupRuntime {
             col_filters: Arc::new(std::sync::Mutex::new(Vec::new())),
             stream_cancel: Rc::new(RefCell::new(None)),
             stream_timer: Rc::new(RefCell::new(None)),
+            query_abort: Rc::new(RefCell::new(None)),
         }
     }
 }
@@ -5417,7 +5422,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 // hid it. The console still updates in place when it is open.
                 cur_db = w.get_schema_name().to_string();
             }
-            rt.spawn(async move {
+            let jh = rt.spawn(async move {
                 let guard = current.lock().await;
                 let t0 = std::time::Instant::now();
                 // Multi-statement: SQL engines split on top-level `;` and run
@@ -5590,6 +5595,11 @@ fn main() -> Result<(), slint::PlatformError> {
                     }
                 });
             });
+            // ponytail: task-abort is a client-side cancel — it frees the pane and
+            // the connection guard immediately; the server statement may keep
+            // running until the connection notices. Add Client::cancel_token() for
+            // a true server-side cancel if that ever matters.
+            *panes[pane].query_abort.borrow_mut() = Some(jh.abort_handle());
         })
     };
 
@@ -6119,6 +6129,32 @@ fn main() -> Result<(), slint::PlatformError> {
             }
             if let Some(w) = weak.upgrade() {
                 set_p_streaming(&w, 0, false);
+            }
+        });
+    }
+
+    // ----- Cancel a running buffered query (hard abort of the tokio task) -----
+    {
+        let weak = window.as_weak();
+        let panes = panes.clone();
+        window.on_cancel_query(move || {
+            if let Some(h) = panes[0].query_abort.borrow_mut().take() {
+                h.abort();
+            }
+            if let Some(w) = weak.upgrade() {
+                set_p_query_running(&w, 0, false);
+            }
+        });
+    }
+    {
+        let weak = window.as_weak();
+        let panes = panes.clone();
+        window.on_p1_cancel_query(move || {
+            if let Some(h) = panes[1].query_abort.borrow_mut().take() {
+                h.abort();
+            }
+            if let Some(w) = weak.upgrade() {
+                set_p_query_running(&w, 1, false);
             }
         });
     }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2524,19 +2524,18 @@ fn main() -> Result<(), slint::PlatformError> {
                 .collect();
             let lines = ModelRc::from(Rc::new(VecModel::from(lines)));
             // Fold arrows: 1 = open head, 2 = closed head, 0 = plain line.
-            // `hidden` blanks out the body lines of a closed statement.
+            // `hidden` blanks out the body lines of a closed region; nested
+            // closed regions just union their ranges.
             let n = ed.lines.len();
             let mut hidden = vec![false; n];
             let mut fold_state = vec![0i32; n];
             let folded = folded_heads.borrow();
-            for (h, e) in editor::statement_line_spans(&ed.lines) {
-                if e > h {
-                    let closed = folded.contains(&h);
-                    fold_state[h] = if closed { 2 } else { 1 };
-                    if closed {
-                        for hl in hidden.iter_mut().take(e + 1).skip(h + 1) {
-                            *hl = true;
-                        }
+            for (h, e) in editor::fold_regions(&ed.lines) {
+                let closed = folded.contains(&h);
+                fold_state[h] = if closed { 2 } else { 1 };
+                if closed {
+                    for hl in hidden.iter_mut().take(e + 1).skip(h + 1) {
+                        *hl = true;
                     }
                 }
             }
@@ -2593,7 +2592,7 @@ fn main() -> Result<(), slint::PlatformError> {
             // hidden line; pull the caret up to the visible head.
             if now_closed {
                 let mut ed = ed_state.borrow_mut();
-                if let Some((_, e)) = editor::statement_line_spans(&ed.lines)
+                if let Some((_, e)) = editor::fold_regions(&ed.lines)
                     .into_iter()
                     .find(|(h, _)| *h == head)
                 {

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -325,6 +325,7 @@ in-out property <string> rename-text;
     // A "No limit" stream is loading rows progressively (shows the Cancel button).
     in property <bool> streaming;
     callback cancel-stream();
+    callback cancel-query();
     in-out property <string> limit-text: "300";
     callback prev-page();
     callback next-page();
@@ -412,6 +413,7 @@ in-out property <string> rename-text;
     callback p1-format-sql();
     callback p1-explain-query();
     callback p1-cancel-stream();
+    callback p1-cancel-query();
     callback p1-set-limit(string);
     callback p1-prev-page();
     callback p1-next-page();
@@ -1345,6 +1347,7 @@ in-out property <string> rename-text;
                         p1-format-sql() => { root.p1-format-sql(); }
                         p1-explain-query() => { root.p1-explain-query(); }
                         p1-cancel-stream() => { root.p1-cancel-stream(); }
+                        p1-cancel-query() => { root.p1-cancel-query(); }
                         p1-set-limit(t) => { root.p1-set-limit(t); }
                         p1-prev-page() => { root.p1-prev-page(); }
                         p1-next-page() => { root.p1-next-page(); }
@@ -1466,6 +1469,7 @@ in-out property <string> rename-text;
                         query-running: root.query-running;
                         streaming: root.streaming;
                         cancel-stream() => { root.cancel-stream(); }
+                        cancel-query() => { root.cancel-query(); }
                         limit-text <=> root.limit-text;
                         run => {
                             root.run-query();

--- a/app/src/ui/code-editor.slint
+++ b/app/src/ui/code-editor.slint
@@ -201,7 +201,7 @@ export component CodeEditor inherits Rectangle {
         y: below-y + self.pop-h > root.height && root.cursor-line * root.line-h - self.pop-h - 6px > 0
             ? root.cursor-line * root.line-h - self.pop-h - 6px
             : below-y;
-        width: 260px;
+        width: 360px;
         height: pop-h;
         border-radius: Tokens.radius;
         border-width: 1px;
@@ -211,6 +211,14 @@ export component CodeEditor inherits Rectangle {
         drop-shadow-color: Tokens.text.with-alpha(0.25);
         clip: true;
         ScrollView {
+            // Keep the keyboard-selected row visible: scroll only when the
+            // selection would fall outside the viewport (rows are 22px, +4px
+            // list padding). Clamped so the top rows sit at 0 and wrap-around
+            // (last -> first) snaps back up.
+            viewport-y: -clamp(
+                root.completion-selected * 22px - self.visible-height + 22px + 8px,
+                0,
+                max(0, root.completion-items.length * 22px + 8px - self.visible-height));
             VerticalLayout {
                 padding: 4px;
                 for it[i] in root.completion-items: Rectangle {
@@ -234,6 +242,10 @@ export component CodeEditor inherits Rectangle {
                         }
                     }
                     Text {
+                        // The label is the identity the user picks — give it all
+                        // the slack so a long schema.table stays readable; the
+                        // secondary `sub` yields first.
+                        horizontal-stretch: 1;
                         text: it.label;
                         color: Tokens.text;
                         font-family: Tokens.mono;
@@ -241,13 +253,13 @@ export component CodeEditor inherits Rectangle {
                         vertical-alignment: center;
                         overflow: elide;
                     }
-                    Rectangle { horizontal-stretch: 1; }
                     Text {
                         text: it.sub;
                         color: Tokens.text-faint;
                         font-family: Tokens.mono;
                         font-size: Tokens.font-xs;
                         vertical-alignment: center;
+                        overflow: elide;
                     }
                 }
                 cta := TouchArea { clicked => { root.completion-choose(i); } }

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -186,6 +186,31 @@ export component SecondaryButton inherits Rectangle {
     }
 }
 
+// Destructive / warning action (Cancel a running query, abort a stream).
+// Red outline + text so it reads as "stop this", distinct from a plain button.
+export component DangerButton inherits Rectangle {
+    in property <string> text;
+    in property <bool> enabled: true;
+    callback clicked;
+    height: Tokens.button-h;
+    width: label.preferred-width + 2 * Tokens.sp4;
+    border-radius: Tokens.radius;
+    border-width: 1px;
+    border-color: Tokens.error;
+    background: ta.has-hover ? Tokens.error-tint : transparent;
+    animate background { duration: Tokens.fade; }
+    label := Text {
+        text: root.text;
+        color: Tokens.error;
+        font-size: Tokens.font-sm;
+        font-weight: 600;
+    }
+    ta := TouchArea {
+        enabled: root.enabled;
+        clicked => { root.clicked(); }
+    }
+}
+
 // Plain text button (footer actions: Import, Backup, Copy, Export CSV…).
 export component TextButton inherits Rectangle {
     in property <string> text;

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -9,7 +9,7 @@ import { GridColumn, GridCell, StructField, Span, ChartBar, IndexRow, DocRow } f
 import { CodeEditor } from "code-editor.slint";
 import { TabularGrid } from "tabular-grid.slint";
 import { PaletteItem } from "palette.slint";
-import { SecondaryButton, PrimaryButton, TextButton, ExportButton } from "components.slint";
+import { SecondaryButton, PrimaryButton, TextButton, ExportButton, DangerButton } from "components.slint";
 import { ScrollView } from "std-widgets.slint";
 
 export component QueryPane inherits Rectangle {
@@ -221,8 +221,8 @@ export component QueryPane inherits Rectangle {
                     }
                     if root.streaming: VerticalLayout {
                         alignment: center;
-                        SecondaryButton {
-                            text: "✕ Cancel";
+                        DangerButton {
+                            text: "⏹ Cancel";
                             height: 28px;
                             clicked => { root.cancel-stream(); }
                         }
@@ -231,8 +231,8 @@ export component QueryPane inherits Rectangle {
                     // in-flight query task so a slow query never hangs the pane.
                     if root.query-running && !root.streaming: VerticalLayout {
                         alignment: center;
-                        SecondaryButton {
-                            text: "✕ Cancel";
+                        DangerButton {
+                            text: "⏹ Cancel";
                             height: 28px;
                             clicked => { root.cancel-query(); }
                         }
@@ -589,8 +589,8 @@ export component QueryPane inherits Rectangle {
                 }
                 HorizontalLayout {
                     alignment: center;
-                    SecondaryButton {
-                        text: "✕ Cancel";
+                    DangerButton {
+                        text: "⏹ Cancel";
                         height: 28px;
                         clicked => { root.cancel-query(); }
                     }

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -42,6 +42,7 @@ export component QueryPane inherits Rectangle {
     callback format-sql();
     callback explain-query();
     callback cancel-stream();
+    callback cancel-query();
     callback set-limit(string);
 
     // ----- find bar -----
@@ -224,6 +225,16 @@ export component QueryPane inherits Rectangle {
                             text: "✕ Cancel";
                             height: 28px;
                             clicked => { root.cancel-stream(); }
+                        }
+                    }
+                    // Buffered (non-streaming) run: a hard cancel that aborts the
+                    // in-flight query task so a slow query never hangs the pane.
+                    if root.query-running && !root.streaming: VerticalLayout {
+                        alignment: center;
+                        SecondaryButton {
+                            text: "✕ Cancel";
+                            height: 28px;
+                            clicked => { root.cancel-query(); }
                         }
                     }
                     Rectangle { horizontal-stretch: 1; }
@@ -568,11 +579,20 @@ export component QueryPane inherits Rectangle {
             // in-flight query indicator
             if root.query-running: VerticalLayout {
                 alignment: center;
+                spacing: Tokens.sp3;
                 Text {
                     text: "Running…";
                     color: Tokens.text-dim;
                     font-size: Tokens.font-md;
                     horizontal-alignment: center;
+                }
+                HorizontalLayout {
+                    alignment: center;
+                    SecondaryButton {
+                        text: "✕ Cancel";
+                        height: 28px;
+                        clicked => { root.cancel-query(); }
+                    }
                 }
             }
 

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -432,6 +432,7 @@ export component QueryPane inherits Rectangle {
                 height: 100%;
                 columns: root.columns;
                 cells: root.cells;
+                read-only: root.read-only;
                 col-count: root.col-count;
                 col-widths: root.col-widths;
                 sorted-col: root.grid-sort-col;

--- a/app/src/ui/tabular-grid.slint
+++ b/app/src/ui/tabular-grid.slint
@@ -8,6 +8,9 @@ import { ComboBox, DatePickerPopup, ListView, ScrollView } from "std-widgets.sli
 export component TabularGrid inherits Rectangle {
     in property <[GridColumn]> columns;
     in property <[GridCell]> cells;
+    // When true the cell overlay opens as a selectable, non-editable viewer so
+    // a query-result value can be selected and copied instead of edited.
+    in property <bool> read-only;
     in property <int> col-count;
     in property <[length]> col-widths;     // per-column pixel widths (drag-resizable)
     in property <int> sorted-col: -1;       // display col currently sorted, -1 none
@@ -316,7 +319,7 @@ export component TabularGrid inherits Rectangle {
                         background: Tokens.card;
                         border-width: 2px;
                         border-color: Tokens.edit-outline;
-                        if root.is-boolean(root.columns[c].type-name): ComboBox {
+                        if !root.read-only && root.is-boolean(root.columns[c].type-name): ComboBox {
                             x: 1px;
                             y: 1px;
                             width: parent.width - 2px;
@@ -328,7 +331,7 @@ export component TabularGrid inherits Rectangle {
                                 root.cell-edited(r, c, value);
                             }
                         }
-                        if root.is-date(root.columns[c].type-name): HorizontalLayout {
+                        if !root.read-only && root.is-date(root.columns[c].type-name): HorizontalLayout {
                             padding-left: Tokens.sp2;
                             padding-right: 2px;
                             spacing: Tokens.sp1;
@@ -365,12 +368,14 @@ export component TabularGrid inherits Rectangle {
                                 }
                             }
                         }
-                        if !root.is-boolean(root.columns[c].type-name) && !root.is-date(root.columns[c].type-name): edit-input := TextInput {
+                        if root.read-only || (!root.is-boolean(root.columns[c].type-name) && !root.is-date(root.columns[c].type-name)): edit-input := TextInput {
                             x: Tokens.sp2;
                             y: Tokens.sp1;
                             width: parent.width - 2 * Tokens.sp2;
                             height: parent.height - 2 * Tokens.sp1;
                             vertical-alignment: top;
+                            // Read-only view: selectable + copyable, edits blocked.
+                            read-only: root.read-only;
                             text: cell.is-null ? "" : cell.text;
                             edited => { root.editing-value = self.text; }
                             color: Tokens.text;
@@ -378,12 +383,15 @@ export component TabularGrid inherits Rectangle {
                             font-size: Tokens.font-sm;
                             single-line: false;
                             wrap: word-wrap;
-                            accepted => { root.cell-edited(r, c, self.text); }
+                            accepted => { if (!root.read-only) { root.cell-edited(r, c, self.text); } }
                             key-pressed(e) => {
                                 if (e.text == Key.Escape) {
                                     root.edit-cancelled();
                                     return accept;
                                 }
+                                // Read-only view: let selection/copy shortcuts
+                                // through, don't commit or advance.
+                                if (root.read-only) { return reject; }
                                 if (e.text == Key.Return) {
                                     root.cell-edited(r, c, self.text);
                                     return accept;

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -110,6 +110,7 @@ export component WorkArea inherits Rectangle {
     in property <bool> read-only: true;
     in property <bool> streaming;
     callback cancel-stream();
+    callback cancel-query();
     in-out property <string> limit-text;
     // Draggable height of the SQL editor pane (session-local).
     in-out property <length> editor-h: 340px;
@@ -181,6 +182,7 @@ export component WorkArea inherits Rectangle {
     callback p1-format-sql();
     callback p1-explain-query();
     callback p1-cancel-stream();
+    callback p1-cancel-query();
     callback p1-set-limit(string);
     callback p1-prev-page();
     callback p1-next-page();
@@ -532,6 +534,7 @@ export component WorkArea inherits Rectangle {
             format-sql() => { root.format-sql(); }
             explain-query() => { root.explain-query(); }
             cancel-stream() => { root.cancel-stream(); }
+            cancel-query() => { root.cancel-query(); }
             set-limit(t) => { root.set-limit(t); }
             find-open: root.find-open;
             find-text: root.find-text;
@@ -646,6 +649,7 @@ export component WorkArea inherits Rectangle {
                 format-sql() => { root.p1-format-sql(); }
                 explain-query() => { root.p1-explain-query(); }
                 cancel-stream() => { root.p1-cancel-stream(); }
+                cancel-query() => { root.p1-cancel-query(); }
                 set-limit(t) => { root.p1-set-limit(t); }
                 find-open: root.p1-find-open;
                 find-text: root.p1-find-text;


### PR DESCRIPTION
## Summary
- Make a long-running query recoverable and the SQL editor behave like a real IDE.
- Fix autocomplete readability/navigation, read-only cell selection, and code folding.

## Changes
- **Query cancel**: store each pane's task `AbortHandle`; new `cancel-query` callback wired QueryPane → WorkArea → MainWindow, surfaced as a toolbar + running-overlay Cancel button. Client-side abort (frees pane + connection guard; server statement may finish — `Client::cancel_token()` left as a future upgrade).
- **Cancel styling**: dedicated `DangerButton` (red outline/text, red-tint hover) for the query and stream cancel actions.
- **Autocomplete**: widen the popup, let the label take the row's slack (secondary text elides first), and drive `viewport-y` from the selected index so arrow-key navigation keeps the highlight visible.
- **Completion hints**: drop the schema prefix from column hints (bare table name only) so the field label stops eliding.
- **Read-only cells**: double-clicking a cell in a read-only result now opens a selectable, copyable viewer (select-all, edits blocked, Esc closes) instead of a dead double-click.
- **Folding**: replace statement-level folding with indent-based regions (VSCode model) so each clause/subquery is its own collapsible block; drop the unused `statement_line_spans`.

## Test plan
- [x] `cargo build -p rdb` (FE) builds
- [x] `cargo clippy -p rdb --bin rdb` clean
- [x] `cargo fmt -p rdb --check` clean
- [x] `cargo test -p rdb --bin rdb` (142 passed) incl. new `fold_regions_by_indent` and existing `select_word` tests
- [x] Manual: slow query → Cancel stops it and clears "Running…"; long `schema.table` field → label readable + arrow-key selection stays in view; double-click a read-only result cell → text selectable/copyable; multi-line query → nested fold arrows collapse independently