### PR TITLE
ci: fix release title prefix for manifest-mode outputs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,14 +30,16 @@ jobs:
           manifest-file: .release-please-manifest.json
 
       # The tag stays vX.Y.Z (release-build.yml keys off `v*`); only the
-      # GitHub Release display title gets the "RDB: " prefix.
+      # GitHub Release display title gets the "RDB " prefix. Manifest mode
+      # path-prefixes the release outputs, so gate on `app--release_created`
+      # (the bare `release_created` is empty here and left the step skipped).
       - name: Prefix release title with product name
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs['app--release_created'] }}
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
-          gh release edit "${{ steps.release.outputs.tag_name }}" \
-            --title "RDB: ${{ steps.release.outputs.tag_name }}"
+          gh release edit "${{ steps.release.outputs['app--tag_name'] }}" \
+            --title "RDB ${{ steps.release.outputs['app--tag_name'] }}"
 
       # Match the CHANGELOG to the release title. release-please regenerates
       # only the newest block on each run, so prefixing the top-most heading on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5594,7 +5594,7 @@ dependencies = [
 
 [[package]]
 name = "rdb"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "copypasta",


### PR DESCRIPTION
## Summary

- The GitHub Release title customization added in `c402d2c` never took effect — the latest release still shows a bare `v0.27.0` instead of `RDB v0.27.0`.
- Root cause: the title step gated on `steps.release.outputs.release_created`, but release-please runs in manifest mode (`packages.app`), which emits path-prefixed outputs. The bare names are empty, so the step was skipped on every run (verified in the Actions logs).

## Changes

- `.github/workflows/release-please.yml`: gate the "Prefix release title" step on `steps.release.outputs['app--release_created']` and read `steps.release.outputs['app--tag_name']`; title now renders `RDB vX.Y.Z` (space).
- `Cargo.lock`: sync the `rdb` package version to `0.26.0` (lockfile was stale at `0.25.2`).

## Notes

- CHANGELOG-heading step is untouched (it gates on the top-level `pr` output and already works); the `RDB:` changelog prefix is unchanged.
- Only affects future releases — no backfill of already-published releases.

## Test plan

- [x] YAML parses (`yaml.safe_load`)
- [x] `cargo test --workspace --lib` green (111 passed)
- [ ] Next release run: created GitHub Release title reads `RDB vX.Y.Z` and the step is no longer skipped (only observable in CI on a real release)
