### PR TITLE
docs: document release note commit conventions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,9 @@
 <!--
 Title: conventional-commits style, ≤ 70 chars, no trailing period.
+Use feat(app): ... for App Features release notes.
+Use feature(driver-<engine>): ... for Driver Features release notes.
 e.g. feat(app): cancel an in-flight connection
+e.g. feature(driver-postgres): introspect materialized views
 Keep the PR focused — one logical change is easier to review and revert.
 -->
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,19 @@ release on `develop`): conventional commits drive an auto-maintained release
 PR that bumps the version and `app/CHANGELOG.md`; merging it tags `vX.Y.Z`
 and cuts a GitHub Release. The `app` package (`rdb`) is the tracked version.
 
+Release note sections are configured in `release-please-config.json` and are
+triggered by conventional commit **type**:
+
+- `feat(app): ...` -> **App Features**
+- `feature(driver-<engine>): ...` or `feature(driver): ...` ->
+  **Driver Features** (`release-please` treats `feature` like `feat` for minor
+  version bumps)
+- `fix(<scope>): ...` -> **Bug Fixes**
+- `perf(<scope>): ...` -> **Performance Improvements**
+
+Keep the scope specific (`app`, `driver-postgres`, `driver-mysql`, `core`,
+`connstore`) so generated changelog lines stay readable.
+
 ## Architecture
 
 - `app/` — Slint UI binary (main entry point)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,13 +62,44 @@ concrete driver is `AnyDriver`.
 We follow [Conventional Commits](https://www.conventionalcommits.org/); the
 `release-please` workflow parses them to drive the changelog and version bumps.
 
-- Types: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`, `build`, `ci`.
+- Types: `feat`, `feature`, `fix`, `perf`, `chore`, `refactor`, `docs`,
+  `test`, `build`, `ci`.
+- Use `feat(app): ...` for user-facing application/UI features. These appear
+  under **App Features** in the generated changelog.
+- Use `feature(driver-<engine>): ...` or `feature(driver): ...` for database
+  driver capabilities. These appear under **Driver Features** in the generated
+  changelog. `release-please` treats `feature` the same as `feat` for version
+  bumping.
+- Use `fix(<scope>): ...` for bug fixes and `perf(<scope>): ...` for
+  performance improvements. These keep the standard release-please sections.
 - Subject line ≤ 72 chars, imperative mood, no trailing period.
 - Wrap the body at 72 chars and explain **why** the change exists — the diff
   already shows the what.
 - One logical change per commit. Each commit should leave the tree in a
   buildable, testable state so `git revert` stays safe.
 - Do **not** hand-edit the `release-please`-managed sections of any changelog.
+
+Example release notes from commit headers:
+
+```markdown
+### App Features
+
+* **app:** add saved-query folders
+
+### Driver Features
+
+* **driver-postgres:** introspect materialized views
+* **driver-redis:** support key TTL editing
+
+### Bug Fixes
+
+* **app:** keep tabs after reconnect
+* **driver-mysql:** parse unsigned bigint columns
+
+### Performance Improvements
+
+* **app:** virtualize large result grids
+```
 
 ## Branching & pull requests
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,5 +13,62 @@
         }
       ]
     }
-  }
+  },
+  "changelog-sections": [
+    {
+      "type": "feat",
+      "section": "App Features"
+    },
+    {
+      "type": "feature",
+      "section": "Driver Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance Improvements"
+    },
+    {
+      "type": "revert",
+      "section": "Reverts"
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous Chores",
+      "hidden": true
+    },
+    {
+      "type": "docs",
+      "section": "Documentation",
+      "hidden": true
+    },
+    {
+      "type": "style",
+      "section": "Styles",
+      "hidden": true
+    },
+    {
+      "type": "refactor",
+      "section": "Code Refactoring",
+      "hidden": true
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": true
+    },
+    {
+      "type": "build",
+      "section": "Build System",
+      "hidden": true
+    },
+    {
+      "type": "ci",
+      "section": "Continuous Integration",
+      "hidden": true
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- split release-please feature changelog headings into App Features and Driver Features
- document which conventional commit headers feed each generated release note section
- add examples for app, driver, bug fix, and performance entries

## Validation
- `python3 -m json.tool release-please-config.json`
- `git diff --check`

## Notes
- release-please maps changelog headings by commit type, not by scope.
- `feature` is intentionally used for driver features because release-please treats it like `feat` for minor version bumps while allowing a separate Driver Features heading.
