### PR TITLE
feat(app): query workspace UX fixes and reconnect shortcut

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5594,7 +5594,7 @@ dependencies = [
 
 [[package]]
 name = "rdb"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "copypasta",

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -679,6 +679,9 @@ struct GroupRuntime {
     results: Arc<std::sync::Mutex<Vec<StoredResult>>>,
     active_result: Arc<std::sync::Mutex<usize>>,
     result_new_tab: Arc<std::sync::atomic::AtomicBool>,
+    // Set by "Run Selection" when the selection holds 2+ statements: the next
+    // run stores one result tab per statement instead of last-wins.
+    split_results: Arc<std::sync::atomic::AtomicBool>,
     displayed_grid: Arc<std::sync::Mutex<Option<model::GridModel>>>,
     browse: Arc<std::sync::Mutex<BrowseState>>,
     hidden_cols: Arc<std::sync::Mutex<HashSet<usize>>>,
@@ -704,6 +707,7 @@ impl GroupRuntime {
             results: Arc::new(std::sync::Mutex::new(Vec::new())),
             active_result: Arc::new(std::sync::Mutex::new(0)),
             result_new_tab: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            split_results: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             displayed_grid: Arc::new(std::sync::Mutex::new(None)),
             browse: Arc::new(std::sync::Mutex::new(BrowseState {
                 limit: 300,
@@ -6245,6 +6249,7 @@ fn main() -> Result<(), slint::PlatformError> {
             let results = panes[pane].results.clone();
             let active_result = panes[pane].active_result.clone();
             let result_new_tab = panes[pane].result_new_tab.clone();
+            let split_results = panes[pane].split_results.clone();
             let active_id = if pane == 1 {
                 &active_group1_tab_id
             } else {
@@ -6280,6 +6285,8 @@ fn main() -> Result<(), slint::PlatformError> {
             let query_console = query_console.clone();
             // ⌘\ set this; consume it so the next plain run replaces again.
             let new_tab = result_new_tab.swap(false, std::sync::atomic::Ordering::SeqCst);
+            // Run Selection over 2+ statements set this; consume it likewise.
+            let split = split_results.swap(false, std::sync::atomic::Ordering::SeqCst);
             // Currently selected database (top dropdown). Mongo line queries with
             // no `use(...)` run against it, matching what the user sees browsing.
             let mut cur_db = String::new();
@@ -6299,6 +6306,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 // each in order, stopping at the first error. The last result
                 // is what the grid shows (TablePlus semantics). Redis/Mongo
                 // take the whole text as a single command.
+                let mut split_views: Vec<model::ResultView> = Vec::new();
                 let (outcome, n_stmts) = match guard.as_ref() {
                     Some((engine, driver)) => {
                         let stmts = if matches!(
@@ -6355,6 +6363,12 @@ fn main() -> Result<(), slint::PlatformError> {
                                 }
                                 break;
                             }
+                            // Run Selection multi-tab: keep each statement's result.
+                            if split {
+                                if let Ok(rs) = &out {
+                                    split_views.push(model::to_result_view(rs));
+                                }
+                            }
                         }
                         (out, n)
                     }
@@ -6385,6 +6399,68 @@ fn main() -> Result<(), slint::PlatformError> {
                         }
                         match (view, err) {
                             (Some(v), _) => {
+                                // Run Selection over 2+ statements: store one
+                                // result tab per statement and show the first.
+                                if split && split_views.len() >= 2 {
+                                    let stored: Vec<StoredResult> = split_views
+                                        .iter()
+                                        .map(|vw| {
+                                            let rows = match vw {
+                                                model::ResultView::Table(g) => g.rows.len(),
+                                                model::ResultView::Documents(d) => {
+                                                    d.grid.rows.len()
+                                                }
+                                                model::ResultView::Affected(_) => 0,
+                                            }
+                                                as u64;
+                                            StoredResult {
+                                                view: vw.clone(),
+                                                meta: query_timing_meta(
+                                                    rows, 1, elapsed_ms, queue_ms, driver_ms,
+                                                    model_ms,
+                                                ),
+                                                latency: format!("{elapsed_ms} ms"),
+                                                grid: GridState::default(),
+                                            }
+                                        })
+                                        .collect();
+                                    let (first, all) = {
+                                        let mut tabs = workspace_tabs.lock().unwrap();
+                                        let Some(tab) =
+                                            tabs.iter_mut().find(|tab| tab.id == target_id)
+                                        else {
+                                            return;
+                                        };
+                                        tab.loading = false;
+                                        tab.results = stored;
+                                        tab.active_result = 0;
+                                        tab.view = tab.results.first().cloned();
+                                        (tab.results[0].clone(), tab.results.clone())
+                                    };
+                                    if !is_active {
+                                        return;
+                                    }
+                                    let count = all.len();
+                                    *results.lock().unwrap() = all;
+                                    *active_result.lock().unwrap() = 0;
+                                    set_result_tabs(&w, pane, count, 0);
+                                    present_view(
+                                        &w,
+                                        pane,
+                                        first.view,
+                                        &first.meta,
+                                        &first.latency,
+                                        &last_view,
+                                        &displayed_grid,
+                                        &hidden_cols,
+                                        &sort_state,
+                                        &col_order,
+                                        &col_filters,
+                                        &edit_buf,
+                                        &browse,
+                                    );
+                                    return;
+                                }
                                 let shown = match &v {
                                     model::ResultView::Table(g) => g.rows.len(),
                                     model::ResultView::Documents(d) => d.grid.rows.len(),
@@ -7238,6 +7314,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let ed_state = ed_state.clone();
         let recent_queries = recent_queries.clone();
         let history_cap = history_cap.clone();
+        let panes = panes.clone();
         window.on_run_selection(move || {
             let stmt = {
                 let ed = ed_state.borrow();
@@ -7248,11 +7325,13 @@ fn main() -> Result<(), slint::PlatformError> {
             };
             if !stmt.is_empty() {
                 let mut stream = false;
+                let mut not_table = false;
                 if let Some(w) = weak.upgrade() {
-                    if active_tab_kind(&w) != "table" {
+                    not_table = active_tab_kind(&w) != "table";
+                    if not_table {
                         w.set_grid_read_only(true);
                     }
-                    stream = active_tab_kind(&w) != "table"
+                    stream = not_table
                         && browse.lock().unwrap().limit == 0
                         && cur_engine
                             .borrow()
@@ -7263,6 +7342,12 @@ fn main() -> Result<(), slint::PlatformError> {
                 if stream {
                     run_stream(0, stmt);
                 } else {
+                    // 2+ selected statements → one result tab each.
+                    if not_table && editor::split_statements(&stmt).len() >= 2 {
+                        panes[0]
+                            .split_results
+                            .store(true, std::sync::atomic::Ordering::SeqCst);
+                    }
                     run_sql(0, stmt);
                 }
             }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2074,6 +2074,57 @@ fn restore_grid_state(w: &MainWindow, pane: usize, g: &GroupRuntime, sr: &Stored
     *g.displayed_grid.lock().unwrap() = view_grid(&filtered);
     apply_result(w, pane, filtered);
 }
+/// Build the ⌘K palette model, grouped GitHub-style under non-selectable
+/// "section" header rows. `needle` (lowercase) filters both groups; empty
+/// shows everything. Empty groups drop their header.
+fn build_palette_items(
+    names: &[(String, &'static str)],
+    w: &MainWindow,
+    needle: &str,
+) -> Vec<PaletteItem> {
+    let section = |t: &str| PaletteItem {
+        label: t.into(),
+        kind: "section".into(),
+        sub: SharedString::default(),
+        local: false,
+    };
+    let mut items: Vec<PaletteItem> = Vec::new();
+    let conns: Vec<&(String, &'static str)> = names
+        .iter()
+        .filter(|(n, _)| needle.is_empty() || n.to_lowercase().contains(needle))
+        .collect();
+    if !conns.is_empty() {
+        items.push(section("Connections"));
+        for (n, badge) in conns {
+            items.push(PaletteItem {
+                label: n.clone().into(),
+                kind: (*badge).into(),
+                sub: SharedString::default(),
+                local: false,
+            });
+        }
+    }
+    let tables: Vec<SharedString> = w
+        .get_schema_tree()
+        .iter()
+        .filter(|n| {
+            n.kind == "table" && (needle.is_empty() || n.label.to_lowercase().contains(needle))
+        })
+        .map(|n| n.label.clone())
+        .collect();
+    if !tables.is_empty() {
+        items.push(section("Tables"));
+        for label in tables {
+            items.push(PaletteItem {
+                label,
+                kind: "table".into(),
+                sub: SharedString::default(),
+                local: false,
+            });
+        }
+    }
+    items
+}
 fn set_p_editing(w: &MainWindow, pane: usize, row: i32, col: i32) {
     if pane == 0 {
         w.set_editing_row(row);
@@ -9533,23 +9584,7 @@ fn main() -> Result<(), slint::PlatformError> {
                         .iter()
                         .map(|s| (s.name.clone(), AnyDriver::badge(s.engine)))
                         .collect();
-                    let mut items: Vec<PaletteItem> = names
-                        .iter()
-                        .map(|(n, badge)| PaletteItem {
-                            label: n.clone().into(),
-                            kind: (*badge).into(),
-                            sub: SharedString::default(),
-                            local: false,
-                        })
-                        .collect();
-                    for n in w.get_schema_tree().iter().filter(|n| n.kind == "table") {
-                        items.push(PaletteItem {
-                            label: n.label.clone(),
-                            kind: "table".into(),
-                            sub: SharedString::default(),
-                            local: false,
-                        });
-                    }
+                    let items = build_palette_items(&names, &w, "");
                     w.set_palette_items(ModelRc::from(Rc::new(VecModel::from(items))));
                 }
             }
@@ -9562,35 +9597,13 @@ fn main() -> Result<(), slint::PlatformError> {
         let store = store.clone();
         window.on_palette_filter(move |q| {
             if let Some(w) = weak.upgrade() {
-                let needle = q.to_lowercase();
                 let names: Vec<(String, &'static str)> = store
                     .borrow()
                     .list()
                     .iter()
                     .map(|s| (s.name.clone(), AnyDriver::badge(s.engine)))
                     .collect();
-                let mut items: Vec<PaletteItem> = names
-                    .iter()
-                    .filter(|(n, _)| n.to_lowercase().contains(&needle))
-                    .map(|(n, badge)| PaletteItem {
-                        label: n.clone().into(),
-                        kind: (*badge).into(),
-                        sub: SharedString::default(),
-                        local: false,
-                    })
-                    .collect();
-                for n in w
-                    .get_schema_tree()
-                    .iter()
-                    .filter(|n| n.kind == "table" && n.label.to_lowercase().contains(&needle))
-                {
-                    items.push(PaletteItem {
-                        label: n.label.clone(),
-                        kind: "table".into(),
-                        sub: SharedString::default(),
-                        local: false,
-                    });
-                }
+                let items = build_palette_items(&names, &w, &q.to_lowercase());
                 w.set_palette_items(ModelRc::from(Rc::new(VecModel::from(items))));
             }
         });

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -604,6 +604,11 @@ struct GridState {
     hidden: Vec<usize>,
     col_order: Vec<usize>,
     col_widths: Vec<f32>,
+    // Client-side search bar state (the "Filter" box above the grid). Kept per
+    // result so switching result/query tabs doesn't drop the active filter.
+    grid_filter: String,
+    filter_col: String,
+    filter_op: String,
 }
 
 #[derive(Clone)]
@@ -1993,6 +1998,9 @@ fn capture_grid_state(w: &MainWindow, pane: usize, g: &GroupRuntime) -> GridStat
         hidden,
         col_order: g.col_order.lock().unwrap().clone(),
         col_widths: get_p_col_widths(w, pane),
+        grid_filter: w.get_grid_filter().to_string(),
+        filter_col: w.get_filter_col().to_string(),
+        filter_op: w.get_filter_op().to_string(),
     }
 }
 /// Re-apply a result's saved grid view after `present_view` reset it to defaults.
@@ -2034,11 +2042,25 @@ fn restore_grid_state(w: &MainWindow, pane: usize, g: &GroupRuntime, sr: &Stored
             ModelRc::from(Rc::new(VecModel::from(st.col_widths.clone()))),
         );
     }
+    // Re-apply the search-bar filter that `present_view` reset to empty.
+    let fcol = if st.filter_col.is_empty() {
+        "any column".to_string()
+    } else {
+        st.filter_col.clone()
+    };
+    let fop = if st.filter_op.is_empty() {
+        "=".to_string()
+    } else {
+        st.filter_op.clone()
+    };
+    w.set_grid_filter(st.grid_filter.clone().into());
+    w.set_filter_col(fcol.clone().into());
+    w.set_filter_op(fop.clone().into());
     let filtered = compute_view(
         &sr.view,
-        "",
-        "any column",
-        "=",
+        &st.grid_filter.to_lowercase(),
+        &fcol,
+        &fop,
         &st.col_filters,
         &hidden,
         &st.col_order,
@@ -4820,6 +4842,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let results = results.clone();
         let active_result = active_result.clone();
         let last_view = last_view.clone();
+        let panes = panes.clone();
         Rc::new(move |w| {
             let Some(id) = active_id.lock().unwrap().clone() else {
                 return;
@@ -4833,8 +4856,14 @@ fn main() -> Result<(), slint::PlatformError> {
             if tab.kind == "table" {
                 tab.browse = browse.lock().unwrap().clone();
             } else if tab.kind == "sql" {
+                // Snapshot the live grid (sort/filters/search) into the active
+                // result before cloning, so it survives a tab switch.
+                let ai = *active_result.lock().unwrap();
+                if let Some(r) = results.lock().unwrap().get_mut(ai) {
+                    r.grid = capture_grid_state(w, 0, &panes[0]);
+                }
                 tab.results = results.lock().unwrap().clone();
-                tab.active_result = *active_result.lock().unwrap();
+                tab.active_result = ai;
             }
             if tab.kind != "function" {
                 tab.view = last_view.lock().unwrap().clone().map(|view| StoredResult {
@@ -4987,6 +5016,13 @@ fn main() -> Result<(), slint::PlatformError> {
                     &panes[pane].edit_buf,
                     &panes[pane].browse,
                 );
+                // present_view reset the grid to defaults; re-apply the saved
+                // sort/filters/search for the active result (sql tabs only).
+                if tab.kind == "sql" {
+                    if let Some(sr) = tab.results.get(tab.active_result) {
+                        restore_grid_state(w, pane, &panes[pane], sr);
+                    }
+                }
             } else {
                 *last_view.lock().unwrap() = None;
                 *panes[pane].displayed_grid.lock().unwrap() = None;
@@ -6376,6 +6412,30 @@ fn main() -> Result<(), slint::PlatformError> {
                                     tab.results.clear();
                                     tab.active_result = 0;
                                 } else {
+                                    // ⌘\ opens a new result tab; snapshot the
+                                    // outgoing result's live grid (sort/filters/
+                                    // search) so returning to it keeps its state.
+                                    if new_tab && is_active {
+                                        if let Some(r) = tab.results.get_mut(tab.active_result) {
+                                            let mut hidden: Vec<usize> = hidden_cols
+                                                .lock()
+                                                .unwrap()
+                                                .iter()
+                                                .copied()
+                                                .collect();
+                                            hidden.sort_unstable();
+                                            r.grid = GridState {
+                                                col_filters: col_filters.lock().unwrap().clone(),
+                                                sort: *sort_state.lock().unwrap(),
+                                                hidden,
+                                                col_order: col_order.lock().unwrap().clone(),
+                                                col_widths: get_p_col_widths(&w, pane),
+                                                grid_filter: w.get_grid_filter().to_string(),
+                                                filter_col: w.get_filter_col().to_string(),
+                                                filter_op: w.get_filter_op().to_string(),
+                                            };
+                                        }
+                                    }
                                     store_result(
                                         &mut tab.results,
                                         &mut tab.active_result,

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -839,10 +839,13 @@ callback create-table-commit();
                 Rectangle { horizontal-stretch: 1; }
 
                 // --- center: ⌘K pill (flanked by stretch spacers) ---
+                // Stretches toward the corner clusters, capped so it stays
+                // readable on wide windows.
                 VerticalLayout {
                     alignment: center;
+                    horizontal-stretch: 3;
                     SearchCommandPill {
-                        width: 248px;
+                        max-width: 720px;
                         activated => { root.toggle-palette(); }
                     }
                 }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -611,6 +611,10 @@ callback create-table-commit();
                     root.commit-edits();
                     return accept;
                 }
+                if (e.text == "r" && e.modifiers.shift) {
+                    root.reconnect();
+                    return accept;
+                }
                 if (e.text == "r") {
                     root.refresh-result();
                     return accept;
@@ -2568,6 +2572,7 @@ callback create-table-commit();
                     { k: "⌘\\", a: "Run in new tab" },
                     { k: "⌘S", a: "Save / commit edits" },
                     { k: "⌘R", a: "Refresh result" },
+                    { k: "⌘⇧R", a: "Reconnect" },
                     { k: "⌘F", a: "Find" },
                     { k: "⌘O", a: "Open connection" },
                     { k: "⌘⇧O", a: "Open database" },

--- a/app/src/ui/palette.slint
+++ b/app/src/ui/palette.slint
@@ -87,17 +87,35 @@ export component ListModal inherits Rectangle {
                         spacing: 1px;
                         alignment: start;
                         for it[i] in root.items: Rectangle {
+                            // Non-selectable group header (GitHub-style sections).
+                            property <bool> is-section: it.kind == "section";
                             property <bool> is-group: it.kind == "group";
                             property <bool> two-line: it.sub != "";
-                            height: two-line ? 44px : 34px;
+                            height: is-section ? 28px : two-line ? 44px : 34px;
                             border-radius: Tokens.radius;
-                            background: i == root.selected ? Tokens.chrome
+                            background: is-section ? transparent
+                                : i == root.selected ? Tokens.chrome
                                 : it-ta.has-hover ? Tokens.canvas : transparent;
                             it-ta := TouchArea {
-                                clicked => { root.selected = i; }
-                                double-clicked => { root.choose(i); }
+                                clicked => { if (!is-section) { root.selected = i; } }
+                                double-clicked => { if (!is-section) { root.choose(i); } }
                             }
-                            HorizontalLayout {
+                            // Section header: small dim caps, no icon.
+                            if is-section: HorizontalLayout {
+                                padding-left: Tokens.sp2;
+                                padding-right: Tokens.sp2;
+                                VerticalLayout {
+                                    alignment: end;
+                                    Text {
+                                        text: it.label;
+                                        color: Tokens.text-faint;
+                                        font-size: Tokens.font-xs;
+                                        font-weight: 700;
+                                        vertical-alignment: bottom;
+                                    }
+                                }
+                            }
+                            if !is-section: HorizontalLayout {
                                 padding-left: Tokens.sp2;
                                 padding-right: Tokens.sp2;
                                 spacing: Tokens.sp3;

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -554,8 +554,6 @@ export component QueryPane inherits Rectangle {
                                 property <GridCell> detail-cell: root.cells[root.selected-row * root.col-count + c];
                                 // Formatted JSON for this cell (read-only results only), else "".
                                 property <string> pretty: root.read-only && root.detail-pretty.length > c ? root.detail-pretty[c] : "";
-                                // Give a JSON value room to breathe; plain cells stay compact.
-                                height: pretty != "" ? 220px : 96px;
                                 VerticalLayout {
                                     spacing: Tokens.sp1;
                                     HorizontalLayout {
@@ -588,27 +586,33 @@ export component QueryPane inherits Rectangle {
                                             }
                                         }
                                     }
+                                    // Box grows to fit the value; short values stay
+                                    // compact, long ones cap out and scroll inside.
                                     Rectangle {
-                                        vertical-stretch: 1;
+                                        height: clamp(detail-input.preferred-height + 2 * Tokens.sp2, 44px, 220px);
                                         clip: true;
                                         border-radius: Tokens.radius;
                                         border-width: 1px;
                                         border-color: detail-input.has-focus ? Tokens.accent : Tokens.border-strong;
                                         background: Tokens.canvas;
-                                        detail-input := TextInput {
+                                        ScrollView {
                                             x: Tokens.sp2;
                                             y: Tokens.sp2;
                                             width: parent.width - 2 * Tokens.sp2;
                                             height: parent.height - 2 * Tokens.sp2;
-                                            text: pretty != "" ? pretty : (detail-cell.is-null ? "" : detail-cell.text);
-                                            enabled: !root.read-only;
-                                            single-line: false;
-                                            wrap: word-wrap;
-                                            vertical-alignment: top;
-                                            color: root.read-only ? Tokens.text-dim : Tokens.text;
-                                            font-family: Tokens.mono;
-                                            font-size: Tokens.font-sm;
-                                            edited => { root.stage-cell(root.selected-row, c, self.text); }
+                                            detail-input := TextInput {
+                                                width: parent.visible-width;
+                                                height: max(parent.visible-height, self.preferred-height);
+                                                text: pretty != "" ? pretty : (detail-cell.is-null ? "" : detail-cell.text);
+                                                enabled: !root.read-only;
+                                                single-line: false;
+                                                wrap: word-wrap;
+                                                vertical-alignment: top;
+                                                color: root.read-only ? Tokens.text-dim : Tokens.text;
+                                                font-family: Tokens.mono;
+                                                font-size: Tokens.font-sm;
+                                                edited => { root.stage-cell(root.selected-row, c, self.text); }
+                                            }
                                         }
                                         if detail-cell.is-null && detail-input.text == "": Text {
                                             x: Tokens.sp2;

--- a/app/src/ui/tokens.slint
+++ b/app/src/ui/tokens.slint
@@ -72,7 +72,7 @@ export global Tokens {
     // ----- modal / palette -----
     out property <color> veil: dark ? #101114.with-alpha(0.55) : #FAFAF9.with-alpha(0.55);
     out property <length> modal-radius: 12px;
-    out property <length> palette-width: 400px;
+    out property <length> palette-width: 640px;
 
     // ----- metrics -----
     out property <length> titlebar-h: 44px;


### PR DESCRIPTION
## Summary

- Fix query-result UX bugs where the client-side filter was dropped on tab and query switches, and where selecting multiple statements only ran one result.
- Improve the row details panel, the header search, and add a reconnect shortcut.

## Changes

**Result filter persistence**
- Store the filter box state (`grid_filter`/`filter_col`/`filter_op`) in `GridState`.
- Snapshot the active result's grid before switching query tabs or opening a new result tab via `⌘\`, and re-apply it in `restore_tab`.

**Multi-statement Run Selection**
- Running a selection of 2+ statements now stores one result tab per statement and shows the first. Plain Run and single-statement runs keep the existing last-wins behavior.

**Details panel**
- Value boxes size to their content between a min and max, with an inner `ScrollView` so long JSON scrolls instead of clipping and short values stay compact.

**Header search + command palette**
- Header pill stretches toward the corner clusters (capped) instead of a fixed 248px.
- `⌘K` palette widened and split into non-selectable section headers (Connections, Tables).

**Reconnect shortcut**
- `⌘⇧R` bound to reconnect (`⌘R` stays refresh result) and listed in the settings shortcut reference.

## Test plan

- [x] `cargo build -p rdb`
- [x] `cargo fmt -p rdb -- --check`
- [x] `cargo clippy -p rdb -- -D warnings`
- [x] Filter a result, switch tabs / `⌘\`, return → filter intact
- [x] Run Selection over 2 statements → 2 result tabs
- [x] Details on a JSON-heavy row → capped scrollable box; short value → compact box
- [x] `⌘K` → wider grouped palette; header pill wider
- [x] `⌘⇧R` reconnects; shortcut listed in settings; `⌘R` still refreshes
