### PR TITLE
fix(app): MongoDB UX, query lifecycle, and picker/result polish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5594,7 +5594,7 @@ dependencies = [
 
 [[package]]
 name = "rdb"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "copypasta",

--- a/app/src/completion.rs
+++ b/app/src/completion.rs
@@ -250,7 +250,12 @@ pub fn suggest(
         let owner_word = trailing_word(before_dot);
         let owner = resolve_alias(before_cursor, owner_word);
         let cols = columns_of(nodes, &owner);
-        if cols.is_empty() && is_database(nodes, owner_word) {
+        if !cols.is_empty() {
+            cols
+        } else if owner_word.eq_ignore_ascii_case("db") {
+            // MongoDB: `db.` is the current database — offer its collections.
+            tables(scope)
+        } else if is_database(nodes, owner_word) {
             tables(schema_scope(nodes, owner_word))
         } else {
             cols
@@ -350,6 +355,20 @@ mod tests {
             c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
             ["config_id", "name"]
         );
+    }
+
+    #[test]
+    fn mongo_db_dot_suggests_collections() {
+        // MongoDB: `db.` is the current database, so it must surface the active
+        // schema's collections even though `db` is not a schema node.
+        let mut ns = nodes();
+        ns.push(VmTreeNode {
+            label: "log_inbound".into(),
+            kind: "collection".into(),
+        });
+        let (n, c) = suggest("db.log", &ns, "public");
+        assert_eq!(n, 3);
+        assert!(c.iter().any(|x| x.label == "log_inbound"));
     }
 
     /// Typing a mid-word `_` segment finds the identifier, and a true prefix

--- a/app/src/completion.rs
+++ b/app/src/completion.rs
@@ -266,6 +266,7 @@ pub fn suggest(
     before_cursor: &str,
     nodes: &[VmTreeNode],
     active_schema: &str,
+    mongo: bool,
 ) -> (usize, Vec<Candidate>) {
     // Default table/column suggestions come from the active schema only, so the
     // popup follows the connected schema without the user picking it first.
@@ -287,10 +288,10 @@ pub fn suggest(
         let cols = columns_of(nodes, &owner);
         if !cols.is_empty() {
             cols
-        } else if owner_word.eq_ignore_ascii_case("db") {
+        } else if mongo && owner_word.eq_ignore_ascii_case("db") {
             // MongoDB: `db.` is the current database — offer its collections.
             tables(scope)
-        } else if is_collection(nodes, owner_word) {
+        } else if mongo && is_collection(nodes, owner_word) {
             // MongoDB: `db.<collection>.` — offer collection methods.
             mongo_methods()
         } else if is_database(nodes, owner_word) {
@@ -298,6 +299,16 @@ pub fn suggest(
         } else {
             cols
         }
+    } else if mongo {
+        // MongoDB has no SQL keywords: offer the `db` handle and the active
+        // database's collections instead of DELETE/SELECT/… noise.
+        let mut c = vec![Candidate {
+            label: "db".into(),
+            kind: "keyword".into(),
+            sub: String::new(),
+        }];
+        c.extend(tables(scope));
+        c
     } else {
         // Keyword context comes from the current line; `before_cursor` may span
         // several lines (alias resolution needs the whole statement).
@@ -365,15 +376,15 @@ mod tests {
 
     #[test]
     fn empty_and_whitespace_context_suppress_popup() {
-        assert!(suggest("", &nodes(), "public").1.is_empty());
-        assert!(suggest("   ", &nodes(), "public").1.is_empty());
+        assert!(suggest("", &nodes(), "public", false).1.is_empty());
+        assert!(suggest("   ", &nodes(), "public", false).1.is_empty());
         // trailing space after a keyword: wait for the user to start typing
-        assert!(suggest("select ", &nodes(), "public").1.is_empty());
+        assert!(suggest("select ", &nodes(), "public", false).1.is_empty());
     }
 
     #[test]
     fn from_prefix_suggests_matching_table() {
-        let (n, c) = suggest("select * from ste", &nodes(), "public");
+        let (n, c) = suggest("select * from ste", &nodes(), "public", false);
         assert_eq!(n, 3);
         assert_eq!(
             c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
@@ -387,6 +398,7 @@ mod tests {
             "select * from step_config where step_config.",
             &nodes(),
             "public",
+            false,
         );
         assert_eq!(n, 0);
         assert_eq!(
@@ -404,7 +416,7 @@ mod tests {
             label: "log_inbound".into(),
             kind: "collection".into(),
         });
-        let (n, c) = suggest("db.log", &ns, "public");
+        let (n, c) = suggest("db.log", &ns, "public", true);
         assert_eq!(n, 3);
         assert!(c.iter().any(|x| x.label == "log_inbound"));
     }
@@ -417,9 +429,23 @@ mod tests {
             label: "log_inbound".into(),
             kind: "collection".into(),
         });
-        let (_, c) = suggest("db.log_inbound.fi", &ns, "public");
+        let (_, c) = suggest("db.log_inbound.fi", &ns, "public", true);
         assert!(c.iter().any(|x| x.label == "find"));
         assert!(c.iter().any(|x| x.label == "findOne"));
+    }
+
+    #[test]
+    fn mongo_bare_word_suggests_db_not_sql_keywords() {
+        // On MongoDB, typing a letter must offer `db` and collections — never SQL
+        // keywords like DELETE.
+        let mut ns = nodes();
+        ns.push(VmTreeNode {
+            label: "log_inbound".into(),
+            kind: "collection".into(),
+        });
+        let (_, c) = suggest("d", &ns, "public", true);
+        assert!(c.iter().any(|x| x.label == "db"));
+        assert!(!c.iter().any(|x| x.label == "DELETE"));
     }
 
     /// Typing a mid-word `_` segment finds the identifier, and a true prefix
@@ -444,7 +470,7 @@ mod tests {
                 kind: "field".into(),
             },
         ];
-        let (_, c) = suggest("select teknis", &n, "public");
+        let (_, c) = suggest("select teknis", &n, "public", false);
         let labels: Vec<&str> = c.iter().map(|x| x.label.as_str()).collect();
         assert!(labels.contains(&"flag_teknis"));
         // `teknis_id` is a real prefix → ranks ahead of the mid-word match.
@@ -473,6 +499,7 @@ mod tests {
             "select * from oss_rba_common.step_journal where step",
             &two,
             "public",
+            false,
         );
         let labels: Vec<&str> = c.iter().map(|x| x.label.as_str()).collect();
         assert!(labels.contains(&"step_id"));
@@ -481,13 +508,14 @@ mod tests {
             "select * from users;\nselect * from oss_rba_common.step_journal where step",
             &two,
             "public",
+            false,
         );
         assert!(c2.iter().any(|x| x.label == "step_id"));
     }
 
     #[test]
     fn bare_word_completes_keyword() {
-        let (n, c) = suggest("sele", &nodes(), "public");
+        let (n, c) = suggest("sele", &nodes(), "public", false);
         assert_eq!(n, 4);
         assert_eq!(
             c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
@@ -498,14 +526,19 @@ mod tests {
     #[test]
     fn select_context_offers_columns() {
         // Type-triggered: a prefix is required before the popup appears.
-        let (_, c) = suggest("select n", &nodes(), "public");
+        let (_, c) = suggest("select n", &nodes(), "public", false);
         let labels: Vec<&str> = c.iter().map(|x| x.label.as_str()).collect();
         assert!(labels.contains(&"name"));
     }
 
     #[test]
     fn alias_dot_resolves_to_table_columns() {
-        let (_, c) = suggest("select * from step_config sc where sc.", &nodes(), "public");
+        let (_, c) = suggest(
+            "select * from step_config sc where sc.",
+            &nodes(),
+            "public",
+            false,
+        );
         assert_eq!(
             c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
             ["config_id", "name"]
@@ -517,13 +550,13 @@ mod tests {
     #[test]
     fn schema_qualified_alias_join_resolves_columns() {
         let a = "select * from public.step_config a left join public.users b on a.";
-        let (_, c) = suggest(a, &nodes(), "public");
+        let (_, c) = suggest(a, &nodes(), "public", false);
         assert_eq!(
             c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
             ["config_id", "name"]
         );
         let b = "select * from public.step_config a left join public.users b on b.";
-        let (_, c) = suggest(b, &nodes(), "public");
+        let (_, c) = suggest(b, &nodes(), "public", false);
         assert_eq!(
             c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
             ["id"]
@@ -535,7 +568,7 @@ mod tests {
     #[test]
     fn multiline_join_alias_resolves_columns() {
         let sql = "select * from public.step_config a\nleft join public.users b on a.";
-        let (_, c) = suggest(sql, &nodes(), "public");
+        let (_, c) = suggest(sql, &nodes(), "public", false);
         assert_eq!(
             c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
             ["config_id", "name"]
@@ -544,14 +577,14 @@ mod tests {
 
     #[test]
     fn star_context_offers_from_keyword() {
-        let (_, c) = suggest("select * f", &nodes(), "public");
+        let (_, c) = suggest("select * f", &nodes(), "public", false);
         let labels: Vec<&str> = c.iter().map(|x| x.label.as_str()).collect();
         assert!(labels.contains(&"FROM"));
     }
 
     #[test]
     fn schema_dot_suggests_its_tables() {
-        let (n, c) = suggest("select * from public.", &nodes(), "public");
+        let (n, c) = suggest("select * from public.", &nodes(), "public", false);
         assert_eq!(n, 0);
         assert_eq!(
             c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
@@ -571,7 +604,7 @@ mod tests {
                 kind: "field".into(),
             },
         ];
-        let (_, c) = suggest("select * from users where users.", &typed, "public");
+        let (_, c) = suggest("select * from users where users.", &typed, "public", false);
         assert_eq!(c[0].label, "id");
     }
 
@@ -591,12 +624,12 @@ mod tests {
             mk("oid", "field"),
         ];
         // Type-triggered: a prefix ("t") is required before the popup appears.
-        let (_, c) = suggest("select * from t", &two, "public");
+        let (_, c) = suggest("select * from t", &two, "public", false);
         let labels: Vec<&str> = c.iter().map(|x| x.label.as_str()).collect();
         assert!(labels.contains(&"t_users"));
         assert!(!labels.contains(&"t_orders"));
 
-        let (_, c) = suggest("select * from t", &two, "other");
+        let (_, c) = suggest("select * from t", &two, "other", false);
         let labels: Vec<&str> = c.iter().map(|x| x.label.as_str()).collect();
         assert!(labels.contains(&"t_orders"));
         assert!(!labels.contains(&"t_users"));
@@ -622,7 +655,7 @@ mod tests {
     #[test]
     fn from_offers_schema_names() {
         // Type-triggered: "a" narrows to the analytics schema name.
-        let (_, c) = suggest("select * from a", &two_schema_nodes(), "public");
+        let (_, c) = suggest("select * from a", &two_schema_nodes(), "public", false);
         let labels: Vec<&str> = c.iter().map(|x| x.label.as_str()).collect();
         assert!(labels.contains(&"analytics"));
     }
@@ -631,7 +664,12 @@ mod tests {
     /// active (all schemas live in the completion tree).
     #[test]
     fn dot_lists_non_active_schema_tables() {
-        let (n, c) = suggest("select * from analytics.", &two_schema_nodes(), "public");
+        let (n, c) = suggest(
+            "select * from analytics.",
+            &two_schema_nodes(),
+            "public",
+            false,
+        );
         assert_eq!(n, 0);
         assert_eq!(
             c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),

--- a/app/src/completion.rs
+++ b/app/src/completion.rs
@@ -42,6 +42,41 @@ fn keywords() -> Vec<Candidate> {
         .collect()
 }
 
+/// mongosh collection methods, offered after `db.<collection>.` so Mongo
+/// completion reaches parity with SQL column completion.
+const MONGO_METHODS: &[&str] = &[
+    "find",
+    "findOne",
+    "aggregate",
+    "countDocuments",
+    "distinct",
+    "insertOne",
+    "insertMany",
+    "updateOne",
+    "updateMany",
+    "deleteOne",
+    "deleteMany",
+];
+
+fn mongo_methods() -> Vec<Candidate> {
+    MONGO_METHODS
+        .iter()
+        .map(|m| Candidate {
+            label: (*m).to_string(),
+            kind: "keyword".into(),
+            sub: String::new(),
+        })
+        .collect()
+}
+
+/// Does `name` match a collection node (MongoDB) in the tree?
+fn is_collection(nodes: &[VmTreeNode], name: &str) -> bool {
+    let nl = name.to_lowercase();
+    nodes
+        .iter()
+        .any(|n| n.kind == "collection" && n.label.to_lowercase() == nl)
+}
+
 /// Every column across the schema (deduped by name), for SELECT/WHERE contexts
 /// where the owning table isn't yet known.
 fn all_columns(nodes: &[VmTreeNode]) -> Vec<Candidate> {
@@ -255,6 +290,9 @@ pub fn suggest(
         } else if owner_word.eq_ignore_ascii_case("db") {
             // MongoDB: `db.` is the current database — offer its collections.
             tables(scope)
+        } else if is_collection(nodes, owner_word) {
+            // MongoDB: `db.<collection>.` — offer collection methods.
+            mongo_methods()
         } else if is_database(nodes, owner_word) {
             tables(schema_scope(nodes, owner_word))
         } else {
@@ -369,6 +407,19 @@ mod tests {
         let (n, c) = suggest("db.log", &ns, "public");
         assert_eq!(n, 3);
         assert!(c.iter().any(|x| x.label == "log_inbound"));
+    }
+
+    #[test]
+    fn mongo_collection_dot_suggests_methods() {
+        // `db.<collection>.` offers mongosh methods (parity with SQL columns).
+        let mut ns = nodes();
+        ns.push(VmTreeNode {
+            label: "log_inbound".into(),
+            kind: "collection".into(),
+        });
+        let (_, c) = suggest("db.log_inbound.fi", &ns, "public");
+        assert!(c.iter().any(|x| x.label == "find"));
+        assert!(c.iter().any(|x| x.label == "findOne"));
     }
 
     /// Typing a mid-word `_` segment finds the identifier, and a true prefix

--- a/app/src/dispatch.rs
+++ b/app/src/dispatch.rs
@@ -78,6 +78,14 @@ impl AnyDriver {
         })
     }
 
+    /// Push the user's NoSQL collection cap onto a live connection. Only NoSQL
+    /// engines (MongoDB) have a sidebar collection cap; RDBMS variants no-op.
+    pub fn set_collection_limit(&self, n: usize) {
+        if let AnyDriver::Mongo(d) = self {
+            d.set_collection_limit(n);
+        }
+    }
+
     /// Part of the driver surface; wired into the UI status check later.
     pub async fn ping(&self) -> Result<()> {
         match self {

--- a/app/src/editor.rs
+++ b/app/src/editor.rs
@@ -706,10 +706,14 @@ impl EditorState {
         if seg_start < chars.len() {
             segments.push((seg_start, chars.len()));
         }
+        // Inclusive upper bound so a caret parked right after a `;` (offset == the
+        // segment's end, which also equals the next segment's start) runs the
+        // statement it just closed, not the following one. `find` yields the
+        // earliest match, so the closing segment wins.
         let (s, e) = segments
             .iter()
             .copied()
-            .find(|&(s, e)| offset >= s && offset < e)
+            .find(|&(s, e)| offset >= s && offset <= e)
             .or_else(|| segments.last().copied())
             .unwrap_or((0, chars.len()));
         let stmt: String = chars[s..e].iter().collect();
@@ -952,6 +956,16 @@ mod tests {
         ed.line = 2;
         ed.col = 0;
         assert_eq!(ed.current_statement(), "SELECT 3");
+    }
+
+    #[test]
+    fn statement_caret_right_after_semicolon_runs_that_statement() {
+        // Caret parked at the end of line 0 (just after its `;`) must run that
+        // statement, not the next one.
+        let mut ed = EditorState::from_text("SELECT 1;\nSELECT 2;");
+        ed.line = 0;
+        ed.col = 9; // right after the first `;`
+        assert_eq!(ed.current_statement(), "SELECT 1;");
     }
 
     #[test]

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2919,7 +2919,11 @@ fn main() -> Result<(), slint::PlatformError> {
     }
 
     // (engine, driver) so run-query can parse text for the right paradigm.
-    let current: Arc<tokio::sync::Mutex<Option<(rdb_connstore::Engine, AnyDriver)>>> =
+    // The live driver behind an Arc so callers clone it out of the mutex and run
+    // queries/pings lock-free: the mutex only guards the slot swap, never a whole
+    // query. Drivers are `&self`, internally pooled and cheap to clone, so this
+    // removes query↔ping (and query↔query) serialization.
+    let current: Arc<tokio::sync::Mutex<Option<(rdb_connstore::Engine, Arc<AnyDriver>)>>> =
         Arc::new(tokio::sync::Mutex::new(None));
 
     // Set of group labels the user has collapsed in the sidebar.
@@ -4124,8 +4128,11 @@ fn main() -> Result<(), slint::PlatformError> {
                 }
             };
             rt.spawn(async move {
-                let guard = current.lock_owned().await;
-                let Some((_, driver)) = guard.as_ref() else {
+                let driver = {
+                    let guard = current.lock().await;
+                    guard.as_ref().map(|(_, d)| d.clone())
+                };
+                let Some(driver) = driver else {
                     clear_loading();
                     return;
                 };
@@ -4159,7 +4166,6 @@ fn main() -> Result<(), slint::PlatformError> {
                     Some(engine),
                     "",
                 );
-                drop(guard);
                 *raw_nodes.lock().unwrap() = nodes;
                 let _ = slint::invoke_from_event_loop(move || {
                     if let Some(w) = weak2.upgrade() {
@@ -4204,15 +4210,17 @@ fn main() -> Result<(), slint::PlatformError> {
             let weak2 = weak.clone();
             let current = current.clone();
             rt.spawn(async move {
-                let guard = current.lock_owned().await;
-                let res = match guard.as_ref() {
-                    Some((_, driver)) => driver
+                let driver = {
+                    let guard = current.lock().await;
+                    guard.as_ref().map(|(_, d)| d.clone())
+                };
+                let res = match driver {
+                    Some(driver) => driver
                         .query(&rdb_core::query::Query::Sql(sql))
                         .await
                         .map(|_| ()),
                     None => Err(rdb_core::error::RdbError::Query("not connected".into())),
                 };
-                drop(guard);
                 let _ = slint::invoke_from_event_loop(move || {
                     if let Some(w) = weak2.upgrade() {
                         match res {
@@ -4365,15 +4373,17 @@ fn main() -> Result<(), slint::PlatformError> {
             let weak2 = weak.clone();
             let current = current.clone();
             rt.spawn(async move {
-                let guard = current.lock_owned().await;
-                let res = match guard.as_ref() {
-                    Some((_, driver)) => driver
+                let driver = {
+                    let guard = current.lock().await;
+                    guard.as_ref().map(|(_, d)| d.clone())
+                };
+                let res = match driver {
+                    Some(driver) => driver
                         .query(&rdb_core::query::Query::Sql(sql))
                         .await
                         .map(|_| ()),
                     None => Err(rdb_core::error::RdbError::Query("not connected".into())),
                 };
-                drop(guard);
                 let _ = slint::invoke_from_event_loop(move || {
                     if let Some(w) = weak2.upgrade() {
                         match res {
@@ -4401,12 +4411,15 @@ fn main() -> Result<(), slint::PlatformError> {
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(10)).await;
                 // None = no driver (picker); Some(ok) = pinged a live connection.
-                let alive = {
+                // Clone the driver out of the mutex before pinging so a slow ping
+                // never blocks an in-flight query.
+                let driver = {
                     let guard = current.lock().await;
-                    match guard.as_ref() {
-                        Some((_, driver)) => Some(driver.ping().await.is_ok()),
-                        None => None,
-                    }
+                    guard.as_ref().map(|(_, d)| d.clone())
+                };
+                let alive = match driver {
+                    Some(driver) => Some(driver.ping().await.is_ok()),
+                    None => None,
                 };
                 let Some(ok) = alive else { continue };
                 let weak = weak.clone();
@@ -6085,7 +6098,7 @@ fn main() -> Result<(), slint::PlatformError> {
                             .into_iter()
                             .map(SharedString::from)
                             .collect();
-                        *slot = Some((engine, driver));
+                        *slot = Some((engine, Arc::new(driver)));
                         drop(slot);
                         let nodes = model::to_tree_model(&schema);
                         let fields = model::to_structure_model(&schema);
@@ -6202,8 +6215,11 @@ fn main() -> Result<(), slint::PlatformError> {
                         if matches!(engine, rdb_connstore::Engine::Postgres)
                             && all_schema_names.len() > 1
                         {
-                            let guard = store_driver.lock_owned().await;
-                            if let Some((_, driver)) = guard.as_ref() {
+                            let driver = {
+                                let guard = store_driver.lock().await;
+                                guard.as_ref().map(|(_, d)| d.clone())
+                            };
+                            if let Some(driver) = driver {
                                 let mut all = Vec::new();
                                 for name in &all_schema_names {
                                     if let Ok(s) = driver.schema_for(name).await {
@@ -6352,7 +6368,10 @@ fn main() -> Result<(), slint::PlatformError> {
             }
             let started = std::time::Instant::now();
             let jh = rt.spawn(async move {
-                let guard = current.lock().await;
+                let picked = {
+                    let guard = current.lock().await;
+                    guard.as_ref().map(|(e, d)| (*e, d.clone()))
+                };
                 let queue_ms = started.elapsed().as_millis() as u64;
                 let driver_started = std::time::Instant::now();
                 // Multi-statement: SQL engines split on top-level `;` and run
@@ -6360,7 +6379,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 // is what the grid shows (TablePlus semantics). Redis/Mongo
                 // take the whole text as a single command.
                 let mut split_views: Vec<model::ResultView> = Vec::new();
-                let (outcome, n_stmts) = match guard.as_ref() {
+                let (outcome, n_stmts) = match picked.as_ref() {
                     Some((engine, driver)) => {
                         let stmts = if matches!(
                             engine,
@@ -6904,18 +6923,23 @@ fn main() -> Result<(), slint::PlatformError> {
             *stream_timer.borrow_mut() = Some(timer);
 
             // Producer task: stream from the driver, forward Send batches to the
-            // UI channel. Holds the driver lock for the whole stream (like a DB
-            // client cursor); Cancel or a new run stops it at the next batch.
+            // UI channel. The driver is cloned out of the mutex up front (the
+            // mongodb/pg client is internally pooled), so the whole stream runs
+            // without holding the lock; Cancel or a new run stops it at the next
+            // batch.
             let q = rdb_core::query::Query::Sql(sql);
             let current = current.clone();
             rt.spawn(async move {
                 let t0 = std::time::Instant::now();
-                let guard = current.lock().await;
+                let driver = {
+                    let guard = current.lock().await;
+                    guard.as_ref().map(|(_, d)| d.clone())
+                };
                 let (ctx, mut crx) = tokio::sync::mpsc::channel::<rdb_core::result::StreamItem>(4);
                 let cancel_prod = cancel.clone();
                 let producer = async move {
-                    match guard.as_ref() {
-                        Some((_engine, driver)) => {
+                    match driver {
+                        Some(driver) => {
                             driver
                                 .query_stream(&q, STREAM_BATCH, cancel_prod, ctx)
                                 .await
@@ -8030,8 +8054,11 @@ fn main() -> Result<(), slint::PlatformError> {
             let active_tab_id = active_tab_id.clone();
             let query_console = query_console.clone();
             rt.spawn(async move {
-                let guard = current.lock().await;
-                let Some((engine, driver)) = guard.as_ref() else {
+                let picked = {
+                    let guard = current.lock().await;
+                    guard.as_ref().map(|(e, d)| (*e, d.clone()))
+                };
+                let Some((engine, driver)) = picked.as_ref() else {
                     return;
                 };
                 let total = driver.count(&table).await.ok();
@@ -8187,8 +8214,11 @@ fn main() -> Result<(), slint::PlatformError> {
             let current = current.clone();
             let browse = browse.clone();
             rt.spawn(async move {
-                let guard = current.lock().await;
-                let Some((_, driver)) = guard.as_ref() else {
+                let driver = {
+                    let guard = current.lock().await;
+                    guard.as_ref().map(|(_, d)| d.clone())
+                };
+                let Some(driver) = driver else {
                     return;
                 };
                 let total = driver.count(&table).await.ok();
@@ -8452,12 +8482,13 @@ fn main() -> Result<(), slint::PlatformError> {
                     let weak2 = weak.clone();
                     let db = label.clone();
                     rt.spawn(async move {
-                        let containers = {
+                        let drv = {
                             let guard = driver.lock().await;
-                            match &*guard {
-                                Some((_, drv)) => drv.containers(&db).await.unwrap_or_default(),
-                                None => return,
-                            }
+                            guard.as_ref().map(|(_, d)| d.clone())
+                        };
+                        let containers = match drv {
+                            Some(drv) => drv.containers(&db).await.unwrap_or_default(),
+                            None => return,
                         };
                         let rows = {
                             let mut nodes = raw_nodes.lock().unwrap();
@@ -9536,14 +9567,15 @@ fn main() -> Result<(), slint::PlatformError> {
                 w.set_result_status(SharedString::from("saving…"));
             }
             rt.spawn(async move {
-                let outcome = {
+                let driver = {
                     let guard = current.lock().await;
-                    match guard.as_ref() {
-                        Some((_, driver)) => driver.commit(&ops).await,
-                        None => Err(rdb_core::error::RdbError::Connection(
-                            "not connected".into(),
-                        )),
-                    }
+                    guard.as_ref().map(|(_, d)| d.clone())
+                };
+                let outcome = match driver {
+                    Some(driver) => driver.commit(&ops).await,
+                    None => Err(rdb_core::error::RdbError::Connection(
+                        "not connected".into(),
+                    )),
                 };
                 let _ = slint::invoke_from_event_loop(move || {
                     let Some(w) = weak2.upgrade() else {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -3202,14 +3202,16 @@ fn main() -> Result<(), slint::PlatformError> {
         let weak = window.as_weak();
         let panes = panes.clone();
         let completion_nodes = completion_nodes.clone();
+        let cur_engine = cur_engine.clone();
         Rc::new(move |pane| {
             let Some(w) = weak.upgrade() else {
                 return;
             };
             let before = panes[pane].ed_state.borrow().before_cursor_doc();
             let schema = w.get_schema_name().to_string();
+            let mongo = matches!(*cur_engine.borrow(), Some(rdb_connstore::Engine::Mongo));
             let (word_len, cands) =
-                completion::suggest(&before, &completion_nodes.lock().unwrap(), &schema);
+                completion::suggest(&before, &completion_nodes.lock().unwrap(), &schema, mongo);
             if cands.is_empty() {
                 set_p_completion_visible(&w, pane, false);
                 *panes[pane].completion_ctx.borrow_mut() = (0, Vec::new());

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -5375,10 +5375,25 @@ fn main() -> Result<(), slint::PlatformError> {
         let workspace_tabs = workspace_tabs.clone();
         let active_tab_id = active_tab_id.clone();
         let current_connection_id = current_connection_id.clone();
+        let panes = panes.clone();
         window.on_disconnect(move || {
             let Some(w) = weak.upgrade() else {
                 return;
             };
+            // Stop any in-flight query first: disconnecting must not leave a query
+            // running on the server. Fire the same cancels the Cancel buttons use
+            // for both panes — aborting the task drops its Arc<AnyDriver> clone so
+            // the connection closes and the server terminates the query.
+            for p in [0usize, 1] {
+                if let Some(c) = panes[p].stream_cancel.borrow().as_ref() {
+                    c.store(true, std::sync::atomic::Ordering::SeqCst);
+                }
+                if let Some(h) = panes[p].query_abort.borrow_mut().take() {
+                    h.abort();
+                }
+                set_p_query_running(&w, p, false);
+                set_p_streaming(&w, p, false);
+            }
             w.set_connected(false);
             w.set_selected_conn(-1);
             w.set_active_table(SharedString::default());

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2907,6 +2907,7 @@ fn main() -> Result<(), slint::PlatformError> {
         settings.borrow().get().editor.history_max_entries.max(1) as usize,
     ));
     window.set_history_max_entries(history_cap.get() as i32);
+    window.set_nosql_collection_limit(settings.borrow().get().nosql_collection_limit.max(1) as i32);
     window.set_app_version(env!("CARGO_PKG_VERSION").into());
 
     // Fixed window size for the screenshot loop: RDB_WIN=WxH (logical px).
@@ -2923,8 +2924,8 @@ fn main() -> Result<(), slint::PlatformError> {
     // queries/pings lock-free: the mutex only guards the slot swap, never a whole
     // query. Drivers are `&self`, internally pooled and cheap to clone, so this
     // removes query↔ping (and query↔query) serialization.
-    let current: Arc<tokio::sync::Mutex<Option<(rdb_connstore::Engine, Arc<AnyDriver>)>>> =
-        Arc::new(tokio::sync::Mutex::new(None));
+    type DriverSlot = Arc<tokio::sync::Mutex<Option<(rdb_connstore::Engine, Arc<AnyDriver>)>>>;
+    let current: DriverSlot = Arc::new(tokio::sync::Mutex::new(None));
 
     // Set of group labels the user has collapsed in the sidebar.
     let collapsed: Rc<RefCell<HashSet<String>>> = Rc::new(RefCell::new(HashSet::new()));
@@ -6051,6 +6052,11 @@ fn main() -> Result<(), slint::PlatformError> {
             let fn_defs = fn_defs.clone();
             let expanded_tables = expanded_tables.clone();
             let loaded_dbs = loaded_dbs.clone();
+            // NoSQL collection cap to push onto the fresh connection (Mongo only).
+            let nosql_limit = weak
+                .upgrade()
+                .map(|w| w.get_nosql_collection_limit().max(1) as usize)
+                .unwrap_or(200);
             let handle = rt.spawn(async move {
                 let mut slot = match claimed {
                     Some(g) => g,
@@ -6063,6 +6069,9 @@ fn main() -> Result<(), slint::PlatformError> {
                     let cfg =
                         cfg.map_err(|e| rdb_core::error::RdbError::Connection(e.to_string()))?;
                     let driver = AnyDriver::connect(engine, &cfg).await?;
+                    // Apply the NoSQL collection cap before any schema fetch so
+                    // the first sidebar load already honors it (Mongo only).
+                    driver.set_collection_limit(nosql_limit);
                     // MongoDB: when the connection names a database, scope the
                     // sidebar to it (matching the schema switcher) instead of
                     // listing every database on the server.
@@ -9749,6 +9758,91 @@ fn main() -> Result<(), slint::PlatformError> {
                 w.set_history_max_entries(cap as i32);
                 rebuild_query_tree("");
             }
+        });
+    }
+    // ----- NoSQL collection-limit setting (MongoDB sidebar cap) -----
+    {
+        let weak = window.as_weak();
+        let rt = rt.clone();
+        let current = current.clone();
+        let raw_nodes = raw_nodes.clone();
+        let expanded_tables = expanded_tables.clone();
+        let loaded_dbs = loaded_dbs.clone();
+        let cur_engine = cur_engine.clone();
+        let settings = settings.clone();
+        window.on_set_nosql_collection_limit(move |value| {
+            let n = match value {
+                50 | 100 | 200 | 500 | 1000 => value as usize,
+                _ => 200,
+            };
+            let _ = settings
+                .borrow_mut()
+                .update(|s| s.nosql_collection_limit = n as u32);
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            w.set_nosql_collection_limit(n as i32);
+            // Only MongoDB has a sidebar collection cap; nothing else to refresh.
+            if !matches!(*cur_engine.borrow(), Some(rdb_connstore::Engine::Mongo)) {
+                return;
+            }
+            let schema_name = w.get_schema_name().to_string();
+            if schema_name.is_empty() {
+                return;
+            }
+            // Push the new cap onto the live driver and refetch the open
+            // database's collections so the change shows immediately.
+            w.set_tree_loading(true);
+            let weak2 = weak.clone();
+            let current = current.clone();
+            let raw_nodes = raw_nodes.clone();
+            let expanded_tables = expanded_tables.clone();
+            let loaded_dbs = loaded_dbs.clone();
+            rt.spawn(async move {
+                let clear_loading = move |weak: slint::Weak<MainWindow>| {
+                    let _ = slint::invoke_from_event_loop(move || {
+                        if let Some(w) = weak.upgrade() {
+                            w.set_tree_loading(false);
+                        }
+                    });
+                };
+                let driver = {
+                    let guard = current.lock().await;
+                    guard.as_ref().map(|(_, d)| d.clone())
+                };
+                let Some(driver) = driver else {
+                    clear_loading(weak2);
+                    return;
+                };
+                driver.set_collection_limit(n);
+                let Ok(schema) = driver.schema_for(&schema_name).await else {
+                    clear_loading(weak2);
+                    return;
+                };
+                let nodes = model::to_tree_model(&schema);
+                let (exp, loaded) = {
+                    let mut e = expanded_tables.lock().unwrap();
+                    let mut l = loaded_dbs.lock().unwrap();
+                    e.insert(schema_name.clone());
+                    l.insert(schema_name.clone());
+                    (e.clone(), l.clone())
+                };
+                let rows = schema_display_rows(
+                    &nodes,
+                    &exp,
+                    &default_collapsed_cats(),
+                    &loaded,
+                    Some(rdb_connstore::Engine::Mongo),
+                    "",
+                );
+                *raw_nodes.lock().unwrap() = nodes;
+                let _ = slint::invoke_from_event_loop(move || {
+                    if let Some(w) = weak2.upgrade() {
+                        w.set_schema_tree(ModelRc::from(Rc::new(VecModel::from(rows))));
+                        w.set_tree_loading(false);
+                    }
+                });
+            });
         });
     }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -6049,6 +6049,8 @@ fn main() -> Result<(), slint::PlatformError> {
             let raw_nodes = raw_nodes.clone();
             let completion_nodes = completion_nodes.clone();
             let fn_defs = fn_defs.clone();
+            let expanded_tables = expanded_tables.clone();
+            let loaded_dbs = loaded_dbs.clone();
             let handle = rt.spawn(async move {
                 let mut slot = match claimed {
                     Some(g) => g,
@@ -6061,8 +6063,19 @@ fn main() -> Result<(), slint::PlatformError> {
                     let cfg =
                         cfg.map_err(|e| rdb_core::error::RdbError::Connection(e.to_string()))?;
                     let driver = AnyDriver::connect(engine, &cfg).await?;
-                    let schema = driver.schema().await?;
-                    Ok::<_, rdb_core::error::RdbError>((driver, schema))
+                    // MongoDB: when the connection names a database, scope the
+                    // sidebar to it (matching the schema switcher) instead of
+                    // listing every database on the server.
+                    let scoped_db = if matches!(engine, rdb_connstore::Engine::Mongo) {
+                        cfg.database.clone().filter(|d| !d.is_empty())
+                    } else {
+                        None
+                    };
+                    let schema = match &scoped_db {
+                        Some(db) => driver.schema_for(db).await?,
+                        None => driver.schema().await?,
+                    };
+                    Ok::<_, rdb_core::error::RdbError>((driver, schema, scoped_db))
                 };
                 let result =
                     match tokio::time::timeout(std::time::Duration::from_secs(15), attempt).await {
@@ -6073,7 +6086,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     };
 
                 match result {
-                    Ok((driver, schema)) => {
+                    Ok((driver, schema, scoped_db)) => {
                         // Postgres: list real namespaces so the sidebar schema
                         // switcher offers more than "public". Engine-specific SQL
                         // lives in the driver, not here.
@@ -6102,15 +6115,28 @@ fn main() -> Result<(), slint::PlatformError> {
                         drop(slot);
                         let nodes = model::to_tree_model(&schema);
                         let fields = model::to_structure_model(&schema);
+                        // Scoped Mongo tree holds only the selected database: open
+                        // it and mark it loaded so its collections show at once
+                        // (mirrors the schema switcher).
+                        let (exp, loaded) = match &scoped_db {
+                            Some(db) => {
+                                let mut e = expanded_tables.lock().unwrap();
+                                let mut l = loaded_dbs.lock().unwrap();
+                                e.insert(db.clone());
+                                l.insert(db.clone());
+                                (e.clone(), l.clone())
+                            }
+                            None => (HashSet::new(), HashSet::new()),
+                        };
                         // Stash raw nodes for later expand/collapse rebuilds, and
                         // render the initial view (Functions collapsed, Tables open,
                         // fields hidden). Matches the reseed done on connect above;
                         // collapsed_categories itself is !Send so can't cross here.
                         let rows = schema_display_rows(
                             &nodes,
-                            &HashSet::new(),
+                            &exp,
                             &default_collapsed_cats(),
-                            &HashSet::new(),
+                            &loaded,
                             Some(engine),
                             "",
                         );
@@ -6124,6 +6150,10 @@ fn main() -> Result<(), slint::PlatformError> {
                                 } else {
                                     pg_schemas
                                 }
+                            } else if scoped_db.is_some() && !db_names.is_empty() {
+                                // Mongo scoped its tree to one database: still list
+                                // every database so the switcher can reach them.
+                                db_names.clone()
                             } else {
                                 schema
                                     .databases
@@ -6134,12 +6164,16 @@ fn main() -> Result<(), slint::PlatformError> {
                         if schema_names.is_empty() {
                             schema_names.push(SharedString::from("public"));
                         }
-                        // Default to "public" when present, else the first name.
-                        let schema_current = schema_names
-                            .iter()
-                            .find(|s| s.as_str() == "public")
-                            .unwrap_or(&schema_names[0])
-                            .clone();
+                        // Scoped Mongo starts on its selected database; otherwise
+                        // default to "public" when present, else the first name.
+                        let schema_current = match &scoped_db {
+                            Some(db) => SharedString::from(db.clone()),
+                            None => schema_names
+                                .iter()
+                                .find(|s| s.as_str() == "public")
+                                .unwrap_or(&schema_names[0])
+                                .clone(),
+                        };
                         // SQL editor only makes sense for the SQL engines.
                         let sql_capable = matches!(
                             engine,

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -522,6 +522,9 @@ callback create-table-commit();
     callback set-update-check(bool);
     in property <int> history-max-entries: 50;
     callback set-history-max-entries(int);
+    // Max collections listed per database for NoSQL (MongoDB); RDBMS unaffected.
+    in property <int> nosql-collection-limit: 200;
+    callback set-nosql-collection-limit(int);
     in-out property <bool> shortcuts-open: false;
     // Settings modal active section: 0 Appearance, 1 Updates, 2 About.
     in-out property <int> settings-tab: 0;
@@ -2403,6 +2406,33 @@ callback create-table-commit();
                             selected(value) => {
                                 root.set-history-max-entries(value == "25" ? 25
                                     : value == "100" ? 100 : value == "200" ? 200 : 50);
+                            }
+                        }
+                    }
+                    // NoSQL-only: caps how many collections the MongoDB sidebar
+                    // lists per database. RDBMS table listings are unaffected.
+                    HorizontalLayout {
+                        spacing: Tokens.sp3;
+                        VerticalLayout {
+                            alignment: center;
+                            horizontal-stretch: 1;
+                            Text {
+                                text: "Max collections (MongoDB)";
+                                color: Tokens.text;
+                                font-size: 13px;
+                            }
+                        }
+                        SelectBox {
+                            width: 82px;
+                            model: ["50", "100", "200", "500", "1000"];
+                            current-value: root.nosql-collection-limit == 50 ? "50"
+                                : root.nosql-collection-limit == 100 ? "100"
+                                : root.nosql-collection-limit == 500 ? "500"
+                                : root.nosql-collection-limit == 1000 ? "1000" : "200";
+                            selected(value) => {
+                                root.set-nosql-collection-limit(value == "50" ? 50
+                                    : value == "100" ? 100 : value == "500" ? 500
+                                    : value == "1000" ? 1000 : 200);
                             }
                         }
                     }

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -587,9 +587,6 @@ export component FilterField inherits Rectangle {
     border-width: 1px;
     border-color: input.has-focus ? Tokens.accent : Tokens.border;
     background: Tokens.card;
-    // Keep long single-line content inside the box instead of spilling past the
-    // border over neighbouring toolbar controls (Mongo JSON filter).
-    clip: true;
     HorizontalLayout {
         padding-left: Tokens.sp2;
         padding-right: 6px;
@@ -598,14 +595,23 @@ export component FilterField inherits Rectangle {
             alignment: center;
             AppIcon { name: "search"; size: 14px; color: Tokens.text-faint; }
         }
-        input := TextInput {
-            font-size: Tokens.font-sm;
-            color: Tokens.text;
-            vertical-alignment: center;
-            single-line: true;
+        // Clip the input to a bounded viewport: a single-line TextInput inside a
+        // layout would otherwise grow to its full text width and spill past the
+        // box. Clipping here lets it scroll to keep the caret (and the newest
+        // characters) visible while typing long content (Mongo JSON filter).
+        Rectangle {
             horizontal-stretch: 1;
-            accepted => { root.submitted(); }
-            edited => { root.edited(self.text); }
+            clip: true;
+            input := TextInput {
+                width: parent.width;
+                height: parent.height;
+                font-size: Tokens.font-sm;
+                color: Tokens.text;
+                vertical-alignment: center;
+                single-line: true;
+                accepted => { root.submitted(); }
+                edited => { root.edited(self.text); }
+            }
         }
         if root.trailing-cap != "": VerticalLayout {
             alignment: center;

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -587,6 +587,9 @@ export component FilterField inherits Rectangle {
     border-width: 1px;
     border-color: input.has-focus ? Tokens.accent : Tokens.border;
     background: Tokens.card;
+    // Keep long single-line content inside the box instead of spilling past the
+    // border over neighbouring toolbar controls (Mongo JSON filter).
+    clip: true;
     HorizontalLayout {
         padding-left: Tokens.sp2;
         padding-right: 6px;

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -602,6 +602,11 @@ export component FilterField inherits Rectangle {
         // x on cursor moves so the newest characters stay visible while typing.
         Rectangle {
             horizontal-stretch: 1;
+            // Do not let the input's text width inflate the field: without this
+            // the viewport's preferred width tracks the (unbounded) text and the
+            // whole FilterField grows, defeating the clip.
+            preferred-width: 0px;
+            min-width: 0px;
             clip: true;
             input := TextInput {
                 width: max(parent.width, self.preferred-width);

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -595,15 +595,16 @@ export component FilterField inherits Rectangle {
             alignment: center;
             AppIcon { name: "search"; size: 14px; color: Tokens.text-faint; }
         }
-        // Clip the input to a bounded viewport: a single-line TextInput inside a
-        // layout would otherwise grow to its full text width and spill past the
-        // box. Clipping here lets it scroll to keep the caret (and the newest
-        // characters) visible while typing long content (Mongo JSON filter).
+        // Bounded, clipped viewport that scrolls to the caret. A single-line
+        // TextInput does not scroll on its own (Slint docs): it grows to its full
+        // text width, so long content (e.g. a Mongo JSON filter) would spill past
+        // the box. Grow the input to its text width, clip it here, and shift its
+        // x on cursor moves so the newest characters stay visible while typing.
         Rectangle {
             horizontal-stretch: 1;
             clip: true;
             input := TextInput {
-                width: parent.width;
+                width: max(parent.width, self.preferred-width);
                 height: parent.height;
                 font-size: Tokens.font-sm;
                 color: Tokens.text;
@@ -611,6 +612,13 @@ export component FilterField inherits Rectangle {
                 single-line: true;
                 accepted => { root.submitted(); }
                 edited => { root.edited(self.text); }
+                cursor-position-changed(cursor-position) => {
+                    if cursor-position.x + self.x < 4px {
+                        self.x = -cursor-position.x + 4px;
+                    } else if cursor-position.x + self.x > parent.width - 4px - self.text-cursor-width {
+                        self.x = parent.width - cursor-position.x - 4px - self.text-cursor-width;
+                    }
+                }
             }
         }
         if root.trailing-cap != "": VerticalLayout {

--- a/app/src/ui/conn-form.slint
+++ b/app/src/ui/conn-form.slint
@@ -133,6 +133,7 @@ export component ConnForm inherits Rectangle {
                 SecondaryButton {
                     text: "Import";
                     height: 30px;
+                    tooltip: "Fill the form from a connection URL";
                     clicked => { root.import-url(); }
                 }
             }

--- a/app/src/ui/picker.slint
+++ b/app/src/ui/picker.slint
@@ -4,7 +4,7 @@
 import { Tokens } from "tokens.slint";
 import {
     DbBadge, OutlineChip, PrimaryButton, SecondaryButton, TextButton,
-    TagChip, FilterField
+    TagChip, FilterField, Tooltip
 } from "components.slint";
 import { AppIcon } from "icons.slint";
 import { ConnItem, KvRow } from "structs.slint";
@@ -198,6 +198,16 @@ export component ConnPicker inherits Rectangle {
                                                             round((self.mouse-y - self.pressed-y) / 40px));
                                                     }
                                                 }
+                                                changed has-hover => {
+                                                    if self.has-hover {
+                                                        Tooltip.text = "Drag to reorder";
+                                                        Tooltip.x = self.absolute-position.x + self.width / 2;
+                                                        Tooltip.y = self.absolute-position.y + self.height + 4px;
+                                                        Tooltip.shown = true;
+                                                    } else if Tooltip.text == "Drag to reorder" {
+                                                        Tooltip.shown = false;
+                                                    }
+                                                }
                                             }
                                         }
                                     }
@@ -259,6 +269,16 @@ export component ConnPicker inherits Rectangle {
                                             }
                                             star-ta := TouchArea {
                                                 clicked => { root.toggle-favorite(item.index); }
+                                                changed has-hover => {
+                                                    if self.has-hover {
+                                                        Tooltip.text = item.favorite ? "Remove favorite" : "Add to favorites";
+                                                        Tooltip.x = self.absolute-position.x + self.width / 2;
+                                                        Tooltip.y = self.absolute-position.y + self.height + 4px;
+                                                        Tooltip.shown = true;
+                                                    } else {
+                                                        Tooltip.shown = false;
+                                                    }
+                                                }
                                             }
                                         }
                                     }
@@ -278,8 +298,14 @@ export component ConnPicker inherits Rectangle {
                         spacing: Tokens.sp4;
                         Rectangle {
                             width: new-row.preferred-width;
+                            height: 32px;
+                            border-radius: Tokens.radius;
+                            background: new-ta.has-hover ? Tokens.chrome : transparent;
+                            animate background { duration: Tokens.fade; }
                             new-row := HorizontalLayout {
                                 spacing: Tokens.sp2;
+                                padding-left: Tokens.sp3;
+                                padding-right: Tokens.sp3;
                                 Text {
                                     text: "+";
                                     color: Tokens.text;
@@ -294,7 +320,10 @@ export component ConnPicker inherits Rectangle {
                                     vertical-alignment: center;
                                 }
                             }
-                            new-ta := TouchArea { clicked => { root.add-clicked(); } }
+                            new-ta := TouchArea {
+                                mouse-cursor: pointer;
+                                clicked => { root.add-clicked(); }
+                            }
                         }
                         Rectangle { horizontal-stretch: 1; }
                         VerticalLayout {

--- a/app/src/ui/picker.slint
+++ b/app/src/ui/picker.slint
@@ -296,7 +296,9 @@ export component ConnPicker inherits Rectangle {
                         padding-left: Tokens.sp6;
                         padding-right: Tokens.sp6;
                         spacing: Tokens.sp4;
-                        Rectangle {
+                        VerticalLayout {
+                            alignment: center;
+                            Rectangle {
                             width: new-row.preferred-width;
                             height: 30px;
                             border-radius: Tokens.radius;
@@ -325,6 +327,7 @@ export component ConnPicker inherits Rectangle {
                             new-ta := TouchArea {
                                 mouse-cursor: pointer;
                                 clicked => { root.add-clicked(); }
+                            }
                             }
                         }
                         Rectangle { horizontal-stretch: 1; }

--- a/app/src/ui/picker.slint
+++ b/app/src/ui/picker.slint
@@ -302,7 +302,7 @@ export component ConnPicker inherits Rectangle {
                             width: new-row.preferred-width;
                             height: 30px;
                             border-radius: Tokens.radius;
-                            background: new-ta.has-hover ? Tokens.chrome : transparent;
+                            background: new-ta.has-hover ? Tokens.border : transparent;
                             animate background { duration: Tokens.fade; }
                             new-row := HorizontalLayout {
                                 spacing: Tokens.sp2;

--- a/app/src/ui/picker.slint
+++ b/app/src/ui/picker.slint
@@ -298,7 +298,7 @@ export component ConnPicker inherits Rectangle {
                         spacing: Tokens.sp4;
                         Rectangle {
                             width: new-row.preferred-width;
-                            height: 32px;
+                            height: 30px;
                             border-radius: Tokens.radius;
                             background: new-ta.has-hover ? Tokens.chrome : transparent;
                             animate background { duration: Tokens.fade; }
@@ -306,10 +306,12 @@ export component ConnPicker inherits Rectangle {
                                 spacing: Tokens.sp2;
                                 padding-left: Tokens.sp3;
                                 padding-right: Tokens.sp3;
+                                alignment: center;
                                 Text {
                                     text: "+";
                                     color: Tokens.text;
-                                    font-size: 15px;
+                                    font-size: Tokens.font-md;
+                                    font-weight: 500;
                                     vertical-alignment: center;
                                 }
                                 Text {

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -10,7 +10,7 @@ import { CodeEditor } from "code-editor.slint";
 import { TabularGrid } from "tabular-grid.slint";
 import { PaletteItem } from "palette.slint";
 import { SecondaryButton, PrimaryButton, TextButton, ExportButton, DangerButton } from "components.slint";
-import { ScrollView } from "std-widgets.slint";
+import { ScrollView, TextEdit } from "std-widgets.slint";
 import { AppIcon } from "icons.slint";
 
 export component QueryPane inherits Rectangle {
@@ -587,32 +587,31 @@ export component QueryPane inherits Rectangle {
                                         }
                                     }
                                     // Box grows to fit the value; short values stay
-                                    // compact, long ones cap out and scroll inside.
+                                    // compact, long ones cap out. TextEdit owns its
+                                    // own scrollbar so big values wrap and scroll
+                                    // reliably (the old ScrollView+TextInput had a
+                                    // cyclic height that broke scrolling).
                                     Rectangle {
-                                        height: clamp(detail-input.preferred-height + 2 * Tokens.sp2, 44px, 220px);
-                                        clip: true;
-                                        border-radius: Tokens.radius;
-                                        border-width: 1px;
-                                        border-color: detail-input.has-focus ? Tokens.accent : Tokens.border-strong;
-                                        background: Tokens.canvas;
-                                        ScrollView {
-                                            x: Tokens.sp2;
-                                            y: Tokens.sp2;
-                                            width: parent.width - 2 * Tokens.sp2;
-                                            height: parent.height - 2 * Tokens.sp2;
-                                            detail-input := TextInput {
-                                                width: parent.visible-width;
-                                                height: max(parent.visible-height, self.preferred-height);
-                                                text: pretty != "" ? pretty : (detail-cell.is-null ? "" : detail-cell.text);
-                                                enabled: !root.read-only;
-                                                single-line: false;
-                                                wrap: word-wrap;
-                                                vertical-alignment: top;
-                                                color: root.read-only ? Tokens.text-dim : Tokens.text;
-                                                font-family: Tokens.mono;
-                                                font-size: Tokens.font-sm;
-                                                edited => { root.stage-cell(root.selected-row, c, self.text); }
-                                            }
+                                        height: clamp(measurer.preferred-height + 2 * Tokens.sp2, 44px, 220px);
+                                        // Invisible height probe: same width/font as the
+                                        // editor, so the box sizes to the wrapped content.
+                                        measurer := Text {
+                                            width: parent.width - 24px;
+                                            text: pretty != "" ? pretty : (detail-cell.is-null ? "" : detail-cell.text);
+                                            wrap: word-wrap;
+                                            font-family: Tokens.mono;
+                                            font-size: Tokens.font-sm;
+                                            color: transparent;
+                                        }
+                                        detail-input := TextEdit {
+                                            width: 100%;
+                                            height: 100%;
+                                            read-only: root.read-only;
+                                            text: pretty != "" ? pretty : (detail-cell.is-null ? "" : detail-cell.text);
+                                            wrap: word-wrap;
+                                            font-family: Tokens.mono;
+                                            font-size: Tokens.font-sm;
+                                            edited => { root.stage-cell(root.selected-row, c, self.text); }
                                         }
                                         if detail-cell.is-null && detail-input.text == "": Text {
                                             x: Tokens.sp2;

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -761,11 +761,22 @@ export component QueryPane inherits Rectangle {
                 }
             }
 
-            // Affected-rows toast
-            if root.view-mode == 0 && (root.browse-mode || root.sql-view-mode == 0) && root.result-kind == 3: Text {
-                text: root.result-status;
-                color: root.status-error ? Tokens.error : Tokens.text-dim;
-                font-size: Tokens.font-md;
+            // Affected-rows toast / error message. Scroll + wrap so a long error
+            // (Postgres echoes the whole failing statement) stays readable.
+            if root.view-mode == 0 && (root.browse-mode || root.sql-view-mode == 0) && root.result-kind == 3: ScrollView {
+                width: 100%;
+                height: 100%;
+                VerticalLayout {
+                    width: parent.visible-width;
+                    padding: Tokens.sp3;
+                    alignment: start;
+                    Text {
+                        text: root.result-status;
+                        color: root.status-error ? Tokens.error : Tokens.text-dim;
+                        font-size: Tokens.font-md;
+                        wrap: word-wrap;
+                    }
+                }
             }
 
             // Structure view
@@ -821,14 +832,20 @@ export component QueryPane inherits Rectangle {
                 }
             }
 
-            // Message view (SQL footer segment)
-            if !root.browse-mode && root.view-mode == 0 && root.sql-view-mode == 1: VerticalLayout {
-                padding: Tokens.sp3;
-                alignment: start;
-                Text {
-                    text: root.result-status == "" ? "No messages" : root.result-status;
-                    color: root.status-error ? Tokens.error : Tokens.text-dim;
-                    font-size: Tokens.font-md;
+            // Message view (SQL footer segment). Scroll + wrap for long errors.
+            if !root.browse-mode && root.view-mode == 0 && root.sql-view-mode == 1: ScrollView {
+                width: 100%;
+                height: 100%;
+                VerticalLayout {
+                    width: parent.visible-width;
+                    padding: Tokens.sp3;
+                    alignment: start;
+                    Text {
+                        text: root.result-status == "" ? "No messages" : root.result-status;
+                        color: root.status-error ? Tokens.error : Tokens.text-dim;
+                        font-size: Tokens.font-md;
+                        wrap: word-wrap;
+                    }
                 }
             }
 

--- a/app/src/ui/tabular-grid.slint
+++ b/app/src/ui/tabular-grid.slint
@@ -3,7 +3,7 @@
 // Cells are flat row-major: row r, col c at r*col-count + c.
 import { Tokens } from "tokens.slint";
 import { GridColumn, GridCell } from "structs.slint";
-import { ComboBox, DatePickerPopup, ScrollView } from "std-widgets.slint";
+import { ComboBox, DatePickerPopup, ScrollView, TextEdit } from "std-widgets.slint";
 
 export component TabularGrid inherits Rectangle {
     in property <[GridColumn]> columns;
@@ -515,35 +515,20 @@ export component TabularGrid inherits Rectangle {
                         vertical-alignment: center;
                     }
                 }
-                Rectangle {
+                // TextEdit owns its own viewport/scrollbar, so a large value
+                // wraps and scrolls reliably (the old ScrollView+TextInput had a
+                // cyclic height dependency that broke scrolling on big values).
+                detail-input := TextEdit {
                     vertical-stretch: 1;
-                    background: Tokens.chrome;
-                    border-radius: Tokens.radius;
-                    border-width: 1px;
-                    border-color: Tokens.border;
-                    inspector-scroll := ScrollView {
-                        // Pin the viewport to the visible width so only vertical
-                        // scroll kicks in; the TextInput grows to its content height
-                        // so a long value scrolls with a real scrollbar.
-                        viewport-width: self.visible-width;
-                        detail-input := TextInput {
-                            x: Tokens.sp2;
-                            y: Tokens.sp1;
-                            width: inspector-scroll.visible-width - 2 * Tokens.sp2;
-                            height: max(inspector-scroll.visible-height - 2 * Tokens.sp1, self.preferred-height);
-                            read-only: true;
-                            text: root.editing-value;
-                            color: Tokens.text;
-                            font-family: Tokens.mono;
-                            font-size: Tokens.font-sm;
-                            wrap: word-wrap;
-                            single-line: false;
-                            init => { self.focus(); self.select-all(); }
-                            key-pressed(e) => {
-                                if (e.text == Key.Escape) { root.edit-cancelled(); return accept; }
-                                return reject;
-                            }
-                        }
+                    read-only: true;
+                    text: root.editing-value;
+                    wrap: word-wrap;
+                    font-family: Tokens.mono;
+                    font-size: Tokens.font-sm;
+                    init => { self.focus(); self.select-all(); }
+                    key-pressed(e) => {
+                        if (e.text == Key.Escape) { root.edit-cancelled(); return accept; }
+                        return reject;
                     }
                 }
                 // Say *why* this is view-only: a manual query result has no row

--- a/crates/connstore/src/settings.rs
+++ b/crates/connstore/src/settings.rs
@@ -81,6 +81,9 @@ pub struct AppSettings {
     pub last_update_check: Option<i64>,
     pub ui_state: UiState,
     pub editor: EditorPrefs,
+    /// Max collections listed per database for NoSQL engines (MongoDB). RDBMS
+    /// table listings are unaffected. A large value effectively shows them all.
+    pub nosql_collection_limit: u32,
 }
 
 impl Default for AppSettings {
@@ -91,6 +94,7 @@ impl Default for AppSettings {
             last_update_check: None,
             ui_state: UiState::default(),
             editor: EditorPrefs::default(),
+            nosql_collection_limit: 200,
         }
     }
 }
@@ -172,6 +176,7 @@ mod tests {
         assert_eq!(s.get().last_update_check, None);
         assert_eq!(s.get().editor.default_page_size, 100);
         assert_eq!(s.get().editor.history_max_entries, 50);
+        assert_eq!(s.get().nosql_collection_limit, 200);
     }
 
     #[test]

--- a/crates/driver-mongo/src/driver.rs
+++ b/crates/driver-mongo/src/driver.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
 use futures::stream::TryStreamExt;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use mongodb::bson::{doc, Document};
@@ -22,7 +24,13 @@ pub struct MongoDriver {
     client: Client,
     /// Default database used when an op does not imply one.
     default_db: String,
+    /// Max collections listed per database (the sidebar cap). Interior-mutable
+    /// so the UI can push the user's NoSQL limit onto a live connection.
+    collection_limit: Arc<AtomicUsize>,
 }
+
+/// Fallback collection cap when the UI has not pushed a limit yet.
+const DEFAULT_COLLECTION_LIMIT: usize = 200;
 
 /// Mongo's internal databases. Hidden from the sidebar so the user's own
 /// databases aren't buried, matching Compass/TablePlus defaults.
@@ -79,6 +87,12 @@ fn build_uri(cfg: &ConnConfig) -> String {
 }
 
 impl MongoDriver {
+    /// Push the user's NoSQL collection cap onto this live connection. Affects
+    /// subsequent sidebar refreshes.
+    pub fn set_collection_limit(&self, n: usize) {
+        self.collection_limit.store(n.max(1), Ordering::Relaxed);
+    }
+
     /// Resolve a collection in the op's database, falling back to the
     /// connection's default database when the op names none.
     fn collection(&self, op: &MongoOp) -> Collection<Document> {
@@ -102,7 +116,11 @@ impl Driver for MongoDriver {
         let client =
             Client::with_options(options).map_err(|e| RdbError::Connection(e.to_string()))?;
         let default_db = cfg.database.clone().unwrap_or_else(|| "admin".to_string());
-        Ok(MongoDriver { client, default_db })
+        Ok(MongoDriver {
+            client,
+            default_db,
+            collection_limit: Arc::new(AtomicUsize::new(DEFAULT_COLLECTION_LIMIT)),
+        })
     }
 
     async fn ping(&self) -> Result<()> {
@@ -135,6 +153,19 @@ impl Driver for MongoDriver {
         Ok(Schema { databases })
     }
 
+    /// All non-system databases, backing the "schema:" switcher so the user can
+    /// still reach every database even when the tree is scoped to one on connect.
+    async fn list_databases(&self) -> Result<Vec<String>> {
+        Ok(self
+            .client
+            .list_database_names()
+            .await
+            .map_err(|e| RdbError::Schema(e.to_string()))?
+            .into_iter()
+            .filter(|n| !is_system_db(n))
+            .collect())
+    }
+
     /// Scope the sidebar to one database: return just that database with its
     /// collections loaded, so picking it in the schema picker shows only its
     /// collections instead of every database.
@@ -149,10 +180,10 @@ impl Driver for MongoDriver {
         })
     }
 
-    /// Collections of one database, capped so a database with thousands of
-    /// collections stays light. ponytail: fixed cap, add paging if it matters.
+    /// Collections of one database, capped by the user's NoSQL collection limit
+    /// so a database with thousands of collections stays light.
     async fn containers(&self, database: &str) -> Result<Vec<Container>> {
-        const MAX_COLLECTIONS: usize = 20;
+        let limit = self.collection_limit.load(Ordering::Relaxed);
         let coll_names = self
             .client
             .database(database)
@@ -161,7 +192,7 @@ impl Driver for MongoDriver {
             .map_err(|e| RdbError::Schema(e.to_string()))?;
         Ok(coll_names
             .into_iter()
-            .take(MAX_COLLECTIONS)
+            .take(limit)
             .map(|name| Container {
                 name,
                 kind: ContainerKind::Collection,


### PR DESCRIPTION
## Summary
- Fix a connect-then-query stall and stop disconnect from leaving a query running on the server.
- Make the MongoDB experience first-class: scope the sidebar to the selected database, a configurable collection limit, and engine-aware autocomplete.
- Round out connection-picker and query-result UX (tooltips, button affordances, scrollable errors, non-overflowing filter).

## Changes
### Backend / core
- `connstore`: persisted `nosql_collection_limit` setting.
- `driver-mongo`: runtime-settable collection cap (replaces the hard 20), `list_databases` returns all non-system DBs.
- `app`: store the live driver behind an `Arc` and run queries/pings without holding the global mutex (removes query↔ping serialization / first-query stall).

### MongoDB UX
- Connect scopes the sidebar to the connection's selected database (switcher still lists all).
- NoSQL collection-limit setting wired through dispatch → driver, applied on connect and on change.
- Engine-aware autocomplete: `db` + collections instead of SQL keywords; `db.` → collections; `db.<collection>.` → mongosh methods.

### Editor / results
- Run executes the statement under the caret even when it sits right after a `;`.
- Result message/error views are scrollable with word-wrap (long failed queries).
- Disconnect cancels the in-flight query (aborts the task + closes the connection) instead of leaving it running.

### Connection picker / modal
- Tooltips on the favorite star, drag grip, and Import button.
- "+ New Connection" reads/behaves like a button (hover, centered, consistent colour).
- Filter field clips + scrolls to the caret and no longer inflates with its text (verified with an offscreen render).

## Test plan
- [x] `make fmt-check`
- [x] `make lint` (workspace, `-D warnings`)
- [x] `cargo test -p rdb --bins` (156 passed) + `connstore` / `driver-mongo` unit tests
- [x] `make fe-build`
- [x] Offscreen `slint-viewer` render confirms the filter field clips long text
- [x] Manual: disconnect during a long query → query stops on the server; reconnect works
- [x] Manual: MongoDB connect scoped to selected DB; `db.`/`db.coll.` autocomplete; collection-limit setting takes effect
- [x] Manual: picker tooltips, New Connection hover/alignment, scrollable long error
