### PR TITLE
feat: add Windows install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,22 @@ brew install suiflex/tap/rdb
 
 Upgrade later with `brew upgrade rdb`.
 
+### Windows
+
+```powershell
+irm https://raw.githubusercontent.com/suiflex/rdb/develop/scripts/install.ps1 | iex
+```
+
+Optional:
+
+```powershell
+$env:RDB_VERSION="v0.28.0"; $env:INSTALL_DIR="$env:LOCALAPPDATA\Programs\RDB\bin"; irm https://raw.githubusercontent.com/suiflex/rdb/develop/scripts/install.ps1 | iex
+```
+
+The script installs `rdb.exe` into
+`%LOCALAPPDATA%\Programs\RDB\bin` by default and warns if that directory is not
+on `PATH`.
+
 ### Scoop (Windows)
 
 ```powershell

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,102 @@
+param(
+  [string]$Version = $env:RDB_VERSION,
+  [string]$InstallDir = $env:INSTALL_DIR
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$Repo = "suiflex/rdb"
+$Binary = "rdb.exe"
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+function Write-Step {
+  param([string]$Message)
+  Write-Host "==> $Message"
+}
+
+function Get-Arch {
+  $raw = if ($env:PROCESSOR_ARCHITEW6432) {
+    $env:PROCESSOR_ARCHITEW6432
+  } else {
+    $env:PROCESSOR_ARCHITECTURE
+  }
+
+  switch -Regex ($raw) {
+    "^(AMD64|x86_64)$" { return "x86_64" }
+    "^ARM64$" { return "aarch64" }
+    default { throw "unsupported architecture: $raw" }
+  }
+}
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+  $Version = "latest"
+}
+
+$Arch = Get-Arch
+$Target = "$Arch-pc-windows-msvc"
+$ApiUrl = if ($Version -eq "latest") {
+  "https://api.github.com/repos/$Repo/releases/latest"
+} else {
+  "https://api.github.com/repos/$Repo/releases/tags/$Version"
+}
+
+Write-Step "Looking up $Repo release ($Version)"
+$Headers = @{
+  Accept = "application/vnd.github+json"
+  "User-Agent" = "rdb-windows-installer"
+}
+$Release = Invoke-RestMethod -Uri $ApiUrl -Headers $Headers
+$AssetName = "rdb-$Target.zip"
+$Asset = $Release.assets | Where-Object { $_.name -eq $AssetName } | Select-Object -First 1
+if (-not $Asset) {
+  throw "could not find release asset: $AssetName"
+}
+
+if ([string]::IsNullOrWhiteSpace($InstallDir)) {
+  $LocalAppData = if ($env:LOCALAPPDATA) {
+    $env:LOCALAPPDATA
+  } else {
+    Join-Path $HOME "AppData\Local"
+  }
+  $InstallDir = Join-Path $LocalAppData "Programs\RDB\bin"
+}
+
+$TmpDir = Join-Path ([IO.Path]::GetTempPath()) "rdb-install-$([Guid]::NewGuid())"
+$ArchivePath = Join-Path $TmpDir $AssetName
+$ExtractDir = Join-Path $TmpDir "extracted"
+
+New-Item -ItemType Directory -Path $ExtractDir -Force | Out-Null
+
+try {
+  Write-Step "Downloading $AssetName"
+  Invoke-WebRequest -Uri $Asset.browser_download_url -OutFile $ArchivePath -Headers $Headers
+
+  Expand-Archive -Path $ArchivePath -DestinationPath $ExtractDir -Force
+  $BinPath = Get-ChildItem -Path $ExtractDir -Filter $Binary -Recurse -File |
+    Select-Object -First 1
+  if (-not $BinPath) {
+    throw "downloaded archive does not contain $Binary"
+  }
+
+  New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+  $DestPath = Join-Path $InstallDir $Binary
+  Copy-Item -Path $BinPath.FullName -Destination $DestPath -Force
+  try {
+    Unblock-File -Path $DestPath
+  } catch {
+    # Older PowerShell hosts may not have attachment-zone data to clear.
+  }
+
+  Write-Step "Installed to $DestPath"
+
+  $PathEntries = ($env:PATH -split ";") | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  $OnPath = $PathEntries | Where-Object { $_.TrimEnd("\") -ieq $InstallDir.TrimEnd("\") }
+  if (-not $OnPath) {
+    Write-Warning "$InstallDir is not on PATH yet"
+    Write-Warning "Add it to PATH, then open a new terminal to run rdb"
+  }
+} finally {
+  Remove-Item -Path $TmpDir -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/website/src/pages/download.astro
+++ b/website/src/pages/download.astro
@@ -42,7 +42,7 @@ const platforms: Platform[] = [
   {
     id: "windows",
     name: "Windows",
-    hint: "Standalone executable. Unzip (or download the .exe) and run rdb.exe.",
+    hint: "Use the PowerShell installer, Scoop, or download the standalone rdb.exe.",
     rows: [
       row("Executable", "x64", "rdb-x86_64-pc-windows-msvc.exe"),
       row("Executable", "ARM64", "rdb-aarch64-pc-windows-msvc.exe"),
@@ -137,6 +137,13 @@ const platforms: Platform[] = [
         <div>
           <h3 class="mb-2 font-mono text-xs text-fg-3">npm (all platforms)</h3>
           <CodeBlock code="npm i -g @suiflex/rdb" label="npm install" />
+        </div>
+        <div>
+          <h3 class="mb-2 font-mono text-xs text-fg-3">Install script (Windows)</h3>
+          <CodeBlock
+            code="irm https://raw.githubusercontent.com/suiflex/rdb/develop/scripts/install.ps1 | iex"
+            label="Windows install script"
+          />
         </div>
         <div>
           <h3 class="mb-2 font-mono text-xs text-fg-3">Scoop (Windows)</h3>


### PR DESCRIPTION
## Summary

- Add a command-line Windows installer for users who prefer terminal setup.
- Surface the PowerShell install command in the README and website download page.
- Closes #162.

## Changes

- Add `scripts/install.ps1` for x64 and ARM64 Windows release assets.
- Document the PowerShell installer and optional version/install-dir overrides.
- Add the Windows install command to the website download page.

## Test plan

- [x] `git diff --check`
- [x] `npm --prefix website run build`
- [x] `SKIP_NETWORK=1 npm --prefix website run test`
- [ ] `pwsh` syntax check: local machine does not have PowerShell installed.