### PR TITLE
ci: push website release data with RELEASE_PLEASE_TOKEN

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -167,7 +167,11 @@ jobs:
         run: npm --prefix website run fetch-release
       - name: Commit website release data
         env:
-          GH_TOKEN: ${{ secrets.TAP_PUBLISH_TOKEN }}
+          # Push back to this repo with the workflow's own token: the personal
+          # PAT (TAP_PUBLISH_TOKEN) has no write access to suiflex/rdb, only to
+          # the tap repo, so it was denied here. GITHUB_TOKEN + contents:write
+          # pushes as github-actions[bot].
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if git diff --quiet -- website/src/data/release.json; then
             echo "website release data already current"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -167,11 +167,12 @@ jobs:
         run: npm --prefix website run fetch-release
       - name: Commit website release data
         env:
-          # Push back to this repo with the workflow's own token: the personal
-          # PAT (TAP_PUBLISH_TOKEN) has no write access to suiflex/rdb, only to
-          # the tap repo, so it was denied here. GITHUB_TOKEN + contents:write
-          # pushes as github-actions[bot].
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # TAP_PUBLISH_TOKEN is scoped to the tap repo only, so it was denied
+          # here (403). GITHUB_TOKEN can't push either: develop is protected and
+          # only the mulhamna account is in the PR-bypass list (no apps). Reuse
+          # RELEASE_PLEASE_TOKEN — the same PAT release-please already uses to
+          # write to develop — which bypasses protection and has repo write.
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
           if git diff --quiet -- website/src/data/release.json; then
             echo "website release data already current"


### PR DESCRIPTION
## Summary

- The `update-website-release` job fails on every release with a `403` when it pushes the regenerated `release.json` back to `develop`.

## Root cause

- `TAP_PUBLISH_TOKEN` is a fine-grained PAT scoped to the **tap repo only**, so it has no write access to `suiflex/rdb` → `remote: Permission to suiflex/rdb.git denied to mulhamna`.
- `GITHUB_TOKEN` can't be used either: `develop` is protected and requires a PR, and only the `mulhamna` account is in the bypass list (`apps: []`), so a `github-actions[bot]` push would be rejected.

## Changes

- Push the website release-data commit with `RELEASE_PLEASE_TOKEN` — the same PAT release-please already uses to write to `develop`. It authenticates as `mulhamna` (in the bypass list) and has repo write.
- `TAP_PUBLISH_TOKEN` stays untouched in the tap-publish jobs (homebrew/scoop), where it's correct.

## Test plan

- [ ] Next `v*` tag release: `update-website-release` pushes `release.json` to `develop` with no `403`.