### PR TITLE
feat: create db/schema/table, live connection status, update nudges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,7 +1028,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2010,8 +2010,8 @@ dependencies = [
  "read-fonts 0.37.0",
  "roxmltree",
  "smallvec",
- "windows",
- "windows-core",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
  "yeslogic-fontconfig-sys",
 ]
 
@@ -2212,7 +2212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2853,7 +2853,7 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "webbrowser",
- "windows",
+ "windows 0.62.2",
  "winit",
  "zbus",
 ]
@@ -3018,7 +3018,7 @@ dependencies = [
  "softbuffer",
  "unicode-segmentation",
  "vtable",
- "windows",
+ "windows 0.62.2",
  "write-fonts",
 ]
 
@@ -3054,7 +3054,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3373,7 +3373,7 @@ dependencies = [
  "socket2 0.6.4",
  "widestring",
  "windows-registry",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3443,7 +3443,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.19",
  "walkdir",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3618,7 +3618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3797,6 +3797,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 dependencies = [
  "twox-hash",
+]
+
+[[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "time",
+ "uuid",
 ]
 
 [[package]]
@@ -4253,6 +4267,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4595,6 +4623,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.0",
  "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -4873,7 +4902,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5570,6 +5599,7 @@ dependencies = [
  "async-trait",
  "copypasta",
  "json5",
+ "notify-rust",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
@@ -6617,7 +6647,7 @@ checksum = "6a71c01d325d40b1031dee67d251a5e0132e79e2a9ec272149a4f4a0d4b8b3be"
 dependencies = [
  "bitflags 2.13.0",
  "skia-bindings",
- "windows",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -7114,6 +7144,17 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
+dependencies = [
+ "thiserror 2.0.19",
+ "windows 0.61.3",
+ "windows-version",
 ]
 
 [[package]]
@@ -8357,14 +8398,36 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -8373,7 +8436,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -8384,9 +8460,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
@@ -8395,9 +8482,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -8424,6 +8511,12 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
@@ -8443,12 +8536,22 @@ dependencies = [
 
 [[package]]
 name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
- "windows-link",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -8457,9 +8560,18 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -8468,7 +8580,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -8477,7 +8598,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -8522,7 +8643,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -8562,7 +8683,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -8575,11 +8696,29 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -36,6 +36,8 @@ copypasta = "0.10"
 ureq = "3"
 semver = "1"
 open = "5"
+# native desktop notification nudging the user when an update is out
+notify-rust = "4"
 # native Save-As dialog for CSV export. xdg-portal drives the Linux backend
 # through the XDG Desktop Portal (D-Bus) instead of the unmaintained gtk-rs
 # GTK3 bindings; tokio matches the app runtime. macOS/Windows use their

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -850,6 +850,82 @@ fn quote_ident(name: &str, engine: rdb_connstore::Engine) -> String {
     }
 }
 
+/// One column as entered in the new-table designer.
+struct ColSpec {
+    name: String,
+    ty: String,
+    nullable: bool,
+    pk: bool,
+}
+
+/// Build a `CREATE TABLE` statement from the designer rows, quoting every
+/// identifier for `engine`. `schema` qualifies the table when the engine uses
+/// namespaces (Postgres). Returns a user-facing message on invalid input.
+fn build_create_table(
+    schema: Option<&str>,
+    table: &str,
+    cols: &[ColSpec],
+    engine: rdb_connstore::Engine,
+) -> std::result::Result<String, String> {
+    let table = table.trim();
+    if table.is_empty() {
+        return Err("Table name can't be empty".into());
+    }
+    if cols.is_empty() {
+        return Err("Add at least one column".into());
+    }
+    let mut defs = Vec::new();
+    let mut pks = Vec::new();
+    for c in cols {
+        let n = c.name.trim();
+        let ty = c.ty.trim();
+        if n.is_empty() {
+            return Err("Column name can't be empty".into());
+        }
+        if ty.is_empty() {
+            return Err(format!("Type for \"{n}\" can't be empty"));
+        }
+        let mut d = format!("{} {ty}", quote_ident(n, engine));
+        if !c.nullable {
+            d.push_str(" NOT NULL");
+        }
+        defs.push(d);
+        if c.pk {
+            pks.push(quote_ident(n, engine));
+        }
+    }
+    if !pks.is_empty() {
+        defs.push(format!("PRIMARY KEY ({})", pks.join(", ")));
+    }
+    let target = match schema {
+        Some(s) => format!("{}.{}", quote_ident(s, engine), quote_ident(table, engine)),
+        None => quote_ident(table, engine),
+    };
+    Ok(format!(
+        "CREATE TABLE {target} (\n  {}\n)",
+        defs.join(",\n  ")
+    ))
+}
+
+/// Default type for the seeded primary-key column of a new table, per engine.
+fn default_pk_type(engine: rdb_connstore::Engine) -> &'static str {
+    match engine {
+        rdb_connstore::Engine::Postgres => "serial",
+        rdb_connstore::Engine::MySql => "INT",
+        rdb_connstore::Engine::Sqlite => "INTEGER",
+        _ => "int",
+    }
+}
+
+/// Default type for an added column, per engine.
+fn default_col_type(engine: rdb_connstore::Engine) -> &'static str {
+    match engine {
+        rdb_connstore::Engine::MySql => "VARCHAR(255)",
+        rdb_connstore::Engine::Sqlite => "TEXT",
+        _ => "text",
+    }
+}
+
 /// Connect + ping, bounded to 8s so "Testing connection…" always resolves.
 /// Returns the elapsed milliseconds on success.
 // ponytail: timeout-bounded, no hard abort; add CancellationToken if a true
@@ -3627,6 +3703,167 @@ fn main() -> Result<(), slint::PlatformError> {
             });
         });
     }
+    // ----- new-table designer: Rust owns the column rows so add/remove go
+    // through callbacks; the dialog inputs two-way bind into the row fields -----
+    let table_cols: Rc<VecModel<TableCol>> = Rc::new(VecModel::default());
+    window.set_table_cols(ModelRc::from(table_cols.clone()));
+    {
+        let weak = window.as_weak();
+        let cur_engine = cur_engine.clone();
+        let table_cols = table_cols.clone();
+        window.on_new_table(move || {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let Some(engine) = *cur_engine.borrow() else {
+                return;
+            };
+            // Seed with a sensible primary key so the common case is one click.
+            table_cols.set_vec(vec![TableCol {
+                name: "id".into(),
+                type_name: default_pk_type(engine).into(),
+                nullable: false,
+                pk: true,
+            }]);
+            w.set_table_name(SharedString::default());
+            w.set_table_error(SharedString::default());
+            w.set_table_modal_open(true);
+        });
+    }
+    {
+        let cur_engine = cur_engine.clone();
+        let table_cols = table_cols.clone();
+        window.on_table_add_col(move || {
+            let ty = cur_engine.borrow().map(default_col_type).unwrap_or("text");
+            table_cols.push(TableCol {
+                name: SharedString::default(),
+                type_name: ty.into(),
+                nullable: true,
+                pk: false,
+            });
+        });
+    }
+    {
+        let table_cols = table_cols.clone();
+        window.on_table_remove_col(move |i| {
+            let i = i.max(0) as usize;
+            if i < table_cols.row_count() {
+                table_cols.remove(i);
+            }
+        });
+    }
+    {
+        let table_cols = table_cols.clone();
+        window.on_table_set_col_name(move |i, t| {
+            let i = i.max(0) as usize;
+            if let Some(mut c) = table_cols.row_data(i) {
+                c.name = t;
+                table_cols.set_row_data(i, c);
+            }
+        });
+    }
+    {
+        let table_cols = table_cols.clone();
+        window.on_table_set_col_type(move |i, t| {
+            let i = i.max(0) as usize;
+            if let Some(mut c) = table_cols.row_data(i) {
+                c.type_name = t;
+                table_cols.set_row_data(i, c);
+            }
+        });
+    }
+    {
+        let table_cols = table_cols.clone();
+        window.on_table_toggle_null(move |i| {
+            let i = i.max(0) as usize;
+            if let Some(mut c) = table_cols.row_data(i) {
+                c.nullable = !c.nullable;
+                table_cols.set_row_data(i, c);
+            }
+        });
+    }
+    {
+        let table_cols = table_cols.clone();
+        window.on_table_toggle_pk(move |i| {
+            let i = i.max(0) as usize;
+            if let Some(mut c) = table_cols.row_data(i) {
+                c.pk = !c.pk;
+                // A primary key can't be null; clear the flag to keep the DDL valid.
+                if c.pk {
+                    c.nullable = false;
+                }
+                table_cols.set_row_data(i, c);
+            }
+        });
+    }
+    {
+        let weak = window.as_weak();
+        let rt = rt.clone();
+        let current = current.clone();
+        let cur_engine = cur_engine.clone();
+        let table_cols = table_cols.clone();
+        window.on_create_table_commit(move || {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let Some(engine) = *cur_engine.borrow() else {
+                return;
+            };
+            let cols: Vec<ColSpec> = table_cols
+                .iter()
+                .map(|c| ColSpec {
+                    name: c.name.to_string(),
+                    ty: c.type_name.to_string(),
+                    nullable: c.nullable,
+                    pk: c.pk,
+                })
+                .collect();
+            // Postgres browses namespaces, so qualify with the current schema;
+            // other engines scope to the connection's database already.
+            let schema = matches!(engine, rdb_connstore::Engine::Postgres)
+                .then(|| w.get_schema_name().to_string());
+            let sql = match build_create_table(
+                schema.as_deref(),
+                w.get_table_name().as_ref(),
+                &cols,
+                engine,
+            ) {
+                Ok(s) => s,
+                Err(e) => {
+                    w.set_table_error(SharedString::from(e));
+                    return;
+                }
+            };
+            w.set_table_error(SharedString::default());
+            let selected = w.get_selected_conn();
+            let weak2 = weak.clone();
+            let current = current.clone();
+            rt.spawn(async move {
+                let guard = current.lock_owned().await;
+                let res = match guard.as_ref() {
+                    Some((_, driver)) => driver
+                        .query(&rdb_core::query::Query::Sql(sql))
+                        .await
+                        .map(|_| ()),
+                    None => Err(rdb_core::error::RdbError::Query("not connected".into())),
+                };
+                drop(guard);
+                let _ = slint::invoke_from_event_loop(move || {
+                    if let Some(w) = weak2.upgrade() {
+                        match res {
+                            Ok(()) => {
+                                w.set_table_modal_open(false);
+                                // Reconnect to reload the tree so the new table shows.
+                                w.invoke_connect_clicked(selected);
+                            }
+                            Err(e) => w.set_table_error(SharedString::from(format!("{e}"))),
+                        }
+                    }
+                });
+            });
+        });
+    }
+
     // ----- background health poll: flip the breadcrumb dot red when a live
     // connection stops answering, green again when it recovers -----
     // ponytail: one fixed 30s loop for the lifetime of the app; make the
@@ -9052,6 +9289,54 @@ fn main() -> Result<(), slint::PlatformError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn create_table_sql_quotes_and_pk() {
+        let cols = vec![
+            ColSpec {
+                name: "id".into(),
+                ty: "serial".into(),
+                nullable: false,
+                pk: true,
+            },
+            ColSpec {
+                name: "na\"me".into(),
+                ty: "text".into(),
+                nullable: true,
+                pk: false,
+            },
+        ];
+        let sql = build_create_table(
+            Some("public"),
+            "users",
+            &cols,
+            rdb_connstore::Engine::Postgres,
+        )
+        .unwrap();
+        assert_eq!(
+            sql,
+            "CREATE TABLE \"public\".\"users\" (\n  \"id\" serial NOT NULL,\n  \"na\"\"me\" text,\n  PRIMARY KEY (\"id\")\n)"
+        );
+
+        // MySQL: backtick quoting, no schema qualifier.
+        let my = build_create_table(None, "t", &cols[..1], rdb_connstore::Engine::MySql).unwrap();
+        assert_eq!(
+            my,
+            "CREATE TABLE `t` (\n  `id` serial NOT NULL,\n  PRIMARY KEY (`id`)\n)"
+        );
+    }
+
+    #[test]
+    fn create_table_rejects_bad_input() {
+        assert!(build_create_table(None, "  ", &[], rdb_connstore::Engine::Postgres).is_err());
+        let no_type = vec![ColSpec {
+            name: "x".into(),
+            ty: "".into(),
+            nullable: true,
+            pk: false,
+        }];
+        assert!(build_create_table(None, "t", &no_type, rdb_connstore::Engine::Postgres).is_err());
+    }
 
     #[test]
     fn persisted_tabs_round_trip() {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -3866,14 +3866,14 @@ fn main() -> Result<(), slint::PlatformError> {
 
     // ----- background health poll: flip the breadcrumb dot red when a live
     // connection stops answering, green again when it recovers -----
-    // ponytail: one fixed 30s loop for the lifetime of the app; make the
+    // ponytail: one fixed 10s loop for the lifetime of the app; make the
     // interval configurable only if asked.
     {
         let weak = window.as_weak();
         let current = current.clone();
         rt.spawn(async move {
             loop {
-                tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                tokio::time::sleep(std::time::Duration::from_secs(10)).await;
                 // None = no driver (picker); Some(ok) = pinged a live connection.
                 let alive = {
                     let guard = current.lock().await;
@@ -9256,6 +9256,9 @@ fn main() -> Result<(), slint::PlatformError> {
                 }
                 let version = tag.trim_start_matches('v').to_string();
                 let hint = update::InstallMethod::detect().upgrade_hint().to_string();
+                // Native nudge for when the window isn't in focus at launch; the
+                // in-app banner still shows for when it is.
+                update::notify_update(&version, &hint);
                 let _ = slint::invoke_from_event_loop(move || {
                     if let Some(w) = weak.upgrade() {
                         w.set_update_version(version.into());

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -3627,6 +3627,41 @@ fn main() -> Result<(), slint::PlatformError> {
             });
         });
     }
+    // ----- background health poll: flip the breadcrumb dot red when a live
+    // connection stops answering, green again when it recovers -----
+    // ponytail: one fixed 30s loop for the lifetime of the app; make the
+    // interval configurable only if asked.
+    {
+        let weak = window.as_weak();
+        let current = current.clone();
+        rt.spawn(async move {
+            loop {
+                tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                // None = no driver (picker); Some(ok) = pinged a live connection.
+                let alive = {
+                    let guard = current.lock().await;
+                    match guard.as_ref() {
+                        Some((_, driver)) => Some(driver.ping().await.is_ok()),
+                        None => None,
+                    }
+                };
+                let Some(ok) = alive else { continue };
+                let weak = weak.clone();
+                let _ = slint::invoke_from_event_loop(move || {
+                    if let Some(w) = weak.upgrade() {
+                        // Only touch a live workspace; never override "connecting".
+                        if w.get_connected() {
+                            w.set_conn_status(SharedString::from(if ok {
+                                "connected"
+                            } else {
+                                "error"
+                            }));
+                        }
+                    }
+                });
+            }
+        });
+    }
     {
         let weak = window.as_weak();
         let store = store.clone();
@@ -5098,6 +5133,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 w.set_selected_conn(idx);
                 // Show progress + clear any prior failure immediately.
                 w.set_connecting(true);
+                w.set_conn_status(SharedString::from("connecting"));
                 w.set_picker_error(SharedString::default());
                 w.global::<Theme>()
                     .set_accent(theme::accent_or_default(sc.color.as_deref().unwrap_or("")));
@@ -5335,6 +5371,7 @@ fn main() -> Result<(), slint::PlatformError> {
                                     sfields,
                                 ))));
                                 w.set_status_latency(SharedString::from("connected"));
+                                w.set_conn_status(SharedString::from("connected"));
                                 w.set_picker_error(SharedString::default());
                                 w.set_connecting(false);
                                 // Swap the picker for the workspace.

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -840,6 +840,16 @@ fn sync_query_console(w: &MainWindow, log: &Arc<std::sync::Mutex<Vec<String>>>) 
 
 /// 1-based display bounds of the current page window plus prev/next
 /// availability. `shown` is how many rows the page actually returned.
+/// Quote a database/schema/table identifier for `engine`, doubling the quote
+/// char so a name with an embedded quote can't break out. MySQL uses backticks,
+/// everything else standard double-quotes.
+fn quote_ident(name: &str, engine: rdb_connstore::Engine) -> String {
+    match engine {
+        rdb_connstore::Engine::MySql => format!("`{}`", name.replace('`', "``")),
+        _ => format!("\"{}\"", name.replace('"', "\"\"")),
+    }
+}
+
 /// Connect + ping, bounded to 8s so "Testing connection…" always resolves.
 /// Returns the elapsed milliseconds on success.
 // ponytail: timeout-bounded, no hard abort; add CancellationToken if a true
@@ -3556,6 +3566,62 @@ fn main() -> Result<(), slint::PlatformError> {
                         let empty_cols: Vec<StructField> = Vec::new();
                         w.set_structure_columns(ModelRc::from(Rc::new(VecModel::from(empty_cols))));
                         w.set_tree_loading(false);
+                    }
+                });
+            });
+        });
+    }
+    // ----- create database / schema from the breadcrumb "New…" prompt -----
+    {
+        let weak = window.as_weak();
+        let rt = rt.clone();
+        let current = current.clone();
+        let cur_engine = cur_engine.clone();
+        window.on_create_commit(move || {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let kind = w.get_create_kind().to_string();
+            let name = w.get_create_text().trim().to_string();
+            if name.is_empty() {
+                w.set_create_error(SharedString::from("Name can't be empty"));
+                return;
+            }
+            let Some(engine) = *cur_engine.borrow() else {
+                w.set_create_error(SharedString::from("Not connected"));
+                return;
+            };
+            let ident = quote_ident(&name, engine);
+            let sql = match kind.as_str() {
+                "database" => format!("CREATE DATABASE {ident}"),
+                "schema" => format!("CREATE SCHEMA {ident}"),
+                _ => return,
+            };
+            w.set_create_error(SharedString::default());
+            let selected = w.get_selected_conn();
+            let weak2 = weak.clone();
+            let current = current.clone();
+            rt.spawn(async move {
+                let guard = current.lock_owned().await;
+                let res = match guard.as_ref() {
+                    Some((_, driver)) => driver
+                        .query(&rdb_core::query::Query::Sql(sql))
+                        .await
+                        .map(|_| ()),
+                    None => Err(rdb_core::error::RdbError::Query("not connected".into())),
+                };
+                drop(guard);
+                let _ = slint::invoke_from_event_loop(move || {
+                    if let Some(w) = weak2.upgrade() {
+                        match res {
+                            // Reconnect to refresh the db/schema lists + tree from
+                            // the server — the just-created object then shows up.
+                            Ok(()) => {
+                                w.set_create_modal_open(false);
+                                w.invoke_connect_clicked(selected);
+                            }
+                            Err(e) => w.set_create_error(SharedString::from(format!("{e}"))),
+                        }
                     }
                 });
             });

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -8951,6 +8951,46 @@ fn main() -> Result<(), slint::PlatformError> {
         });
     }
 
+    // ----- manual "Check now" from settings: bypasses the daily throttle and
+    // reports the outcome inline so the toggle no longer feels like a no-op -----
+    {
+        let weak = window.as_weak();
+        window.on_check_updates_now(move || {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            w.set_update_check_status(SharedString::from("Checking…"));
+            let weak = weak.clone();
+            std::thread::spawn(move || {
+                let current = env!("CARGO_PKG_VERSION");
+                let tag = update::fetch_latest_tag();
+                let _ = slint::invoke_from_event_loop(move || {
+                    if let Some(w) = weak.upgrade() {
+                        match tag {
+                            Some(t) if update::is_newer(&t, current) => {
+                                let version = t.trim_start_matches('v').to_string();
+                                let hint =
+                                    update::InstallMethod::detect().upgrade_hint().to_string();
+                                w.set_update_check_status(SharedString::from(format!(
+                                    "Update available — v{version}"
+                                )));
+                                w.set_update_version(version.into());
+                                w.set_update_hint(hint.into());
+                                w.set_update_available(true);
+                            }
+                            Some(_) => w.set_update_check_status(SharedString::from(format!(
+                                "Up to date (v{current})"
+                            ))),
+                            None => w.set_update_check_status(SharedString::from(
+                                "Check failed — try again",
+                            )),
+                        }
+                    }
+                });
+            });
+        });
+    }
+
     // ----- update check: once/day, gated by the setting, off the UI thread -----
     // Skip in mock mode so the reference screenshots stay deterministic.
     if !mock::mock_mode() {

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -1431,6 +1431,7 @@ callback create-table-commit();
                         result-status: root.result-status;
                         status-error: root.status-error;
                         status-latency: root.status-latency;
+                        conn-status: root.conn-status;
                         sort-text: root.sort-text;
                         grid-sort-col: root.grid-sort-col;
                         grid-sort-asc: root.grid-sort-asc;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -164,6 +164,15 @@ in-out property <bool> rename-modal-open: false;
 in-out property <int> rename-target: -1;
 in-out property <int> rename-group: 0;
 in-out property <string> rename-text;
+// Create a database or schema from the breadcrumb "New…" buttons. `create-kind`
+// is "database" | "schema"; `create-commit` runs CREATE on the trimmed name and
+// leaves the modal open with `create-error` set on failure.
+in-out property <bool> create-modal-open: false;
+in-out property <string> create-kind;
+in-out property <string> create-title;
+in-out property <string> create-text;
+in-out property <string> create-error;
+callback create-commit();
     callback toggle-group(string);
     callback toggle-favorite(int);          // star/unstar a saved connection
     callback reorder-conn(int, int);        // (dragged store index, row-step delta)
@@ -1710,7 +1719,12 @@ in-out property <string> rename-text;
             root.db-modal-open = false;
         }
         new-item => {
-            root.open-add-form();
+            root.db-modal-open = false;
+            root.create-kind = "database";
+            root.create-title = "New database";
+            root.create-text = "";
+            root.create-error = "";
+            root.create-modal-open = true;
         }
     }
 
@@ -1727,7 +1741,14 @@ in-out property <string> rename-text;
         dismiss => {
             root.schema-modal-open = false;
         }
-        new-item => { }
+        new-item => {
+            root.schema-modal-open = false;
+            root.create-kind = "schema";
+            root.create-title = "New schema";
+            root.create-text = "";
+            root.create-error = "";
+            root.create-modal-open = true;
+        }
     }
 
     // ----- Rename query tab -----
@@ -1800,6 +1821,79 @@ in-out property <string> rename-text;
                             root.rename-commit();
                             root.rename-modal-open = false;
                         }
+                    }
+                }
+            }
+        }
+    }
+
+    // ----- Create database / schema (name prompt) -----
+    create-modal := Rectangle {
+        visible: root.create-modal-open;
+        background: Tokens.veil;
+        TouchArea { clicked => { root.create-modal-open = false; } }
+        changed visible => {
+            if (self.visible) { cti.focus(); }
+        }
+        Rectangle {
+            width: 360px;
+            x: (parent.width - self.width) / 2;
+            y: 120px;
+            height: cbox.preferred-height;
+            border-radius: Tokens.modal-radius;
+            background: Tokens.card;
+            border-width: 1px;
+            border-color: Tokens.border;
+            drop-shadow-blur: 42px;
+            drop-shadow-offset-y: 12px;
+            drop-shadow-color: #1C191426;
+            TouchArea {}
+            cbox := VerticalLayout {
+                padding: Tokens.sp4;
+                spacing: Tokens.sp3;
+                Text {
+                    text: root.create-title;
+                    color: Tokens.text;
+                    font-size: 15px;
+                    font-weight: 700;
+                    horizontal-alignment: center;
+                }
+                Rectangle {
+                    height: 34px;
+                    border-radius: Tokens.radius;
+                    background: Tokens.canvas;
+                    border-width: 1px;
+                    border-color: Tokens.border;
+                    cti := TextInput {
+                        x: Tokens.sp2;
+                        width: parent.width - 2 * Tokens.sp2;
+                        vertical-alignment: center;
+                        text <=> root.create-text;
+                        color: Tokens.text;
+                        font-family: Tokens.mono;
+                        font-size: Tokens.font-md;
+                        single-line: true;
+                        accepted => { root.create-commit(); }
+                    }
+                }
+                if root.create-error != "": Text {
+                    text: root.create-error;
+                    color: Tokens.error;
+                    font-size: Tokens.font-sm;
+                    wrap: word-wrap;
+                }
+                HorizontalLayout {
+                    spacing: Tokens.sp2;
+                    alignment: end;
+                    SecondaryButton {
+                        text: "Cancel";
+                        height: 30px;
+                        clicked => { root.create-modal-open = false; }
+                    }
+                    PrimaryButton {
+                        text: "Create";
+                        height: 30px;
+                        clicked => { root.create-commit(); }
                     }
                 }
             }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -202,6 +202,9 @@ callback create-commit();
     in property <bool> connected: false;
     in property <string> picker-error;
     in property <bool> connecting;
+    // Live health of the active connection, reflected in the breadcrumb dot:
+    // "connecting" (amber) | "connected" (green) | "error" (red, ping dropped).
+    in property <string> conn-status: "connecting";
     callback disconnect();
     callback conn-filter(string);
 
@@ -701,6 +704,9 @@ callback create-commit();
                         BreadcrumbChip {
                             text: root.bc-conn;
                             show-dot: true;
+                            dot-color: root.conn-status == "error" ? Tokens.error
+                                : root.conn-status == "connecting" ? Tokens.warn
+                                : Tokens.ok;
                             mono: true;
                             clicked => { root.open-conn-modal(); }
                         }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -20,6 +20,7 @@ import {
     KvRow,
     TabItem,
     StructField,
+    TableCol,
     Span,
     ChartBar,
     IndexRow,
@@ -173,6 +174,22 @@ in-out property <string> create-title;
 in-out property <string> create-text;
 in-out property <string> create-error;
 callback create-commit();
+// New-table designer (sidebar "+"). Column rows live in a Rust VecModel so
+// add/remove go through callbacks; the field inputs two-way bind into the rows.
+in property <[TableCol]> table-cols;
+in-out property <bool> table-modal-open: false;
+in-out property <string> table-name;
+in-out property <string> table-error;
+callback new-table();               // open the designer for the current schema
+callback table-add-col();
+callback table-remove-col(int);
+// Slint can't two-way bind into model rows, so edits round-trip through Rust,
+// which owns the VecModel and writes the changed row back.
+callback table-set-col-name(int, string);
+callback table-set-col-type(int, string);
+callback table-toggle-null(int);
+callback table-toggle-pk(int);
+callback create-table-commit();
     callback toggle-group(string);
     callback toggle-favorite(int);          // star/unstar a saved connection
     callback reorder-conn(int, int);        // (dragged store index, row-step delta)
@@ -976,7 +993,7 @@ callback create-commit();
                     toggle-node(t) => { root.toggle-schema-node(t); }
                     select-schema(s) => { root.select-schema(s); }
                     filter-tree(t) => { root.filter-tree(t); }
-                    add-item() => { root.new-tab(); }
+                    add-item() => { root.new-table(); }
                 }
 
                 // work column: tab bar + work area (takes all remaining width)
@@ -1690,7 +1707,7 @@ callback create-commit();
                     toggle-node(t) => { root.toggle-schema-node(t); }
                     select-schema(s) => { root.select-schema(s); }
                     filter-tree(t) => { root.filter-tree(t); }
-                    add-item() => { root.new-tab(); }
+                    add-item() => { root.new-table(); }
                 }
             }
         }
@@ -1902,6 +1919,198 @@ callback create-commit();
                         text: "Create";
                         height: 30px;
                         clicked => { root.create-commit(); }
+                    }
+                }
+            }
+        }
+    }
+
+    // ----- New table designer (sidebar "+") -----
+    // ponytail: columns + types + null/PK cover the common case; FKs, indexes and
+    // check constraints stay a SQL-tab job until asked.
+    table-modal := Rectangle {
+        visible: root.table-modal-open;
+        background: Tokens.veil;
+        TouchArea { clicked => { root.table-modal-open = false; } }
+        changed visible => {
+            if (self.visible) { tname.focus(); }
+        }
+        Rectangle {
+            width: 620px;
+            x: (parent.width - self.width) / 2;
+            y: 80px;
+            height: min(tbox.preferred-height, parent.height - 160px);
+            border-radius: Tokens.modal-radius;
+            background: Tokens.card;
+            border-width: 1px;
+            border-color: Tokens.border;
+            drop-shadow-blur: 42px;
+            drop-shadow-offset-y: 12px;
+            drop-shadow-color: #1C191426;
+            TouchArea {}
+            tbox := VerticalLayout {
+                padding: Tokens.sp4;
+                spacing: Tokens.sp3;
+                Text {
+                    text: "New table in " + root.schema-name;
+                    color: Tokens.text;
+                    font-size: 15px;
+                    font-weight: 700;
+                    horizontal-alignment: center;
+                }
+                // table name
+                Rectangle {
+                    height: 34px;
+                    border-radius: Tokens.radius;
+                    background: Tokens.canvas;
+                    border-width: 1px;
+                    border-color: Tokens.border;
+                    tname := TextInput {
+                        x: Tokens.sp2;
+                        width: parent.width - 2 * Tokens.sp2;
+                        vertical-alignment: center;
+                        text <=> root.table-name;
+                        color: Tokens.text;
+                        font-family: Tokens.mono;
+                        font-size: Tokens.font-md;
+                        single-line: true;
+                    }
+                }
+                // column header
+                HorizontalLayout {
+                    spacing: Tokens.sp2;
+                    Text { text: "Column"; color: Tokens.text-dim; font-size: Tokens.font-sm; horizontal-stretch: 1; }
+                    Text { text: "Type"; color: Tokens.text-dim; font-size: Tokens.font-sm; horizontal-stretch: 1; }
+                    Text { text: "Null"; color: Tokens.text-dim; font-size: Tokens.font-sm; width: 40px; horizontal-alignment: center; }
+                    Text { text: "PK"; color: Tokens.text-dim; font-size: Tokens.font-sm; width: 40px; horizontal-alignment: center; }
+                    Rectangle { width: 28px; }
+                }
+                // column rows (scrolls when many)
+                Rectangle {
+                    vertical-stretch: 1;
+                    min-height: 44px;
+                    ScrollView {
+                        VerticalLayout {
+                            spacing: Tokens.sp2;
+                            for col[i] in root.table-cols: HorizontalLayout {
+                                spacing: Tokens.sp2;
+                                Rectangle {
+                                    horizontal-stretch: 1;
+                                    height: 30px;
+                                    border-radius: Tokens.radius;
+                                    background: Tokens.canvas;
+                                    border-width: 1px;
+                                    border-color: Tokens.border;
+                                    TextInput {
+                                        x: Tokens.sp2;
+                                        width: parent.width - 2 * Tokens.sp2;
+                                        vertical-alignment: center;
+                                        text: col.name;
+                                        edited => { root.table-set-col-name(i, self.text); }
+                                        color: Tokens.text;
+                                        font-family: Tokens.mono;
+                                        font-size: Tokens.font-sm;
+                                        single-line: true;
+                                    }
+                                }
+                                Rectangle {
+                                    horizontal-stretch: 1;
+                                    height: 30px;
+                                    border-radius: Tokens.radius;
+                                    background: Tokens.canvas;
+                                    border-width: 1px;
+                                    border-color: Tokens.border;
+                                    TextInput {
+                                        x: Tokens.sp2;
+                                        width: parent.width - 2 * Tokens.sp2;
+                                        vertical-alignment: center;
+                                        text: col.type-name;
+                                        edited => { root.table-set-col-type(i, self.text); }
+                                        color: Tokens.text;
+                                        font-family: Tokens.mono;
+                                        font-size: Tokens.font-sm;
+                                        single-line: true;
+                                    }
+                                }
+                                // nullable toggle
+                                Rectangle {
+                                    width: 40px;
+                                    height: 30px;
+                                    null-ta := TouchArea { clicked => { root.table-toggle-null(i); } }
+                                    Rectangle {
+                                        width: 18px;
+                                        height: 18px;
+                                        border-radius: 4px;
+                                        border-width: 1px;
+                                        border-color: Tokens.border-strong;
+                                        background: col.nullable ? Tokens.accent : transparent;
+                                        Text {
+                                            text: col.nullable ? "✓" : "";
+                                            color: #FFFFFF;
+                                            font-size: 12px;
+                                        }
+                                    }
+                                }
+                                // primary-key toggle
+                                Rectangle {
+                                    width: 40px;
+                                    height: 30px;
+                                    pk-ta := TouchArea { clicked => { root.table-toggle-pk(i); } }
+                                    Rectangle {
+                                        width: 18px;
+                                        height: 18px;
+                                        border-radius: 4px;
+                                        border-width: 1px;
+                                        border-color: Tokens.border-strong;
+                                        background: col.pk ? Tokens.accent : transparent;
+                                        Text {
+                                            text: col.pk ? "✓" : "";
+                                            color: #FFFFFF;
+                                            font-size: 12px;
+                                        }
+                                    }
+                                }
+                                // remove row
+                                Rectangle {
+                                    width: 28px;
+                                    height: 30px;
+                                    rm-ta := TouchArea { clicked => { root.table-remove-col(i); } }
+                                    Text {
+                                        text: "✕";
+                                        color: rm-ta.has-hover ? Tokens.error : Tokens.text-faint;
+                                        font-size: 13px;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                HorizontalLayout {
+                    SecondaryButton {
+                        text: "+ Add column";
+                        height: 28px;
+                        clicked => { root.table-add-col(); }
+                    }
+                    Rectangle { horizontal-stretch: 1; }
+                }
+                if root.table-error != "": Text {
+                    text: root.table-error;
+                    color: Tokens.error;
+                    font-size: Tokens.font-sm;
+                    wrap: word-wrap;
+                }
+                HorizontalLayout {
+                    spacing: Tokens.sp2;
+                    alignment: end;
+                    SecondaryButton {
+                        text: "Cancel";
+                        height: 30px;
+                        clicked => { root.table-modal-open = false; }
+                    }
+                    PrimaryButton {
+                        text: "Create";
+                        height: 30px;
+                        clicked => { root.create-table-commit(); }
                     }
                 }
             }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -478,6 +478,8 @@ callback create-commit();
     in property <string> update-hint;      // install-method upgrade instruction
     callback update-open();                // open the release page
     callback update-dismiss();             // hide until next launch
+    callback check-updates-now();          // manual check from settings
+    in property <string> update-check-status; // settings feedback line
 
     // ----- app settings modal -----
     in-out property <bool> settings-open: false;
@@ -2165,6 +2167,24 @@ callback create-commit();
                                     y: (parent.height - self.height) / 2;
                                 }
                             }
+                        }
+                    }
+                }
+
+                // --- manual update check ---
+                HorizontalLayout {
+                    spacing: Tokens.sp3;
+                    SecondaryButton {
+                        text: "Check now";
+                        clicked => { root.check-updates-now(); }
+                    }
+                    VerticalLayout {
+                        alignment: center;
+                        horizontal-stretch: 1;
+                        Text {
+                            text: root.update-check-status;
+                            color: Tokens.text-dim;
+                            font-size: 12px;
                         }
                     }
                 }

--- a/app/src/ui/structs.slint
+++ b/app/src/ui/structs.slint
@@ -38,6 +38,8 @@ export struct ConnItem {
 // One Host/Port/… row of the connection-detail card.
 export struct KvRow { k: string, v: string }
 export struct StructField { name: string, type-name: string, nullable: bool }
+// One editable row of the new-table designer.
+export struct TableCol { name: string, type-name: string, nullable: bool, pk: bool }
 // `kind` picks the tab glyph; preview table tabs are italic until pinned.
 export struct TabItem { title: string, kind: string, preview: bool }
 // One lexed editor token; `kind`: 0 plain · 1 keyword · 2 string ·

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -46,6 +46,9 @@ export component WorkArea inherits Rectangle {
     in property <bool> status-error;
     in property <bool> query-running;
     in property <string> status-latency;
+    // Live connection health: "connecting" | "connected" | "error". Overrides the
+    // query-status dot/text so a dropped connection can't keep reading "connected".
+    in property <string> conn-status;
     in-out property <int> selected-row: 0;
     in-out property <int> selected-col: -1;
     in property <int> editing-row: -1;
@@ -902,11 +905,17 @@ export component WorkArea inherits Rectangle {
                         height: 7px;
                         border-radius: 4px;
                         y: (parent.height - self.height) / 2;
-                        background: root.status-error ? Tokens.error : Tokens.ok;
+                        background: root.conn-status == "error" ? Tokens.error
+                            : root.conn-status == "connecting" ? Tokens.warn
+                            : root.status-error ? Tokens.error : Tokens.ok;
                     }
                     Text {
-                        text: root.status-latency;
-                        color: root.status-error ? Tokens.error : Tokens.ok;
+                        text: root.conn-status == "error" ? "disconnected"
+                            : root.conn-status == "connecting" ? "connecting…"
+                            : root.status-latency;
+                        color: root.conn-status == "error" ? Tokens.error
+                            : root.conn-status == "connecting" ? Tokens.warn
+                            : root.status-error ? Tokens.error : Tokens.ok;
                         font-size: Tokens.font-sm;
                         font-family: Tokens.mono;
                         vertical-alignment: center;

--- a/app/src/update.rs
+++ b/app/src/update.rs
@@ -59,6 +59,15 @@ pub fn release_page() -> &'static str {
     RELEASES_PAGE
 }
 
+/// Fire a native desktop notification inviting the user to update. Best-effort:
+/// any platform/permission failure is swallowed so it never disrupts startup.
+pub fn notify_update(version: &str, hint: &str) {
+    let _ = notify_rust::Notification::new()
+        .summary(&format!("RDB {version} is available"))
+        .body(&format!("A new version is out — {hint}."))
+        .show();
+}
+
 /// True if `latest_tag` (e.g. "v1.2.0") is a strictly newer semver than the
 /// running `current` version. Unparseable input is treated as "not newer" so a
 /// malformed tag never nags the user.


### PR DESCRIPTION
## Summary

- Breadcrumb "New…" now creates the object the user is looking at (database / schema) instead of opening the connection form or doing nothing.
- Sidebar "+" opens a table designer instead of a SQL query tab.
- Connection health is now visible and truthful — the status footer no longer reads "connected" after access is cut.
- Update check is discoverable: manual "Check now" in settings plus a native desktop notification on launch.

## Changes

**Create database / schema (issues 1 & 2)**
- Open-database and Switch-schema "New…" open a name-prompt modal that runs `CREATE DATABASE` / `CREATE SCHEMA` on the active connection, identifier quoted per engine, then reconnects to refresh the list. Errors stay in the modal.

**Table designer (issue 3)**
- Sidebar "+" opens a column-based designer (name, type, null, PK). Builds a quoted `CREATE TABLE` for the current schema, runs it, reloads the tree. The `SQL` button still makes query tabs. Column rows live in a Rust `VecModel`; edits round-trip through callbacks. FKs/indexes/constraints stay a SQL-tab job.

**Connection status (issue 4)**
- New `conn-status` (connecting / connected / error) drives the breadcrumb dot and the bottom-right status footer, so a dropped connection shows red "disconnected" instead of a stale "connected".
- A single background poll pings the driver every 10s and flips the state on loss/recovery.

**Update check (issue 5)**
- "Check now" button in Settings reports Checking… / Up to date / Update available inline, bypassing the daily throttle.
- Native desktop notification fires on the launch check when a newer release exists, alongside the existing banner.

## Test plan

- [x] `make fmt-check`
- [x] `make lint` (clippy, warnings as errors)
- [x] `cargo test -p rdb --bins` (new `build_create_table` unit tests)
- [x] `make fe-build`
- [x] Manual: create database / schema from the breadcrumb "New…"
- [x] Manual: sidebar "+" → designer → 2 cols + PK → Create → table shows in tree
- [x] Manual: cut the DB connection → footer + dot turn red "disconnected" within ~10s
- [x] Manual: Settings → "Check now" shows Up to date / Update available
