### PR TITLE
fix(app): connection-switch data loss, result-tab state, autocomplete, editor, JSON

### DIFF
--- a/app/src/completion.rs
+++ b/app/src/completion.rs
@@ -189,6 +189,32 @@ fn columns_of(nodes: &[VmTreeNode], owner: &str) -> Vec<Candidate> {
     Vec::new()
 }
 
+/// Columns of every table named by a `FROM`/`JOIN` in the current statement, so
+/// a `WHERE`/`SELECT` completion offers the real columns in scope — including
+/// cross-schema tables the active-schema `all_columns` would miss. Scoped to the
+/// current statement (text after the last `;`) so a prior statement's tables
+/// don't leak in.
+fn from_table_columns(before_cursor: &str, nodes: &[VmTreeNode]) -> Vec<Candidate> {
+    let stmt = before_cursor.rsplit(';').next().unwrap_or(before_cursor);
+    let words: Vec<&str> = stmt
+        .split(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == '.'))
+        .filter(|w| !w.is_empty())
+        .collect();
+    let mut cols = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for i in 0..words.len() {
+        let w = words[i].to_uppercase();
+        if (w == "FROM" || w == "JOIN") && i + 1 < words.len() {
+            for c in columns_of(nodes, words[i + 1]) {
+                if seen.insert(c.label.to_lowercase()) {
+                    cols.push(c);
+                }
+            }
+        }
+    }
+    cols
+}
+
 /// The last SQL keyword token on `line`, uppercased (via the editor lexer).
 fn last_keyword(line: &str) -> Option<String> {
     crate::editor::lex_line(line)
@@ -245,7 +271,11 @@ pub fn suggest(
             // next clause (FROM/WHERE/…) is always reachable, e.g. after `*`.
             Some("SELECT") | Some("WHERE") | Some("AND") | Some("OR") | Some("ON")
             | Some("HAVING") | Some("SET") | Some("BY") | Some("VALUES") => {
-                let mut c = all_columns(scope);
+                // Columns of the statement's own FROM/JOIN tables come first (they
+                // are what's actually in scope, cross-schema included), then the
+                // active-schema columns/tables and keywords as a fallback.
+                let mut c = from_table_columns(before_cursor, nodes);
+                c.extend(all_columns(scope));
                 c.extend(tables(scope));
                 c.extend(keywords());
                 c
@@ -349,6 +379,40 @@ mod tests {
         assert!(labels.contains(&"flag_teknis"));
         // `teknis_id` is a real prefix → ranks ahead of the mid-word match.
         assert_eq!(labels.first(), Some(&"teknis_id"));
+    }
+
+    /// WHERE on a cross-schema table (not the active schema) still offers that
+    /// table's columns, resolved from the statement's FROM clause.
+    #[test]
+    fn where_offers_from_table_columns_cross_schema() {
+        let mk = |l: &str, k: &str| VmTreeNode {
+            label: l.into(),
+            kind: k.into(),
+        };
+        let two = vec![
+            mk("public", "database"),
+            mk("users", "table"),
+            mk("id", "field"),
+            mk("oss_rba_common", "database"),
+            mk("step_journal", "table"),
+            mk("step_id", "field"),
+            mk("journal_id", "field"),
+        ];
+        // Active schema is public; the query reads oss_rba_common.step_journal.
+        let (_, c) = suggest(
+            "select * from oss_rba_common.step_journal where step",
+            &two,
+            "public",
+        );
+        let labels: Vec<&str> = c.iter().map(|x| x.label.as_str()).collect();
+        assert!(labels.contains(&"step_id"));
+        // A prior statement's tables must not leak past a `;`.
+        let (_, c2) = suggest(
+            "select * from users;\nselect * from oss_rba_common.step_journal where step",
+            &two,
+            "public",
+        );
+        assert!(c2.iter().any(|x| x.label == "step_id"));
     }
 
     #[test]

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1031,6 +1031,18 @@ fn save_recent(list: &[String]) {
     }
 }
 
+/// Pretty-print (indent) a JSON string for read-only display. Returns `None`
+/// when the text isn't a JSON object/array, so plain cells are shown as-is.
+fn pretty_json(s: &str) -> Option<String> {
+    let t = s.trim();
+    if !(t.starts_with('{') || t.starts_with('[')) {
+        return None;
+    }
+    serde_json::from_str::<serde_json::Value>(t)
+        .ok()
+        .and_then(|v| serde_json::to_string_pretty(&v).ok())
+}
+
 /// Strip SQL line comments (`--` to end of line) and blank lines, so a
 /// commented-out scratch statement leaves only its runnable SQL. Word-scan, not
 /// a parser: a `--` inside a string literal is a rare edge we accept trimming.
@@ -1728,6 +1740,33 @@ fn set_p_grid_col_filters(w: &MainWindow, pane: usize, m: ModelRc<SharedString>)
         w.set_p1_grid_col_filters(m);
     }
 }
+fn set_p_detail_pretty(w: &MainWindow, pane: usize, m: ModelRc<SharedString>) {
+    if pane == 0 {
+        w.set_grid_detail_pretty(m);
+    } else {
+        w.set_p1_detail_pretty(m);
+    }
+}
+/// Per-column indented JSON for one grid row, empty where the value isn't JSON.
+/// Feeds the Details panel so a JSON cell reads as formatted text there too.
+fn detail_pretty_row(g: &model::GridModel, row: usize) -> Vec<SharedString> {
+    g.rows
+        .get(row)
+        .map(|r| {
+            r.iter()
+                .map(|cell| {
+                    pretty_json(&cell.text)
+                        .map(SharedString::from)
+                        .unwrap_or_default()
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+fn refresh_detail_pretty(w: &MainWindow, pane: usize, g: &model::GridModel, row: i32) {
+    let rows = detail_pretty_row(g, row.max(0) as usize);
+    set_p_detail_pretty(w, pane, ModelRc::from(Rc::new(VecModel::from(rows))));
+}
 fn set_p_editing(w: &MainWindow, pane: usize, row: i32, col: i32) {
     if pane == 0 {
         w.set_editing_row(row);
@@ -2331,6 +2370,10 @@ fn present_view(
     };
     set_p_chart_bars(w, pane, ModelRc::from(Rc::new(VecModel::from(bars))));
     apply_result(w, pane, v);
+    // Seed the Details JSON preview for the first row of the new result.
+    if let Some(g) = displayed_grid.lock().unwrap().as_ref() {
+        refresh_detail_pretty(w, pane, g, 0);
+    }
     let st = browse.lock().unwrap().clone();
     if st.table.is_some() {
         let (start, end, prev, next) = page_bounds(st.page, st.limit, st.total, shown);
@@ -6804,10 +6847,14 @@ fn main() -> Result<(), slint::PlatformError> {
     // ----- right-pane grid interactions -----
     {
         let weak = window.as_weak();
+        let panes = panes.clone();
         window.on_p1_select_cell(move |row, col| {
             if let Some(w) = weak.upgrade() {
                 w.set_p1_selected_row(row);
                 w.set_p1_selected_col(col);
+                if let Some(g) = panes[1].displayed_grid.lock().unwrap().as_ref() {
+                    refresh_detail_pretty(&w, 1, g, row);
+                }
             }
         });
     }
@@ -6831,6 +6878,13 @@ fn main() -> Result<(), slint::PlatformError> {
                     .unwrap_or_default()
             } else {
                 SharedString::default()
+            };
+            let value = if w.get_p1_grid_read_only() {
+                pretty_json(value.as_str())
+                    .map(SharedString::from)
+                    .unwrap_or(value)
+            } else {
+                value
             };
             w.set_p1_editing_value(value);
             set_p_editing(&w, 1, row, col);
@@ -8395,6 +8449,7 @@ fn main() -> Result<(), slint::PlatformError> {
     // ----- row nav (j/k) -----
     {
         let weak = window.as_weak();
+        let displayed_grid = displayed_grid.clone();
         window.on_move_row(move |delta| {
             if let Some(w) = weak.upgrade() {
                 let n = w.get_grid_col_count();
@@ -8406,6 +8461,9 @@ fn main() -> Result<(), slint::PlatformError> {
                 if total > 0 {
                     let next = (w.get_selected_row() + delta).clamp(0, total - 1);
                     w.set_selected_row(next);
+                    if let Some(g) = displayed_grid.lock().unwrap().as_ref() {
+                        refresh_detail_pretty(&w, 0, g, next);
+                    }
                 }
             }
         });
@@ -8414,10 +8472,14 @@ fn main() -> Result<(), slint::PlatformError> {
     // ----- cell selection (click in the grid) -----
     {
         let weak = window.as_weak();
+        let displayed_grid = displayed_grid.clone();
         window.on_select_cell(move |r, c| {
             if let Some(w) = weak.upgrade() {
                 w.set_selected_row(r);
                 w.set_selected_col(c);
+                if let Some(g) = displayed_grid.lock().unwrap().as_ref() {
+                    refresh_detail_pretty(&w, 0, g, r);
+                }
             }
         });
     }
@@ -8501,6 +8563,15 @@ fn main() -> Result<(), slint::PlatformError> {
                     .unwrap_or_default()
             } else {
                 SharedString::default()
+            };
+            // Read-only (query result): show JSON indented so it's readable.
+            // Editable grids keep the raw text so a save writes back verbatim.
+            let value = if w.get_grid_read_only() {
+                pretty_json(value.as_str())
+                    .map(SharedString::from)
+                    .unwrap_or(value)
+            } else {
+                value
             };
             w.set_editing_value(value);
             w.set_editing_row(r);

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1747,6 +1747,13 @@ fn set_p_detail_pretty(w: &MainWindow, pane: usize, m: ModelRc<SharedString>) {
         w.set_p1_detail_pretty(m);
     }
 }
+fn set_p_selected_row(w: &MainWindow, pane: usize, row: i32) {
+    if pane == 0 {
+        w.set_selected_row(row);
+    } else {
+        w.set_p1_selected_row(row);
+    }
+}
 /// Per-column indented JSON for one grid row, empty where the value isn't JSON.
 /// Feeds the Details panel so a JSON cell reads as formatted text there too.
 fn detail_pretty_row(g: &model::GridModel, row: usize) -> Vec<SharedString> {
@@ -2370,6 +2377,11 @@ fn present_view(
     };
     set_p_chart_bars(w, pane, ModelRc::from(Rc::new(VecModel::from(bars))));
     apply_result(w, pane, v);
+    // A fresh result starts on the first row. A stale selection left over from a
+    // larger previous result is out of range for the new (smaller) one, and the
+    // Details gate `(selected-row + 1) * col-count <= cells.length` then evaluates
+    // false — so the panel silently vanishes even while its toggle is on.
+    set_p_selected_row(w, pane, 0);
     // Seed the Details JSON preview for the first row of the new result.
     if let Some(g) = displayed_grid.lock().unwrap().as_ref() {
         refresh_detail_pretty(w, pane, g, 0);

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -593,11 +593,25 @@ fn install_macos_app_icon() {}
 
 /// One cached SQL result, shown as a result tab. ⌘⏎ replaces the active one;
 /// ⌘\ appends a new one.
+/// Client-side grid view state (filters/sort/hidden/order/widths) for one result,
+/// so switching Result tabs restores each result exactly as it was left. An empty
+/// `col_order` is the "never touched" sentinel — restore is skipped, leaving the
+/// freshly-presented defaults.
+#[derive(Clone, Default)]
+struct GridState {
+    col_filters: Vec<String>,
+    sort: (i32, bool),
+    hidden: Vec<usize>,
+    col_order: Vec<usize>,
+    col_widths: Vec<f32>,
+}
+
 #[derive(Clone)]
 struct StoredResult {
     view: model::ResultView,
     meta: String,
     latency: String,
+    grid: GridState,
 }
 
 /// The live editor + result state a single **workspace tab group** owns
@@ -1773,6 +1787,79 @@ fn detail_pretty_row(g: &model::GridModel, row: usize) -> Vec<SharedString> {
 fn refresh_detail_pretty(w: &MainWindow, pane: usize, g: &model::GridModel, row: i32) {
     let rows = detail_pretty_row(g, row.max(0) as usize);
     set_p_detail_pretty(w, pane, ModelRc::from(Rc::new(VecModel::from(rows))));
+}
+fn get_p_col_widths(w: &MainWindow, pane: usize) -> Vec<f32> {
+    if pane == 0 {
+        w.get_grid_col_widths().iter().collect()
+    } else {
+        w.get_p1_col_widths().iter().collect()
+    }
+}
+/// Snapshot the live client-side grid view of a group, to stash on the result the
+/// user is leaving so switching back restores filters/sort/hidden/order/widths.
+fn capture_grid_state(w: &MainWindow, pane: usize, g: &GroupRuntime) -> GridState {
+    let mut hidden: Vec<usize> = g.hidden_cols.lock().unwrap().iter().copied().collect();
+    hidden.sort_unstable();
+    GridState {
+        col_filters: g.col_filters.lock().unwrap().clone(),
+        sort: *g.sort_state.lock().unwrap(),
+        hidden,
+        col_order: g.col_order.lock().unwrap().clone(),
+        col_widths: get_p_col_widths(w, pane),
+    }
+}
+/// Re-apply a result's saved grid view after `present_view` reset it to defaults.
+/// No-op when nothing was saved (`col_order` empty = never touched).
+fn restore_grid_state(w: &MainWindow, pane: usize, g: &GroupRuntime, sr: &StoredResult) {
+    let st = &sr.grid;
+    if st.col_order.is_empty() {
+        return;
+    }
+    let ncols = match &sr.view {
+        model::ResultView::Table(grid) => grid.columns.len(),
+        model::ResultView::Documents(d) => d.grid.columns.len(),
+        _ => return,
+    };
+    let hidden: HashSet<usize> = st.hidden.iter().copied().collect();
+    *g.col_filters.lock().unwrap() = st.col_filters.clone();
+    *g.sort_state.lock().unwrap() = st.sort;
+    *g.hidden_cols.lock().unwrap() = hidden.clone();
+    *g.col_order.lock().unwrap() = st.col_order.clone();
+    set_p_grid_sort(w, pane, st.sort.0, st.sort.1);
+    set_p_grid_col_filters(
+        w,
+        pane,
+        ModelRc::from(Rc::new(VecModel::from(display_col_filters(
+            &st.col_filters,
+            &st.col_order,
+            &hidden,
+        )))),
+    );
+    // Column hiding is a left-group feature (no p1 setter); flags apply there.
+    if pane == 0 {
+        let flags: Vec<bool> = (0..ncols).map(|c| hidden.contains(&c)).collect();
+        w.set_col_hidden(ModelRc::from(Rc::new(VecModel::from(flags))));
+    }
+    if !st.col_widths.is_empty() {
+        set_p_col_widths(
+            w,
+            pane,
+            ModelRc::from(Rc::new(VecModel::from(st.col_widths.clone()))),
+        );
+    }
+    let filtered = compute_view(
+        &sr.view,
+        "",
+        "any column",
+        "=",
+        &st.col_filters,
+        &hidden,
+        &st.col_order,
+        st.sort.0,
+        st.sort.1,
+    );
+    *g.displayed_grid.lock().unwrap() = view_grid(&filtered);
+    apply_result(w, pane, filtered);
 }
 fn set_p_editing(w: &MainWindow, pane: usize, row: i32, col: i32) {
     if pane == 0 {
@@ -4559,6 +4646,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     view,
                     meta: w.get_results_meta().to_string(),
                     latency: w.get_status_latency().to_string(),
+                    grid: GridState::default(),
                 });
             }
             // Persist SQL scratch tabs so they survive a restart. Cheap JSON
@@ -6066,6 +6154,7 @@ fn main() -> Result<(), slint::PlatformError> {
                                     view: v.clone(),
                                     meta: meta.clone(),
                                     latency: latency.clone(),
+                                    grid: GridState::default(),
                                 };
                                 let mut tabs = workspace_tabs.lock().unwrap();
                                 let Some(tab) = tabs.iter_mut().find(|tab| tab.id == target_id)
@@ -6317,6 +6406,7 @@ fn main() -> Result<(), slint::PlatformError> {
                                         view: view.clone(),
                                         meta: meta.clone(),
                                         latency: latency.clone(),
+                                        grid: GridState::default(),
                                     };
                                     if let Some(tab) = workspace_tabs
                                         .lock()
@@ -8036,11 +8126,21 @@ fn main() -> Result<(), slint::PlatformError> {
         let browse = browse.clone();
         let workspace_tabs = workspace_tabs.clone();
         let active_tab_id = active_tab_id.clone();
+        let panes = panes.clone();
         window.on_select_result_tab(move |i| {
             let Some(w) = weak.upgrade() else {
                 return;
             };
             let i = i.max(0) as usize;
+            // Stash the current result's live grid view before leaving it, so a
+            // round-trip back restores its filters/sort/hidden/order/widths.
+            let old = *active_result.lock().unwrap();
+            {
+                let state = capture_grid_state(&w, 0, &panes[0]);
+                if let Some(cur) = results.lock().unwrap().get_mut(old) {
+                    cur.grid = state;
+                }
+            }
             let sr = results.lock().unwrap().get(i).cloned();
             let Some(sr) = sr else {
                 return;
@@ -8060,7 +8160,7 @@ fn main() -> Result<(), slint::PlatformError> {
             present_view(
                 &w,
                 0,
-                sr.view,
+                sr.view.clone(),
                 &sr.meta,
                 &sr.latency,
                 &last_view,
@@ -8072,6 +8172,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 &edit_buf,
                 &browse,
             );
+            restore_grid_state(&w, 0, &panes[0], &sr);
         });
     }
     {
@@ -8152,6 +8253,13 @@ fn main() -> Result<(), slint::PlatformError> {
                 return;
             };
             let i = i.max(0) as usize;
+            let old = *panes[1].active_result.lock().unwrap();
+            {
+                let state = capture_grid_state(&w, 1, &panes[1]);
+                if let Some(cur) = panes[1].results.lock().unwrap().get_mut(old) {
+                    cur.grid = state;
+                }
+            }
             let sr = panes[1].results.lock().unwrap().get(i).cloned();
             let Some(sr) = sr else {
                 return;
@@ -8171,7 +8279,7 @@ fn main() -> Result<(), slint::PlatformError> {
             present_view(
                 &w,
                 1,
-                sr.view,
+                sr.view.clone(),
                 &sr.meta,
                 &sr.latency,
                 &last_view,
@@ -8183,6 +8291,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 &panes[1].edit_buf,
                 &panes[1].browse,
             );
+            restore_grid_state(&w, 1, &panes[1], &sr);
         });
     }
     {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -5561,7 +5561,17 @@ fn main() -> Result<(), slint::PlatformError> {
         let db_override = db_override.clone();
         let tabs_restored = tabs_restored.clone();
         let restore_tab = restore_tab.clone();
+        let save_active_tab = save_active_tab.clone();
+        let save_p1_tab = save_p1_tab.clone();
         window.on_connect_clicked(move |idx| {
+            // Flush the live editor text + results of the active tab(s) into the
+            // workspace model before it is rebuilt for the new connection. Without
+            // this a connection switch reads stale/empty tab text (the query looked
+            // duplicated or lost) and dropped the results of the inactive tabs.
+            if let Some(w) = weak.upgrade() {
+                save_active_tab(&w);
+                save_p1_tab(&w);
+            }
             let i = idx as usize;
             // One-shot: set by the database switcher, empty for a fresh picker
             // connect (which then uses the connection's saved database).

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2666,6 +2666,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     let spans: Vec<Span> = spans
                         .into_iter()
                         .map(|sp| Span {
+                            cols: sp.text.chars().count() as i32,
                             text: sp.text.into(),
                             kind: sp.kind,
                             sel: sp.sel,
@@ -3482,6 +3483,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     let spans: Vec<Span> = editor::lex_line(l)
                         .into_iter()
                         .map(|sp| Span {
+                            cols: sp.text.chars().count() as i32,
                             text: sp.text.into(),
                             kind: sp.kind,
                             sel: false,

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -150,6 +150,9 @@ export component MainWindow inherits Window {
     callback sort-col(int);
     callback reorder-col(int, length);
     in property <[string]> grid-col-filters;
+    // Per-column indented JSON for the selected row (Details panel preview).
+    in property <[string]> grid-detail-pretty;
+    in property <[string]> p1-detail-pretty;
     callback set-col-filter(int, string);
     in property <[TreeNode]> query-tree;  // sidebar Queries/History rows
     in property <[string]> schema-list;
@@ -1396,6 +1399,7 @@ callback create-table-commit();
                         p1-grid-sort-col: root.p1-grid-sort-col;
                         p1-grid-sort-asc: root.p1-grid-sort-asc;
                         p1-grid-col-filters: root.p1-grid-col-filters;
+                        p1-detail-pretty: root.p1-detail-pretty;
                         p1-selected-row <=> root.p1-selected-row;
                         p1-selected-col <=> root.p1-selected-col;
                         p1-editing-row: root.p1-editing-row;
@@ -1469,6 +1473,7 @@ callback create-table-commit();
                         sort-col(i) => { root.sort-col(i); }
                         reorder-col(i, x) => { root.reorder-col(i, x); }
                         grid-col-filters: root.grid-col-filters;
+                        grid-detail-pretty: root.grid-detail-pretty;
                         set-col-filter(i, t) => { root.set-col-filter(i, t); }
                         editor-lines: root.editor-lines;
                         editor-fold-state: root.editor-fold-state;

--- a/app/src/ui/code-editor.slint
+++ b/app/src/ui/code-editor.slint
@@ -148,8 +148,14 @@ export component CodeEditor inherits Rectangle {
                             spacing: 0;
                             alignment: start;
                             for span in line: Rectangle {
+                                // Pin each span to the caret's charw grid so the
+                                // rendered text and the caret/hit-test stay in lock
+                                // step — no drift, even glyph spacing on long lines.
+                                width: root.charw * span.cols;
+                                clip: true;
                                 background: span.sel ? Tokens.accent.with-alpha(0.18) : transparent;
                                 Text {
+                                    x: 0;
                                     vertical-alignment: center;
                                     text: span.text;
                                     font-family: Tokens.mono;

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -97,6 +97,9 @@ export component QueryPane inherits Rectangle {
     in property <int> grid-sort-col: -1;
     in property <bool> grid-sort-asc: true;
     in property <[string]> grid-col-filters;
+    // Per-column indented JSON for the selected row; blank when not JSON. Lets the
+    // Details panel show a formatted, read-only JSON value.
+    in property <[string]> detail-pretty;
     in-out property <int> selected-row: 0;
     in-out property <int> selected-col: -1;
     in property <int> editing-row: -1;
@@ -546,7 +549,10 @@ export component QueryPane inherits Rectangle {
                             spacing: Tokens.sp3;
                             for c in root.col-count: Rectangle {
                                 property <GridCell> detail-cell: root.cells[root.selected-row * root.col-count + c];
-                                height: 96px;
+                                // Formatted JSON for this cell (read-only results only), else "".
+                                property <string> pretty: root.read-only && root.detail-pretty.length > c ? root.detail-pretty[c] : "";
+                                // Give a JSON value room to breathe; plain cells stay compact.
+                                height: pretty != "" ? 220px : 96px;
                                 VerticalLayout {
                                     spacing: Tokens.sp1;
                                     HorizontalLayout {
@@ -591,7 +597,7 @@ export component QueryPane inherits Rectangle {
                                             y: Tokens.sp2;
                                             width: parent.width - 2 * Tokens.sp2;
                                             height: parent.height - 2 * Tokens.sp2;
-                                            text: detail-cell.is-null ? "" : detail-cell.text;
+                                            text: pretty != "" ? pretty : (detail-cell.is-null ? "" : detail-cell.text);
                                             enabled: !root.read-only;
                                             single-line: false;
                                             wrap: word-wrap;

--- a/app/src/ui/structs.slint
+++ b/app/src/ui/structs.slint
@@ -44,8 +44,9 @@ export struct TableCol { name: string, type-name: string, nullable: bool, pk: bo
 export struct TabItem { title: string, kind: string, preview: bool }
 // One lexed editor token; `kind`: 0 plain · 1 keyword · 2 string ·
 // 3 function · 4 comment · 5 number (mirrors app/src/editor.rs).
-// `sel` = inside the selection (background highlight).
-export struct Span { text: string, kind: int, sel: bool }
+// `sel` = inside the selection (background highlight). `cols` = char count, so
+// the renderer can pin the span to the same charw grid the caret uses.
+export struct Span { text: string, kind: int, sel: bool, cols: int }
 // One horizontal bar of the results chart; `frac` is value/max in [0,1].
 export struct ChartBar { label: string, value: string, frac: float }
 // One row of the Indexes view: index name + definition/columns.

--- a/app/src/ui/tabular-grid.slint
+++ b/app/src/ui/tabular-grid.slint
@@ -521,12 +521,16 @@ export component TabularGrid inherits Rectangle {
                     border-radius: Tokens.radius;
                     border-width: 1px;
                     border-color: Tokens.border;
-                    ScrollView {
+                    inspector-scroll := ScrollView {
+                        // Pin the viewport to the visible width so only vertical
+                        // scroll kicks in; the TextInput grows to its content height
+                        // so a long value scrolls with a real scrollbar.
+                        viewport-width: self.visible-width;
                         detail-input := TextInput {
                             x: Tokens.sp2;
                             y: Tokens.sp1;
-                            width: parent.visible-width - 2 * Tokens.sp2;
-                            height: max(parent.visible-height - 2 * Tokens.sp1, self.preferred-height);
+                            width: inspector-scroll.visible-width - 2 * Tokens.sp2;
+                            height: max(inspector-scroll.visible-height - 2 * Tokens.sp1, self.preferred-height);
                             read-only: true;
                             text: root.editing-value;
                             color: Tokens.text;

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -65,6 +65,7 @@ export component WorkArea inherits Rectangle {
     callback sort-col(int);
     callback reorder-col(int, length);
     in property <[string]> grid-col-filters;
+    in property <[string]> grid-detail-pretty;
     callback set-col-filter(int, string);
     in-out property <bool> sql-open: false;
     // SQL editor model (Rust lexer output) + cursor
@@ -169,6 +170,7 @@ export component WorkArea inherits Rectangle {
     in property <int> p1-grid-sort-col: -1;
     in property <bool> p1-grid-sort-asc: true;
     in property <[string]> p1-grid-col-filters;
+    in property <[string]> p1-detail-pretty;
     in-out property <int> p1-selected-row;
     in-out property <int> p1-selected-col: -1;
     in property <int> p1-editing-row: -1;
@@ -585,6 +587,7 @@ export component WorkArea inherits Rectangle {
             grid-sort-col: root.grid-sort-col;
             grid-sort-asc: root.grid-sort-asc;
             grid-col-filters: root.grid-col-filters;
+            detail-pretty: root.grid-detail-pretty;
             selected-row <=> root.selected-row;
             selected-col <=> root.selected-col;
             editing-row: root.editing-row;
@@ -701,6 +704,7 @@ export component WorkArea inherits Rectangle {
                 grid-sort-col: root.p1-grid-sort-col;
                 grid-sort-asc: root.p1-grid-sort-asc;
                 grid-col-filters: root.p1-grid-col-filters;
+                detail-pretty: root.p1-detail-pretty;
                 selected-row <=> root.p1-selected-row;
                 selected-col <=> root.p1-selected-col;
                 editing-row: root.p1-editing-row;


### PR DESCRIPTION
## Summary

- Fix a batch of SQL-workspace issues from heavy real use: data loss on connection switch, result-tab filter loss, weak cross-schema autocomplete, editor caret drift, a hidden details panel, and raw/cut-off JSON cells.

## Changes

**Connection switch (data loss)**
- Flush the active tab of both groups before rebuilding the workspace for a new connection, so each SQL tab keeps its own editor text (no more duplicated/lost query) and its results.

**Result tabs**
- Stash and restore each result's client-side grid view — column filters, sort, hidden columns, order, widths — when switching between Result tabs.

**Autocomplete**
- Resolve the FROM/JOIN tables in the current statement and offer their columns first, cross-schema included, so a query against another schema's table (e.g. `oss_rba_common.step_journal`) suggests its columns.

**Editor**
- Carry each syntax span's char count and pin its box to the caret's `charw` grid, so the rendered text and the caret/hit-test stay aligned on long lines.

**Details panel**
- Reset the selected row to the first row on every new result so the panel stays visible instead of failing its in-range gate.
- Slimmer already; now shows the selected row's JSON columns formatted.

**JSON cells**
- Pretty-print (indent) JSON for read-only display in the cell inspector and the details panel; editable grids keep raw text.
- Let a long value scroll vertically in the cell inspector.

## Test plan

- [x] `make fmt-check`
- [x] `make lint` (clippy, warnings as errors)
- [x] `cargo test -p rdb --bins` — all pass, incl. new cross-schema completion test
- [x] `make fe-build`
- [x] Manual (`make fe-run`): connection switch keeps each tab's text + results; Result-tab round-trip keeps filter/sort/hidden; `where step` on a cross-schema table suggests its columns; caret sits on the glyph on long lines; details panel stays visible after a smaller result; json cell double-click shows indented, scrollable JSON.
