### PR TITLE
fix(app): hide console window on Windows

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
+
 //! rdb-app: Slint desktop binary.
 //!
 //! Async bridge pattern (canonical):


### PR DESCRIPTION
## Summary

- mark the RDB executable as a Windows GUI application
- prevent an extra console window from opening alongside the Slint UI

## Root cause

Rust binaries use the Windows console subsystem by default unless the crate declares the GUI subsystem.

## Validation

- `make fmt-check`
- `make fe-build`
- `cargo clippy -p rdb --all-targets -- -D warnings`
- `git diff --check`

Fixes #152.
