### PR TITLE
docs: update website release data for v0.28.0

### DIFF
--- a/website/src/data/release.json
+++ b/website/src/data/release.json
@@ -1,78 +1,78 @@
 {
-  "tag": "v0.27.0",
-  "published": "2026-07-29",
+  "tag": "v0.28.0",
+  "published": "2026-07-30",
   "assets": [
     {
       "name": "rdb-aarch64-apple-darwin.dmg",
-      "size": 8257280,
-      "sha256": "d663d083a400052aaccbc17dd2c2ce96563cb980777e4828eeeceeb5e364e407",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.27.0/rdb-aarch64-apple-darwin.dmg"
+      "size": 8274281,
+      "sha256": "4e867ade139149c8b343e5a630d617dafb20dba8975703cb5b1e2014856d006d",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.28.0/rdb-aarch64-apple-darwin.dmg"
     },
     {
       "name": "rdb-aarch64-apple-darwin.tar.gz",
-      "size": 7737570,
-      "sha256": "b0b397a44ca49228b823103f1ec522a1cfa390c367cbc3fd289cf6ea17652226",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.27.0/rdb-aarch64-apple-darwin.tar.gz"
+      "size": 7756651,
+      "sha256": "e39cf112f8d5d9f3a59a26caf97eb19dbe6432d8dc16965367a6b106aa1c4f58",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.28.0/rdb-aarch64-apple-darwin.tar.gz"
     },
     {
       "name": "rdb-aarch64-pc-windows-msvc.exe",
-      "size": 17289216,
-      "sha256": "8f3973ee349c83e4b10f17dab914b624c39b1ff5ae49477be65fb795b0aa135e",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.27.0/rdb-aarch64-pc-windows-msvc.exe"
+      "size": 17354752,
+      "sha256": "0666016b1cd8f754888e836bb767227409ffe0777e0e751980b4f2efa7d13675",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.28.0/rdb-aarch64-pc-windows-msvc.exe"
     },
     {
       "name": "rdb-aarch64-pc-windows-msvc.zip",
-      "size": 7972663,
-      "sha256": "5941f4297962e4ccecf2842444fd351bb3d61875e8793a00861844421310c468",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.27.0/rdb-aarch64-pc-windows-msvc.zip"
+      "size": 7992740,
+      "sha256": "fdb9ec33489b3408cb0407bcaeb8ae5fbaf4e1d3b0ed11821f42ed6a9567d4d1",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.28.0/rdb-aarch64-pc-windows-msvc.zip"
     },
     {
       "name": "rdb-aarch64-unknown-linux-gnu",
-      "size": 20417392,
-      "sha256": "55f463d9620d19d56fc6966d239aebecb04f6948b9f6f665ca50822d7656ef8b",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.27.0/rdb-aarch64-unknown-linux-gnu"
+      "size": 20482928,
+      "sha256": "04c461263a11744dd138e3f2d92f1de84190bd347b998488856ec17d74b91c5e",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.28.0/rdb-aarch64-unknown-linux-gnu"
     },
     {
       "name": "rdb-aarch64-unknown-linux-gnu.tar.gz",
-      "size": 9823737,
-      "sha256": "ae20c98d18d2b164341c51b68c6f1ce91a67948524851b1d0bf3b619f51a2316",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.27.0/rdb-aarch64-unknown-linux-gnu.tar.gz"
+      "size": 9849012,
+      "sha256": "bfff36026cbe299a97176abbd6109a037cd257893312f24b8ffae9422e1b834b",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.28.0/rdb-aarch64-unknown-linux-gnu.tar.gz"
     },
     {
       "name": "rdb-x86_64-apple-darwin.dmg",
-      "size": 9280739,
-      "sha256": "3e8246d406f3115311ebc41fc51504061bce855b7755c1497c9bf88bc50f595b",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.27.0/rdb-x86_64-apple-darwin.dmg"
+      "size": 9301413,
+      "sha256": "eafd08d3261ff4698a433123aad1aa53640070095e624e50148f6d350c2c23c6",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.28.0/rdb-x86_64-apple-darwin.dmg"
     },
     {
       "name": "rdb-x86_64-apple-darwin.tar.gz",
-      "size": 8277591,
-      "sha256": "10fb5ed4730cd27972a693bd363c277fd44e8af6c0aa3747710a4dcad499303f",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.27.0/rdb-x86_64-apple-darwin.tar.gz"
+      "size": 8299076,
+      "sha256": "22f639bf0c65f4a6feebd208634b7f8c39565c9fa14e3e2eb194982a412f6fa1",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.28.0/rdb-x86_64-apple-darwin.tar.gz"
     },
     {
       "name": "rdb-x86_64-pc-windows-msvc.exe",
-      "size": 18738176,
-      "sha256": "9f910297a99bb6ee4adfbaceaaa00e9563ecdd5821b34ecb8bdac855dfafd285",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.27.0/rdb-x86_64-pc-windows-msvc.exe"
+      "size": 18807296,
+      "sha256": "50b4c4387f8abe2eecf2472cda6317ce4a64f72f7ffa7b75b187707717fb572a",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.28.0/rdb-x86_64-pc-windows-msvc.exe"
     },
     {
       "name": "rdb-x86_64-pc-windows-msvc.zip",
-      "size": 8447571,
-      "sha256": "c89666463214e7d85d7e0f92b9983eef84d4ce6f384be79dad80689dd75c972a",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.27.0/rdb-x86_64-pc-windows-msvc.zip"
+      "size": 8469694,
+      "sha256": "40d73d9512405a5d0654aba712789873c90aaeb13ecc237362cc9215ed7c2ad2",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.28.0/rdb-x86_64-pc-windows-msvc.zip"
     },
     {
       "name": "rdb-x86_64-unknown-linux-gnu",
-      "size": 25262360,
-      "sha256": "9a3f5904b272cef921ec25d108bf2056286e1495300f96ff9bb42041c902a318",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.27.0/rdb-x86_64-unknown-linux-gnu"
+      "size": 25356856,
+      "sha256": "04c0fcab34e59431e5cfaa04f0ac02d2231f9ed87ac76ba4f3356d06d1b21551",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.28.0/rdb-x86_64-unknown-linux-gnu"
     },
     {
       "name": "rdb-x86_64-unknown-linux-gnu.tar.gz",
-      "size": 10175600,
-      "sha256": "6fa08b73501ec75177dd2a82545c2e064c422a725c42946a091fe1655ebf5b0b",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.27.0/rdb-x86_64-unknown-linux-gnu.tar.gz"
+      "size": 10202102,
+      "sha256": "2271695a28f56a885b1adf909382534172083f5b94d61882d6b7c66c4f8eae27",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.28.0/rdb-x86_64-unknown-linux-gnu.tar.gz"
     }
   ]
 }


### PR DESCRIPTION
Automated release-data refresh for v0.28.0.