### PR TITLE
feat(app): v0.29.0 prep — split-pane, editor, tabs, mongo fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ desktop.ini
 .agents
 docs/superpowers
 .forgeguard
+.mcp.json
 
 # Env & secrets
 .env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5594,7 +5594,7 @@ dependencies = [
 
 [[package]]
 name = "rdb"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "copypasta",

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -38,6 +38,12 @@ use dispatch::AnyDriver;
 
 /// Label used for connections with no explicit group.
 const UNGROUPED: &str = "Ungrouped";
+const MIN_FONT_SIZE: i32 = 10;
+const MAX_FONT_SIZE: i32 = 18;
+
+fn clamp_font_size(size: i32) -> i32 {
+    size.clamp(MIN_FONT_SIZE, MAX_FONT_SIZE)
+}
 
 /// Open a native "save file" dialog and write `contents` to the chosen path.
 ///
@@ -2901,6 +2907,9 @@ fn main() -> Result<(), slint::PlatformError> {
     window
         .global::<Theme>()
         .set_dark(settings.borrow().get().theme.is_dark());
+    window
+        .global::<Tokens>()
+        .set_font_base(clamp_font_size(settings.borrow().get().editor.font_size as i32) as f32);
     window.set_update_check_enabled(settings.borrow().get().update_check);
     window.set_sidebar_right(settings.borrow().get().ui_state.sidebar_right);
     let history_cap = Rc::new(Cell::new(
@@ -9748,6 +9757,21 @@ fn main() -> Result<(), slint::PlatformError> {
             let _ = settings
                 .borrow_mut()
                 .update(|s| s.ui_state.sidebar_right = v);
+        });
+    }
+
+    // ----- app-wide font size -----
+    {
+        let weak = window.as_weak();
+        let settings = settings.clone();
+        window.on_set_font_size(move |value| {
+            let size = clamp_font_size(value);
+            let _ = settings
+                .borrow_mut()
+                .update(|s| s.editor.font_size = size as u16);
+            if let Some(w) = weak.upgrade() {
+                w.global::<Tokens>().set_font_base(size as f32);
+            }
         });
     }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1605,6 +1605,11 @@ fn is_bare_select(engine: rdb_connstore::Engine, sql: &str) -> bool {
     ) {
         return false;
     }
+    // Multiple statements can't stream as one cursor (Postgres rejects multiple
+    // commands in a prepared statement); they take the split-and-run path.
+    if editor::split_statements(sql).len() > 1 {
+        return false;
+    }
     let trimmed = sql.trim_end().trim_end_matches(';').trim_end();
     let words: Vec<&str> = trimmed
         .split(|c: char| !c.is_ascii_alphanumeric() && c != '_')

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -7109,6 +7109,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let recent_queries = recent_queries.clone();
         let history_cap = history_cap.clone();
         let rebuild_query_tree = rebuild_query_tree.clone();
+        let panes = panes.clone();
         window.on_run_query(move || {
             if let Some(w) = weak.upgrade() {
                 // ⌘⏎ / Run: the highlighted selection, else just the statement
@@ -7141,6 +7142,14 @@ fn main() -> Result<(), slint::PlatformError> {
                 if stream {
                     run_stream(0, text);
                 } else {
+                    // 2+ selected statements → one result tab each (same as the
+                    // Run Selection button).
+                    if active_tab_kind(&w) != "table" && editor::split_statements(&text).len() >= 2
+                    {
+                        panes[0]
+                            .split_results
+                            .store(true, std::sync::atomic::Ordering::SeqCst);
+                    }
                     run_sql(0, text);
                 }
                 if w.get_sidebar_mode() != 0 {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1059,12 +1059,13 @@ fn active_tab_kind(w: &MainWindow) -> String {
         .unwrap_or_default()
 }
 
-/// Clipboard write; errors are ignored (no clipboard on some CI machines).
-fn clip_set(s: &str) {
+/// Clipboard write; returns false when no clipboard is available.
+fn clip_set(s: &str) -> bool {
     use copypasta::ClipboardProvider;
     if let Ok(mut c) = copypasta::ClipboardContext::new() {
-        let _ = c.set_contents(s.to_string());
+        return c.set_contents(s.to_string()).is_ok();
     }
+    false
 }
 
 /// Clipboard read; None when empty or unavailable.
@@ -7323,7 +7324,9 @@ fn main() -> Result<(), slint::PlatformError> {
                         }
                     }
                 }
-                3 => clip_set(&sql),
+                3 => {
+                    clip_set(&sql);
+                }
                 4 => {
                     let removed = {
                         let mut list = saved.borrow_mut();
@@ -7388,7 +7391,24 @@ fn main() -> Result<(), slint::PlatformError> {
     }
 
     // ----- Details panel: copy one field value to the clipboard -----
-    window.on_copy_text(move |s| clip_set(&s));
+    {
+        let weak = window.as_weak();
+        window.on_copy_text(move |s| {
+            let copied = clip_set(&s);
+            if let Some(w) = weak.upgrade() {
+                let msg = if copied {
+                    "copied field"
+                } else {
+                    "copy failed"
+                };
+                if w.get_active_pane() == 1 {
+                    w.set_p1_result_status(msg.into());
+                } else {
+                    w.set_result_status(msg.into());
+                }
+            }
+        });
+    }
 
     // ----- Copy results (TSV → clipboard) / Export CSV (~/Downloads) -----
     {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1959,6 +1959,27 @@ fn set_p_grid_col_filters(w: &MainWindow, pane: usize, m: ModelRc<SharedString>)
         w.set_p1_grid_col_filters(m);
     }
 }
+fn set_p_filter_columns(w: &MainWindow, pane: usize, m: ModelRc<SharedString>) {
+    if pane == 0 {
+        w.set_filter_columns(m);
+    } else {
+        w.set_p1_filter_columns(m);
+    }
+}
+fn set_p_filter_col(w: &MainWindow, pane: usize, v: SharedString) {
+    if pane == 0 {
+        w.set_filter_col(v);
+    } else {
+        w.set_p1_filter_col(v);
+    }
+}
+fn set_p_grid_filter(w: &MainWindow, pane: usize, v: SharedString) {
+    if pane == 0 {
+        w.set_grid_filter(v);
+    } else {
+        w.set_p1_grid_filter(v);
+    }
+}
 fn set_p_detail_pretty(w: &MainWindow, pane: usize, m: ModelRc<SharedString>) {
     if pane == 0 {
         w.set_grid_detail_pretty(m);
@@ -2658,7 +2679,7 @@ fn present_view(
         model::ResultView::Affected(_) => 0,
     } as u64;
     *last_view.lock().unwrap() = Some(v.clone());
-    w.set_grid_filter(SharedString::default());
+    set_p_grid_filter(w, pane, SharedString::default());
     hidden_cols.lock().unwrap().clear();
     *col_order.lock().unwrap() = (0..ncols).collect();
     *sort_state.lock().unwrap() = (-1, true);
@@ -2692,14 +2713,18 @@ fn present_view(
     ]))));
     let mut fcols: Vec<SharedString> = vec![SharedString::from("any column")];
     fcols.extend(colnames.iter().cloned());
-    w.set_filter_columns(ModelRc::from(Rc::new(VecModel::from(fcols))));
-    w.set_filter_col(
+    set_p_filter_columns(w, pane, ModelRc::from(Rc::new(VecModel::from(fcols))));
+    set_p_filter_col(
+        w,
+        pane,
         colnames
             .first()
             .cloned()
             .unwrap_or_else(|| SharedString::from("any column")),
     );
-    w.set_all_columns(ModelRc::from(Rc::new(VecModel::from(colnames))));
+    if pane == 0 {
+        w.set_all_columns(ModelRc::from(Rc::new(VecModel::from(colnames))));
+    }
     *displayed_grid.lock().unwrap() = view_grid(&v);
     {
         let st = browse.lock().unwrap();
@@ -6035,6 +6060,11 @@ fn main() -> Result<(), slint::PlatformError> {
                     sc.engine,
                 )))));
                 w.set_filter_op(SharedString::from("="));
+                // Mirror the operator list to the right split pane's filter row.
+                w.set_p1_filter_operators(ModelRc::from(Rc::new(VecModel::from(
+                    filter_operators(sc.engine),
+                ))));
+                w.set_p1_filter_op(SharedString::from("="));
                 // Re-present the active tab's stored result so a connection
                 // switch keeps the last result visible instead of blanking the
                 // grid. No-op (clears) when the tab has no stored result, e.g.
@@ -7870,6 +7900,101 @@ fn main() -> Result<(), slint::PlatformError> {
             apply_result(&w, 1, filtered);
         });
     }
+    // ----- right pane: filter row Apply (client-side, mirrors group 0) -----
+    {
+        let weak = window.as_weak();
+        let panes = panes.clone();
+        window.on_p1_apply_filter(move || {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let view = {
+                let results = panes[1].results.lock().unwrap();
+                let active = *panes[1].active_result.lock().unwrap();
+                results.get(active).map(|result| result.view.clone())
+            };
+            let Some(view) = view else {
+                return;
+            };
+            if matches!(view, model::ResultView::Affected(_)) {
+                return;
+            }
+            let needle = w.get_p1_grid_filter().to_string().to_lowercase();
+            let fcol = w.get_p1_filter_col().to_string();
+            let fop = w.get_p1_filter_op().to_string();
+            let hidden = panes[1].hidden_cols.lock().unwrap().clone();
+            let order = panes[1].col_order.lock().unwrap().clone();
+            let cfilters = panes[1].col_filters.lock().unwrap().clone();
+            let (scol, sasc) = *panes[1].sort_state.lock().unwrap();
+            // Filtering renumbers rows, so pending edits keyed by row index would
+            // land on the wrong rows — drop them.
+            panes[1].edit_buf.lock().unwrap().clear();
+            set_p_editing(&w, 1, -1, -1);
+            let filtered = compute_view(
+                &view, &needle, &fcol, &fop, &cfilters, &hidden, &order, scol, sasc,
+            );
+            *panes[1].displayed_grid.lock().unwrap() = view_grid(&filtered);
+            apply_result(&w, 1, filtered);
+        });
+    }
+    // ----- right pane: Copy result grid as TSV -----
+    {
+        let weak = window.as_weak();
+        let panes = panes.clone();
+        window.on_p1_copy_results(move || {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let Some(grid) = panes[1].displayed_grid.lock().unwrap().clone() else {
+                return;
+            };
+            use copypasta::ClipboardProvider;
+            let msg = match copypasta::ClipboardContext::new()
+                .and_then(|mut cb| cb.set_contents(export::to_tsv(&grid)))
+            {
+                Ok(()) => format!("copied {} rows", grid.rows.len()),
+                Err(e) => format!("copy failed: {e}"),
+            };
+            set_p_results_meta(&w, 1, SharedString::from(msg));
+        });
+    }
+    // ----- right pane: Export result grid -----
+    {
+        let weak = window.as_weak();
+        let panes = panes.clone();
+        window.on_p1_export_results(move |fmt| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let Some(grid) = panes[1].displayed_grid.lock().unwrap().clone() else {
+                set_p_results_meta(&w, 1, SharedString::from("nothing to export"));
+                return;
+            };
+            let (ext, filter, contents) = match fmt {
+                1 => ("json", "JSON", export::to_json(&grid)),
+                2 => ("tsv", "TSV", export::to_tsv(&grid)),
+                3 => {
+                    let table = w.get_p1_active_table();
+                    let table = if table.is_empty() {
+                        "results"
+                    } else {
+                        table.as_str()
+                    };
+                    ("sql", "SQL", export::to_sql_insert(&grid, table))
+                }
+                4 => ("md", "Markdown", export::to_markdown(&grid)),
+                _ => ("csv", "CSV", export::to_csv(&grid)),
+            };
+            save_via_dialog(
+                &w,
+                format!("rdb-export.{ext}"),
+                filter.to_string(),
+                ext.to_string(),
+                contents,
+                |w, msg| set_p_results_meta(w, 1, SharedString::from(msg)),
+            );
+        });
+    }
     {
         let weak = window.as_weak();
         let panes = panes.clone();
@@ -8426,6 +8551,36 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let run_browse = run_browse.clone();
         window.on_p1_refresh_page(move || run_browse(1));
+    }
+    // ----- right pane: Mongo browse filter (mirrors group 0) -----
+    {
+        let weak = window.as_weak();
+        let panes = panes.clone();
+        let run_browse = run_browse.clone();
+        window.on_p1_apply_mongo_filter(move || {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let raw = w.get_p1_mongo_filter().to_string();
+            let trimmed = raw.trim();
+            if !trimmed.is_empty() {
+                if let Err(e) = serde_json::from_str::<serde_json::Value>(trimmed) {
+                    set_p_status_error(&w, 1, true);
+                    set_p_result_status(
+                        &w,
+                        1,
+                        SharedString::from(format!("invalid filter JSON: {e}")),
+                    );
+                    return;
+                }
+            }
+            {
+                let mut st = panes[1].browse.lock().unwrap();
+                st.mongo_filter = trimmed.to_string();
+                st.page = 0;
+            }
+            run_browse(1);
+        });
     }
 
     // ----- Mongo browse filter bar (Compass-style filter document) -----

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -5928,15 +5928,16 @@ fn main() -> Result<(), slint::PlatformError> {
             let (init_tabs, init_active, init_active_p1, init_active_group) = if restore {
                 load_query_tabs()
             } else {
-                // Retain the SQL scratch tabs (with their results) so switching
-                // connection leaves the last result on screen — "standby". Drop
-                // the connection-scoped table/function tabs (their data would be
-                // stale) and only clear the in-flight loading flag so no tab is
-                // left showing a stuck spinner.
+                // Retain every open tab across the switch so the workspace
+                // behaves like a set of persistent documents — the SQL scratch
+                // tabs keep their results ("standby") and the connection-scoped
+                // table/collection tabs stay open too, their last data now a
+                // snapshot until the user hits Refresh against the new
+                // connection. Only the in-flight loading flag is cleared so no
+                // tab is left showing a stuck spinner.
                 let mut kept: Vec<WorkspaceTab> =
                     std::mem::take(&mut *workspace_tabs.lock().unwrap())
                         .into_iter()
-                        .filter(|t| t.kind == "sql")
                         .collect();
                 for t in &mut kept {
                     t.loading = false;

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1806,6 +1806,26 @@ fn paint_grid_with_edits(
     set_p_cells(w, pane, ModelRc::from(Rc::new(VecModel::from(flat))));
 }
 
+/// Update a `VecModel` to hold `rows` by mutating it in place — set existing
+/// indices, push/remove the tail — instead of replacing the whole model. The
+/// editor's line model is bound to a `for` that renders a per-line `TouchArea`;
+/// swapping in a fresh model recreates every row and drops the `TouchArea`
+/// currently grabbing a mouse drag, which kills drag-select. In-place updates
+/// keep the row items (and the grab) alive.
+fn sync_vec_model<T: Clone + 'static>(m: &VecModel<T>, rows: Vec<T>) {
+    let cur = m.row_count();
+    for (i, r) in rows.iter().enumerate() {
+        if i < cur {
+            m.set_row_data(i, r.clone());
+        } else {
+            m.push(r.clone());
+        }
+    }
+    while m.row_count() > rows.len() {
+        m.remove(m.row_count() - 1);
+    }
+}
+
 /// The grid a view displays, if it has one (for edit-buffer bookkeeping).
 fn view_grid(v: &model::ResultView) -> Option<model::GridModel> {
     match v {
@@ -3098,6 +3118,11 @@ fn main() -> Result<(), slint::PlatformError> {
     let sync_editor = {
         let weak = window.as_weak();
         let panes = panes.clone();
+        // Persistent per-pane line models, mutated in place each sync so the
+        // per-line TouchAreas survive (a fresh model would drop the one holding
+        // an in-flight drag). See `sync_vec_model`.
+        let line_models: [Rc<VecModel<ModelRc<Span>>>; 2] =
+            [Rc::new(VecModel::default()), Rc::new(VecModel::default())];
         move |pane: usize| {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -3132,7 +3157,10 @@ fn main() -> Result<(), slint::PlatformError> {
                     ModelRc::from(Rc::new(VecModel::from(spans)))
                 })
                 .collect();
-            let lines = ModelRc::from(Rc::new(VecModel::from(lines)));
+            // Update the persistent model in place; same instance → the `for`
+            // keeps its row items and the TouchArea grabbing a drag stays alive.
+            sync_vec_model(&line_models[pane], lines);
+            let lines = ModelRc::from(line_models[pane].clone());
             // Fold arrows: 1 = open head, 2 = closed head, 0 = plain line.
             // `hidden` blanks out the body lines of a closed region; nested
             // closed regions just union their ranges.

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -450,11 +450,24 @@ callback create-table-commit();
     in property <int> p1-editing-col: -1;
     in-out property <string> p1-editing-value;
     in property <int> p1-scroll-grid-tick;
-    in property <int> p1-doc-view;
+    in-out property <int> p1-doc-view;
     in property <[DocRow]> p1-doc-tree;
     in property <[StructField]> p1-structure-columns;
     in property <[IndexRow]> p1-index-rows;
     in property <[ChartBar]> p1-chart-bars;
+    // Browse toolbar mirror for the right split pane.
+    in property <string> p1-sort-text;
+    in-out property <string> p1-mongo-filter;
+    in-out property <string> p1-grid-filter;
+    in property <[string]> p1-filter-columns;
+    in-out property <string> p1-filter-col: "any column";
+    in property <[string]> p1-filter-operators;
+    in-out property <string> p1-filter-op: "=";
+    in property <int> p1-focus-filter-tick;
+    callback p1-apply-mongo-filter();
+    callback p1-apply-filter();
+    callback p1-add-row();
+    callback p1-mark-delete();
     callback p1-run();
     callback p1-run-selection();
     callback p1-format-sql();
@@ -1439,11 +1452,23 @@ callback create-table-commit();
                         p1-editing-col: root.p1-editing-col;
                         p1-editing-value <=> root.p1-editing-value;
                         p1-scroll-grid-tick: root.p1-scroll-grid-tick;
-                        p1-doc-view: root.p1-doc-view;
+                        p1-doc-view <=> root.p1-doc-view;
                         p1-doc-tree: root.p1-doc-tree;
                         p1-structure-columns: root.p1-structure-columns;
                         p1-index-rows: root.p1-index-rows;
                         p1-chart-bars: root.p1-chart-bars;
+                        p1-sort-text: root.p1-sort-text;
+                        p1-mongo-filter <=> root.p1-mongo-filter;
+                        p1-grid-filter <=> root.p1-grid-filter;
+                        p1-filter-columns: root.p1-filter-columns;
+                        p1-filter-col <=> root.p1-filter-col;
+                        p1-filter-operators: root.p1-filter-operators;
+                        p1-filter-op <=> root.p1-filter-op;
+                        p1-focus-filter-tick: root.p1-focus-filter-tick;
+                        p1-apply-mongo-filter() => { root.p1-apply-mongo-filter(); }
+                        p1-apply-filter() => { root.p1-apply-filter(); }
+                        p1-add-row() => { root.p1-add-row(); }
+                        p1-mark-delete() => { root.p1-mark-delete(); }
                         p1-run() => { root.p1-run(); }
                         p1-run-selection() => { root.p1-run-selection(); }
                         p1-format-sql() => { root.p1-format-sql(); }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -317,6 +317,7 @@ callback create-table-commit();
     // Place the sidebar on the right (detail panel flips to the left).
     in-out property <bool> sidebar-right: false;
     callback set-sidebar-side(bool);
+    callback set-font-size(int);
     in-out property <bool> results-collapsed: false;
     callback editor-key(string, bool, bool, bool) -> bool;
     callback editor-press(int, int);
@@ -581,6 +582,14 @@ callback create-table-commit();
                 return reject;
             }
             if (e.modifiers.control || e.modifiers.meta) {
+                if (e.text == "+" || e.text == "=") {
+                    root.set-font-size(round(Tokens.font-base / 1px) + 1);
+                    return accept;
+                }
+                if (e.text == "-") {
+                    root.set-font-size(round(Tokens.font-base / 1px) - 1);
+                    return accept;
+                }
                 if (e.text == "k") {
                     root.toggle-palette();
                     return accept;
@@ -2603,6 +2612,7 @@ callback create-table-commit();
                     { k: "⌘S", a: "Save / commit edits" },
                     { k: "⌘R", a: "Refresh result" },
                     { k: "⌘⇧R", a: "Reconnect" },
+                    { k: "⌘+ / ⌘-", a: "Zoom in / out" },
                     { k: "⌘F", a: "Find" },
                     { k: "⌘O", a: "Open connection" },
                     { k: "⌘⇧O", a: "Open database" },

--- a/app/src/ui/code-editor.slint
+++ b/app/src/ui/code-editor.slint
@@ -58,6 +58,10 @@ export component CodeEditor inherits Rectangle {
         }
 
         edit-scroll := ScrollView {
+            // Let the per-line TouchArea own mouse drags for text selection;
+            // otherwise the Flickable hijacks a >8px drag as a pan and cancels
+            // the selection. Wheel/trackpad scrolling is unaffected.
+            mouse-drag-pan-enabled: false;
             width: 100%;
             height: 100%;
             VerticalLayout {

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -7,15 +7,15 @@ import { AppIcon } from "icons.slint";
 export component Toggle inherits TouchArea {
     in property <bool> checked;
     callback toggled();
-    width: 42px;
-    height: 24px;
+    width: 42px + 2 * Tokens.zoom-delta;
+    height: 24px + Tokens.zoom-delta;
     clicked => { root.toggled(); }
     Rectangle {
         border-radius: 12px;
         background: root.checked ? Tokens.accent : Tokens.border-strong;
         Rectangle {
-            width: 18px;
-            height: 18px;
+            width: 18px + Tokens.zoom-delta;
+            height: 18px + Tokens.zoom-delta;
             border-radius: 9px;
             background: #FFFFFF;
             x: root.checked ? parent.width - self.width - 3px : 3px;
@@ -36,7 +36,7 @@ export component ToggleRow inherits HorizontalLayout {
         Text {
             text: root.label;
             color: Tokens.text;
-            font-size: 13px;
+            font-size: Tokens.font-md;
         }
     }
     VerticalLayout {
@@ -66,7 +66,7 @@ export component SelectBox inherits Rectangle {
     in property <[string]> model;
     in-out property <string> current-value;
     callback selected(string);
-    height: 30px;
+    height: Tokens.button-h + 4px;
     border-radius: Tokens.radius;
     border-width: 1px;
     border-color: ta.has-hover ? Tokens.border-strong : Tokens.border;
@@ -105,7 +105,7 @@ export component SelectBox inherits Rectangle {
             VerticalLayout {
                 padding: 4px;
                 for opt in root.model: Rectangle {
-                    height: 28px;
+                    height: Tokens.button-h + 2px;
                     border-radius: 6px;
                     background: opt-ta.has-hover ? Tokens.accent-tint : transparent;
                     opt-ta := TouchArea {
@@ -379,7 +379,7 @@ export component FormField inherits Rectangle {
 // Small bordered key cap (⌘K, ⌘P, ⌘↵).
 export component KeyCap inherits Rectangle {
     in property <string> text;
-    height: 18px;
+    height: Tokens.font-base + 5px;
     width: label.preferred-width + 10px;
     border-radius: 4px;
     border-width: 1px;
@@ -388,7 +388,7 @@ export component KeyCap inherits Rectangle {
     label := Text {
         text: root.text;
         color: Tokens.text-faint;
-        font-size: 10px;
+        font-size: Tokens.font-xs;
     }
 }
 
@@ -396,7 +396,7 @@ export component KeyCap inherits Rectangle {
 export component SearchCommandPill inherits Rectangle {
     in property <string> placeholder: "Search or run a command...";
     callback activated;
-    height: 28px;
+    height: Tokens.button-h + 2px;
     border-radius: Tokens.radius;
     border-width: 1px;
     border-color: ta.has-hover ? Tokens.border-strong : Tokens.border;
@@ -433,7 +433,7 @@ export component BreadcrumbChip inherits Rectangle {
     in property <bool> caret: false;
     in property <bool> mono: false;
     callback clicked;
-    height: 28px;
+    height: Tokens.button-h + 2px;
     width: content.preferred-width + 2 * Tokens.sp3;
     border-radius: Tokens.radius;
     border-width: 1px;
@@ -495,7 +495,7 @@ export component UnderlineSegment inherits Rectangle {
 // Grey tag chip (mono text: profin, fintech).
 export component TagChip inherits Rectangle {
     in property <string> text;
-    height: 24px;
+    height: Tokens.button-h - 2px;
     width: label.preferred-width + 2 * Tokens.sp3;
     border-radius: Tokens.radius;
     background: Tokens.chrome;
@@ -514,8 +514,8 @@ export component GlyphButton inherits Rectangle {
     in property <bool> danger-hover: false; // close button: red fill + white glyph
     in property <string> tooltip;           // optional hover label
     callback clicked;
-    width: 28px;
-    height: 28px;
+    width: Tokens.button-h + 2px;
+    height: Tokens.button-h + 2px;
     border-radius: Tokens.radius;
     background: ta.has-hover ? (danger-hover ? Tokens.error : Tokens.border) : transparent;
     animate background { duration: Tokens.fade; }

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -574,6 +574,7 @@ export component QueryPane inherits Rectangle {
                                         // copy this field's value to the clipboard
                                         Rectangle {
                                             width: 18px;
+                                            height: 18px;
                                             AppIcon {
                                                 x: 2px;
                                                 y: 2px;
@@ -582,45 +583,53 @@ export component QueryPane inherits Rectangle {
                                                 color: copy-ta.has-hover ? Tokens.accent : Tokens.text-faint;
                                             }
                                             copy-ta := TouchArea {
-                                                clicked => { root.copy-text(detail-cell.is-null ? "" : detail-cell.text); }
+                                                width: 100%;
+                                                height: 100%;
+                                                clicked => { root.copy-text(pretty != "" ? pretty : (detail-cell.is-null ? "" : detail-cell.text)); }
                                             }
                                         }
                                     }
-                                    // Box grows to fit the value; short values stay
-                                    // compact, long ones cap out. TextEdit owns its
-                                    // own scrollbar so big values wrap and scroll
-                                    // reliably (the old ScrollView+TextInput had a
-                                    // cyclic height that broke scrolling).
                                     Rectangle {
-                                        height: clamp(measurer.preferred-height + 2 * Tokens.sp2, 44px, 220px);
+                                        height: root.read-only
+                                            ? max(measurer.preferred-height + 2 * Tokens.sp2, 44px)
+                                            : clamp(measurer.preferred-height + 2 * Tokens.sp2, 44px, 220px);
+                                        background: Tokens.chrome;
+                                        border-radius: Tokens.radius;
+                                        border-width: 1px;
+                                        border-color: Tokens.border-strong;
                                         // Invisible height probe: same width/font as the
                                         // editor, so the box sizes to the wrapped content.
                                         measurer := Text {
-                                            width: parent.width - 24px;
+                                            width: parent.width - 2 * Tokens.sp2;
                                             text: pretty != "" ? pretty : (detail-cell.is-null ? "" : detail-cell.text);
                                             wrap: word-wrap;
                                             font-family: Tokens.mono;
                                             font-size: Tokens.font-sm;
                                             color: transparent;
                                         }
-                                        detail-input := TextEdit {
-                                            width: 100%;
-                                            height: 100%;
-                                            read-only: root.read-only;
+                                        if root.read-only: Text {
+                                            x: Tokens.sp2;
+                                            y: Tokens.sp1;
+                                            width: parent.width - 2 * Tokens.sp2;
                                             text: pretty != "" ? pretty : (detail-cell.is-null ? "" : detail-cell.text);
                                             wrap: word-wrap;
+                                            color: detail-cell.is-null ? Tokens.text-ghost : Tokens.text;
+                                            font-family: Tokens.mono;
+                                            font-size: Tokens.font-sm;
+                                            font-italic: detail-cell.is-null;
+                                        }
+                                        if !root.read-only: edit-detail-input := TextInput {
+                                            x: Tokens.sp2;
+                                            y: Tokens.sp1;
+                                            width: parent.width - 2 * Tokens.sp2;
+                                            height: parent.height - 2 * Tokens.sp1;
+                                            text: detail-cell.is-null ? "" : detail-cell.text;
+                                            wrap: word-wrap;
+                                            single-line: false;
+                                            color: Tokens.text;
                                             font-family: Tokens.mono;
                                             font-size: Tokens.font-sm;
                                             edited => { root.stage-cell(root.selected-row, c, self.text); }
-                                        }
-                                        if detail-cell.is-null && detail-input.text == "": Text {
-                                            x: Tokens.sp2;
-                                            y: Tokens.sp2;
-                                            text: "NULL";
-                                            color: Tokens.text-ghost;
-                                            font-family: Tokens.mono;
-                                            font-size: Tokens.font-sm;
-                                            font-italic: true;
                                         }
                                     }
                                 }

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -9,15 +9,15 @@ import { GridColumn, GridCell, StructField, Span, ChartBar, IndexRow, DocRow } f
 import { CodeEditor } from "code-editor.slint";
 import { TabularGrid } from "tabular-grid.slint";
 import { PaletteItem } from "palette.slint";
-import { SecondaryButton, PrimaryButton, TextButton, ExportButton, DangerButton } from "components.slint";
-import { ScrollView, TextEdit } from "std-widgets.slint";
+import { SecondaryButton, PrimaryButton, TextButton, ExportButton, DangerButton, FilterField, UnderlineSegment } from "components.slint";
+import { ScrollView, TextEdit, ComboBox } from "std-widgets.slint";
 import { AppIcon } from "icons.slint";
 
 export component QueryPane inherits Rectangle {
     // ----- tab-global context (forwarded from WorkArea) -----
     in property <bool> browse-mode: false;
     in property <string> table-name;
-    in property <bool> browse-editor-open: false;
+    in-out property <bool> browse-editor-open: false;
     in property <bool> fn-mode: false;
     in property <bool> results-collapsed: false;
     in property <bool> detail-visible: true;
@@ -122,8 +122,24 @@ export component QueryPane inherits Rectangle {
     callback stage-cell(int, int, string);
     callback edit-cancelled();
 
+    // ----- browse toolbar (relocated from WorkArea so each pane owns it) -----
+    in property <string> sort-text;            // e.g. "sort: id ↑"
+    in-out property <string> mongo-filter;     // Compass-style Mongo filter doc
+    callback apply-mongo-filter();
+    callback add-row();
+    callback mark-delete();
+    callback apply-filter();
+    // Row add/delete need this pane's commit path; only the primary pane commits.
+    in property <bool> writable: true;
+    in property <int> focus-filter-tick;
+    in property <[string]> filter-columns;     // "any column" + real columns
+    in-out property <string> filter-col: "any column";
+    in property <[string]> filter-operators;
+    in-out property <string> filter-op: "=";
+    in-out property <string> grid-filter;
+
     // ----- other result views -----
-    in property <int> doc-view: 0;
+    in-out property <int> doc-view: 0;
     in property <[DocRow]> doc-tree;
     callback toggle-doc-node(string);
     in property <[StructField]> structure-columns;
@@ -137,16 +153,178 @@ export component QueryPane inherits Rectangle {
         height: 100%;
         spacing: 0;
 
-        if root.browse-mode && root.split: Rectangle {
+        // ================= browse toolbar =================
+        // Each pane owns its toolbar so the split (right) pane keeps full
+        // browse actions — parity with the primary pane.
+        if root.browse-mode: Rectangle {
             height: 42px;
             background: Tokens.canvas;
             HorizontalLayout {
                 padding-left: Tokens.sp3;
                 padding-right: Tokens.sp3;
                 spacing: Tokens.sp3;
-                Text { text: root.table-name; color: Tokens.text; font-size: Tokens.font-sm; font-weight: 600; vertical-alignment: center; }
+
+                // "+ Filter" dashed chip
+                VerticalLayout {
+                    alignment: center;
+                    Rectangle {
+                        height: 26px;
+                        width: fl.preferred-width + 2 * Tokens.sp3;
+                        border-radius: Tokens.radius;
+                        border-width: 1px;
+                        border-color: filter-ta.has-hover ? Tokens.text-faint : Tokens.border-strong;
+                        background: root.filter-open ? Tokens.accent-tint : Tokens.card;
+                        fl := Text {
+                            text: "+ Filter";
+                            color: root.filter-open ? Tokens.on-tint : Tokens.text-dim;
+                            font-size: Tokens.font-sm;
+                            font-weight: 500;
+                        }
+                        filter-ta := TouchArea {
+                            clicked => { root.filter-open = !root.filter-open; }
+                        }
+                    }
+                }
+                // Mongo filter document (server-side find filter).
+                if root.result-kind == 1: VerticalLayout {
+                    alignment: center;
+                    FilterField {
+                        width: 260px;
+                        height: 28px;
+                        placeholder: "Filter — { \"field\": value }";
+                        text <=> root.mongo-filter;
+                        submitted => { root.apply-mongo-filter(); }
+                    }
+                }
+                // sort text
+                Text {
+                    text: root.sort-text;
+                    color: Tokens.text-faint;
+                    font-size: Tokens.font-sm;
+                    font-family: Tokens.mono;
+                    vertical-alignment: center;
+                }
                 Rectangle { horizontal-stretch: 1; }
-                TextButton { text: "Refresh"; clicked => { root.refresh-page(); } }
+                // Reveal the query editor over the browse grid.
+                VerticalLayout {
+                    alignment: center;
+                    TextButton {
+                        text: root.browse-editor-open ? "Query ▾" : "Query ▸";
+                        clicked => { root.browse-editor-open = !root.browse-editor-open; }
+                    }
+                }
+                // Mongo document view switch (grid table ⇄ JSON tree)
+                if root.result-kind == 1: VerticalLayout {
+                    alignment: center;
+                    HorizontalLayout {
+                        spacing: Tokens.sp3;
+                        UnderlineSegment {
+                            text: "Grid";
+                            active: root.doc-view == 0;
+                            clicked => { root.doc-view = 0; }
+                        }
+                        UnderlineSegment {
+                            text: "Tree";
+                            active: root.doc-view == 1;
+                            clicked => { root.doc-view = 1; }
+                        }
+                    }
+                }
+                VerticalLayout {
+                    alignment: center;
+                    TextButton { text: "Copy"; clicked => { root.copy-results(); } }
+                }
+                VerticalLayout {
+                    alignment: center;
+                    ExportButton { export(i) => { root.export-results(i); } }
+                }
+                VerticalLayout {
+                    alignment: center;
+                    TextButton {
+                        text: root.sql-view-mode == 2 ? "Data" : "Chart";
+                        clicked => { root.sql-view-mode = root.sql-view-mode == 2 ? 0 : 2; }
+                    }
+                }
+                if root.writable: VerticalLayout {
+                    alignment: center;
+                    SecondaryButton {
+                        text: "+ Row";
+                        enabled: !root.read-only;
+                        clicked => { root.add-row(); }
+                    }
+                }
+                if root.writable: VerticalLayout {
+                    alignment: center;
+                    SecondaryButton {
+                        text: "− Row";
+                        enabled: !root.read-only;
+                        clicked => { root.mark-delete(); }
+                    }
+                }
+                if root.read-only && root.table-name != "": Text {
+                    text: "read-only";
+                    color: Tokens.text-faint;
+                    font-size: Tokens.font-sm;
+                    vertical-alignment: center;
+                }
+                VerticalLayout {
+                    alignment: center;
+                    Rectangle {
+                        width: 26px;
+                        height: 26px;
+                        border-radius: Tokens.radius;
+                        border-width: 1px;
+                        border-color: Tokens.border-strong;
+                        background: refresh-ta.has-hover ? Tokens.chrome : Tokens.card;
+                        AppIcon {
+                            name: "refresh";
+                            size: 14px;
+                            color: Tokens.text-dim;
+                        }
+                        refresh-ta := TouchArea { clicked => { root.refresh-page(); } }
+                    }
+                }
+            }
+        }
+
+        // One TablePlus-style condition row.
+        if root.browse-mode && root.filter-open: Rectangle {
+            property <int> focus-tick: root.focus-filter-tick;
+            changed focus-tick => { filter-value.focus-input(); }
+            height: 38px;
+            background: Tokens.chrome;
+            border-width: 1px;
+            border-color: Tokens.border;
+            HorizontalLayout {
+                padding-left: Tokens.sp3;
+                padding-right: Tokens.sp3;
+                padding-top: 4px;
+                padding-bottom: 4px;
+                spacing: Tokens.sp2;
+                ComboBox {
+                    width: 180px;
+                    model: root.filter-columns;
+                    current-value <=> root.filter-col;
+                }
+                ComboBox {
+                    width: 120px;
+                    model: root.filter-operators;
+                    current-value <=> root.filter-op;
+                }
+                filter-value := FilterField {
+                    horizontal-stretch: 1;
+                    max-width: 420px;
+                    placeholder: root.filter-op == "IS NULL" || root.filter-op == "IS NOT NULL"
+                        ? "No value required" : "Value";
+                    text <=> root.grid-filter;
+                    submitted => { root.apply-filter(); }
+                }
+                PrimaryButton {
+                    text: "Apply";
+                    height: 28px;
+                    clicked => { root.apply-filter(); }
+                }
+                Rectangle { horizontal-stretch: 1; }
             }
         }
 

--- a/app/src/ui/tokens.slint
+++ b/app/src/ui/tokens.slint
@@ -75,16 +75,18 @@ export global Tokens {
     out property <length> palette-width: 640px;
 
     // ----- metrics -----
-    out property <length> titlebar-h: 44px;
-    out property <length> doc-tab-row-h: 35px;
-    out property <length> doc-tab-h: 30px;
+    in-out property <length> font-base: 13px;
+    out property <length> zoom-delta: font-base - 13px;
+    out property <length> titlebar-h: 44px + zoom-delta;
+    out property <length> doc-tab-row-h: 35px + zoom-delta;
+    out property <length> doc-tab-h: 30px + zoom-delta;
     out property <length> sidebar-w: 218px;
-    out property <length> grid-row-h: 24px;
-    out property <length> grid-header-h: 27px;
-    out property <length> status-bar-h: 34px;
+    out property <length> grid-row-h: 24px + zoom-delta;
+    out property <length> grid-header-h: 27px + zoom-delta;
+    out property <length> status-bar-h: 34px + zoom-delta;
     out property <length> radius: 7px;
     out property <length> radius-lg: 8px;
-    out property <length> button-h: 26px;
+    out property <length> button-h: 26px + zoom-delta;
     out property <length> selection-bar-w: 2px; // accent left bar on selection
 
     // ----- spacing (4px grid) -----
@@ -95,15 +97,15 @@ export global Tokens {
     out property <length> sp6: 24px;
 
     // ----- typography -----
-    out property <length> font-xs: 11px;
-    out property <length> font-sm: 12px;
-    out property <length> font-md: 13px;
+    out property <length> font-xs: font-base - 2px;
+    out property <length> font-sm: font-base - 1px;
+    out property <length> font-md: font-base;
     out property <int>    weight-emphasis: 600;
     out property <string> mono: "IBM Plex Mono";
 
     // ----- icons -----
-    out property <length> icon-sm: 14px;
-    out property <length> icon-md: 16px;
+    out property <length> icon-sm: 14px + zoom-delta;
+    out property <length> icon-md: 16px + zoom-delta;
 
     // ----- motion -----
     out property <duration> fade: 100ms;

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -179,11 +179,24 @@ export component WorkArea inherits Rectangle {
     in property <int> p1-editing-col: -1;
     in-out property <string> p1-editing-value;
     in property <int> p1-scroll-grid-tick;
-    in property <int> p1-doc-view;
+    in-out property <int> p1-doc-view;
     in property <[DocRow]> p1-doc-tree;
     in property <[StructField]> p1-structure-columns;
     in property <[IndexRow]> p1-index-rows;
     in property <[ChartBar]> p1-chart-bars;
+    // Browse toolbar mirror for the right pane.
+    in property <string> p1-sort-text;
+    in-out property <string> p1-mongo-filter;
+    in-out property <string> p1-grid-filter;
+    in property <[string]> p1-filter-columns;
+    in-out property <string> p1-filter-col: "any column";
+    in property <[string]> p1-filter-operators;
+    in-out property <string> p1-filter-op: "=";
+    in property <int> p1-focus-filter-tick;
+    callback p1-apply-mongo-filter();
+    callback p1-apply-filter();
+    callback p1-add-row();
+    callback p1-mark-delete();
     // Pane 1 callbacks carry no pane arg here; they are wired to pane-1 handlers
     // on MainWindow (a later step). Left unhandled = no-op until then.
     callback p1-run();
@@ -282,184 +295,8 @@ export component WorkArea inherits Rectangle {
         height: 100%;
         spacing: 0;
 
-        // ================= browse toolbar =================
-        if root.browse-mode && !root.split: Rectangle {
-            height: 42px;
-            background: Tokens.canvas;
-            HorizontalLayout {
-                padding-left: Tokens.sp3;
-                padding-right: Tokens.sp3;
-                spacing: Tokens.sp3;
-
-                // "+ Filter" dashed chip
-                VerticalLayout {
-                    alignment: center;
-                    Rectangle {
-                        height: 26px;
-                        width: fl.preferred-width + 2 * Tokens.sp3;
-                        border-radius: Tokens.radius;
-                        border-width: 1px;
-                        border-color: filter-ta.has-hover ? Tokens.text-faint : Tokens.border-strong;
-                        // Slint has no dashed borders; hairline chip approximates
-                        background: root.filter-open ? Tokens.accent-tint : Tokens.card;
-                        fl := Text {
-                            text: "+ Filter";
-                            color: root.filter-open ? Tokens.on-tint : Tokens.text-dim;
-                            font-size: Tokens.font-sm;
-                            font-weight: 500;
-                        }
-                        filter-ta := TouchArea {
-                            clicked => { root.filter-open = !root.filter-open; }
-                        }
-                    }
-                }
-                // Mongo filter document (server-side find filter). Enter runs it;
-                // gated on Documents result-kind like the Grid/Tree toggle.
-                if root.result-kind == 1: VerticalLayout {
-                    alignment: center;
-                    FilterField {
-                        width: 260px;
-                        height: 28px;
-                        placeholder: "Filter — { \"field\": value }";
-                        text <=> root.mongo-filter;
-                        submitted => { root.apply-mongo-filter(); }
-                    }
-                }
-                // sort text
-                Text {
-                    text: root.sort-text;
-                    color: Tokens.text-faint;
-                    font-size: Tokens.font-sm;
-                    font-family: Tokens.mono;
-                    vertical-alignment: center;
-                }
-                Rectangle { horizontal-stretch: 1; }
-                // Reveal the query editor over the browse grid so you can run a
-                // line query (e.g. Mongo db.coll.find(...)) without a new tab.
-                VerticalLayout {
-                    alignment: center;
-                    TextButton {
-                        text: root.browse-editor-open ? "Query ▾" : "Query ▸";
-                        clicked => { root.browse-editor-open = !root.browse-editor-open; }
-                    }
-                }
-                // Mongo document view switch (grid table ⇄ JSON tree)
-                if root.result-kind == 1: VerticalLayout {
-                    alignment: center;
-                    HorizontalLayout {
-                        spacing: Tokens.sp3;
-                        UnderlineSegment {
-                            text: "Grid";
-                            active: root.doc-view == 0;
-                            clicked => { root.doc-view = 0; }
-                        }
-                        UnderlineSegment {
-                            text: "Tree";
-                            active: root.doc-view == 1;
-                            clicked => { root.doc-view = 1; }
-                        }
-                    }
-                }
-                // Copy / Export / Chart — parity with the query-result toolbar so
-                // browsing a table offers the same result actions.
-                VerticalLayout {
-                    alignment: center;
-                    TextButton { text: "Copy"; clicked => { root.copy-results(); } }
-                }
-                VerticalLayout {
-                    alignment: center;
-                    ExportButton { export(i) => { root.export-results(i); } }
-                }
-                VerticalLayout {
-                    alignment: center;
-                    TextButton {
-                        text: root.sql-view-mode == 2 ? "Data" : "Chart";
-                        clicked => { root.sql-view-mode = root.sql-view-mode == 2 ? 0 : 2; }
-                    }
-                }
-                VerticalLayout {
-                    alignment: center;
-                    SecondaryButton {
-                        text: "+ Row";
-                        enabled: !root.read-only;
-                        clicked => { root.add-row(); }
-                    }
-                }
-                VerticalLayout {
-                    alignment: center;
-                    SecondaryButton {
-                        text: "− Row";
-                        enabled: !root.read-only;
-                        clicked => { root.mark-delete(); }
-                    }
-                }
-                if root.read-only && root.active-table != "": Text {
-                    text: "read-only";
-                    color: Tokens.text-faint;
-                    font-size: Tokens.font-sm;
-                    vertical-alignment: center;
-                }
-                VerticalLayout {
-                    alignment: center;
-                    Rectangle {
-                        width: 26px;
-                        height: 26px;
-                        border-radius: Tokens.radius;
-                        border-width: 1px;
-                        border-color: Tokens.border-strong;
-                        background: refresh-ta.has-hover ? Tokens.chrome : Tokens.card;
-                        AppIcon {
-                            name: "refresh";
-                            size: 14px;
-                            color: Tokens.text-dim;
-                        }
-                        refresh-ta := TouchArea { clicked => { root.refresh-page(); } }
-                    }
-                }
-            }
-        }
-
-        // One TablePlus-style condition row. Apply and Enter share the same
-        // callback; the toolbar and footer no longer expose duplicate triggers.
-        if root.browse-mode && !root.split && root.filter-open: Rectangle {
-            property <int> focus-tick: root.focus-filter-tick;
-            changed focus-tick => { filter-value.focus-input(); }
-            height: 38px;
-            background: Tokens.chrome;
-            border-width: 1px;
-            border-color: Tokens.border;
-            HorizontalLayout {
-                padding-left: Tokens.sp3;
-                padding-right: Tokens.sp3;
-                padding-top: 4px;
-                padding-bottom: 4px;
-                spacing: Tokens.sp2;
-                ComboBox {
-                    width: 180px;
-                    model: root.filter-columns;
-                    current-value <=> root.filter-col;
-                }
-                ComboBox {
-                    width: 120px;
-                    model: root.filter-operators;
-                    current-value <=> root.filter-op;
-                }
-                filter-value := FilterField {
-                    horizontal-stretch: 1;
-                    max-width: 420px;
-                    placeholder: root.filter-op == "IS NULL" || root.filter-op == "IS NOT NULL"
-                        ? "No value required" : "Value";
-                    text <=> root.grid-filter;
-                    submitted => { root.apply-filter(); }
-                }
-                PrimaryButton {
-                    text: "Apply";
-                    height: 28px;
-                    clicked => { root.apply-filter(); }
-                }
-                Rectangle { horizontal-stretch: 1; }
-            }
-        }
+        // Browse toolbar + filter row now live inside QueryPane so each pane
+        // (including the split/right pane) owns the full set of browse actions.
 
         // ================= function view =================
         if root.fn-mode: Rectangle {
@@ -526,7 +363,19 @@ export component WorkArea inherits Rectangle {
             browse-mode: root.browse-mode;
             table-name: root.active-table;
             refresh-page() => { root.refresh-page(); }
-            browse-editor-open: root.browse-editor-open;
+            browse-editor-open <=> root.browse-editor-open;
+            sort-text: root.sort-text;
+            mongo-filter <=> root.mongo-filter;
+            apply-mongo-filter() => { root.apply-mongo-filter(); }
+            add-row() => { root.add-row(); }
+            mark-delete() => { root.mark-delete(); }
+            apply-filter() => { root.apply-filter(); }
+            focus-filter-tick: root.focus-filter-tick;
+            filter-columns: root.filter-columns;
+            filter-col <=> root.filter-col;
+            filter-operators: root.filter-operators;
+            filter-op <=> root.filter-op;
+            grid-filter <=> root.grid-filter;
             fn-mode: root.fn-mode;
             results-collapsed: root.results-collapsed;
             detail-visible: root.detail-visible;
@@ -607,7 +456,7 @@ export component WorkArea inherits Rectangle {
             cell-advance(r, c, t, fwd) => { root.cell-advance(r, c, t, fwd); }
             stage-cell(r, c, t) => { root.stage-cell(r, c, t); }
             edit-cancelled() => { root.edit-cancelled(); }
-            doc-view: root.doc-view;
+            doc-view <=> root.doc-view;
             doc-tree: root.doc-tree;
             toggle-doc-node(p) => { root.toggle-doc-node(p); }
             structure-columns: root.structure-columns;
@@ -643,7 +492,21 @@ export component WorkArea inherits Rectangle {
                 // Each workspace group owns its browse state.
                 browse-mode: root.p1-active-table != "";
                 table-name: root.p1-active-table;
-                browse-editor-open: root.browse-editor-open;
+                browse-editor-open <=> root.browse-editor-open;
+                // Right pane has no commit path yet; hide row add/delete.
+                writable: false;
+                sort-text: root.p1-sort-text;
+                mongo-filter <=> root.p1-mongo-filter;
+                apply-mongo-filter() => { root.p1-apply-mongo-filter(); }
+                add-row() => { root.p1-add-row(); }
+                mark-delete() => { root.p1-mark-delete(); }
+                apply-filter() => { root.p1-apply-filter(); }
+                focus-filter-tick: root.p1-focus-filter-tick;
+                filter-columns: root.p1-filter-columns;
+                filter-col <=> root.p1-filter-col;
+                filter-operators: root.p1-filter-operators;
+                filter-op <=> root.p1-filter-op;
+                grid-filter <=> root.p1-grid-filter;
                 fn-mode: root.fn-mode;
                 results-collapsed: root.results-collapsed;
                 detail-visible: root.detail-visible;
@@ -725,7 +588,7 @@ export component WorkArea inherits Rectangle {
                 cell-advance(r, c, t, fwd) => { root.p1-cell-advance(r, c, t, fwd); }
                 stage-cell(r, c, t) => { root.p1-stage-cell(r, c, t); }
                 edit-cancelled() => { root.p1-edit-cancelled(); }
-                doc-view: root.p1-doc-view;
+                doc-view <=> root.p1-doc-view;
                 doc-tree: root.p1-doc-tree;
                 toggle-doc-node(p) => { root.p1-toggle-doc-node(p); }
                 structure-columns: root.p1-structure-columns;

--- a/crates/driver-mongo/src/driver.rs
+++ b/crates/driver-mongo/src/driver.rs
@@ -156,14 +156,17 @@ impl Driver for MongoDriver {
     /// All non-system databases, backing the "schema:" switcher so the user can
     /// still reach every database even when the tree is scoped to one on connect.
     async fn list_databases(&self) -> Result<Vec<String>> {
-        Ok(self
+        let mut names: Vec<String> = self
             .client
             .list_database_names()
             .await
             .map_err(|e| RdbError::Schema(e.to_string()))?
             .into_iter()
             .filter(|n| !is_system_db(n))
-            .collect())
+            .collect();
+        // Alphabetical, matching how the SQL drivers ORDER BY name.
+        names.sort();
+        Ok(names)
     }
 
     /// Scope the sidebar to one database: return just that database with its
@@ -184,12 +187,15 @@ impl Driver for MongoDriver {
     /// so a database with thousands of collections stays light.
     async fn containers(&self, database: &str) -> Result<Vec<Container>> {
         let limit = self.collection_limit.load(Ordering::Relaxed);
-        let coll_names = self
+        let mut coll_names = self
             .client
             .database(database)
             .list_collection_names()
             .await
             .map_err(|e| RdbError::Schema(e.to_string()))?;
+        // Sort before the limit so the A–Z cap is a stable prefix, not a
+        // random slice — mirrors ORDER BY name in the SQL drivers.
+        coll_names.sort();
         Ok(coll_names
             .into_iter()
             .take(limit)

--- a/npm/README.md
+++ b/npm/README.md
@@ -17,11 +17,74 @@ The postinstall step downloads the prebuilt `rdb` binary for your platform
 rdb
 ```
 
-## Links
+## Features
 
-- Source & docs: https://github.com/suiflex/rdb
-- Also available via Homebrew (`brew install suiflex/tap/rdb`) and
-  Scoop (`scoop install rdb`).
+- **Multi-engine** — PostgreSQL, MySQL/MariaDB, Redis, MongoDB, SQLite, Cassandra in one app
+- **Native UI** — GPU-rendered via Slint (no webview, no Chromium, no Electron)
+- **Fast & light** — no GC, no runtime; aggressive release optimization (LTO, `opt-level=z`, `panic=abort`)
+- **Secure connections** — passwords stored in OS keychain (macOS Keychain, libsecret) with AES-GCM encrypted-file fallback
+- **Schema browser** — sidebar tree: databases → tables/collections/keys → columns/fields
+- **Tabbed query editor** — multiple tabs per session, one per engine
+- **Results grid** — resizable columns, client-side row filtering, copy support
+- **Command palette** — `Cmd+K` to jump to any connection or table instantly
+- **DSN import** — paste a connection URL, fields auto-fill
+- **Connection test** — verify creds before saving
+- **Light / dark mode** toggle
+
+## Supported Engines
+
+| Engine | Protocol | Result type |
+|--------|----------|-------------|
+| PostgreSQL | `tokio-postgres` | Tabular |
+| MySQL / MariaDB | `mysql_async` | Tabular |
+| Redis | `redis` crate | Key-value / raw |
+| MongoDB | `mongodb` crate | Documents (JSON) |
+| SQLite | `rusqlite` | Tabular |
+| Cassandra | `scylla` | Tabular |
+
+## Design
+
+### Core design rule
+
+The UI (`app/`) depends only on `rdb-core`. It never imports a concrete driver crate. Adding a new engine = a new `driver-*` crate that implements the `Driver` trait; the UI is untouched.
+
+### Async bridge
+
+Slint's event loop runs on the main thread. All I/O (connect, query, schema fetch) spawns on a `tokio` multi-thread runtime. Results return to the UI thread via `invoke_from_event_loop`.
+
+### Driver trait
+
+```rust
+#[async_trait]
+pub trait Driver: Send + Sync {
+    async fn connect(cfg: &ConnConfig) -> Result<Self> where Self: Sized;
+    async fn ping(&self) -> Result<()>;
+    async fn schema(&self) -> Result<Schema>;
+    async fn query(&self, q: &Query) -> Result<ResultSet>;
+    async fn close(self) -> Result<()>;
+}
+```
+
+### Query enum
+
+```rust
+pub enum Query {
+    Sql(String),           // PostgreSQL, MySQL, SQLite, Cassandra
+    Command(Vec<String>),  // Redis: ["GET", "key"]
+    Mongo(MongoOp),        // find / insert / aggregate
+}
+```
+
+### ResultSet enum
+
+```rust
+pub enum ResultSet {
+    Tabular   { cols: Vec<Column>, rows: Vec<Row> },
+    Documents(Vec<serde_json::Value>),
+    KeyValue(Vec<(String, RedisValue)>),
+    Affected(u64),
+}
+```
 
 ## License
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -2,7 +2,7 @@
   "name": "@suiflex/rdb",
   "version": "0.14.0",
   "description": "RDB — native cross-platform database manager (PostgreSQL, MySQL, Redis, MongoDB)",
-  "homepage": "https://github.com/suiflex/rdb",
+  "homepage": "https://rdb.suiflex.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/suiflex/rdb.git"


### PR DESCRIPTION
## Summary

- Prepares the v0.29.0 release: fixes and features across the app UI and the
  Mongo driver gathered on this branch.
- Focus areas: split-pane feature parity, SQL editor usability (drag-select,
  multi-statement runs), tab persistence, and deterministic Mongo ordering.

## Changes

### App — workspace / tabs
- Keep open table/collection tabs when switching connection (standby snapshot
  until refreshed) instead of dropping them.
- Full browse toolbar in the split (right) pane: Filter chip + row, sort text,
  Query and Grid/Tree toggles, Copy, Export, Chart — wired to the p1 pane
  state, with row add/delete kept on the primary pane (the one with a commit
  path).

### App — SQL editor
- Enable mouse drag-select: stop the editor ScrollView from hijacking the drag
  as a pan, and update the line model in place so the per-line TouchArea holding
  a drag is not recreated mid-gesture.
- Run selected statements into separate result tabs on plain Run (⌘⏎), matching
  the Run Selection button.
- Don't stream a multi-statement selection as one query (was hitting Postgres
  42601 "cannot insert multiple commands into a prepared statement").

### Driver — Mongo
- Sort collections and databases alphabetically, matching the ORDER BY the SQL
  drivers already apply.

### Earlier on-branch commits
- App zoom shortcuts, details values stay visible, npm docs/homepage, Cargo.lock
  refresh, ignore .mcp.json.

## Test plan

- [x] `make fmt-check`
- [x] `make lint`
- [x] `make be-test`
- [x] `cargo build -p rdb`
- [x] Mongo connection: collections list A–Z
- [x] Open collection tab, switch connection → tab persists; switch back → still there
- [x] Split a browse tab → right pane shows full toolbar; Copy/Export/Filter/Chart work
- [x] Editor: mouse drag selects text (single and multi-line); double-click word-select and wheel scroll still work
- [x] Select 2+ statements, Run (⌘⏎) → one result tab per statement