### PR TITLE
feat(app): sidebar query actions, settings redesign, release naming

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,11 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
       - uses: googleapis/release-please-action@v5
         id: release
         with:
@@ -33,3 +38,24 @@ jobs:
         run: |
           gh release edit "${{ steps.release.outputs.tag_name }}" \
             --title "RDB: ${{ steps.release.outputs.tag_name }}"
+
+      # Match the CHANGELOG to the release title. release-please regenerates
+      # only the newest block on each run, so prefixing the top-most heading on
+      # the release-PR branch is idempotent and leaves older headings untouched.
+      - name: Prefix CHANGELOG heading with product name
+        if: ${{ steps.release.outputs.pr }}
+        run: |
+          branch=$(printf '%s' '${{ steps.release.outputs.pr }}' | jq -r '.headBranchName')
+          git fetch origin "$branch"
+          git checkout "$branch"
+          awk '!done && /^## \[/ { sub(/^## \[/, "## RDB: ["); done=1 } { print }' \
+            app/CHANGELOG.md > app/CHANGELOG.md.tmp
+          mv app/CHANGELOG.md.tmp app/CHANGELOG.md
+          if git diff --quiet -- app/CHANGELOG.md; then
+            echo "CHANGELOG heading already prefixed"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "docs: prefix changelog heading with RDB"
+          git push origin "$branch"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,8 +17,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v5
+        id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           target-branch: develop
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # The tag stays vX.Y.Z (release-build.yml keys off `v*`); only the
+      # GitHub Release display title gets the "RDB: " prefix.
+      - name: Prefix release title with product name
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          gh release edit "${{ steps.release.outputs.tag_name }}" \
+            --title "RDB: ${{ steps.release.outputs.tag_name }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5594,7 +5594,7 @@ dependencies = [
 
 [[package]]
 name = "rdb"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "async-trait",
  "copypasta",

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -9993,6 +9993,14 @@ fn main() -> Result<(), slint::PlatformError> {
             }
         });
     }
+    {
+        let weak = window.as_weak();
+        window.on_update_copy_hint(move || {
+            if let Some(w) = weak.upgrade() {
+                clip_set(&w.get_update_hint());
+            }
+        });
+    }
 
     // ----- manual "Check now" from settings: bypasses the daily throttle and
     // reports the outcome inline so the toggle no longer feels like a no-op -----

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1137,6 +1137,37 @@ fn save_saved(list: &[(String, String)]) {
     }
 }
 
+/// Build a short, unique slug name when saving a history query into the Saved
+/// list — first non-comment line, alphanumerics only, deduped against existing.
+fn derive_query_name(sql: &str, existing: &[(String, String)]) -> String {
+    let first = sql
+        .lines()
+        .map(|l| l.split("--").next().unwrap_or("").trim())
+        .find(|l| !l.is_empty())
+        .unwrap_or("")
+        .to_lowercase();
+    let mut slug: String = first
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    while slug.contains("--") {
+        slug = slug.replace("--", "-");
+    }
+    let slug: String = slug.trim_matches('-').chars().take(32).collect();
+    let base = if slug.is_empty() {
+        "query".to_string()
+    } else {
+        slug
+    };
+    if !existing.iter().any(|(n, _)| n == &base) {
+        return base;
+    }
+    (2..)
+        .map(|i| format!("{base}-{i}"))
+        .find(|c| !existing.iter().any(|(n, _)| n == c))
+        .unwrap_or(base)
+}
+
 /// Pretty-print (indent) a JSON string for read-only display. Returns `None`
 /// when the text isn't a JSON object/array, so plain cells are shown as-is.
 fn pretty_json(s: &str) -> Option<String> {
@@ -6840,10 +6871,12 @@ fn main() -> Result<(), slint::PlatformError> {
         });
     }
 
-    // ----- History context menu: insert, run, copy, or remove one entry. -----
+    // ----- History context menu: insert, run, copy, save to queries, or
+    // remove one entry. -----
     {
         let weak = window.as_weak();
         let recent_queries = recent_queries.clone();
+        let saved_queries = saved_queries.clone();
         let rebuild_query_tree = rebuild_query_tree.clone();
         window.on_history_action(move |idx, action| {
             let Some(w) = weak.upgrade() else {
@@ -6858,7 +6891,19 @@ fn main() -> Result<(), slint::PlatformError> {
                         clip_set(query);
                     }
                 }
-                3 if remove_recent(&recent_queries, idx) => {
+                3 => {
+                    // Promote a history entry into the curated Saved list.
+                    let Some(sql) = recent_queries.borrow().get(idx).cloned() else {
+                        return;
+                    };
+                    let name = derive_query_name(&sql, &saved_queries.borrow());
+                    saved_queries.borrow_mut().push((name, sql));
+                    if !mock::mock_mode() {
+                        save_saved(&saved_queries.borrow());
+                    }
+                    rebuild_query_tree("");
+                }
+                4 if remove_recent(&recent_queries, idx) => {
                     if !mock::mock_mode() {
                         save_recent(&recent_queries.borrow());
                     }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -6865,6 +6865,90 @@ fn main() -> Result<(), slint::PlatformError> {
         });
     }
 
+    // ----- Saved query ▶: run it directly (fresh result, editor untouched) -----
+    {
+        let weak = window.as_weak();
+        let run_sql = run_sql.clone();
+        let run_stream = run_stream.clone();
+        let cur_engine = cur_engine.clone();
+        let saved = saved_queries.clone();
+        window.on_run_saved_query(move |idx| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let Some((_, text)) = saved.get(idx.max(0) as usize) else {
+                return;
+            };
+            let text = (*text).to_string();
+            if text.trim().is_empty() {
+                return;
+            }
+            if active_tab_kind(&w) != "table" {
+                w.set_grid_read_only(true);
+            }
+            let stream = active_tab_kind(&w) != "table"
+                && cur_engine
+                    .borrow()
+                    .map(|e| is_bare_select(e, &text))
+                    .unwrap_or(false);
+            if stream {
+                run_stream(0, text);
+            } else {
+                run_sql(0, text);
+            }
+        });
+    }
+
+    // ----- Saved query context menu: run, open in new tab, insert, copy -----
+    {
+        let weak = window.as_weak();
+        let saved = saved_queries.clone();
+        let ed_state = ed_state.clone();
+        let sync_editor = sync_editor.clone();
+        let workspace_tabs = workspace_tabs.clone();
+        let active_tab_id = active_tab_id.clone();
+        window.on_query_action(move |idx, action| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let idx = idx.max(0) as usize;
+            let Some((name, sql)) = saved.get(idx) else {
+                return;
+            };
+            let (name, sql) = ((*name).to_string(), (*sql).to_string());
+            match action {
+                0 => w.invoke_run_saved_query(idx as i32),
+                1 => {
+                    // Force a fresh tab, then load the query into it.
+                    w.invoke_new_tab();
+                    w.invoke_open_query(SharedString::from(name), idx as i32);
+                }
+                2 => {
+                    // Append to the editor, never clobbering what's there.
+                    {
+                        let mut ed = ed_state.borrow_mut();
+                        let end_line = ed.lines.len().saturating_sub(1) as i32;
+                        let end_col =
+                            ed.lines.last().map(|l| l.chars().count()).unwrap_or(0) as i32;
+                        ed.move_to(end_line, end_col, false);
+                        let prefix = if ed.text().trim().is_empty() { "" } else { "\n\n" };
+                        ed.insert(&format!("{prefix}{sql}"));
+                    }
+                    sync_editor(0);
+                    if let Some(id) = active_tab_id.lock().unwrap().clone() {
+                        let new_text = ed_state.borrow().text();
+                        let mut tabs = workspace_tabs.lock().unwrap();
+                        if let Some(tab) = tabs.iter_mut().find(|t| t.id == id) {
+                            tab.query_text = new_text;
+                        }
+                    }
+                }
+                3 => clip_set(&sql),
+                _ => {}
+            }
+        });
+    }
+
     // ----- run query in the right split pane -----
     {
         let run_sql = run_sql.clone();

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1087,6 +1087,56 @@ fn save_recent(list: &[String]) {
     }
 }
 
+/// Seed shown the first time, before the user has a `saved_queries.json`.
+fn default_saved() -> Vec<(String, String)> {
+    [
+        (
+            "emiten-per-sektor",
+            "-- emiten per sektor\nSELECT s.name AS sector, count(*) AS total\nFROM emiten e\nJOIN sectors s ON s.id = e.id_sector\nWHERE e.country = 'indonesia'\nGROUP BY s.name\nORDER BY total DESC;",
+        ),
+        (
+            "seed-sectors",
+            "INSERT INTO sectors (name) VALUES\n  ('Financials'),\n  ('Energy'),\n  ('Healthcare'),\n  ('Industrials'),\n  ('Academic & Educational Services');",
+        ),
+        (
+            "dup-email-check",
+            "SELECT email, count(*)\nFROM users\nGROUP BY email\nHAVING count(*) > 1;",
+        ),
+        (
+            "tx-volume-daily",
+            "SELECT date_trunc('day', created_at) AS day, sum(amount)\nFROM transactions\nGROUP BY 1\nORDER BY 1 DESC;",
+        ),
+    ]
+    .into_iter()
+    .map(|(n, s)| (n.to_string(), s.to_string()))
+    .collect()
+}
+
+/// Load persisted saved queries. A missing/unreadable file falls back to the
+/// seed; a present-but-empty file stays empty so "delete all" sticks.
+fn load_saved() -> Vec<(String, String)> {
+    let Ok(path) = rdb_connstore::ConnStore::saved_queries_path() else {
+        return default_saved();
+    };
+    match std::fs::read_to_string(path) {
+        Ok(s) => serde_json::from_str(&s).unwrap_or_else(|_| default_saved()),
+        Err(_) => default_saved(),
+    }
+}
+
+/// Persist saved queries (best-effort; I/O errors are ignored).
+fn save_saved(list: &[(String, String)]) {
+    let Ok(path) = rdb_connstore::ConnStore::saved_queries_path() else {
+        return;
+    };
+    if let Some(dir) = path.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    if let Ok(json) = serde_json::to_string_pretty(list) {
+        let _ = std::fs::write(path, json);
+    }
+}
+
 /// Pretty-print (indent) a JSON string for read-only display. Returns `None`
 /// when the text isn't a JSON object/array, so plain cells are shown as-is.
 fn pretty_json(s: &str) -> Option<String> {
@@ -3582,24 +3632,14 @@ fn main() -> Result<(), slint::PlatformError> {
     }
 
     // ----- saved/recent queries (sidebar Queries tab) -----
-    let saved_queries: Rc<Vec<(&str, &str)>> = Rc::new(vec![
-        (
-            "emiten-per-sektor",
-            "-- emiten per sektor\nSELECT s.name AS sector, count(*) AS total\nFROM emiten e\nJOIN sectors s ON s.id = e.id_sector\nWHERE e.country = 'indonesia'\nGROUP BY s.name\nORDER BY total DESC;",
-        ),
-        (
-            "seed-sectors",
-            "INSERT INTO sectors (name) VALUES\n  ('Financials'),\n  ('Energy'),\n  ('Healthcare'),\n  ('Industrials'),\n  ('Academic & Educational Services');",
-        ),
-        (
-            "dup-email-check",
-            "SELECT email, count(*)\nFROM users\nGROUP BY email\nHAVING count(*) > 1;",
-        ),
-        (
-            "tx-volume-daily",
-            "SELECT date_trunc('day', created_at) AS day, sum(amount)\nFROM transactions\nGROUP BY 1\nORDER BY 1 DESC;",
-        ),
-    ]);
+    // User-curated saved queries: seeded on first run, then editable (delete)
+    // and persisted to disk. Mock mode always shows the seed and never writes.
+    let saved_queries: Rc<RefCell<Vec<(String, String)>>> =
+        Rc::new(RefCell::new(if mock::mock_mode() {
+            default_saved()
+        } else {
+            load_saved()
+        }));
     // Live history: filled as queries run; mock mode seeds a few for the
     // screenshot harness.
     let recent_queries: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(if mock::mock_mode() {
@@ -3626,6 +3666,7 @@ fn main() -> Result<(), slint::PlatformError> {
             let history_only = w.get_sidebar_mode() == 2;
             let mut rows: Vec<TreeNode> = Vec::new();
             if !history_only {
+                let saved = saved.borrow();
                 rows.push(TreeNode {
                     label: "Saved".into(),
                     depth: 0,
@@ -3636,10 +3677,10 @@ fn main() -> Result<(), slint::PlatformError> {
                 });
                 for (i, (name, _)) in saved.iter().enumerate() {
                     rows.push(TreeNode {
-                        label: (*name).into(),
+                        label: name.as_str().into(),
                         depth: 1,
                         kind: "query".into(),
-                        expanded: *name == active,
+                        expanded: name == active,
                         db: SharedString::default(),
                         count: i as i32,
                     });
@@ -3687,14 +3728,18 @@ fn main() -> Result<(), slint::PlatformError> {
             let Some(w) = weak.upgrade() else {
                 return;
             };
-            let (title, text, is_saved) =
-                if let Some((name, sql)) = saved.iter().find(|(n, _)| *n == label.as_str()) {
-                    ((*name).to_string(), (*sql).to_string(), true)
-                } else if let Some(sql) = recent.borrow().get(idx.max(0) as usize) {
-                    ("Query".to_string(), sql.clone(), false)
-                } else {
-                    return;
-                };
+            let saved_hit = saved
+                .borrow()
+                .iter()
+                .find(|(n, _)| n == label.as_str())
+                .map(|(n, s)| (n.clone(), s.clone()));
+            let (title, text, is_saved) = if let Some((name, sql)) = saved_hit {
+                (name, sql, true)
+            } else if let Some(sql) = recent.borrow().get(idx.max(0) as usize) {
+                ("Query".to_string(), sql.clone(), false)
+            } else {
+                return;
+            };
             if active_tab_id.lock().unwrap().is_none() || active_tab_kind(&w) != "sql" {
                 w.invoke_new_tab();
             }
@@ -6876,10 +6921,13 @@ fn main() -> Result<(), slint::PlatformError> {
             let Some(w) = weak.upgrade() else {
                 return;
             };
-            let Some((_, text)) = saved.get(idx.max(0) as usize) else {
+            let Some(text) = saved
+                .borrow()
+                .get(idx.max(0) as usize)
+                .map(|(_, s)| s.clone())
+            else {
                 return;
             };
-            let text = (*text).to_string();
             if text.trim().is_empty() {
                 return;
             }
@@ -6899,7 +6947,8 @@ fn main() -> Result<(), slint::PlatformError> {
         });
     }
 
-    // ----- Saved query context menu: run, open in new tab, insert, copy -----
+    // ----- Saved query context menu: run, open in new tab, insert, copy,
+    // delete (persisted). -----
     {
         let weak = window.as_weak();
         let saved = saved_queries.clone();
@@ -6907,15 +6956,15 @@ fn main() -> Result<(), slint::PlatformError> {
         let sync_editor = sync_editor.clone();
         let workspace_tabs = workspace_tabs.clone();
         let active_tab_id = active_tab_id.clone();
+        let rebuild_query_tree = rebuild_query_tree.clone();
         window.on_query_action(move |idx, action| {
             let Some(w) = weak.upgrade() else {
                 return;
             };
             let idx = idx.max(0) as usize;
-            let Some((name, sql)) = saved.get(idx) else {
+            let Some((name, sql)) = saved.borrow().get(idx).cloned() else {
                 return;
             };
-            let (name, sql) = ((*name).to_string(), (*sql).to_string());
             match action {
                 0 => w.invoke_run_saved_query(idx as i32),
                 1 => {
@@ -6931,7 +6980,11 @@ fn main() -> Result<(), slint::PlatformError> {
                         let end_col =
                             ed.lines.last().map(|l| l.chars().count()).unwrap_or(0) as i32;
                         ed.move_to(end_line, end_col, false);
-                        let prefix = if ed.text().trim().is_empty() { "" } else { "\n\n" };
+                        let prefix = if ed.text().trim().is_empty() {
+                            ""
+                        } else {
+                            "\n\n"
+                        };
                         ed.insert(&format!("{prefix}{sql}"));
                     }
                     sync_editor(0);
@@ -6944,6 +6997,23 @@ fn main() -> Result<(), slint::PlatformError> {
                     }
                 }
                 3 => clip_set(&sql),
+                4 => {
+                    let removed = {
+                        let mut list = saved.borrow_mut();
+                        if idx < list.len() {
+                            list.remove(idx);
+                            true
+                        } else {
+                            false
+                        }
+                    };
+                    if removed {
+                        if !mock::mock_mode() {
+                            save_saved(&saved.borrow());
+                        }
+                        rebuild_query_tree("");
+                    }
+                }
                 _ => {}
             }
         });

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -209,6 +209,10 @@ callback create-table-commit();
     callback insert-query(int);
     callback rerun-query(int);
     callback history-action(int, int);
+    // Saved query actions: run directly, or menu (0 run, 1 new tab, 2 insert,
+    // 3 copy, 4 delete).
+    callback run-saved-query(int);
+    callback query-action(int, int);
     callback sidebar-mode-changed(int);
 
     // ----- connections screen detail panel -----
@@ -1026,6 +1030,8 @@ callback create-table-commit();
                     insert-query(i) => { root.insert-query(i); }
                     rerun-query(i) => { root.rerun-query(i); }
                     history-action(i, a) => { root.history-action(i, a); }
+                    run-saved-query(i) => { root.run-saved-query(i); }
+                    query-action(i, a) => { root.query-action(i, a); }
                     mode-changed(m) => { root.sidebar-mode = m; root.sidebar-mode-changed(m); }
                     open-table(db, t) => { root.open-table(db, t); }
                     pin-table(db, t) => { root.pin-table(db, t); }
@@ -1753,6 +1759,8 @@ callback create-table-commit();
                     insert-query(i) => { root.insert-query(i); }
                     rerun-query(i) => { root.rerun-query(i); }
                     history-action(i, a) => { root.history-action(i, a); }
+                    run-saved-query(i) => { root.run-saved-query(i); }
+                    query-action(i, a) => { root.query-action(i, a); }
                     mode-changed(m) => { root.sidebar-mode = m; root.sidebar-mode-changed(m); }
                     open-table(db, t) => { root.open-table(db, t); }
                     pin-table(db, t) => { root.pin-table(db, t); }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -2574,18 +2574,42 @@ callback create-table-commit();
                     { k: "Esc", a: "Close dialog" },
                 ]: HorizontalLayout {
                     spacing: Tokens.sp3;
-                    Text {
-                        width: 72px;
-                        text: row.k;
-                        color: Tokens.text;
-                        font-family: Tokens.mono;
-                        font-size: Tokens.font-sm;
+                    height: 26px;
+                    // fixed key column so every description starts on the same line
+                    Rectangle {
+                        width: 92px;
+                        HorizontalLayout {
+                            alignment: start;
+                            VerticalLayout {
+                                alignment: center;
+                                // kbd chip
+                                Rectangle {
+                                    height: 20px;
+                                    border-radius: Tokens.radius;
+                                    border-width: 1px;
+                                    border-color: Tokens.border-strong;
+                                    background: Tokens.chrome;
+                                    HorizontalLayout {
+                                        padding-left: Tokens.sp2;
+                                        padding-right: Tokens.sp2;
+                                        Text {
+                                            text: row.k;
+                                            color: Tokens.text;
+                                            font-family: Tokens.mono;
+                                            font-size: Tokens.font-sm;
+                                            vertical-alignment: center;
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                     Text {
                         horizontal-stretch: 1;
                         text: row.a;
                         color: Tokens.text-dim;
                         font-size: Tokens.font-sm;
+                        vertical-alignment: center;
                     }
                 }
 

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -512,6 +512,7 @@ callback create-table-commit();
     in property <string> update-hint;      // install-method upgrade instruction
     callback update-open();                // open the release page
     callback update-dismiss();             // hide until next launch
+    callback update-copy-hint();           // copy the upgrade command/hint
     callback check-updates-now();          // manual check from settings
     in property <string> update-check-status; // settings feedback line
 
@@ -2426,10 +2427,50 @@ callback create-table-commit();
                         VerticalLayout {
                             alignment: center;
                             horizontal-stretch: 1;
-                            Text {
+                            // Plain status while no update is pending; the
+                            // actionable card below takes over once one is.
+                            if !root.update-available: Text {
                                 text: root.update-check-status;
                                 color: Tokens.text-dim;
                                 font-size: 12px;
+                            }
+                        }
+                    }
+
+                    // Actionable prompt: surfaces the same update the corner
+                    // banner shows, but with Open + Copy right where the user
+                    // just clicked "Check now".
+                    if root.update-available: Rectangle {
+                        border-radius: Tokens.radius;
+                        border-width: 1px;
+                        border-color: Tokens.accent;
+                        background: Tokens.accent-tint;
+                        VerticalLayout {
+                            padding: Tokens.sp3;
+                            spacing: Tokens.sp2;
+                            Text {
+                                text: "✔ Update available — v" + root.update-version;
+                                color: Tokens.text;
+                                font-size: 13px;
+                                font-weight: 600;
+                            }
+                            Text {
+                                text: root.update-hint;
+                                color: Tokens.text-dim;
+                                font-size: 12px;
+                                wrap: word-wrap;
+                            }
+                            HorizontalLayout {
+                                spacing: Tokens.sp2;
+                                alignment: start;
+                                PrimaryButton {
+                                    text: "Open";
+                                    clicked => { root.update-open(); }
+                                }
+                                SecondaryButton {
+                                    text: "Copy";
+                                    clicked => { root.update-copy-hint(); }
+                                }
                             }
                         }
                     }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -3,7 +3,7 @@ export { Theme }
 import { Tokens } from "tokens.slint";
 export { Tokens }
 import {
-    SearchCommandPill, BreadcrumbChip, GlyphButton, IconButton, PrimaryButton, SecondaryButton, SelectBox, TextButton, Tooltip
+    SearchCommandPill, BreadcrumbChip, GlyphButton, IconButton, PrimaryButton, SecondaryButton, SelectBox, TextButton, Toggle, ToggleRow, Tooltip
 } from "components.slint";
 import { NavCluster } from "nav-cluster.slint";
 import { ConnPicker } from "picker.slint";
@@ -120,7 +120,7 @@ export component MainWindow inherits Window {
             }
             MenuItem {
                 title: "About RDB";
-                activated => { root.about-open = true; }
+                activated => { root.settings-tab = 2; root.settings-open = true; }
             }
         }
     }
@@ -522,7 +522,8 @@ callback create-table-commit();
     in property <int> history-max-entries: 50;
     callback set-history-max-entries(int);
     in-out property <bool> shortcuts-open: false;
-    in-out property <bool> about-open: false;
+    // Settings modal active section: 0 Appearance, 1 Updates, 2 About.
+    in-out property <int> settings-tab: 0;
     in property <string> app-version;
 
     // ----- connection form -----
@@ -565,12 +566,11 @@ callback create-table-commit();
         key-pressed(e) => {
             if (e.text == Key.Escape) {
                 if (root.db-modal-open || root.conn-modal-open || root.palette-open
-                    || root.settings-open || root.shortcuts-open || root.about-open) {
+                    || root.settings-open || root.shortcuts-open) {
                     root.db-modal-open = false;
                     root.conn-modal-open = false;
                     root.settings-open = false;
                     root.shortcuts-open = false;
-                    root.about-open = false;
                     if (root.palette-open) { root.toggle-palette(); }
                     return accept;
                 }
@@ -2308,7 +2308,7 @@ callback create-table-commit();
         }
 
         Rectangle {
-            width: 420px;
+            width: 460px;
             x: (parent.width - self.width) / 2;
             y: 120px;
             height: settings-card.preferred-height;
@@ -2336,173 +2336,134 @@ callback create-table-commit();
                     horizontal-alignment: center;
                 }
 
-                // --- appearance ---
+                // --- section tabs ---
                 HorizontalLayout {
-                    spacing: Tokens.sp3;
-                    VerticalLayout {
-                        alignment: center;
-                        horizontal-stretch: 1;
+                    spacing: 2px;
+                    for tab[i] in ["Appearance", "Updates", "About"]: Rectangle {
+                        height: 28px;
+                        border-radius: Tokens.radius;
+                        background: root.settings-tab == i ? Tokens.accent-tint
+                            : (seg-ta.has-hover ? Tokens.chrome : transparent);
                         Text {
-                            text: "Dark mode";
-                            color: Tokens.text;
-                            font-size: 13px;
+                            text: tab;
+                            color: root.settings-tab == i ? Tokens.accent : Tokens.text-dim;
+                            font-size: Tokens.font-sm;
+                            font-weight: root.settings-tab == i ? Tokens.weight-emphasis : 400;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
                         }
-                    }
-                    VerticalLayout {
-                        alignment: center;
-                        TouchArea {
-                            width: 42px;
-                            height: 24px;
-                            clicked => { root.toggle-theme(); }
-                            Rectangle {
-                                border-radius: 12px;
-                                background: Tokens.dark ? Tokens.accent : Tokens.border-strong;
-                                Rectangle {
-                                    width: 18px;
-                                    height: 18px;
-                                    border-radius: 9px;
-                                    background: #FFFFFF;
-                                    x: Tokens.dark ? parent.width - self.width - 3px : 3px;
-                                    y: (parent.height - self.height) / 2;
-                                }
-                            }
+                        seg-ta := TouchArea {
+                            clicked => { root.settings-tab = i; }
                         }
                     }
                 }
+                Rectangle { height: 1px; background: Tokens.border; }
 
-                // --- sidebar side ---
-                HorizontalLayout {
+                // --- Appearance ---
+                if root.settings-tab == 0: VerticalLayout {
                     spacing: Tokens.sp3;
-                    VerticalLayout {
-                        alignment: center;
-                        horizontal-stretch: 1;
-                        Text {
-                            text: "Sidebar on the right";
-                            color: Tokens.text;
-                            font-size: 13px;
+                    ToggleRow {
+                        label: "Dark mode";
+                        checked: Tokens.dark;
+                        toggled => { root.toggle-theme(); }
+                    }
+                    ToggleRow {
+                        label: "Sidebar on the right";
+                        checked: root.sidebar-right;
+                        toggled => {
+                            root.sidebar-right = !root.sidebar-right;
+                            root.set-sidebar-side(root.sidebar-right);
                         }
                     }
-                    VerticalLayout {
-                        alignment: center;
-                        TouchArea {
-                            width: 42px;
-                            height: 24px;
+                    HorizontalLayout {
+                        spacing: Tokens.sp3;
+                        VerticalLayout {
+                            alignment: center;
+                            horizontal-stretch: 1;
+                            Text {
+                                text: "History entries";
+                                color: Tokens.text;
+                                font-size: 13px;
+                            }
+                        }
+                        SelectBox {
+                            width: 82px;
+                            model: ["25", "50", "100", "200"];
+                            current-value: root.history-max-entries == 25 ? "25"
+                                : root.history-max-entries == 100 ? "100"
+                                : root.history-max-entries == 200 ? "200" : "50";
+                            selected(value) => {
+                                root.set-history-max-entries(value == "25" ? 25
+                                    : value == "100" ? 100 : value == "200" ? 200 : 50);
+                            }
+                        }
+                    }
+                    HorizontalLayout {
+                        SecondaryButton {
+                            text: "Keyboard Shortcuts";
                             clicked => {
-                                root.sidebar-right = !root.sidebar-right;
-                                root.set-sidebar-side(root.sidebar-right);
-                            }
-                            Rectangle {
-                                border-radius: 12px;
-                                background: root.sidebar-right ? Tokens.accent : Tokens.border-strong;
-                                Rectangle {
-                                    width: 18px;
-                                    height: 18px;
-                                    border-radius: 9px;
-                                    background: #FFFFFF;
-                                    x: root.sidebar-right ? parent.width - self.width - 3px : 3px;
-                                    y: (parent.height - self.height) / 2;
-                                }
+                                root.settings-open = false;
+                                root.shortcuts-open = true;
                             }
                         }
                     }
                 }
 
-                // --- updates ---
-                HorizontalLayout {
+                // --- Updates ---
+                if root.settings-tab == 1: VerticalLayout {
                     spacing: Tokens.sp3;
-                    VerticalLayout {
-                        alignment: center;
-                        horizontal-stretch: 1;
-                        Text {
-                            text: "Check for updates on launch";
-                            color: Tokens.text;
-                            font-size: 13px;
-                        }
+                    ToggleRow {
+                        label: "Check for updates on launch";
+                        checked: root.update-check-enabled;
+                        toggled => { root.set-update-check(!root.update-check-enabled); }
                     }
-                    VerticalLayout {
-                        alignment: center;
-                        TouchArea {
-                            width: 42px;
-                            height: 24px;
-                            clicked => { root.set-update-check(!root.update-check-enabled); }
-                            Rectangle {
-                                border-radius: 12px;
-                                background: root.update-check-enabled ? Tokens.accent : Tokens.border-strong;
-                                Rectangle {
-                                    width: 18px;
-                                    height: 18px;
-                                    border-radius: 9px;
-                                    background: #FFFFFF;
-                                    x: root.update-check-enabled ? parent.width - self.width - 3px : 3px;
-                                    y: (parent.height - self.height) / 2;
-                                }
+                    HorizontalLayout {
+                        spacing: Tokens.sp3;
+                        SecondaryButton {
+                            text: "Check now";
+                            clicked => { root.check-updates-now(); }
+                        }
+                        VerticalLayout {
+                            alignment: center;
+                            horizontal-stretch: 1;
+                            Text {
+                                text: root.update-check-status;
+                                color: Tokens.text-dim;
+                                font-size: 12px;
                             }
                         }
                     }
                 }
 
-                // --- manual update check ---
-                HorizontalLayout {
-                    spacing: Tokens.sp3;
-                    SecondaryButton {
-                        text: "Check now";
-                        clicked => { root.check-updates-now(); }
+                // --- About ---
+                if root.settings-tab == 2: VerticalLayout {
+                    spacing: Tokens.sp2;
+                    Text {
+                        text: "RDB";
+                        color: Tokens.text;
+                        font-size: 22px;
+                        font-weight: 700;
+                        horizontal-alignment: center;
                     }
-                    VerticalLayout {
-                        alignment: center;
-                        horizontal-stretch: 1;
-                        Text {
-                            text: root.update-check-status;
-                            color: Tokens.text-dim;
-                            font-size: 12px;
-                        }
+                    Text {
+                        text: "Version " + root.app-version;
+                        color: Tokens.text-dim;
+                        font-size: Tokens.font-sm;
+                        font-family: Tokens.mono;
+                        horizontal-alignment: center;
                     }
-                }
-
-                // --- query history ---
-                HorizontalLayout {
-                    spacing: Tokens.sp3;
-                    VerticalLayout {
-                        alignment: center;
-                        horizontal-stretch: 1;
-                        Text {
-                            text: "History entries";
-                            color: Tokens.text;
-                            font-size: 13px;
-                        }
+                    Text {
+                        text: "Native cross-platform database manager";
+                        color: Tokens.text-dim;
+                        font-size: Tokens.font-sm;
+                        horizontal-alignment: center;
+                        wrap: word-wrap;
                     }
-                    SelectBox {
-                        width: 82px;
-                        model: ["25", "50", "100", "200"];
-                        current-value: root.history-max-entries == 25 ? "25"
-                            : root.history-max-entries == 100 ? "100"
-                            : root.history-max-entries == 200 ? "200" : "50";
-                        selected(value) => {
-                            root.set-history-max-entries(value == "25" ? 25
-                                : value == "100" ? 100 : value == "200" ? 200 : 50);
-                        }
-                    }
-                }
-
-                // --- keyboard shortcuts ---
-                HorizontalLayout {
-                    SecondaryButton {
-                        text: "Keyboard Shortcuts";
-                        clicked => {
-                            root.settings-open = false;
-                            root.shortcuts-open = true;
-                        }
-                    }
-                }
-
-                // --- about ---
-                HorizontalLayout {
-                    SecondaryButton {
-                        text: "About RDB";
-                        clicked => {
-                            root.settings-open = false;
-                            root.about-open = true;
-                        }
+                    Text {
+                        text: "PostgreSQL · MySQL · Redis · MongoDB";
+                        color: Tokens.text-faint;
+                        font-size: Tokens.font-xs;
+                        horizontal-alignment: center;
                     }
                 }
 
@@ -2591,72 +2552,6 @@ callback create-table-commit();
                     PrimaryButton {
                         text: "Done";
                         clicked => { root.shortcuts-open = false; }
-                    }
-                }
-            }
-        }
-    }
-
-    // ----- about modal (veil + centered card) -----
-    if root.about-open: Rectangle {
-        background: Tokens.veil;
-        TouchArea {
-            clicked => { root.about-open = false; }
-        }
-
-        Rectangle {
-            width: 380px;
-            x: (parent.width - self.width) / 2;
-            y: 130px;
-            height: about-card.preferred-height;
-            border-radius: Tokens.modal-radius;
-            background: Tokens.card;
-            border-width: 1px;
-            border-color: Tokens.border;
-            drop-shadow-blur: 42px;
-            drop-shadow-offset-y: 12px;
-            drop-shadow-color: #1C191426;
-
-            TouchArea {}
-
-            about-card := VerticalLayout {
-                padding: Tokens.sp4;
-                padding-top: 22px;
-                spacing: Tokens.sp2;
-
-                Text {
-                    text: "RDB";
-                    color: Tokens.text;
-                    font-size: 22px;
-                    font-weight: 700;
-                    horizontal-alignment: center;
-                }
-                Text {
-                    text: "Version " + root.app-version;
-                    color: Tokens.text-dim;
-                    font-size: Tokens.font-sm;
-                    font-family: Tokens.mono;
-                    horizontal-alignment: center;
-                }
-                Text {
-                    text: "Native cross-platform database manager";
-                    color: Tokens.text-dim;
-                    font-size: Tokens.font-sm;
-                    horizontal-alignment: center;
-                    wrap: word-wrap;
-                }
-                Text {
-                    text: "PostgreSQL · MySQL · Redis · MongoDB";
-                    color: Tokens.text-faint;
-                    font-size: Tokens.font-xs;
-                    horizontal-alignment: center;
-                }
-
-                HorizontalLayout {
-                    alignment: center;
-                    PrimaryButton {
-                        text: "Done";
-                        clicked => { root.about-open = false; }
                     }
                 }
             }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -2582,14 +2582,17 @@ callback create-table-commit();
                             alignment: start;
                             VerticalLayout {
                                 alignment: center;
-                                // kbd chip
+                                // kbd chip — uniform min-width so single keys
+                                // don't look cramped next to the wide ones
                                 Rectangle {
-                                    height: 20px;
+                                    height: 22px;
+                                    min-width: 34px;
                                     border-radius: Tokens.radius;
                                     border-width: 1px;
                                     border-color: Tokens.border-strong;
                                     background: Tokens.chrome;
                                     HorizontalLayout {
+                                        alignment: center;
                                         padding-left: Tokens.sp2;
                                         padding-right: Tokens.sp2;
                                         Text {
@@ -2597,6 +2600,7 @@ callback create-table-commit();
                                             color: Tokens.text;
                                             font-family: Tokens.mono;
                                             font-size: Tokens.font-sm;
+                                            horizontal-alignment: center;
                                             vertical-alignment: center;
                                         }
                                     }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -2460,10 +2460,11 @@ callback create-table-commit();
                         wrap: word-wrap;
                     }
                     Text {
-                        text: "PostgreSQL · MySQL · Redis · MongoDB";
+                        text: "PostgreSQL · MySQL · Redis · MongoDB · SQLite · Cassandra";
                         color: Tokens.text-faint;
                         font-size: Tokens.font-xs;
                         horizontal-alignment: center;
+                        wrap: word-wrap;
                     }
                 }
 

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -2,6 +2,52 @@
 import { Tokens } from "tokens.slint";
 import { AppIcon } from "icons.slint";
 
+// iOS-style on/off switch. One place for the pill + sliding knob so every
+// settings toggle stays identical.
+export component Toggle inherits TouchArea {
+    in property <bool> checked;
+    callback toggled();
+    width: 42px;
+    height: 24px;
+    clicked => { root.toggled(); }
+    Rectangle {
+        border-radius: 12px;
+        background: root.checked ? Tokens.accent : Tokens.border-strong;
+        Rectangle {
+            width: 18px;
+            height: 18px;
+            border-radius: 9px;
+            background: #FFFFFF;
+            x: root.checked ? parent.width - self.width - 3px : 3px;
+            y: (parent.height - self.height) / 2;
+        }
+    }
+}
+
+// A settings line: label on the left, toggle on the right.
+export component ToggleRow inherits HorizontalLayout {
+    in property <string> label;
+    in property <bool> checked;
+    callback toggled();
+    spacing: Tokens.sp3;
+    VerticalLayout {
+        alignment: center;
+        horizontal-stretch: 1;
+        Text {
+            text: root.label;
+            color: Tokens.text;
+            font-size: 13px;
+        }
+    }
+    VerticalLayout {
+        alignment: center;
+        Toggle {
+            checked: root.checked;
+            toggled => { root.toggled(); }
+        }
+    }
+}
+
 // Shared tooltip state. Buttons report their hovered tooltip + window-space
 // anchor here; a single overlay in app-window.slint draws it on the top layer
 // so it is never clipped by content painted after the toolbar row.

--- a/app/src/ui/nav-cluster.slint
+++ b/app/src/ui/nav-cluster.slint
@@ -40,6 +40,8 @@ export component NavCluster inherits HorizontalLayout {
     callback insert-query(int);
     callback rerun-query(int);
     callback history-action(int, int);
+    callback run-saved-query(int);
+    callback query-action(int, int);
     callback mode-changed(int);
     callback open-table(string, string);
     callback pin-table(string, string);
@@ -89,6 +91,8 @@ export component NavCluster inherits HorizontalLayout {
         insert-query(i) => { root.insert-query(i); }
         rerun-query(i) => { root.rerun-query(i); }
         history-action(i, a) => { root.history-action(i, a); }
+        run-saved-query(i) => { root.run-saved-query(i); }
+        query-action(i, a) => { root.query-action(i, a); }
         mode-changed(m) => { root.mode-changed(m); }
         open-table(db, t) => { root.open-table(db, t); }
         pin-table(db, t) => { root.pin-table(db, t); }

--- a/app/src/ui/sidebar.slint
+++ b/app/src/ui/sidebar.slint
@@ -31,6 +31,9 @@ export component Sidebar inherits Rectangle {
     callback rerun-query(int);             // History ▶: run it, editor untouched
     // History menu action: 0 insert, 1 run, 2 copy, 3 delete.
     callback history-action(int, int);
+    callback run-saved-query(int);         // Saved ▶: run it, editor untouched
+    // Saved menu action: 0 run, 1 open in new tab, 2 insert, 3 copy, 4 delete.
+    callback query-action(int, int);
     callback toggle-node(string);
     callback select-schema(string);
     callback filter-tree(string);
@@ -47,6 +50,8 @@ export component Sidebar inherits Rectangle {
     property <string> pending-label;
     property <int> history-menu-index: -1;
     property <length> history-menu-y: 0px;
+    property <int> query-menu-index: -1;
+    property <length> query-menu-y: 0px;
     click-timer := Timer {
         interval: 220ms;
         running: false;
@@ -165,6 +170,11 @@ export component Sidebar inherits Rectangle {
                                 root.history-menu-index = node.count;
                                 root.history-menu-y = self.absolute-position.y - root.absolute-position.y;
                                 history-menu.show();
+                            } else if (e.kind == PointerEventKind.down && e.button == PointerEventButton.right
+                                && node.kind == "query") {
+                                root.query-menu-index = node.count;
+                                root.query-menu-y = self.absolute-position.y - root.absolute-position.y;
+                                query-menu.show();
                             }
                         }
                         clicked => {
@@ -303,9 +313,10 @@ export component Sidebar inherits Rectangle {
                             overflow: elide;
                         }
 
-                        // History ▶: re-run this entry directly (editor untouched).
-                        // Nested TouchArea wins over the row, so the row still appends.
-                        if node.kind == "recent": Rectangle {
+                        // ▶: re-run this entry directly (editor untouched).
+                        // Nested TouchArea wins over the row, so the row still
+                        // performs its own click action (append / open).
+                        if node.kind == "recent" || node.kind == "query": Rectangle {
                             width: 20px;
                             AppIcon {
                                 x: 4px;
@@ -315,7 +326,13 @@ export component Sidebar inherits Rectangle {
                                 color: rerun-ta.has-hover ? Tokens.accent : Tokens.text-faint;
                             }
                             rerun-ta := TouchArea {
-                                clicked => { root.rerun-query(node.count); }
+                                clicked => {
+                                    if (node.kind == "recent") {
+                                        root.rerun-query(node.count);
+                                    } else {
+                                        root.run-saved-query(node.count);
+                                    }
+                                }
                             }
                         }
 
@@ -422,6 +439,41 @@ export component Sidebar inherits Rectangle {
                         clicked => {
                             root.history-action(root.history-menu-index, action);
                             history-menu.close();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    query-menu := PopupWindow {
+        x: root.width - 176px;
+        y: min(root.query-menu-y, root.height - 156px);
+        width: 172px;
+        Rectangle {
+            background: Tokens.card;
+            border-radius: Tokens.radius;
+            border-width: 1px;
+            border-color: Tokens.border-strong;
+            drop-shadow-blur: 12px;
+            drop-shadow-color: Tokens.text.with-alpha(0.25);
+            VerticalLayout {
+                padding: 4px;
+                for label[action] in ["Run", "Open in new tab", "Insert to editor", "Copy query"]: Rectangle {
+                    height: 28px;
+                    border-radius: Tokens.radius;
+                    background: qmenu-ta.has-hover ? Tokens.accent-tint : transparent;
+                    Text {
+                        x: Tokens.sp2;
+                        text: label;
+                        color: Tokens.text;
+                        font-size: Tokens.font-sm;
+                        vertical-alignment: center;
+                    }
+                    qmenu-ta := TouchArea {
+                        clicked => {
+                            root.query-action(root.query-menu-index, action);
+                            query-menu.close();
                         }
                     }
                 }

--- a/app/src/ui/sidebar.slint
+++ b/app/src/ui/sidebar.slint
@@ -459,14 +459,14 @@ export component Sidebar inherits Rectangle {
             drop-shadow-color: Tokens.text.with-alpha(0.25);
             VerticalLayout {
                 padding: 4px;
-                for label[action] in ["Run", "Open in new tab", "Insert to editor", "Copy query"]: Rectangle {
+                for label[action] in ["Run", "Open in new tab", "Insert to editor", "Copy query", "Delete"]: Rectangle {
                     height: 28px;
                     border-radius: Tokens.radius;
-                    background: qmenu-ta.has-hover ? Tokens.accent-tint : transparent;
+                    background: qmenu-ta.has-hover ? (action == 4 ? Tokens.error-tint : Tokens.accent-tint) : transparent;
                     Text {
                         x: Tokens.sp2;
                         text: label;
-                        color: Tokens.text;
+                        color: action == 4 ? Tokens.error : Tokens.text;
                         font-size: Tokens.font-sm;
                         vertical-alignment: center;
                     }

--- a/app/src/ui/sidebar.slint
+++ b/app/src/ui/sidebar.slint
@@ -29,7 +29,7 @@ export component Sidebar inherits Rectangle {
     callback open-query(string, int);      // (label, index in its section)
     callback insert-query(int);            // History row: append its SQL to editor
     callback rerun-query(int);             // History ▶: run it, editor untouched
-    // History menu action: 0 insert, 1 run, 2 copy, 3 delete.
+    // History menu action: 0 insert, 1 run, 2 copy, 3 save to queries, 4 delete.
     callback history-action(int, int);
     callback run-saved-query(int);         // Saved ▶: run it, editor untouched
     // Saved menu action: 0 run, 1 open in new tab, 2 insert, 3 copy, 4 delete.
@@ -424,14 +424,14 @@ export component Sidebar inherits Rectangle {
             drop-shadow-color: Tokens.text.with-alpha(0.25);
             VerticalLayout {
                 padding: 4px;
-                for label[action] in ["Insert to editor", "Run", "Copy query", "Delete"]: Rectangle {
+                for label[action] in ["Insert to editor", "Run", "Copy query", "Save to queries", "Delete"]: Rectangle {
                     height: 28px;
                     border-radius: Tokens.radius;
-                    background: menu-ta.has-hover ? (action == 3 ? Tokens.error-tint : Tokens.accent-tint) : transparent;
+                    background: menu-ta.has-hover ? (action == 4 ? Tokens.error-tint : Tokens.accent-tint) : transparent;
                     Text {
                         x: Tokens.sp2;
                         text: label;
-                        color: action == 3 ? Tokens.error : Tokens.text;
+                        color: action == 4 ? Tokens.error : Tokens.text;
                         font-size: Tokens.font-sm;
                         vertical-alignment: center;
                     }

--- a/crates/connstore/src/store.rs
+++ b/crates/connstore/src/store.rs
@@ -56,6 +56,13 @@ impl ConnStore {
         Ok(dirs.config_dir().join("recent_queries.json"))
     }
 
+    /// Location of `saved_queries.json` in the same config dir — the user's
+    /// curated saved queries (name + SQL), shown in the sidebar Queries tab.
+    pub fn saved_queries_path() -> Result<PathBuf> {
+        let dirs = ProjectDirs::from("dev", "dbm", "dbm").ok_or(ConnStoreError::NoConfigDir)?;
+        Ok(dirs.config_dir().join("saved_queries.json"))
+    }
+
     /// Location of `query_tabs.json` in the same config dir — the persisted
     /// open query tabs and their SQL text, restored on launch.
     pub fn query_tabs_path() -> Result<PathBuf> {


### PR DESCRIPTION
## Summary

- Bring sidebar Saved queries to parity with History (run / open in new tab / insert / copy / delete) and let History entries be saved into the curated list.
- Redesign the Settings modal into tabbed sections and make an available update actionable without leaving the app.
- Prefix the GitHub Release title and CHANGELOG heading with the product name.

## Changes

**Sidebar queries**
- Saved rows get a play button + right-click menu: Run, Open in new tab, Insert to editor, Copy, Delete.
- Saved queries now persist to `saved_queries.json` (seeded on first run) so Delete sticks.
- History rows gain a "Save to queries" action that promotes an entry into the Saved list, auto-naming it from the query.

**Dialogs**
- Settings split into Appearance / Updates / About tabs; extracted a shared `Toggle`/`ToggleRow` component.
- About now lists all six supported engines (adds SQLite, Cassandra).
- Keyboard Shortcuts keys render as uniform kbd chips with aligned columns.

**Updates**
- Updates tab shows an inline "Update available" card with Open + Copy buttons (no self-update machinery; reuses existing update state).

**Release naming (CI)**
- GitHub Release title becomes `RDB: vX.Y.Z` (tag stays `vX.Y.Z`).
- Newest CHANGELOG heading is rewritten to `## RDB: [X.Y.Z]` on the release-please PR branch.

## Test plan

- [x] `cargo build -p rdb`
- [x] `cargo clippy -p rdb --bins -- -D warnings` (and `-p rdb-connstore`)
- [x] `cargo test -p rdb-connstore --lib`
- [x] `cargo fmt --check`
- [x] `make fe-run`: right-click Saved/History rows, verify each action; Delete survives restart
- [x] Settings tabs switch; Updates card shows Open/Copy; About shows 6 engines; Shortcut chips aligned
