### PR TITLE
feat(app): sidebar Queries/History split and Details panel actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ desktop.ini
 .claude
 .agents
 docs/superpowers
+.forgeguard
 
 # Env & secrets
 .env

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -3383,29 +3383,31 @@ fn main() -> Result<(), slint::PlatformError> {
                     });
                 }
             }
-            let recent = recent.borrow();
-            rows.push(TreeNode {
-                label: if history_only { "History" } else { "Recent" }.into(),
-                depth: 0,
-                kind: "qcat".into(),
-                expanded: true,
-                db: SharedString::default(),
-                count: recent.len() as i32,
-            });
-            for (i, q) in recent.iter().enumerate() {
-                let label: String = if q.chars().count() > 24 {
-                    format!("{}…", q.chars().take(23).collect::<String>())
-                } else {
-                    q.clone()
-                };
+            // Queries (mode 1) is the curated Saved list only; History (mode 2)
+            // is the live run history — they no longer duplicate a "Recent" list.
+            if history_only {
+                let recent = recent.borrow();
                 rows.push(TreeNode {
-                    label: label.into(),
-                    depth: 1,
-                    kind: "recent".into(),
-                    expanded: false,
+                    label: "History".into(),
+                    depth: 0,
+                    kind: "qcat".into(),
+                    expanded: true,
                     db: SharedString::default(),
-                    count: i as i32,
+                    count: recent.len() as i32,
                 });
+                for (i, q) in recent.iter().enumerate() {
+                    // Collapse whitespace to one line so a multi-line query does
+                    // not paint over the rows below; the row elides to its width.
+                    let label: String = q.split_whitespace().collect::<Vec<_>>().join(" ");
+                    rows.push(TreeNode {
+                        label: label.chars().take(200).collect::<String>().into(),
+                        depth: 1,
+                        kind: "recent".into(),
+                        expanded: false,
+                        db: SharedString::default(),
+                        count: i as i32,
+                    });
+                }
             }
             w.set_query_tree(ModelRc::from(Rc::new(VecModel::from(rows))));
         }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -6469,6 +6469,78 @@ fn main() -> Result<(), slint::PlatformError> {
         });
     }
 
+    // ----- History: re-run an entry directly (fresh result, editor untouched) -----
+    {
+        let weak = window.as_weak();
+        let run_sql = run_sql.clone();
+        let run_stream = run_stream.clone();
+        let cur_engine = cur_engine.clone();
+        let recent_queries = recent_queries.clone();
+        window.on_rerun_query(move |idx| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let Some(text) = recent_queries.borrow().get(idx.max(0) as usize).cloned() else {
+                return;
+            };
+            if text.trim().is_empty() {
+                return;
+            }
+            // Same stream/buffered rule as a manual run; the result replaces the
+            // grid but the editor buffer is left alone.
+            if active_tab_kind(&w) != "table" {
+                w.set_grid_read_only(true);
+            }
+            let stream = active_tab_kind(&w) != "table"
+                && cur_engine
+                    .borrow()
+                    .map(|e| is_bare_select(e, &text))
+                    .unwrap_or(false);
+            if stream {
+                run_stream(0, text);
+            } else {
+                run_sql(0, text);
+            }
+        });
+    }
+
+    // ----- History: append an entry to the editor (never replaces its text) -----
+    {
+        let weak = window.as_weak();
+        let ed_state = ed_state.clone();
+        let sync_editor = sync_editor.clone();
+        let recent_queries = recent_queries.clone();
+        let workspace_tabs = workspace_tabs.clone();
+        let active_tab_id = active_tab_id.clone();
+        window.on_insert_query(move |idx| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let Some(text) = recent_queries.borrow().get(idx.max(0) as usize).cloned() else {
+                return;
+            };
+            {
+                let mut ed = ed_state.borrow_mut();
+                let end_line = ed.lines.len().saturating_sub(1) as i32;
+                let end_col = ed.lines.last().map(|l| l.chars().count()).unwrap_or(0) as i32;
+                ed.move_to(end_line, end_col, false);
+                // Blank line between what's there and the appended statement.
+                let prefix = if ed.text().trim().is_empty() { "" } else { "\n\n" };
+                ed.insert(&format!("{prefix}{text}"));
+            }
+            sync_editor(0);
+            // Persist the grown buffer to the active tab.
+            if let Some(id) = active_tab_id.lock().unwrap().clone() {
+                let new_text = ed_state.borrow().text();
+                let mut tabs = workspace_tabs.lock().unwrap();
+                if let Some(tab) = tabs.iter_mut().find(|t| t.id == id) {
+                    tab.query_text = new_text;
+                }
+            }
+            let _ = w;
+        });
+    }
+
     // ----- run query in the right split pane -----
     {
         let run_sql = run_sql.clone();

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -6525,7 +6525,11 @@ fn main() -> Result<(), slint::PlatformError> {
                 let end_col = ed.lines.last().map(|l| l.chars().count()).unwrap_or(0) as i32;
                 ed.move_to(end_line, end_col, false);
                 // Blank line between what's there and the appended statement.
-                let prefix = if ed.text().trim().is_empty() { "" } else { "\n\n" };
+                let prefix = if ed.text().trim().is_empty() {
+                    ""
+                } else {
+                    "\n\n"
+                };
                 ed.insert(&format!("{prefix}{text}"));
             }
             sync_editor(0);
@@ -6580,6 +6584,9 @@ fn main() -> Result<(), slint::PlatformError> {
         window.on_p1_run(run_p1.clone());
         window.on_p1_run_selection(run_p1);
     }
+
+    // ----- Details panel: copy one field value to the clipboard -----
+    window.on_copy_text(move |s| clip_set(&s));
 
     // ----- Copy results (TSV → clipboard) / Export CSV (~/Downloads) -----
     {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1031,10 +1031,23 @@ fn save_recent(list: &[String]) {
     }
 }
 
+/// Strip SQL line comments (`--` to end of line) and blank lines, so a
+/// commented-out scratch statement leaves only its runnable SQL. Word-scan, not
+/// a parser: a `--` inside a string literal is a rare edge we accept trimming.
+fn strip_sql_comments(text: &str) -> String {
+    text.lines()
+        .map(|l| l.split("--").next().unwrap_or("").trim_end())
+        .filter(|l| !l.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Record an executed query at the head of the history (dedupe, cap
-/// `RECENT_CAP`) and persist it, except in mock mode.
+/// `RECENT_CAP`) and persist it, except in mock mode. Comment-only text is
+/// dropped and comments are stripped so history keeps only runnable SQL.
 fn record_recent(list: &RefCell<Vec<String>>, text: &str) {
-    let t = text.trim();
+    let t = strip_sql_comments(text);
+    let t = t.trim();
     if t.is_empty() {
         return;
     }
@@ -1044,6 +1057,25 @@ fn record_recent(list: &RefCell<Vec<String>>, text: &str) {
     v.truncate(RECENT_CAP);
     if !mock::mock_mode() {
         save_recent(&v);
+    }
+}
+
+#[cfg(test)]
+mod record_recent_tests {
+    use super::*;
+
+    #[test]
+    fn comment_only_is_not_recorded() {
+        let list = RefCell::new(Vec::new());
+        record_recent(&list, "-- \\ Check Perizinan\n-- mp.username ilike '%x%'");
+        assert!(list.borrow().is_empty());
+    }
+
+    #[test]
+    fn leading_comment_is_stripped_but_sql_kept() {
+        let list = RefCell::new(Vec::new());
+        record_recent(&list, "-- pick emiten\nselect * from emiten; -- trailing");
+        assert_eq!(list.borrow().as_slice(), ["select * from emiten;"]);
     }
 }
 

--- a/app/src/model.rs
+++ b/app/src/model.rs
@@ -716,7 +716,8 @@ mod tests {
         assert_eq!(nodes[0].kind, "database");
         assert_eq!(nodes[1].label, "users");
         assert_eq!(nodes[1].kind, "table");
-        assert_eq!(nodes[2].label, "id: int4");
+        // PK fields carry a trailing "PK" tag in the tree label.
+        assert_eq!(nodes[2].label, "id: int4  PK");
         assert_eq!(nodes[2].kind, "field");
     }
 }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -263,6 +263,7 @@ callback create-table-commit();
     callback format-sql();
     callback explain-query();
     callback copy-results();
+    callback copy-text(string);
     callback export-results(int);
     in property <[ChartBar]> chart-bars;
     in property <[string]> all-columns;
@@ -1551,6 +1552,9 @@ callback create-table-commit();
                         }
                         copy-results() => {
                             root.copy-results();
+                        }
+                        copy-text(t) => {
+                            root.copy-text(t);
                         }
                         export-results(fmt) => {
                             root.export-results(fmt);

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -202,6 +202,9 @@ callback create-table-commit();
     callback filter-tree(string);
     callback open-function(string);
     callback open-query(string, int);
+    // History item actions: append its SQL to the editor, or re-run it directly.
+    callback insert-query(int);
+    callback rerun-query(int);
     callback sidebar-mode-changed(int);
 
     // ----- connections screen detail panel -----
@@ -1011,6 +1014,8 @@ callback create-table-commit();
                     disconnect() => { root.disconnect(); }
                     open-function(f) => { root.open-function(f); }
                     open-query(q, i) => { root.open-query(q, i); }
+                    insert-query(i) => { root.insert-query(i); }
+                    rerun-query(i) => { root.rerun-query(i); }
                     mode-changed(m) => { root.sidebar-mode = m; root.sidebar-mode-changed(m); }
                     open-table(db, t) => { root.open-table(db, t); }
                     pin-table(db, t) => { root.pin-table(db, t); }
@@ -1728,6 +1733,8 @@ callback create-table-commit();
                     disconnect() => { root.disconnect(); }
                     open-function(f) => { root.open-function(f); }
                     open-query(q, i) => { root.open-query(q, i); }
+                    insert-query(i) => { root.insert-query(i); }
+                    rerun-query(i) => { root.rerun-query(i); }
                     mode-changed(m) => { root.sidebar-mode = m; root.sidebar-mode-changed(m); }
                     open-table(db, t) => { root.open-table(db, t); }
                     pin-table(db, t) => { root.pin-table(db, t); }

--- a/app/src/ui/nav-cluster.slint
+++ b/app/src/ui/nav-cluster.slint
@@ -37,6 +37,8 @@ export component NavCluster inherits HorizontalLayout {
     callback disconnect();
     callback open-function(string);
     callback open-query(string, int);
+    callback insert-query(int);
+    callback rerun-query(int);
     callback mode-changed(int);
     callback open-table(string, string);
     callback pin-table(string, string);
@@ -83,6 +85,8 @@ export component NavCluster inherits HorizontalLayout {
         disconnect() => { root.disconnect(); }
         open-function(f) => { root.open-function(f); }
         open-query(q, i) => { root.open-query(q, i); }
+        insert-query(i) => { root.insert-query(i); }
+        rerun-query(i) => { root.rerun-query(i); }
         mode-changed(m) => { root.mode-changed(m); }
         open-table(db, t) => { root.open-table(db, t); }
         pin-table(db, t) => { root.pin-table(db, t); }

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -83,6 +83,7 @@ export component QueryPane inherits Rectangle {
     callback select-result-tab(int);
     callback close-result-tab(int);
     callback copy-results();
+    callback copy-text(string);           // Details: copy a single field value
     callback export-results(int);
 
     // ----- result grid -----
@@ -434,7 +435,9 @@ export component QueryPane inherits Rectangle {
             property <bool> detail-shown: root.detail-visible && root.view-mode == 0
                 && root.result-kind == 0 && root.col-count > 0 && root.selected-row >= 0
                 && (root.selected-row + 1) * root.col-count <= root.cells.length;
-            property <length> detail-w: min(320px, max(240px, self.width * 0.32));
+            // Leaner + more responsive: a smaller slice of the body so the grid
+            // keeps most of the width, clamped so fields stay readable.
+            property <length> detail-w: min(300px, max(200px, self.width * 0.24));
             vertical-stretch: 1;
             background: Tokens.canvas;
 
@@ -493,12 +496,45 @@ export component QueryPane inherits Rectangle {
                                 vertical-alignment: center;
                             }
                             Rectangle { horizontal-stretch: 1; }
-                            Text {
-                                text: "Row " + (root.selected-row + 1);
-                                color: Tokens.text-faint;
-                                font-family: Tokens.mono;
-                                font-size: Tokens.font-xs;
-                                vertical-alignment: center;
+                            // step through rows without going back to the grid
+                            stepper := HorizontalLayout {
+                                property <int> row-count: root.col-count > 0 ? root.cells.length / root.col-count : 0;
+                                spacing: Tokens.sp1;
+                                Rectangle {
+                                    width: 20px;
+                                    Text {
+                                        text: "‹";
+                                        color: root.selected-row > 0 ? Tokens.text : Tokens.text-ghost;
+                                        font-size: Tokens.font-md;
+                                        horizontal-alignment: center;
+                                        vertical-alignment: center;
+                                    }
+                                    TouchArea {
+                                        enabled: root.selected-row > 0;
+                                        clicked => { root.select-cell(root.selected-row - 1, max(0, root.selected-col)); }
+                                    }
+                                }
+                                Text {
+                                    text: "Row " + (root.selected-row + 1);
+                                    color: Tokens.text-faint;
+                                    font-family: Tokens.mono;
+                                    font-size: Tokens.font-xs;
+                                    vertical-alignment: center;
+                                }
+                                Rectangle {
+                                    width: 20px;
+                                    Text {
+                                        text: "›";
+                                        color: root.selected-row + 1 < stepper.row-count ? Tokens.text : Tokens.text-ghost;
+                                        font-size: Tokens.font-md;
+                                        horizontal-alignment: center;
+                                        vertical-alignment: center;
+                                    }
+                                    TouchArea {
+                                        enabled: root.selected-row + 1 < stepper.row-count;
+                                        clicked => { root.select-cell(root.selected-row + 1, max(0, root.selected-col)); }
+                                    }
+                                }
                             }
                         }
                     }
@@ -527,6 +563,20 @@ export component QueryPane inherits Rectangle {
                                             color: Tokens.text-faint;
                                             font-family: Tokens.mono;
                                             font-size: Tokens.font-xs;
+                                        }
+                                        // copy this field's value to the clipboard
+                                        Rectangle {
+                                            width: 18px;
+                                            Text {
+                                                text: "⧉";
+                                                color: copy-ta.has-hover ? Tokens.accent : Tokens.text-faint;
+                                                font-size: Tokens.font-xs;
+                                                horizontal-alignment: center;
+                                                vertical-alignment: center;
+                                            }
+                                            copy-ta := TouchArea {
+                                                clicked => { root.copy-text(detail-cell.is-null ? "" : detail-cell.text); }
+                                            }
                                         }
                                     }
                                     Rectangle {

--- a/app/src/ui/sidebar.slint
+++ b/app/src/ui/sidebar.slint
@@ -27,6 +27,8 @@ export component Sidebar inherits Rectangle {
     callback toggle-fields(string, string); // (database, table) — expand columns inline
     callback open-function(string);
     callback open-query(string, int);      // (label, index in its section)
+    callback insert-query(int);            // History row: append its SQL to editor
+    callback rerun-query(int);             // History ▶: run it, editor untouched
     callback toggle-node(string);
     callback select-schema(string);
     callback filter-tree(string);
@@ -156,7 +158,13 @@ export component Sidebar inherits Rectangle {
                             } else if (is-function) {
                                 root.open-function(node.label);
                             } else if (is-query) {
-                                root.open-query(node.label, node.count);
+                                // Saved opens into the editor; History appends so it
+                                // never clobbers what the user is writing.
+                                if (node.kind == "recent") {
+                                    root.insert-query(node.count);
+                                } else {
+                                    root.open-query(node.label, node.count);
+                                }
                             }
                         }
                         double-clicked => {
@@ -270,6 +278,22 @@ export component Sidebar inherits Rectangle {
                             font-italic: is-hint;
                             vertical-alignment: center;
                             overflow: elide;
+                        }
+
+                        // History ▶: re-run this entry directly (editor untouched).
+                        // Nested TouchArea wins over the row, so the row still appends.
+                        if node.kind == "recent": Rectangle {
+                            width: 20px;
+                            Text {
+                                text: "▶";
+                                color: rerun-ta.has-hover ? Tokens.accent : Tokens.text-faint;
+                                font-size: Tokens.font-xs;
+                                horizontal-alignment: center;
+                                vertical-alignment: center;
+                            }
+                            rerun-ta := TouchArea {
+                                clicked => { root.rerun-query(node.count); }
+                            }
                         }
 
                         // active table row-count badge (e.g. emiten · 986)

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -235,6 +235,7 @@ export component WorkArea inherits Rectangle {
     callback format-sql();
     callback explain-query();
     callback copy-results();
+    callback copy-text(string);
     // Export displayed results. Arg = format: 0 CSV, 1 JSON, 2 TSV, 3 SQL, 4 Markdown.
     callback export-results(int);
 
@@ -572,6 +573,7 @@ export component WorkArea inherits Rectangle {
             select-result-tab(i) => { root.select-result-tab(i); }
             close-result-tab(i) => { root.close-result-tab(i); }
             copy-results() => { root.copy-results(); }
+            copy-text(t) => { root.copy-text(t); }
             export-results(i) => { root.export-results(i); }
             columns: root.columns;
             cells: root.cells;
@@ -687,6 +689,7 @@ export component WorkArea inherits Rectangle {
                 select-result-tab(i) => { root.p1-select-result-tab(i); }
                 close-result-tab(i) => { root.p1-close-result-tab(i); }
                 copy-results() => { root.p1-copy-results(); }
+                copy-text(t) => { root.copy-text(t); }
                 export-results(i) => { root.p1-export-results(i); }
                 columns: root.p1-columns;
                 cells: root.p1-cells;


### PR DESCRIPTION
## Summary

- Clean up the sidebar Queries/History tabs and the result Details panel from real use: the two query tabs were duplicates, history captured commented-out scratch SQL, multi-line entries overprinted each other, clicking a history item wiped the editor, and the Details panel ate a wide slice of the grid with no useful action.

## Changes

**Sidebar Queries / History**
- Split the tabs: Queries shows only the saved list, History owns the run history — they no longer duplicate the same "Recent" list.
- Collapse each history label to a single line so a multi-line query no longer paints over the rows below.
- Strip line comments before recording history and drop the entry when nothing runnable remains, so a commented-out statement never lands there.
- A history row now appends its SQL to the end of the editor (never replaces it), and a ▶ button re-runs the entry directly into a fresh result while leaving the editor untouched.

**Details panel**
- Narrow it and scale its width with the pane so the grid keeps most of the room.
- Add ‹ › to step between rows without returning to the grid.
- Add a copy button on each field to copy its value.

**Test**
- Align the tree-flatten test with the current output (primary-key fields carry a trailing PK tag), which was failing on a clean tree.

## Test plan

- [x] `make fmt-check`
- [x] `make lint` (clippy, warnings as errors)
- [x] `cargo test -p rdb --bins` — all unit tests pass, including new `record_recent` tests and the corrected tree-flatten test (Docker-only `tests/integration.rs` targets are excluded per project CI convention and run via `make test-it`)
- [x] `make fe-build`
- [x] Manual (`make fe-run`): Queries lists saved only; History lists run history; a fully commented statement stays out of History; a history label stays on one line as the sidebar widens; clicking a history row appends to the editor; the ▶ button re-runs it; the Details panel is slimmer, ‹ › steps rows, and the copy button copies a field value.
