### PR TITLE
ci: harden release-please PR JSON handling

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,8 +46,11 @@ jobs:
       # the release-PR branch is idempotent and leaves older headings untouched.
       - name: Prefix CHANGELOG heading with product name
         if: ${{ steps.release.outputs.pr }}
+        env:
+          # Keep generated PR JSON out of the shell script body.
+          RELEASE_PR: ${{ steps.release.outputs.pr }}
         run: |
-          branch=$(printf '%s' '${{ steps.release.outputs.pr }}' | jq -r '.headBranchName')
+          branch=$(printf '%s' "$RELEASE_PR" | jq -r '.headBranchName')
           git fetch origin "$branch"
           git checkout "$branch"
           awk '!done && /^## \[/ { sub(/^## \[/, "## RDB: ["); done=1 } { print }' \


### PR DESCRIPTION
## Summary

- Prevent release-please changelog handling from breaking on generated release PR text.
- Unblock the develop release workflow after the 0.28.0 release PR included an apostrophe in a changelog line.

## Changes

- Pass the release PR JSON through `RELEASE_PR` instead of interpolating it into the shell script body.
- Keep the existing changelog branch lookup and heading-prefix logic unchanged.

## Test plan

- [x] Inspected failing release-please run logs for run `30547189421`.
- [x] `git diff --check`
- [x] Parsed `.github/workflows/release-please.yml` with Ruby YAML.
