### PR TITLE
fix(app): query-pane limit, autocomplete, and result-grid UX

### DIFF
--- a/app/src/completion.rs
+++ b/app/src/completion.rs
@@ -91,6 +91,13 @@ fn resolve_alias(stmt: &str, owner: &str) -> String {
     owner.to_string()
 }
 
+/// True when `word` (already lowercased) matches `label` as a prefix or at the
+/// start of any `_`-delimited segment, so typing `teknis` finds `flag_teknis`.
+fn subword_match(label: &str, word: &str) -> bool {
+    let l = label.to_lowercase();
+    l.starts_with(word) || l.split('_').any(|seg| seg.starts_with(word))
+}
+
 /// The trailing run of identifier chars at the end of `s` (ASCII identifier).
 pub fn trailing_word(s: &str) -> &str {
     let b = s.as_bytes();
@@ -253,7 +260,10 @@ pub fn suggest(
     };
     let wl = word.to_lowercase();
     if !wl.is_empty() {
-        cands.retain(|c| c.label.to_lowercase().starts_with(&wl));
+        cands.retain(|c| subword_match(&c.label, &wl));
+        // Prefix matches rank above mid-word (`_`-segment) matches so the most
+        // literal completion stays on top; stable within each group.
+        cands.sort_by_key(|c| !c.label.to_lowercase().starts_with(&wl));
     }
     // dedup by label (a column name may appear across tables), keep first.
     let mut seen = std::collections::HashSet::new();
@@ -310,6 +320,35 @@ mod tests {
             c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
             ["config_id", "name"]
         );
+    }
+
+    /// Typing a mid-word `_` segment finds the identifier, and a true prefix
+    /// still ranks above the subword hit.
+    #[test]
+    fn subword_matches_underscore_segment() {
+        let n = vec![
+            VmTreeNode {
+                label: "public".into(),
+                kind: "database".into(),
+            },
+            VmTreeNode {
+                label: "licenses".into(),
+                kind: "table".into(),
+            },
+            VmTreeNode {
+                label: "flag_teknis".into(),
+                kind: "field".into(),
+            },
+            VmTreeNode {
+                label: "teknis_id".into(),
+                kind: "field".into(),
+            },
+        ];
+        let (_, c) = suggest("select teknis", &n, "public");
+        let labels: Vec<&str> = c.iter().map(|x| x.label.as_str()).collect();
+        assert!(labels.contains(&"flag_teknis"));
+        // `teknis_id` is a real prefix → ranks ahead of the mid-word match.
+        assert_eq!(labels.first(), Some(&"teknis_id"));
     }
 
     #[test]

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1180,11 +1180,12 @@ fn default_col_width(name: &str, type_name: &str) -> f32 {
     }
     // Size the column to fit its header — bold name + dim type label in the mono
     // font — so real schema names (often long, `_`-joined) read without dragging.
-    // Coefficients approximate the mono advance at font-sm/xs; the arrow + cell
-    // padding is the constant. Clamped so nothing collapses or runs off-screen.
-    let name_px = name.chars().count() as f32 * 7.3;
-    let type_px = type_name.chars().count() as f32 * 5.6;
-    (name_px + type_px + 44.0).clamp(90.0, 360.0)
+    // Coefficients are deliberately a touch above the mono advance at font-sm/xs so
+    // a name never lands right on the elision edge; the arrow + cell padding is the
+    // constant. Clamped so nothing collapses or runs off-screen.
+    let name_px = name.chars().count() as f32 * 8.4;
+    let type_px = type_name.chars().count() as f32 * 6.8;
+    (name_px + type_px + 56.0).clamp(100.0, 460.0)
 }
 
 #[cfg(test)]
@@ -1197,8 +1198,8 @@ mod col_width_tests {
         let short = default_col_width("id", "int4");
         let long = default_col_width("alasan_penolakan", "varchar");
         assert!(long > short);
-        assert!((90.0..=360.0).contains(&short));
-        assert!((90.0..=360.0).contains(&long));
+        assert!((100.0..=460.0).contains(&short));
+        assert!((100.0..=460.0).contains(&long));
         // The bar sentinel keeps its fixed width.
         assert_eq!(default_col_width("share", "bar"), 520.0);
     }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -3080,14 +3080,32 @@ fn main() -> Result<(), slint::PlatformError> {
         let sync_editor = sync_editor.clone();
         let weak = window.as_weak();
         let press: Rc<dyn Fn(usize, i32, i32)> = Rc::new(move |pane, line, col| {
-            if let Some(w) = weak.upgrade() {
-                // Clicking a pane focuses it: drives the accent + which pane
-                // global shortcuts fall back to.
-                w.set_active_pane(pane as i32);
-                set_p_completion_visible(&w, pane, false);
-            }
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            // Clicking a pane focuses it: drives the accent + which pane
+            // global shortcuts fall back to.
+            w.set_active_pane(pane as i32);
+            set_p_completion_visible(&w, pane, false);
+            // A plain click only moves the caret. sync_editor rebuilds the whole
+            // lines model, which destroys every row's TouchArea — and that swallows
+            // the second tap of a double-click, so word-select never fired. When
+            // there is no selection to clear, the line spans are unchanged, so just
+            // nudge the caret and leave the rows (and their TouchAreas) intact.
+            let had_sel = panes[pane].ed_state.borrow().selection().is_some();
             panes[pane].ed_state.borrow_mut().move_to(line, col, false);
-            sync_editor(pane);
+            if had_sel {
+                sync_editor(pane);
+            } else {
+                let ed = panes[pane].ed_state.borrow();
+                if pane == 0 {
+                    w.set_cursor_line(ed.line as i32);
+                    w.set_cursor_col(ed.col as i32);
+                } else {
+                    w.set_p1_cursor_line(ed.line as i32);
+                    w.set_p1_cursor_col(ed.col as i32);
+                }
+            }
         });
         window.on_editor_press({
             let press = press.clone();

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -5866,11 +5866,21 @@ fn main() -> Result<(), slint::PlatformError> {
                             vec![sql.clone()]
                         };
                         let n = stmts.len().max(1);
-                        // Row-limit control (default 300): cap manual SELECTs so a
-                        // huge `SELECT * FROM table` can't stream millions of rows
-                        // in and freeze the grid. Browse text already carries its
-                        // own LIMIT, so cap_select leaves it untouched.
-                        let row_limit = browse.lock().unwrap().limit;
+                        // SQL engines are never auto-capped — the user's SELECT runs
+                        // as written (bare reads take the streaming path instead).
+                        // NoSQL keeps the row-limit control's value. Browse text
+                        // carries its own LIMIT either way, so cap_select no-ops it.
+                        let row_limit = if matches!(
+                            engine,
+                            rdb_connstore::Engine::Postgres
+                                | rdb_connstore::Engine::MySql
+                                | rdb_connstore::Engine::Sqlite
+                                | rdb_connstore::Engine::Cassandra
+                        ) {
+                            0
+                        } else {
+                            browse.lock().unwrap().limit
+                        };
                         let mut out = Err(rdb_core::error::RdbError::Query("empty query".into()));
                         for (i, s) in stmts.iter().enumerate() {
                             let s = cap_select(*engine, s, row_limit);
@@ -6356,7 +6366,6 @@ fn main() -> Result<(), slint::PlatformError> {
         let run_sql = run_sql.clone();
         let run_stream = run_stream.clone();
         let cur_engine = cur_engine.clone();
-        let browse = browse.clone();
         let ed_state = ed_state.clone();
         let recent_queries = recent_queries.clone();
         let rebuild_query_tree = rebuild_query_tree.clone();
@@ -6381,10 +6390,10 @@ fn main() -> Result<(), slint::PlatformError> {
                 if active_tab_kind(&w) != "table" {
                     w.set_grid_read_only(true);
                 }
-                // "No limit" (browse.limit == 0) on a bare SELECT streams the
-                // rows in progressively; everything else runs buffered (capped).
+                // SQL engines never carry an injected LIMIT: a bare SELECT streams
+                // the rows in progressively (cancelable, no artificial cap), and a
+                // statement with its own LIMIT / a write runs buffered as written.
                 let stream = active_tab_kind(&w) != "table"
-                    && browse.lock().unwrap().limit == 0
                     && cur_engine
                         .borrow()
                         .map(|e| is_bare_select(e, &text))
@@ -6424,11 +6433,10 @@ fn main() -> Result<(), slint::PlatformError> {
             let stream = weak
                 .upgrade()
                 .map(|w| {
-                    panes[1].browse.lock().unwrap().limit == 0
-                        && cur_engine
-                            .borrow()
-                            .map(|e| is_bare_select(e, &text))
-                            .unwrap_or(false)
+                    cur_engine
+                        .borrow()
+                        .map(|e| is_bare_select(e, &text))
+                        .unwrap_or(false)
                         && active_tab_kind(&w) != "table"
                 })
                 .unwrap_or(false);

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2685,7 +2685,13 @@ fn main() -> Result<(), slint::PlatformError> {
         let panes = panes.clone();
         let sync_editor = sync_editor.clone();
         Rc::new(move |pane: usize, text: &str| {
-            *panes[pane].ed_state.borrow_mut() = editor::EditorState::from_text(text);
+            let mut ed = editor::EditorState::from_text(text);
+            // Start at the top so a restored tab shows its query from the first
+            // line with the caret in view — matching a fresh tab. Leaving the
+            // caret on the last line (where `from_text` puts it) kept it, and the
+            // autocomplete popup, scrolled out of sight for saved multi-line queries.
+            ed.move_to(0, 0, false);
+            *panes[pane].ed_state.borrow_mut() = ed;
             sync_editor(pane);
         })
     };

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1178,21 +1178,29 @@ fn default_col_width(name: &str, type_name: &str) -> f32 {
     if type_name == "bar" {
         return 520.0;
     }
-    match name {
-        "sector" => 420.0,
-        "total" => 120.0,
-        "name" | "email" => 265.0,
-        "code" => 100.0,
-        "short_name" => 115.0,
-        "country" => 100.0,
-        "exch" => 95.0,
-        "ccy" => 64.0,
-        _ => match type_name {
-            "uuid" | "fk" => 185.0,
-            "timestamptz" | "timestamp" => 190.0,
-            "int4" | "int8" | "numeric" => 80.0,
-            _ => 140.0,
-        },
+    // Size the column to fit its header — bold name + dim type label in the mono
+    // font — so real schema names (often long, `_`-joined) read without dragging.
+    // Coefficients approximate the mono advance at font-sm/xs; the arrow + cell
+    // padding is the constant. Clamped so nothing collapses or runs off-screen.
+    let name_px = name.chars().count() as f32 * 7.3;
+    let type_px = type_name.chars().count() as f32 * 5.6;
+    (name_px + type_px + 44.0).clamp(90.0, 360.0)
+}
+
+#[cfg(test)]
+mod col_width_tests {
+    use super::default_col_width;
+
+    #[test]
+    fn fits_name_within_clamp() {
+        // A longer header is wider, and both stay inside the clamp.
+        let short = default_col_width("id", "int4");
+        let long = default_col_width("alasan_penolakan", "varchar");
+        assert!(long > short);
+        assert!((90.0..=360.0).contains(&short));
+        assert!((90.0..=360.0).contains(&long));
+        // The bar sentinel keeps its fixed width.
+        assert_eq!(default_col_width("share", "bar"), 520.0);
     }
 }
 

--- a/app/src/ui/code-editor.slint
+++ b/app/src/ui/code-editor.slint
@@ -55,7 +55,7 @@ export component CodeEditor inherits Rectangle {
             return reject;
         }
 
-        ScrollView {
+        edit-scroll := ScrollView {
             width: 100%;
             height: 100%;
             VerticalLayout {
@@ -203,15 +203,18 @@ export component CodeEditor inherits Rectangle {
 
     // ----- autocomplete popup (overlays the editor, under the caret) -----
     if root.completion-visible && root.completion-items.length > 0: Rectangle {
-        // y below the caret line by default; if that would run past the editor's
-        // bottom edge (deep in a long query / short results pane), flip it above
-        // the caret line so the list stays fully visible instead of clipped.
+        // Anchor to the caret's *visual* position: the caret lives inside the
+        // scrolled line list, so the popup (a sibling of the scroll view) has to
+        // fold in the padding and the scroll offset — otherwise a restored tab,
+        // whose cursor lands on the last line, paints the popup far below the
+        // viewport and it never shows. Below the caret by default; flip above when
+        // that would clip past the editor's bottom edge.
         property <length> pop-h: min(root.completion-items.length * 22px + 8px, 200px);
-        property <length> below-y: (root.cursor-line + 1) * root.line-h + 6px;
-        x: min(root.gutter-w + Tokens.sp3 + root.cursor-col * root.charw, root.width - self.width - Tokens.sp2);
-        y: below-y + self.pop-h > root.height && root.cursor-line * root.line-h - self.pop-h - 6px > 0
-            ? root.cursor-line * root.line-h - self.pop-h - 6px
-            : below-y;
+        property <length> caret-y: Tokens.sp2 + root.cursor-line * root.line-h + edit-scroll.viewport-y;
+        property <length> below-y: caret-y + root.line-h + 6px;
+        property <length> above-y: caret-y - self.pop-h - 6px;
+        x: min(root.gutter-w + Tokens.sp3 + root.cursor-col * root.charw + edit-scroll.viewport-x, root.width - self.width - Tokens.sp2);
+        y: below-y + self.pop-h > root.height && above-y > 0 ? above-y : below-y;
         width: 360px;
         height: pop-h;
         border-radius: Tokens.radius;

--- a/app/src/ui/code-editor.slint
+++ b/app/src/ui/code-editor.slint
@@ -210,7 +210,10 @@ export component CodeEditor inherits Rectangle {
         // viewport and it never shows. Below the caret by default; flip above when
         // that would clip past the editor's bottom edge.
         property <length> pop-h: min(root.completion-items.length * 22px + 8px, 200px);
-        property <length> caret-y: Tokens.sp2 + root.cursor-line * root.line-h + edit-scroll.viewport-y;
+        // Clamp the caret anchor into the editor's own height so the popup stays
+        // on-screen even when the scroll offset can't be read precisely (a short,
+        // scrolled editor otherwise threw the anchor a thousand px down).
+        property <length> caret-y: clamp(Tokens.sp2 + root.cursor-line * root.line-h + edit-scroll.viewport-y, 0px, root.height);
         property <length> below-y: caret-y + root.line-h + 6px;
         property <length> above-y: caret-y - self.pop-h - 6px;
         x: min(root.gutter-w + Tokens.sp3 + root.cursor-col * root.charw + edit-scroll.viewport-x, root.width - self.width - Tokens.sp2);

--- a/app/src/ui/code-editor.slint
+++ b/app/src/ui/code-editor.slint
@@ -79,14 +79,25 @@ export component CodeEditor inherits Rectangle {
                         clamp(li + floor(line-ta.mouse-y / root.line-h), 0, root.lines.length - 1);
 
                     line-ta := TouchArea {
+                        // Sub-pixel jitter between the two taps of a double-click
+                        // used to fire `moved` → drag a zero-width selection, which
+                        // swallowed the double-click so word-select never landed.
+                        // Only treat it as a drag once the pointer clears a small
+                        // threshold from where it went down.
+                        property <length> press-x;
+                        property <length> press-y;
                         pointer-event(e) => {
                             if (e.kind == PointerEventKind.down) {
                                 focus-scope.focus();
+                                self.press-x = self.mouse-x;
+                                self.press-y = self.mouse-y;
                                 root.press-pos(parent.hit-line, parent.hit-col);
                             }
                         }
                         moved => {
-                            if (self.pressed) {
+                            if (self.pressed
+                                && (abs(self.mouse-x - self.press-x) > 3px
+                                    || abs(self.mouse-y - self.press-y) > 3px)) {
                                 root.drag-pos(parent.hit-line, parent.hit-col);
                             }
                         }

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -324,6 +324,10 @@ export component QueryPane inherits Rectangle {
                 }
                 if !root.editor-collapsed: CodeEditor {
                     vertical-stretch: 1;
+                    // Lift above the results header/tabs below it so the autocomplete
+                    // popup, which overflows the editor's bottom edge, is not covered
+                    // by those later siblings in this column.
+                    z: 1;
                     lines: root.editor-lines;
                     fold-state: root.editor-fold-state;
                     line-hidden: root.editor-line-hidden;

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -581,22 +581,37 @@ export component QueryPane inherits Rectangle {
                 }
             }
 
-            // in-flight query indicator
-            if root.query-running: VerticalLayout {
-                alignment: center;
-                spacing: Tokens.sp3;
-                Text {
-                    text: "Running…";
-                    color: Tokens.text-dim;
-                    font-size: Tokens.font-md;
-                    horizontal-alignment: center;
-                }
-                HorizontalLayout {
-                    alignment: center;
-                    DangerButton {
-                        text: "⏹ Cancel";
-                        height: 28px;
-                        clicked => { root.cancel-query(); }
+            // in-flight query indicator: a solid centered card so it reads
+            // clearly over the (stale) rows behind it instead of floating.
+            if root.query-running: Rectangle {
+                Rectangle {
+                    x: (parent.width - self.width) / 2;
+                    y: (parent.height - self.height) / 2;
+                    width: 168px;
+                    height: 104px;
+                    background: Tokens.card;
+                    border-radius: Tokens.radius-lg;
+                    border-width: 1px;
+                    border-color: Tokens.border-strong;
+                    drop-shadow-blur: 24px;
+                    drop-shadow-color: #00000066;
+                    VerticalLayout {
+                        alignment: center;
+                        spacing: Tokens.sp3;
+                        Text {
+                            text: "Running…";
+                            color: Tokens.text-dim;
+                            font-size: Tokens.font-md;
+                            horizontal-alignment: center;
+                        }
+                        HorizontalLayout {
+                            alignment: center;
+                            DangerButton {
+                                text: "⏹ Cancel";
+                                height: 28px;
+                                clicked => { root.cancel-query(); }
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -186,11 +186,12 @@ export component QueryPane inherits Rectangle {
                             clicked => { root.explain-query(); }
                         }
                     }
-                    // Row limit for manual queries: a number caps the result;
-                    // "No limit" streams the whole table in progressively.
+                    // Row limit only for NoSQL engines: SQL engines write their
+                    // own LIMIT, so the control just misleads there. NoSQL has no
+                    // LIMIT syntax, so the field is the only way to cap the result.
                     VerticalLayout {
                         alignment: center;
-                        visible: root.sql-capable;
+                        visible: !root.sql-capable;
                         HorizontalLayout {
                             spacing: Tokens.sp1;
                             VerticalLayout {

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -150,6 +150,11 @@ export component QueryPane inherits Rectangle {
             vertical-stretch: 0.0;
             preferred-height: root.editor-h;
             background: Tokens.canvas;
+            // Paint above the result body below: when the editor is short the
+            // autocomplete popup overflows past its bottom edge, and without this
+            // the result grid (a later sibling) would cover it. z lifts the whole
+            // editor cell — and so the overflowing popup — over the grid.
+            z: 1;
             VerticalLayout {
                 width: 100%;
                 height: 100%;

--- a/app/src/ui/tabular-grid.slint
+++ b/app/src/ui/tabular-grid.slint
@@ -542,6 +542,14 @@ export component TabularGrid inherits Rectangle {
                         }
                     }
                 }
+                // Say *why* this is view-only: a manual query result has no row
+                // identity, so open the table itself to edit or insert.
+                Text {
+                    text: "View-only — query results have no row identity. Open the table to edit or add rows.";
+                    color: Tokens.text-faint;
+                    font-size: Tokens.font-xs;
+                    wrap: word-wrap;
+                }
             }
         }
     }

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -803,30 +803,35 @@ export component WorkArea inherits Rectangle {
                 if root.browse-mode: HorizontalLayout {
                     spacing: Tokens.sp2;
                     alignment: center;
-                    Text {
-                        text: "Limit";
-                        color: Tokens.text-faint;
-                        font-size: Tokens.font-sm;
-                        vertical-alignment: center;
-                    }
-                    Rectangle {
-                        width: 58px;
-                        height: 24px;
-                        border-radius: Tokens.radius;
-                        border-width: 1px;
-                        border-color: Tokens.border-strong;
-                        background: Tokens.card;
-                        TextInput {
-                            x: 0;
-                            width: parent.width;
-                            text <=> root.limit-text;
-                            horizontal-alignment: center;
-                            vertical-alignment: center;
-                            single-line: true;
-                            color: Tokens.text;
-                            font-family: Tokens.mono;
+                    // Limit box only for NoSQL: SQL browse pages via ‹ › and the
+                    // engine has its own LIMIT, so the control is dropped there.
+                    if !root.sql-capable: HorizontalLayout {
+                        spacing: Tokens.sp2;
+                        Text {
+                            text: "Limit";
+                            color: Tokens.text-faint;
                             font-size: Tokens.font-sm;
-                            accepted => { root.set-limit(self.text); }
+                            vertical-alignment: center;
+                        }
+                        Rectangle {
+                            width: 58px;
+                            height: 24px;
+                            border-radius: Tokens.radius;
+                            border-width: 1px;
+                            border-color: Tokens.border-strong;
+                            background: Tokens.card;
+                            TextInput {
+                                x: 0;
+                                width: parent.width;
+                                text <=> root.limit-text;
+                                horizontal-alignment: center;
+                                vertical-alignment: center;
+                                single-line: true;
+                                color: Tokens.text;
+                                font-family: Tokens.mono;
+                                font-size: Tokens.font-sm;
+                                accepted => { root.set-limit(self.text); }
+                            }
                         }
                     }
                     Rectangle {


### PR DESCRIPTION
## Summary

- Fix a cluster of query-pane and result-grid UX bugs found in real use: a row-limit control that misled on SQL engines, autocomplete that missed underscore-joined names and never popped on restored tabs, truncated column headers, a floating "Running…" indicator, a swallowed double-click, and an unexplained read-only result inspector.

## Changes

**Row limit (SQL)**
- Hide the row-limit control on SQL engines (kept for NoSQL, which has no LIMIT syntax).
- Stop auto-injecting `LIMIT 300` into manual SQL queries: a bare `SELECT` streams progressively (cancelable), anything with its own `LIMIT` runs as written. Table browse keeps its own paged limit, so click-to-view paging and inline editing are unchanged.

**Autocomplete**
- Match completions on `_`-delimited segments (typing `teknis` now finds `flag_teknis`), keeping true-prefix hits ranked first.
- Show the popup on restored/scrolled query tabs: anchor it to the caret's visual position, clamp it into the editor height, place the caret at the top on tab load, and lift it above the result header/tabs and grid so it is not covered.

**Result grid**
- Size columns to fit the header name instead of a hard-coded demo table, so long underscore-joined names read without horizontal dragging.
- Give the in-flight "Running…" indicator a solid card so it no longer floats over the rows.
- Explain in the read-only cell inspector why query results cannot be edited.

**Editor**
- Fix double-click word-select: a click no longer rebuilds the whole lines model (which destroyed the row TouchAreas and swallowed the second tap), and jitter between taps no longer starts a drag.

## Test plan

- [x] `make fmt-check`
- [x] `make lint` (clippy, warnings as errors)
- [x] `cargo test -p rdb --bins` — new `completion` and `col_width` tests pass (one pre-existing failure, `schema_flattens_to_indented_tree_nodes`, also fails on `develop` and is unrelated)
- [x] `make fe-build`
- [x] Manual (`make fe-run`, PostgreSQL): limit control gone on SQL, present on NoSQL; `SELECT * FROM t` no longer capped; `teknis` completes `flag_teknis`; autocomplete pops on a scrolled restored tab; wide-table headers readable; double-click selects a word in the editor.
