### PR TITLE
feat(app): v0.30.0 prep — connection badges, self-update, UX fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,14 @@
 
 ## Project
 
-Native cross-platform database manager (PostgreSQL, MySQL, Redis, MongoDB) built with Rust + Slint UI. Monorepo workspace.
+Native cross-platform database manager (PostgreSQL, MySQL, Redis, MongoDB, SQLite, Cassandra) built with Rust + Slint UI. Monorepo workspace.
+
+Alongside the Rust workspace (`app/`, `crates/*`) the repo also holds: `website/`
+(Astro marketing site, deployed by Cloudflare Pages' Git integration on every
+push to `develop` — not part of the Rust build), `scripts/` (`install.sh` /
+`install.ps1`, the curl/iwr entry points for a direct install), and
+`npm/`/`packaging/` (the npm postinstall wrapper and package-manager
+distribution files for Homebrew/Scoop).
 
 ## Build, Lint, Test
 
@@ -25,9 +32,15 @@ cargo build --release -p rdb   # release binary
 ## CI
 
 One GitHub Actions workflow per component in `.github/workflows/` — `rdb-app`
-plus one per crate (`rdb-core`, `rdb-connstore`, `rdb-driver-*`). Each has a
+plus one per crate: `rdb-core`, `rdb-connstore`, `rdb-driver-postgres`,
+`rdb-driver-mysql`, `rdb-driver-redis`, `rdb-driver-mongo`. Each has a
 `paths:` filter, so editing one component only runs that component's CI (lean).
 
+- **Known gap**: `rdb-driver-sqlite` and `rdb-driver-cassandra` have no
+  dedicated workflow yet, and the root `Makefile`'s `BE_PKGS` (used by
+  `be-build`/`be-test`/`be-check`) doesn't include them either — use
+  `cargo build/test -p rdb-driver-sqlite` (or `-cassandra`) directly until
+  that's wired up.
 - Dependents also watch `crates/core/**`, so a `core` change fans out to retest
   core + all dependents (connstore, drivers, app). Other crates stay independent.
 - Backend jobs run `cargo {fmt,clippy} -p <pkg>` and `cargo test -p <pkg> --lib`
@@ -35,11 +48,23 @@ plus one per crate (`rdb-core`, `rdb-connstore`, `rdb-driver-*`). Each has a
   tests only; the `tests/integration.rs` targets need Docker, so they stay out
   of CI and run locally via `make test-it`.
 - The app job installs Slint system libs and runs `cargo build -p rdb`.
+- `audit.yml` runs `cargo audit` on every `Cargo.toml`/`Cargo.lock` change plus
+  a weekly sweep (new advisories land with no code change).
+- `website.yml` is a CI check only for `website/**` — actual deploy is
+  Cloudflare Pages' own Git integration on push to `develop`.
 
 Releases are handled separately by `release-please.yml` (single workspace
 release on `develop`): conventional commits drive an auto-maintained release
 PR that bumps the version and `app/CHANGELOG.md`; merging it tags `vX.Y.Z`
 and cuts a GitHub Release. The `app` package (`rdb`) is the tracked version.
+
+`release-build.yml` does the actual packaging once that tag lands: builds
+per-target native binaries (macOS `.dmg` with an ad-hoc-codesigned `.app`,
+Windows bare `.exe`, Linux `.tar.gz`), attaches them to the GitHub Release,
+and publishes to the `suiflex/homebrew-tap` formula/cask, the
+`suiflex/scoop-bucket`, and npm (`@suiflex/rdb`, postinstall downloads the
+matching asset). `scripts/install.sh` / `scripts/install.ps1` are the direct
+(non-package-manager) install path and hit the same GitHub Releases API.
 
 Release note sections are configured in `release-please-config.json` and are
 triggered by conventional commit **type**:
@@ -63,6 +88,8 @@ Keep the scope specific (`app`, `driver-postgres`, `driver-mysql`, `core`,
 - `crates/driver-mysql/` — mysql_async
 - `crates/driver-redis/` — redis crate
 - `crates/driver-mongo/` — mongodb crate
+- `crates/driver-sqlite/` — rusqlite (bundled)
+- `crates/driver-cassandra/` — scylla crate (CQL, Cassandra/ScyllaDB)
 
 ## Key Rules
 
@@ -70,6 +97,12 @@ Keep the scope specific (`app`, `driver-postgres`, `driver-mysql`, `core`,
 - Adding new engine = new `driver-*` crate implementing `Driver` trait + a variant in `AnyDriver`.
 - Async I/O on tokio runtime, results bridge back to Slint main thread via `invoke_from_event_loop`.
 - Release profile: `opt-level=z`, LTO, `panic=abort`, strip.
+- In-app self-update (`app/src/self_update.rs`) only ever runs for
+  `InstallMethod::Other` (direct curl/.dmg/.exe installs) — never for
+  Homebrew/Scoop, which must keep showing the upgrade command + release-page
+  link instead (`InstallMethod::self_update_supported`, `app/src/update.rs`).
+  Don't change that gating without a deliberate reason; it's what stops the
+  app from fighting the package manager on those installs.
 
 ## Toolchain
 

--- a/app/src/editor.rs
+++ b/app/src/editor.rs
@@ -665,6 +665,13 @@ impl EditorState {
         &self.lines[self.line]
     }
 
+    /// Replace only the physical line under the caret and keep the caret in it.
+    pub fn replace_current_line(&mut self, text: &str) {
+        self.lines[self.line] = text.to_string();
+        self.col = self.col.min(text.chars().count());
+        self.sel = None;
+    }
+
     /// Statement under the cursor: the `;`-delimited segment containing the
     /// cursor, ignoring semicolons inside single-quoted literals. Falls back
     /// to the current line when the segment is empty.
@@ -991,6 +998,16 @@ mod tests {
         ed.line = 3; // on `y = 2`, past the commented `;`
         ed.col = 0;
         assert_eq!(ed.current_statement(), text);
+    }
+
+    #[test]
+    fn replace_current_line_preserves_other_lines() {
+        let mut ed = EditorState::from_text("select 1\nselect 2\nselect 3");
+        ed.line = 1;
+        ed.col = 8;
+        ed.replace_current_line("SELECT 2");
+        assert_eq!(ed.text(), "select 1\nSELECT 2\nselect 3");
+        assert_eq!((ed.line, ed.col), (1, 8));
     }
 
     // ----- selection -----

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -7656,8 +7656,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 run_sql(1, text);
             }
         };
-        window.on_p1_run(run_p1.clone());
-        window.on_p1_run_selection(run_p1);
+        window.on_p1_run(run_p1);
     }
 
     // ----- Details panel: copy one field value to the clipboard -----
@@ -7737,56 +7736,6 @@ fn main() -> Result<(), slint::PlatformError> {
                 contents,
                 |w, msg| w.set_results_meta(SharedString::from(msg)),
             );
-        });
-    }
-
-    // ----- Run Selection: selected text, else statement under the cursor -----
-    {
-        let weak = window.as_weak();
-        let run_sql = run_sql.clone();
-        let run_stream = run_stream.clone();
-        let cur_engine = cur_engine.clone();
-        let browse = browse.clone();
-        let ed_state = ed_state.clone();
-        let recent_queries = recent_queries.clone();
-        let history_cap = history_cap.clone();
-        let panes = panes.clone();
-        window.on_run_selection(move || {
-            let stmt = {
-                let ed = ed_state.borrow();
-                ed.selected_text()
-                    .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty())
-                    .unwrap_or_else(|| ed.current_statement())
-            };
-            if !stmt.is_empty() {
-                let mut stream = false;
-                let mut not_table = false;
-                if let Some(w) = weak.upgrade() {
-                    not_table = active_tab_kind(&w) != "table";
-                    if not_table {
-                        w.set_grid_read_only(true);
-                    }
-                    stream = not_table
-                        && browse.lock().unwrap().limit == 0
-                        && cur_engine
-                            .borrow()
-                            .map(|e| is_bare_select(e, &stmt))
-                            .unwrap_or(false);
-                }
-                record_recent(&recent_queries, &stmt, history_cap.get());
-                if stream {
-                    run_stream(0, stmt);
-                } else {
-                    // 2+ selected statements → one result tab each.
-                    if not_table && editor::split_statements(&stmt).len() >= 2 {
-                        panes[0]
-                            .split_results
-                            .store(true, std::sync::atomic::Ordering::SeqCst);
-                    }
-                    run_sql(0, stmt);
-                }
-            }
         });
     }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2857,10 +2857,17 @@ fn set_result_tabs(w: &MainWindow, pane: usize, results: &[StoredResult], active
     let items: Vec<ResultTabItem> = results
         .iter()
         .enumerate()
-        .map(|(n, r)| ResultTabItem {
-            label: format!("Result {}", n + 1).into(),
-            engine: r.engine.clone().into(),
-            connection_name: r.connection_name.clone().into(),
+        .map(|(n, r)| {
+            let label = if r.connection_name.is_empty() {
+                format!("Result {}", n + 1)
+            } else {
+                format!("{} {}", r.connection_name, n + 1)
+            };
+            ResultTabItem {
+                label: label.into(),
+                engine: r.engine.clone().into(),
+                connection_name: r.connection_name.clone().into(),
+            }
         })
         .collect();
     let items = ModelRc::from(Rc::new(VecModel::from(items)));

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -46,6 +46,32 @@ fn clamp_font_size(size: i32) -> i32 {
     size.clamp(MIN_FONT_SIZE, MAX_FONT_SIZE)
 }
 
+fn shortcut_labels(
+    os: &str,
+) -> (
+    &'static str,
+    &'static str,
+    &'static str,
+    &'static str,
+    &'static str,
+) {
+    if os == "macos" {
+        ("⌘", "⇧", "", "↩", "⌫")
+    } else {
+        ("Ctrl", "Shift", "+", "Enter", "Backspace")
+    }
+}
+
+#[test]
+fn shortcut_labels_follow_desktop_conventions() {
+    assert_eq!(shortcut_labels("macos"), ("⌘", "⇧", "", "↩", "⌫"));
+    assert_eq!(
+        shortcut_labels("windows"),
+        ("Ctrl", "Shift", "+", "Enter", "Backspace")
+    );
+    assert_eq!(shortcut_labels("linux").0, "Ctrl");
+}
+
 /// Open a native "save file" dialog and write `contents` to the chosen path.
 ///
 /// macOS: rfd's NSSavePanel would not present from this non-bundled + winit
@@ -3014,6 +3040,13 @@ fn main() -> Result<(), slint::PlatformError> {
     let rt = Arc::new(rt);
 
     let window = MainWindow::new()?;
+    let (primary, shift, separator, enter, backspace) = shortcut_labels(std::env::consts::OS);
+    let shortcuts = Shortcut::get(&window);
+    shortcuts.set_primary(primary.into());
+    shortcuts.set_shift(shift.into());
+    shortcuts.set_separator(separator.into());
+    shortcuts.set_enter(enter.into());
+    shortcuts.set_backspace(backspace.into());
 
     // One store for the app lifetime; all CRUD + password ops go through it.
     // RDB_MOCK=1 swaps in a seeded temp store (never the user's real one).
@@ -9646,20 +9679,35 @@ fn main() -> Result<(), slint::PlatformError> {
     // ----- row nav (j/k) -----
     {
         let weak = window.as_weak();
-        let displayed_grid = displayed_grid.clone();
+        let panes = panes.clone();
         window.on_move_row(move |delta| {
             if let Some(w) = weak.upgrade() {
-                let n = w.get_grid_col_count();
+                let pane = w.get_active_pane().clamp(0, 1) as usize;
+                let n = if pane == 0 {
+                    w.get_grid_col_count()
+                } else {
+                    w.get_p1_col_count()
+                };
                 let total = if n > 0 {
-                    (w.get_grid_cells().row_count() as i32) / n
+                    let cells = if pane == 0 {
+                        w.get_grid_cells()
+                    } else {
+                        w.get_p1_cells()
+                    };
+                    (cells.row_count() as i32) / n
                 } else {
                     0
                 };
                 if total > 0 {
-                    let next = (w.get_selected_row() + delta).clamp(0, total - 1);
-                    w.set_selected_row(next);
-                    if let Some(g) = displayed_grid.lock().unwrap().as_ref() {
-                        refresh_detail_pretty(&w, 0, g, next);
+                    let selected = if pane == 0 {
+                        w.get_selected_row()
+                    } else {
+                        w.get_p1_selected_row()
+                    };
+                    let next = (selected + delta).clamp(0, total - 1);
+                    set_p_selected_row(&w, pane, next);
+                    if let Some(g) = panes[pane].displayed_grid.lock().unwrap().as_ref() {
+                        refresh_detail_pretty(&w, pane, g, next);
                     }
                 }
             }
@@ -9925,6 +9973,11 @@ fn main() -> Result<(), slint::PlatformError> {
             let Some(w) = weak.upgrade() else {
                 return;
             };
+            // The right split pane is read-only, so a delete key there must
+            // not mutate the editable left-pane buffer.
+            if w.get_active_pane() == 1 {
+                return;
+            }
             if w.get_grid_read_only() {
                 return;
             }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -199,6 +199,7 @@ fn build_conn_items(
                 name: g.to_uppercase().into(),
                 engine: SharedString::default(),
                 color: theme::accent_or_default(""),
+                has_custom_color: false,
                 is_header: true,
                 expanded,
                 index: -1,
@@ -230,6 +231,7 @@ fn build_conn_items(
                 name: s.name.clone().into(),
                 engine: AnyDriver::badge(s.engine).into(),
                 color: theme::accent_or_default(s.color.as_deref().unwrap_or("")),
+                has_custom_color: s.color.is_some(),
                 is_header: false,
                 expanded: true,
                 index: i as i32,
@@ -2180,7 +2182,7 @@ fn restore_grid_state(w: &MainWindow, pane: usize, g: &GroupRuntime, sr: &Stored
 /// "section" header rows. `needle` (lowercase) filters both groups; empty
 /// shows everything. Empty groups drop their header.
 fn build_palette_items(
-    names: &[(String, &'static str)],
+    names: &[(String, &'static str, slint::Color, bool)],
     w: &MainWindow,
     needle: &str,
 ) -> Vec<PaletteItem> {
@@ -2189,20 +2191,24 @@ fn build_palette_items(
         kind: "section".into(),
         sub: SharedString::default(),
         local: false,
+        color: theme::accent_or_default(""),
+        has_custom_color: false,
     };
     let mut items: Vec<PaletteItem> = Vec::new();
-    let conns: Vec<&(String, &'static str)> = names
+    let conns: Vec<&(String, &'static str, slint::Color, bool)> = names
         .iter()
-        .filter(|(n, _)| needle.is_empty() || n.to_lowercase().contains(needle))
+        .filter(|(n, ..)| needle.is_empty() || n.to_lowercase().contains(needle))
         .collect();
     if !conns.is_empty() {
         items.push(section("Connections"));
-        for (n, badge) in conns {
+        for (n, badge, color, has_custom_color) in conns {
             items.push(PaletteItem {
                 label: n.clone().into(),
                 kind: (*badge).into(),
                 sub: SharedString::default(),
                 local: false,
+                color: *color,
+                has_custom_color: *has_custom_color,
             });
         }
     }
@@ -2222,6 +2228,8 @@ fn build_palette_items(
                 kind: "table".into(),
                 sub: SharedString::default(),
                 local: false,
+                color: theme::accent_or_default(""),
+                has_custom_color: false,
             });
         }
     }
@@ -3353,6 +3361,8 @@ fn main() -> Result<(), slint::PlatformError> {
                     kind: c.kind.clone().into(),
                     sub: c.sub.clone().into(),
                     local: false,
+                    color: theme::accent_or_default(""),
+                    has_custom_color: false,
                 })
                 .collect();
             *panes[pane].completion_ctx.borrow_mut() =
@@ -4111,6 +4121,8 @@ fn main() -> Result<(), slint::PlatformError> {
                     kind: "database".into(),
                     sub: SharedString::default(),
                     local: false,
+                    color: theme::accent_or_default(""),
+                    has_custom_color: false,
                 })
                 .collect();
             if items.is_empty() {
@@ -4154,6 +4166,8 @@ fn main() -> Result<(), slint::PlatformError> {
                     kind: "database".into(),
                     sub: SharedString::default(),
                     local: false,
+                    color: theme::accent_or_default(""),
+                    has_custom_color: false,
                 })
                 .collect();
             if items.is_empty() {
@@ -4594,6 +4608,8 @@ fn main() -> Result<(), slint::PlatformError> {
                         kind: "group".into(),
                         sub: SharedString::default(),
                         local: false,
+                        color: theme::accent_or_default(""),
+                        has_custom_color: false,
                     });
                     map.push(-1);
                 } else {
@@ -4602,6 +4618,8 @@ fn main() -> Result<(), slint::PlatformError> {
                         kind: r.engine,
                         sub: r.subline,
                         local: r.local,
+                        color: r.color,
+                        has_custom_color: r.has_custom_color,
                     });
                     map.push(r.index);
                 }
@@ -4646,6 +4664,8 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_selected_conn(idx);
             w.set_sel_name(s.name.clone().into());
             w.set_sel_engine(AnyDriver::badge(s.engine).into());
+            w.set_sel_color(theme::accent_or_default(s.color.as_deref().unwrap_or("")));
+            w.set_sel_has_custom_color(s.color.is_some());
             let label = AnyDriver::label(s.engine);
             let sub = match s.group.as_deref().filter(|g| !g.trim().is_empty()) {
                 Some(g) => format!("{label} · grup {}", g.to_lowercase()),
@@ -10021,11 +10041,18 @@ fn main() -> Result<(), slint::PlatformError> {
                 let opening = !w.get_palette_open();
                 w.set_palette_open(opening);
                 if opening {
-                    let names: Vec<(String, &'static str)> = store
+                    let names: Vec<(String, &'static str, slint::Color, bool)> = store
                         .borrow()
                         .list()
                         .iter()
-                        .map(|s| (s.name.clone(), AnyDriver::badge(s.engine)))
+                        .map(|s| {
+                            (
+                                s.name.clone(),
+                                AnyDriver::badge(s.engine),
+                                theme::accent_or_default(s.color.as_deref().unwrap_or("")),
+                                s.color.is_some(),
+                            )
+                        })
                         .collect();
                     let items = build_palette_items(&names, &w, "");
                     w.set_palette_items(ModelRc::from(Rc::new(VecModel::from(items))));
@@ -10040,11 +10067,18 @@ fn main() -> Result<(), slint::PlatformError> {
         let store = store.clone();
         window.on_palette_filter(move |q| {
             if let Some(w) = weak.upgrade() {
-                let names: Vec<(String, &'static str)> = store
+                let names: Vec<(String, &'static str, slint::Color, bool)> = store
                     .borrow()
                     .list()
                     .iter()
-                    .map(|s| (s.name.clone(), AnyDriver::badge(s.engine)))
+                    .map(|s| {
+                        (
+                            s.name.clone(),
+                            AnyDriver::badge(s.engine),
+                            theme::accent_or_default(s.color.as_deref().unwrap_or("")),
+                            s.color.is_some(),
+                        )
+                    })
                     .collect();
                 let items = build_palette_items(&names, &w, &q.to_lowercase());
                 w.set_palette_items(ModelRc::from(Rc::new(VecModel::from(items))));

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -21,6 +21,7 @@ mod export;
 mod mock;
 mod model;
 mod query_parse;
+mod self_update;
 #[cfg(feature = "mock")]
 mod shot;
 mod sql_format;
@@ -10822,6 +10823,16 @@ fn main() -> Result<(), slint::PlatformError> {
         });
     }
 
+    // Whether the in-app swap-and-relaunch flow applies to this exact
+    // install; false in mock mode so screenshot tests never depend on the
+    // build machine's binary path. Homebrew/Scoop are never eligible — see
+    // `InstallMethod::self_update_supported`.
+    fn self_update_supported_now() -> bool {
+        !mock::mock_mode()
+            && update::InstallMethod::detect()
+                .self_update_supported(std::env::current_exe().ok().as_deref())
+    }
+
     // ----- update reminder: open the release page / dismiss -----
     {
         window.on_update_open(move || {
@@ -10833,6 +10844,100 @@ fn main() -> Result<(), slint::PlatformError> {
         window.on_update_dismiss(move || {
             if let Some(w) = weak.upgrade() {
                 w.set_update_available(false);
+            }
+        });
+    }
+    // ----- restart to update: idle/error -> download, ready -> swap + relaunch -----
+    {
+        let weak = window.as_weak();
+        let staged_path: Arc<std::sync::Mutex<Option<std::path::PathBuf>>> =
+            Arc::new(std::sync::Mutex::new(None));
+        window.on_restart_to_update(move || {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let stage = w.get_update_stage();
+            match stage.as_str() {
+                "idle" | "error" => {
+                    w.set_update_stage(SharedString::from("downloading"));
+                    w.set_update_progress(0.0);
+                    w.set_update_error(SharedString::default());
+                    let weak2 = weak.clone();
+                    let staged_path = staged_path.clone();
+                    std::thread::spawn(move || {
+                        let last_reported = std::sync::atomic::AtomicI32::new(-1);
+                        let result = self_update::fetch_latest_assets()
+                            .map_err(|e| e.to_string())
+                            .and_then(|assets| {
+                                self_update::pick_asset(&assets).ok_or_else(|| {
+                                    "no matching release asset for this platform".to_string()
+                                })
+                            })
+                            .and_then(|asset| {
+                                let weak3 = weak2.clone();
+                                self_update::download_asset(&asset, |frac| {
+                                    let pct = (frac * 100.0) as i32;
+                                    if pct
+                                        == last_reported
+                                            .swap(pct, std::sync::atomic::Ordering::Relaxed)
+                                    {
+                                        return;
+                                    }
+                                    let weak4 = weak3.clone();
+                                    let _ = slint::invoke_from_event_loop(move || {
+                                        if let Some(w) = weak4.upgrade() {
+                                            w.set_update_progress(pct as f32 / 100.0);
+                                        }
+                                    });
+                                })
+                                .map_err(|e| e.to_string())
+                            });
+                        match result {
+                            Ok(path) => {
+                                *staged_path.lock().unwrap() = Some(path);
+                                let _ = slint::invoke_from_event_loop(move || {
+                                    if let Some(w) = weak2.upgrade() {
+                                        w.set_update_progress(1.0);
+                                        w.set_update_stage(SharedString::from("ready"));
+                                    }
+                                });
+                            }
+                            Err(e) => {
+                                let _ = slint::invoke_from_event_loop(move || {
+                                    if let Some(w) = weak2.upgrade() {
+                                        w.set_update_error(SharedString::from(e));
+                                        w.set_update_stage(SharedString::from("error"));
+                                    }
+                                });
+                            }
+                        }
+                    });
+                }
+                "ready" => {
+                    let Some(path) = staged_path.lock().unwrap().clone() else {
+                        w.set_update_stage(SharedString::from("idle"));
+                        return;
+                    };
+                    w.set_update_stage(SharedString::from("restarting"));
+                    let weak2 = weak.clone();
+                    std::thread::spawn(move || match self_update::perform_swap(&path) {
+                        Ok(()) => {
+                            let _ = slint::invoke_from_event_loop(|| {
+                                let _ = slint::quit_event_loop();
+                            });
+                        }
+                        Err(e) => {
+                            let msg = e.to_string();
+                            let _ = slint::invoke_from_event_loop(move || {
+                                if let Some(w) = weak2.upgrade() {
+                                    w.set_update_error(SharedString::from(msg));
+                                    w.set_update_stage(SharedString::from("error"));
+                                }
+                            });
+                        }
+                    });
+                }
+                _ => {} // "downloading"/"restarting": ignore repeat clicks
             }
         });
     }
@@ -10870,6 +10975,8 @@ fn main() -> Result<(), slint::PlatformError> {
                                 )));
                                 w.set_update_version(version.into());
                                 w.set_update_hint(hint.into());
+                                w.set_update_self_update_supported(self_update_supported_now());
+                                w.set_update_stage(SharedString::from("idle"));
                                 w.set_update_available(true);
                             }
                             Some(_) => w.set_update_check_status(SharedString::from(format!(
@@ -10920,6 +11027,8 @@ fn main() -> Result<(), slint::PlatformError> {
                     if let Some(w) = weak.upgrade() {
                         w.set_update_version(version.into());
                         w.set_update_hint(hint.into());
+                        w.set_update_self_update_supported(self_update_supported_now());
+                        w.set_update_stage(SharedString::from("idle"));
                         w.set_update_available(true);
                     }
                 });

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -8254,10 +8254,17 @@ fn main() -> Result<(), slint::PlatformError> {
         let panes = panes.clone();
         let sync_editor = sync_editor.clone();
         window.on_format_sql(move || {
-            let mut ed = panes[0].ed_state.borrow_mut();
-            if !ed.current_line().trim().is_empty() {
-                let formatted = sql_format::format(ed.current_line());
-                ed.replace_current_line(&formatted);
+            let changed = {
+                let mut ed = panes[0].ed_state.borrow_mut();
+                if ed.current_line().trim().is_empty() {
+                    false
+                } else {
+                    let formatted = sql_format::format(ed.current_line());
+                    ed.replace_current_line(&formatted);
+                    true
+                }
+            };
+            if changed {
                 sync_editor(0);
             }
         });
@@ -8266,10 +8273,17 @@ fn main() -> Result<(), slint::PlatformError> {
         let panes = panes.clone();
         let sync_editor = sync_editor.clone();
         window.on_p1_format_sql(move || {
-            let mut ed = panes[1].ed_state.borrow_mut();
-            if !ed.current_line().trim().is_empty() {
-                let formatted = sql_format::format(ed.current_line());
-                ed.replace_current_line(&formatted);
+            let changed = {
+                let mut ed = panes[1].ed_state.borrow_mut();
+                if ed.current_line().trim().is_empty() {
+                    false
+                } else {
+                    let formatted = sql_format::format(ed.current_line());
+                    ed.replace_current_line(&formatted);
+                    true
+                }
+            };
+            if changed {
                 sync_editor(1);
             }
         });
@@ -9137,11 +9151,11 @@ fn main() -> Result<(), slint::PlatformError> {
         let run_sql = run_sql.clone();
         let recent_queries = recent_queries.clone();
         let history_cap = history_cap.clone();
-        window.on_run_new_tab(move || {
+        let run_new_tab: Rc<dyn Fn(usize)> = Rc::new(move |pane| {
             let Some(w) = weak.upgrade() else {
                 return;
             };
-            let pane = w.get_active_pane().clamp(0, 1) as usize;
+            let pane = pane.min(1);
             let stmt = {
                 let ed = panes[pane].ed_state.borrow();
                 ed.selected_text()
@@ -9162,6 +9176,15 @@ fn main() -> Result<(), slint::PlatformError> {
             record_recent(&recent_queries, &stmt, history_cap.get());
             run_sql(pane, stmt);
         });
+        let weak = window.as_weak();
+        let run_new_tab_active = run_new_tab.clone();
+        window.on_run_new_tab(move || {
+            if let Some(w) = weak.upgrade() {
+                run_new_tab_active(w.get_active_pane().clamp(0, 1) as usize);
+            }
+        });
+        let run_new_tab_p1 = run_new_tab;
+        window.on_p1_run_new_tab(move || run_new_tab_p1(1));
     }
 
     // ----- switch / close result tabs -----

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -625,6 +625,12 @@ struct StoredResult {
     meta: String,
     latency: String,
     grid: GridState,
+    // Connection that produced THIS run — captured when the run started, not
+    // read from the tab, since a long-lived SQL tab can be re-run after the
+    // user switches the active connection (each Result N chip needs its own).
+    connection_id: Option<String>,
+    engine: String,
+    connection_name: String,
 }
 
 fn store_result(
@@ -652,6 +658,9 @@ mod result_tab_tests {
             meta: String::new(),
             latency: String::new(),
             grid: GridState::default(),
+            connection_id: None,
+            engine: String::new(),
+            connection_name: String::new(),
         }
     }
 
@@ -2842,17 +2851,24 @@ fn present_view(
     }
 }
 
-/// Set the result-tab strip labels ("Result 1", …) and active index.
-fn set_result_tabs(w: &MainWindow, pane: usize, count: usize, active: usize) {
-    let labels: Vec<SharedString> = (1..=count)
-        .map(|n| SharedString::from(format!("Result {n}")))
+/// Set the result-tab strip ("Result 1", …, each badged with the connection
+/// that produced it) and active index.
+fn set_result_tabs(w: &MainWindow, pane: usize, results: &[StoredResult], active: usize) {
+    let items: Vec<ResultTabItem> = results
+        .iter()
+        .enumerate()
+        .map(|(n, r)| ResultTabItem {
+            label: format!("Result {}", n + 1).into(),
+            engine: r.engine.clone().into(),
+            connection_name: r.connection_name.clone().into(),
+        })
         .collect();
-    let labels = ModelRc::from(Rc::new(VecModel::from(labels)));
+    let items = ModelRc::from(Rc::new(VecModel::from(items)));
     if pane == 0 {
-        w.set_result_tabs(labels);
+        w.set_result_tabs(items);
         w.set_active_result(active as i32);
     } else {
-        w.set_p1_result_tabs(labels);
+        w.set_p1_result_tabs(items);
         w.set_p1_active_result(active as i32);
     }
 }
@@ -5050,11 +5066,25 @@ fn main() -> Result<(), slint::PlatformError> {
                 tab.active_result = ai;
             }
             if tab.kind != "function" {
+                let (view_id, view_engine, view_name) = tab
+                    .results
+                    .get(tab.active_result)
+                    .map(|r| {
+                        (
+                            r.connection_id.clone(),
+                            r.engine.clone(),
+                            r.connection_name.clone(),
+                        )
+                    })
+                    .unwrap_or_default();
                 tab.view = last_view.lock().unwrap().clone().map(|view| StoredResult {
                     view,
                     meta: w.get_results_meta().to_string(),
                     latency: w.get_status_latency().to_string(),
                     grid: GridState::default(),
+                    connection_id: view_id,
+                    engine: view_engine,
+                    connection_name: view_name,
                 });
             }
             // Persist SQL scratch tabs so they survive a restart. Cheap JSON
@@ -5175,7 +5205,7 @@ fn main() -> Result<(), slint::PlatformError> {
 
             *panes[pane].results.lock().unwrap() = tab.results.clone();
             *panes[pane].active_result.lock().unwrap() = tab.active_result;
-            set_result_tabs(w, pane, tab.results.len(), tab.active_result);
+            set_result_tabs(w, pane, &tab.results, tab.active_result);
             let selected = if tab.kind == "sql" {
                 tab.results
                     .get(tab.active_result)
@@ -6481,6 +6511,8 @@ fn main() -> Result<(), slint::PlatformError> {
         let weak = window.as_weak();
         let rt = rt.clone();
         let current = current.clone();
+        let current_connection_id = current_connection_id.clone();
+        let store = store.clone();
         let last_view = last_view.clone();
         let panes = panes.clone();
         let workspace_tabs = workspace_tabs.clone();
@@ -6548,6 +6580,14 @@ fn main() -> Result<(), slint::PlatformError> {
                 // hid it. The console still updates in place when it is open.
                 cur_db = w.get_schema_name().to_string();
             }
+            // Snapshot which connection is running THIS query — not read back
+            // later from `current_connection_id`, since the user can switch the
+            // active connection while the query is in flight.
+            let query_connection_id = current_connection_id.lock().unwrap().clone();
+            let (query_engine, query_connection_name) = query_connection_id
+                .as_deref()
+                .map(|cid| connection_badge_info(&store.borrow(), cid))
+                .unwrap_or_default();
             let started = std::time::Instant::now();
             let jh = rt.spawn(async move {
                 let picked = {
@@ -6675,6 +6715,9 @@ fn main() -> Result<(), slint::PlatformError> {
                                                 ),
                                                 latency: format!("{elapsed_ms} ms"),
                                                 grid: GridState::default(),
+                                                connection_id: query_connection_id.clone(),
+                                                engine: query_engine.clone(),
+                                                connection_name: query_connection_name.clone(),
                                             }
                                         })
                                         .collect();
@@ -6694,10 +6737,9 @@ fn main() -> Result<(), slint::PlatformError> {
                                     if !is_active {
                                         return;
                                     }
-                                    let count = all.len();
-                                    *results.lock().unwrap() = all;
                                     *active_result.lock().unwrap() = 0;
-                                    set_result_tabs(&w, pane, count, 0);
+                                    set_result_tabs(&w, pane, &all, 0);
+                                    *results.lock().unwrap() = all;
                                     present_view(
                                         &w,
                                         pane,
@@ -6729,6 +6771,9 @@ fn main() -> Result<(), slint::PlatformError> {
                                     meta: meta.clone(),
                                     latency: latency.clone(),
                                     grid: GridState::default(),
+                                    connection_id: query_connection_id.clone(),
+                                    engine: query_engine.clone(),
+                                    connection_name: query_connection_name.clone(),
                                 };
                                 let mut tabs = workspace_tabs.lock().unwrap();
                                 let Some(tab) = tabs.iter_mut().find(|tab| tab.id == target_id)
@@ -6781,14 +6826,9 @@ fn main() -> Result<(), slint::PlatformError> {
                                 *results.lock().unwrap() = tab_results;
                                 *active_result.lock().unwrap() = tab_active;
                                 if is_browse {
-                                    set_result_tabs(&w, pane, 0, 0);
+                                    set_result_tabs(&w, pane, &[], 0);
                                 } else {
-                                    set_result_tabs(
-                                        &w,
-                                        pane,
-                                        results.lock().unwrap().len(),
-                                        tab_active,
-                                    );
+                                    set_result_tabs(&w, pane, &results.lock().unwrap(), tab_active);
                                 }
                                 present_view(
                                     &w,
@@ -6847,6 +6887,8 @@ fn main() -> Result<(), slint::PlatformError> {
         let weak = window.as_weak();
         let rt = rt.clone();
         let current = current.clone();
+        let current_connection_id = current_connection_id.clone();
+        let store = store.clone();
         let query_console = query_console.clone();
         let workspace_tabs = workspace_tabs.clone();
         let active_tab_id = active_tab_id.clone();
@@ -6904,6 +6946,14 @@ fn main() -> Result<(), slint::PlatformError> {
             set_p_result_status(&w, pane, SharedString::from("streaming…"));
             set_p_results_meta(&w, pane, SharedString::default());
 
+            // Snapshot which connection is running THIS stream, same reasoning
+            // as run_sql: the active connection can change before it finishes.
+            let query_connection_id = current_connection_id.lock().unwrap().clone();
+            let (query_engine, query_connection_name) = query_connection_id
+                .as_deref()
+                .map(|cid| connection_badge_info(&store.borrow(), cid))
+                .unwrap_or_default();
+
             // UI-thread accumulator (for filter/sort/export after the stream) and
             // the live cell model we push each batch into.
             let (ui_tx, ui_rx) = std::sync::mpsc::channel::<StreamMsg>();
@@ -6933,6 +6983,9 @@ fn main() -> Result<(), slint::PlatformError> {
                 let active_group1_tab_id = active_group1_tab_id.clone();
                 let stream_timer_stop = stream_timer.clone();
                 let target_id = target_id.clone();
+                let query_connection_id = query_connection_id.clone();
+                let query_engine = query_engine.clone();
+                let query_connection_name = query_connection_name.clone();
                 timer.start(
                     slint::TimerMode::Repeated,
                     std::time::Duration::from_millis(50),
@@ -7006,6 +7059,9 @@ fn main() -> Result<(), slint::PlatformError> {
                                         meta: meta.clone(),
                                         latency: latency.clone(),
                                         grid: GridState::default(),
+                                        connection_id: query_connection_id.clone(),
+                                        engine: query_engine.clone(),
+                                        connection_name: query_connection_name.clone(),
                                     };
                                     let (tab_results, tab_active) = {
                                         let mut tabs = workspace_tabs.lock().unwrap();
@@ -7034,7 +7090,7 @@ fn main() -> Result<(), slint::PlatformError> {
                                         set_result_tabs(
                                             &w,
                                             pane,
-                                            results.lock().unwrap().len(),
+                                            &results.lock().unwrap(),
                                             tab_active,
                                         );
                                         present_view(
@@ -8351,7 +8407,7 @@ fn main() -> Result<(), slint::PlatformError> {
             *last_view.lock().unwrap() = None;
             *displayed_grid.lock().unwrap() = None;
             results.lock().unwrap().clear();
-            set_result_tabs(&w, 0, 0, 0);
+            set_result_tabs(&w, 0, &[], 0);
             clear_grid(&w, 0);
             run_browse(0);
 
@@ -9017,7 +9073,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 ..Default::default()
             };
             *last_view.lock().unwrap() = None;
-            set_result_tabs(&w, 0, 0, 0);
+            set_result_tabs(&w, 0, &[], 0);
             clear_grid(&w, 0);
             w.set_active_pane(0);
             w.set_active_table(SharedString::default());
@@ -9144,7 +9200,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 return;
             };
             let i = i.max(0) as usize;
-            let (count, active, sr) = {
+            let (results_vec, active, sr) = {
                 let mut rv = results.lock().unwrap();
                 if i >= rv.len() {
                     return;
@@ -9154,9 +9210,9 @@ fn main() -> Result<(), slint::PlatformError> {
                 if *ar >= rv.len() {
                     *ar = rv.len().saturating_sub(1);
                 }
-                (rv.len(), *ar, rv.get(*ar).cloned())
+                (rv.clone(), *ar, rv.get(*ar).cloned())
             };
-            set_result_tabs(&w, 0, count, active);
+            set_result_tabs(&w, 0, &results_vec, active);
             if let Some(id) = active_tab_id.lock().unwrap().clone() {
                 if let Some(tab) = workspace_tabs
                     .lock()
@@ -9255,7 +9311,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 return;
             };
             let i = i.max(0) as usize;
-            let (count, active, sr) = {
+            let (results_vec, active, sr) = {
                 let mut rv = panes[1].results.lock().unwrap();
                 if i >= rv.len() {
                     return;
@@ -9265,9 +9321,9 @@ fn main() -> Result<(), slint::PlatformError> {
                 if *ar >= rv.len() {
                     *ar = rv.len().saturating_sub(1);
                 }
-                (rv.len(), *ar, rv.get(*ar).cloned())
+                (rv.clone(), *ar, rv.get(*ar).cloned())
             };
-            set_result_tabs(&w, 1, count, active);
+            set_result_tabs(&w, 1, &results_vec, active);
             if let Some(id) = active_group1_tab_id.lock().unwrap().clone() {
                 if let Some(tab) = workspace_tabs
                     .lock()

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -3576,6 +3576,12 @@ fn main() -> Result<(), slint::PlatformError> {
                         }
                         return true;
                     }
+                    if text.as_str() == "\\" {
+                        if let Some(w) = weak.upgrade() {
+                            w.invoke_run_new_tab();
+                        }
+                        return true;
+                    }
                     // Editor-owned cmd combos; everything else bubbles up to the
                     // window shortcut scope (⌘S commit, ⌘R refresh, …).
                     let handled = {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -8259,7 +8259,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 if ed.current_line().trim().is_empty() {
                     false
                 } else {
-                    let formatted = sql_format::format(ed.current_line());
+                    let formatted = sql_format::format_line(ed.current_line());
                     ed.replace_current_line(&formatted);
                     true
                 }
@@ -8278,7 +8278,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 if ed.current_line().trim().is_empty() {
                     false
                 } else {
-                    let formatted = sql_format::format(ed.current_line());
+                    let formatted = sql_format::format_line(ed.current_line());
                     ed.replace_current_line(&formatted);
                     true
                 }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -633,6 +633,8 @@ struct StoredResult {
     connection_id: Option<String>,
     engine: String,
     connection_name: String,
+    color: slint::Color,
+    has_custom_color: bool,
 }
 
 fn store_result(
@@ -663,6 +665,8 @@ mod result_tab_tests {
             connection_id: None,
             engine: String::new(),
             connection_name: String::new(),
+            color: theme::accent_or_default(""),
+            has_custom_color: false,
         }
     }
 
@@ -771,6 +775,10 @@ struct WorkspaceTab {
     // DbBadge key, e.g. "postgres"; empty when no connection was active yet.
     engine: String,
     connection_name: String,
+    // Connection's custom accent (falls back to a generic color when unset —
+    // has_custom_color says whether to prefer it over the per-engine color).
+    color: slint::Color,
+    has_custom_color: bool,
 }
 
 impl WorkspaceTab {
@@ -795,6 +803,8 @@ impl WorkspaceTab {
             connection_id: None,
             engine: String::new(),
             connection_name: String::new(),
+            color: theme::accent_or_default(""),
+            has_custom_color: false,
         }
     }
 
@@ -807,17 +817,39 @@ fn table_tab_id(connection_id: &str, database: &str, schema: &str, table: &str) 
     format!("table:{connection_id}:{database}:{schema}:{table}")
 }
 
-// Badge key + display name for a saved connection id, empty when unknown
-// (not yet connected, or the connection was deleted since the tab opened).
-fn connection_badge_info(
-    store: &rdb_connstore::ConnStore,
-    connection_id: &str,
-) -> (String, String) {
+// Badge key + display name + accent color for a saved connection id; default
+// (empty strings, generic accent, has_custom_color false) when unknown — not
+// yet connected, or the connection was deleted since the tab opened.
+#[derive(Clone)]
+struct ConnBadgeInfo {
+    engine: String,
+    name: String,
+    color: slint::Color,
+    has_custom_color: bool,
+}
+
+impl Default for ConnBadgeInfo {
+    fn default() -> Self {
+        Self {
+            engine: String::new(),
+            name: String::new(),
+            color: theme::accent_or_default(""),
+            has_custom_color: false,
+        }
+    }
+}
+
+fn connection_badge_info(store: &rdb_connstore::ConnStore, connection_id: &str) -> ConnBadgeInfo {
     store
         .list()
         .iter()
         .find(|c| c.id == connection_id)
-        .map(|c| (AnyDriver::badge(c.engine).to_string(), c.name.clone()))
+        .map(|c| ConnBadgeInfo {
+            engine: AnyDriver::badge(c.engine).to_string(),
+            name: c.name.clone(),
+            color: theme::accent_or_default(c.color.as_deref().unwrap_or("")),
+            has_custom_color: c.color.is_some(),
+        })
         .unwrap_or_default()
 }
 
@@ -918,6 +950,8 @@ fn set_workspace_tabs(w: &MainWindow, tabs: &[WorkspaceTab], active_id: Option<&
             preview: tab.is_preview(),
             engine: tab.engine.clone().into(),
             connection_name: tab.connection_name.clone().into(),
+            color: tab.color,
+            has_custom_color: tab.has_custom_color,
         })
         .collect();
     w.set_tabs(ModelRc::from(Rc::new(VecModel::from(items))));
@@ -936,6 +970,8 @@ fn set_workspace_tabs(w: &MainWindow, tabs: &[WorkspaceTab], active_id: Option<&
             preview: tab.is_preview(),
             engine: tab.engine.clone().into(),
             connection_name: tab.connection_name.clone().into(),
+            color: tab.color,
+            has_custom_color: tab.has_custom_color,
         })
         .collect();
     w.set_p1_tabs(ModelRc::from(Rc::new(VecModel::from(p1_items))));
@@ -2875,6 +2911,8 @@ fn set_result_tabs(w: &MainWindow, pane: usize, results: &[StoredResult], active
                 label: label.into(),
                 engine: r.engine.clone().into(),
                 connection_name: r.connection_name.clone().into(),
+                color: r.color,
+                has_custom_color: r.has_custom_color,
             }
         })
         .collect();
@@ -4066,7 +4104,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 w.get_schema_name(),
                 name
             );
-            let (engine, connection_name) = connection_id
+            let badge = connection_id
                 .as_deref()
                 .map(|cid| connection_badge_info(&store.borrow(), cid))
                 .unwrap_or_default();
@@ -4094,8 +4132,10 @@ fn main() -> Result<(), slint::PlatformError> {
                     split_ratio: 0.5,
                     pane1_query: String::new(),
                     connection_id,
-                    engine,
-                    connection_name,
+                    engine: badge.engine,
+                    connection_name: badge.name,
+                    color: badge.color,
+                    has_custom_color: badge.has_custom_color,
                 });
                 *active_tab_id.lock().unwrap() = Some(id.clone());
                 set_workspace_tabs(&w, &tabs, Some(&id));
@@ -5093,7 +5133,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 tab.active_result = ai;
             }
             if tab.kind != "function" {
-                let (view_id, view_engine, view_name) = tab
+                let (view_id, view_engine, view_name, view_color, view_has_custom_color) = tab
                     .results
                     .get(tab.active_result)
                     .map(|r| {
@@ -5101,9 +5141,19 @@ fn main() -> Result<(), slint::PlatformError> {
                             r.connection_id.clone(),
                             r.engine.clone(),
                             r.connection_name.clone(),
+                            r.color,
+                            r.has_custom_color,
                         )
                     })
-                    .unwrap_or_default();
+                    .unwrap_or_else(|| {
+                        (
+                            None,
+                            String::new(),
+                            String::new(),
+                            theme::accent_or_default(""),
+                            false,
+                        )
+                    });
                 tab.view = last_view.lock().unwrap().clone().map(|view| StoredResult {
                     view,
                     meta: w.get_results_meta().to_string(),
@@ -5112,6 +5162,8 @@ fn main() -> Result<(), slint::PlatformError> {
                     connection_id: view_id,
                     engine: view_engine,
                     connection_name: view_name,
+                    color: view_color,
+                    has_custom_color: view_has_custom_color,
                 });
             }
             // Persist SQL scratch tabs so they survive a restart. Cheap JSON
@@ -5334,14 +5386,16 @@ fn main() -> Result<(), slint::PlatformError> {
                 .clone()
                 .unwrap_or_default();
             let id = format!("query:{connection}:{number}");
-            let (engine, connection_name) = connection_badge_info(&store.borrow(), &connection);
+            let badge = connection_badge_info(&store.borrow(), &connection);
             let right_index = {
                 let mut tabs = workspace_tabs.lock().unwrap();
                 let mut tab = WorkspaceTab::sql(id.clone(), number);
                 tab.group = 1;
                 tab.connection_id = (!connection.is_empty()).then(|| connection.clone());
-                tab.engine = engine;
-                tab.connection_name = connection_name;
+                tab.engine = badge.engine;
+                tab.connection_name = badge.name;
+                tab.color = badge.color;
+                tab.has_custom_color = badge.has_custom_color;
                 tabs.push(tab);
                 let left = active_tab_id.lock().unwrap().clone();
                 set_workspace_tabs(&w, &tabs, left.as_deref());
@@ -6611,7 +6665,7 @@ fn main() -> Result<(), slint::PlatformError> {
             // later from `current_connection_id`, since the user can switch the
             // active connection while the query is in flight.
             let query_connection_id = current_connection_id.lock().unwrap().clone();
-            let (query_engine, query_connection_name) = query_connection_id
+            let query_badge = query_connection_id
                 .as_deref()
                 .map(|cid| connection_badge_info(&store.borrow(), cid))
                 .unwrap_or_default();
@@ -6743,8 +6797,10 @@ fn main() -> Result<(), slint::PlatformError> {
                                                 latency: format!("{elapsed_ms} ms"),
                                                 grid: GridState::default(),
                                                 connection_id: query_connection_id.clone(),
-                                                engine: query_engine.clone(),
-                                                connection_name: query_connection_name.clone(),
+                                                engine: query_badge.engine.clone(),
+                                                connection_name: query_badge.name.clone(),
+                                                color: query_badge.color,
+                                                has_custom_color: query_badge.has_custom_color,
                                             }
                                         })
                                         .collect();
@@ -6799,8 +6855,10 @@ fn main() -> Result<(), slint::PlatformError> {
                                     latency: latency.clone(),
                                     grid: GridState::default(),
                                     connection_id: query_connection_id.clone(),
-                                    engine: query_engine.clone(),
-                                    connection_name: query_connection_name.clone(),
+                                    engine: query_badge.engine.clone(),
+                                    connection_name: query_badge.name.clone(),
+                                    color: query_badge.color,
+                                    has_custom_color: query_badge.has_custom_color,
                                 };
                                 let mut tabs = workspace_tabs.lock().unwrap();
                                 let Some(tab) = tabs.iter_mut().find(|tab| tab.id == target_id)
@@ -6976,7 +7034,7 @@ fn main() -> Result<(), slint::PlatformError> {
             // Snapshot which connection is running THIS stream, same reasoning
             // as run_sql: the active connection can change before it finishes.
             let query_connection_id = current_connection_id.lock().unwrap().clone();
-            let (query_engine, query_connection_name) = query_connection_id
+            let query_badge = query_connection_id
                 .as_deref()
                 .map(|cid| connection_badge_info(&store.borrow(), cid))
                 .unwrap_or_default();
@@ -7011,8 +7069,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 let stream_timer_stop = stream_timer.clone();
                 let target_id = target_id.clone();
                 let query_connection_id = query_connection_id.clone();
-                let query_engine = query_engine.clone();
-                let query_connection_name = query_connection_name.clone();
+                let query_badge = query_badge.clone();
                 timer.start(
                     slint::TimerMode::Repeated,
                     std::time::Duration::from_millis(50),
@@ -7087,8 +7144,10 @@ fn main() -> Result<(), slint::PlatformError> {
                                         latency: latency.clone(),
                                         grid: GridState::default(),
                                         connection_id: query_connection_id.clone(),
-                                        engine: query_engine.clone(),
-                                        connection_name: query_connection_name.clone(),
+                                        engine: query_badge.engine.clone(),
+                                        connection_name: query_badge.name.clone(),
+                                        color: query_badge.color,
+                                        has_custom_color: query_badge.has_custom_color,
                                     };
                                     let (tab_results, tab_active) = {
                                         let mut tabs = workspace_tabs.lock().unwrap();
@@ -8392,7 +8451,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 st.col_filters.clear();
             }
             {
-                let (_, connection_name) = connection_badge_info(&store.borrow(), &connection_id);
+                let badge = connection_badge_info(&store.borrow(), &connection_id);
                 let tab = WorkspaceTab {
                     id: tab_id.clone(),
                     title: label.clone(),
@@ -8411,8 +8470,10 @@ fn main() -> Result<(), slint::PlatformError> {
                     split_ratio: 0.5,
                     pane1_query: String::new(),
                     connection_id: (!connection_id.is_empty()).then(|| connection_id.clone()),
-                    engine: AnyDriver::badge(engine).to_string(),
-                    connection_name,
+                    engine: badge.engine,
+                    connection_name: badge.name,
+                    color: badge.color,
+                    has_custom_color: badge.has_custom_color,
                 };
                 let active_id = active_tab_id.lock().unwrap().clone();
                 let mut tabs = workspace_tabs.lock().unwrap();
@@ -9079,12 +9140,14 @@ fn main() -> Result<(), slint::PlatformError> {
                 .clone()
                 .unwrap_or_default();
             let id = format!("query:{connection}:{number}");
-            let (engine, connection_name) = connection_badge_info(&store.borrow(), &connection);
+            let badge = connection_badge_info(&store.borrow(), &connection);
             let mut tabs = workspace_tabs.lock().unwrap();
             let mut tab = WorkspaceTab::sql(id.clone(), number);
             tab.connection_id = (!connection.is_empty()).then(|| connection.clone());
-            tab.engine = engine;
-            tab.connection_name = connection_name;
+            tab.engine = badge.engine;
+            tab.connection_name = badge.name;
+            tab.color = badge.color;
+            tab.has_custom_color = badge.has_custom_color;
             tabs.push(tab);
             *active_tab_id.lock().unwrap() = Some(id.clone());
             set_workspace_tabs(&w, &tabs, Some(&id));

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -755,6 +755,11 @@ struct WorkspaceTab {
     split: bool,
     split_ratio: f32,
     pane1_query: String,
+    // Connection the tab was created against (snapshot, not live-tracked).
+    connection_id: Option<String>,
+    // DbBadge key, e.g. "postgres"; empty when no connection was active yet.
+    engine: String,
+    connection_name: String,
 }
 
 impl WorkspaceTab {
@@ -776,6 +781,9 @@ impl WorkspaceTab {
             split: false,
             split_ratio: 0.5,
             pane1_query: String::new(),
+            connection_id: None,
+            engine: String::new(),
+            connection_name: String::new(),
         }
     }
 
@@ -786,6 +794,20 @@ impl WorkspaceTab {
 
 fn table_tab_id(connection_id: &str, database: &str, schema: &str, table: &str) -> String {
     format!("table:{connection_id}:{database}:{schema}:{table}")
+}
+
+// Badge key + display name for a saved connection id, empty when unknown
+// (not yet connected, or the connection was deleted since the tab opened).
+fn connection_badge_info(
+    store: &rdb_connstore::ConnStore,
+    connection_id: &str,
+) -> (String, String) {
+    store
+        .list()
+        .iter()
+        .find(|c| c.id == connection_id)
+        .map(|c| (AnyDriver::badge(c.engine).to_string(), c.name.clone()))
+        .unwrap_or_default()
 }
 
 fn workspace_tab_index(tabs: &[WorkspaceTab], active_id: Option<&str>) -> Option<usize> {
@@ -883,6 +905,8 @@ fn set_workspace_tabs(w: &MainWindow, tabs: &[WorkspaceTab], active_id: Option<&
             kind: tab.kind.clone().into(),
             title: tab.title.clone().into(),
             preview: tab.is_preview(),
+            engine: tab.engine.clone().into(),
+            connection_name: tab.connection_name.clone().into(),
         })
         .collect();
     w.set_tabs(ModelRc::from(Rc::new(VecModel::from(items))));
@@ -899,6 +923,8 @@ fn set_workspace_tabs(w: &MainWindow, tabs: &[WorkspaceTab], active_id: Option<&
             kind: tab.kind.clone().into(),
             title: tab.title.clone().into(),
             preview: tab.is_preview(),
+            engine: tab.engine.clone().into(),
+            connection_name: tab.connection_name.clone().into(),
         })
         .collect();
     w.set_p1_tabs(ModelRc::from(Rc::new(VecModel::from(p1_items))));
@@ -1326,6 +1352,12 @@ struct PersistedTab {
     pane1_query: String,
     #[serde(default = "default_split_ratio")]
     split_ratio: f32,
+    #[serde(default)]
+    connection_id: Option<String>,
+    #[serde(default)]
+    engine: String,
+    #[serde(default)]
+    connection_name: String,
 }
 
 fn default_split_ratio() -> f32 {
@@ -1364,6 +1396,9 @@ fn save_query_tabs(w: &MainWindow, tabs: &[WorkspaceTab], active: Option<&str>) 
             split: t.split,
             pane1_query: t.pane1_query.clone(),
             split_ratio: t.split_ratio,
+            connection_id: t.connection_id.clone(),
+            engine: t.engine.clone(),
+            connection_name: t.connection_name.clone(),
         })
         .collect();
     let active = active
@@ -1414,6 +1449,9 @@ fn load_query_tabs() -> (Vec<WorkspaceTab>, Option<String>, Option<String>, usiz
             t.split = p.split;
             t.pane1_query = p.pane1_query;
             t.split_ratio = p.split_ratio.clamp(0.2, 0.8);
+            t.connection_id = p.connection_id;
+            t.engine = p.engine;
+            t.connection_name = p.connection_name;
             t
         })
         .collect();
@@ -3958,6 +3996,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let workspace_tabs = workspace_tabs.clone();
         let active_tab_id = active_tab_id.clone();
         let current_connection_id = current_connection_id.clone();
+        let store = store.clone();
         window.on_open_function(move |name| {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -3987,16 +4026,17 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_fn_name(name.clone());
             w.set_fn_mode(true);
             w.set_active_table(SharedString::default());
+            let connection_id = current_connection_id.lock().unwrap().clone();
             let id = format!(
                 "function:{}:{}:{}",
-                current_connection_id
-                    .lock()
-                    .unwrap()
-                    .as_deref()
-                    .unwrap_or_default(),
+                connection_id.as_deref().unwrap_or_default(),
                 w.get_schema_name(),
                 name
             );
+            let (engine, connection_name) = connection_id
+                .as_deref()
+                .map(|cid| connection_badge_info(&store.borrow(), cid))
+                .unwrap_or_default();
             let mut tabs = workspace_tabs.lock().unwrap();
             if let Some(i) = tabs.iter().position(|tab| tab.id == id) {
                 *active_tab_id.lock().unwrap() = Some(id.clone());
@@ -4020,6 +4060,9 @@ fn main() -> Result<(), slint::PlatformError> {
                     split: false,
                     split_ratio: 0.5,
                     pane1_query: String::new(),
+                    connection_id,
+                    engine,
+                    connection_name,
                 });
                 *active_tab_id.lock().unwrap() = Some(id.clone());
                 set_workspace_tabs(&w, &tabs, Some(&id));
@@ -5217,6 +5260,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let query_number = query_number.clone();
         let save_p1_tab = save_p1_tab.clone();
         let restore_p1_tab = restore_p1_tab.clone();
+        let store = store.clone();
         window.on_new_tab_in_group(move |group| {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -5233,10 +5277,14 @@ fn main() -> Result<(), slint::PlatformError> {
                 .clone()
                 .unwrap_or_default();
             let id = format!("query:{connection}:{number}");
+            let (engine, connection_name) = connection_badge_info(&store.borrow(), &connection);
             let right_index = {
                 let mut tabs = workspace_tabs.lock().unwrap();
                 let mut tab = WorkspaceTab::sql(id.clone(), number);
                 tab.group = 1;
+                tab.connection_id = (!connection.is_empty()).then(|| connection.clone());
+                tab.engine = engine;
+                tab.connection_name = connection_name;
                 tabs.push(tab);
                 let left = active_tab_id.lock().unwrap().clone();
                 set_workspace_tabs(&w, &tabs, left.as_deref());
@@ -8204,6 +8252,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let last_view = last_view.clone();
         let displayed_grid = displayed_grid.clone();
         let results = results.clone();
+        let store = store.clone();
         window.on_open_table(move |db, label| {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -8260,6 +8309,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 st.col_filters.clear();
             }
             {
+                let (_, connection_name) = connection_badge_info(&store.borrow(), &connection_id);
                 let tab = WorkspaceTab {
                     id: tab_id.clone(),
                     title: label.clone(),
@@ -8277,6 +8327,9 @@ fn main() -> Result<(), slint::PlatformError> {
                     split: false,
                     split_ratio: 0.5,
                     pane1_query: String::new(),
+                    connection_id: (!connection_id.is_empty()).then(|| connection_id.clone()),
+                    engine: AnyDriver::badge(engine).to_string(),
+                    connection_name,
                 };
                 let active_id = active_tab_id.lock().unwrap().clone();
                 let mut tabs = workspace_tabs.lock().unwrap();
@@ -8930,6 +8983,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let browse = browse.clone();
         let last_view = last_view.clone();
         let load_editor_text = load_editor_text.clone();
+        let store = store.clone();
         window.on_new_tab(move || {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -8942,8 +8996,13 @@ fn main() -> Result<(), slint::PlatformError> {
                 .clone()
                 .unwrap_or_default();
             let id = format!("query:{connection}:{number}");
+            let (engine, connection_name) = connection_badge_info(&store.borrow(), &connection);
             let mut tabs = workspace_tabs.lock().unwrap();
-            tabs.push(WorkspaceTab::sql(id.clone(), number));
+            let mut tab = WorkspaceTab::sql(id.clone(), number);
+            tab.connection_id = (!connection.is_empty()).then(|| connection.clone());
+            tab.engine = engine;
+            tab.connection_name = connection_name;
+            tabs.push(tab);
             *active_tab_id.lock().unwrap() = Some(id.clone());
             set_workspace_tabs(&w, &tabs, Some(&id));
             save_query_tabs(&w, &tabs, Some(&id));
@@ -10791,6 +10850,9 @@ mod tests {
                     split: true,
                     pane1_query: "select * from orders;".into(),
                     split_ratio: 0.35,
+                    connection_id: Some("c".into()),
+                    engine: "postgres".into(),
+                    connection_name: "prod-db".into(),
                 },
                 PersistedTab {
                     id: "query:c:2".into(),
@@ -10800,6 +10862,9 @@ mod tests {
                     split: false,
                     pane1_query: String::new(),
                     split_ratio: 0.5,
+                    connection_id: None,
+                    engine: String::new(),
+                    connection_name: String::new(),
                 },
             ],
             active: Some("query:c:2".into()),
@@ -10814,6 +10879,9 @@ mod tests {
         assert!(back.tabs[0].split);
         assert_eq!(back.tabs[0].pane1_query, "select * from orders;");
         assert_eq!(back.tabs[0].split_ratio, 0.35);
+        assert_eq!(back.tabs[0].connection_id.as_deref(), Some("c"));
+        assert_eq!(back.tabs[0].engine, "postgres");
+        assert_eq!(back.tabs[0].connection_name, "prod-db");
         assert_eq!(back.active.as_deref(), Some("query:c:2"));
     }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -8598,28 +8598,6 @@ fn main() -> Result<(), slint::PlatformError> {
         });
     }
 
-    {
-        let weak = window.as_weak();
-        let workspace_tabs = workspace_tabs.clone();
-        let active_tab_id = active_tab_id.clone();
-        window.on_pin_tab(move |index| {
-            let active = active_tab_id.lock().unwrap().clone();
-            let mut tabs = workspace_tabs.lock().unwrap();
-            let index = tabs
-                .iter()
-                .enumerate()
-                .filter(|(_, tab)| tab.group == 0)
-                .nth(index.max(0) as usize)
-                .map(|(index, _)| index);
-            if let Some(tab) = index.and_then(|index| tabs.get_mut(index)) {
-                tab.pinned = true;
-                if let Some(w) = weak.upgrade() {
-                    set_workspace_tabs(&w, &tabs, active.as_deref());
-                }
-            }
-        });
-    }
-
     // ----- pagination footer: prev / next / refresh / limit -----
     {
         let weak = window.as_weak();

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -703,8 +703,7 @@ struct GroupRuntime {
     results: Arc<std::sync::Mutex<Vec<StoredResult>>>,
     active_result: Arc<std::sync::Mutex<usize>>,
     result_new_tab: Arc<std::sync::atomic::AtomicBool>,
-    // Set by "Run Selection" when the selection holds 2+ statements: the next
-    // run stores one result tab per statement instead of last-wins.
+    // Set when a run contains 2+ statements: keep one result tab per statement.
     split_results: Arc<std::sync::atomic::AtomicBool>,
     displayed_grid: Arc<std::sync::Mutex<Option<model::GridModel>>>,
     browse: Arc<std::sync::Mutex<BrowseState>>,
@@ -6656,7 +6655,7 @@ fn main() -> Result<(), slint::PlatformError> {
             let query_console = query_console.clone();
             // ⌘\ set this; consume it so the next plain run replaces again.
             let new_tab = result_new_tab.swap(false, std::sync::atomic::Ordering::SeqCst);
-            // Run Selection over 2+ statements set this; consume it likewise.
+            // A multi-statement run sets this; consume it likewise.
             let split = split_results.swap(false, std::sync::atomic::Ordering::SeqCst);
             // Currently selected database (top dropdown). Mongo line queries with
             // no `use(...)` run against it, matching what the user sees browsing.
@@ -7372,8 +7371,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 if stream {
                     run_stream(0, text);
                 } else {
-                    // 2+ selected statements → one result tab each (same as the
-                    // Run Selection button).
+                    // 2+ statements → one result tab each.
                     if active_tab_kind(&w) != "table" && editor::split_statements(&text).len() >= 2
                     {
                         panes[0]
@@ -8200,6 +8198,7 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let weak = window.as_weak();
         let run_sql = run_sql.clone();
+        let panes = panes.clone();
         window.on_explain_query(move || {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -8207,7 +8206,7 @@ fn main() -> Result<(), slint::PlatformError> {
             if !w.get_sql_capable() {
                 return;
             }
-            let text = w.get_query_text().to_string();
+            let text = panes[0].ed_state.borrow().current_line().to_string();
             let trimmed = text.trim();
             if trimmed.is_empty() {
                 return;
@@ -8233,7 +8232,7 @@ fn main() -> Result<(), slint::PlatformError> {
             if !w.get_sql_capable() {
                 return;
             }
-            let text = panes[1].ed_state.borrow().text();
+            let text = panes[1].ed_state.borrow().current_line().to_string();
             let trimmed = text.trim();
             if trimmed.is_empty() {
                 return;
@@ -8252,24 +8251,26 @@ fn main() -> Result<(), slint::PlatformError> {
 
     // ----- Format button: tidy the editor SQL in place -----
     {
-        let weak = window.as_weak();
-        let load_editor_text = load_editor_text.clone();
+        let panes = panes.clone();
+        let sync_editor = sync_editor.clone();
         window.on_format_sql(move || {
-            if let Some(w) = weak.upgrade() {
-                let text = w.get_query_text().to_string();
-                if !text.trim().is_empty() {
-                    load_editor_text(0, &sql_format::format(&text));
-                }
+            let mut ed = panes[0].ed_state.borrow_mut();
+            if !ed.current_line().trim().is_empty() {
+                let formatted = sql_format::format(ed.current_line());
+                ed.replace_current_line(&formatted);
+                sync_editor(0);
             }
         });
     }
     {
-        let load_editor_text = load_editor_text.clone();
         let panes = panes.clone();
+        let sync_editor = sync_editor.clone();
         window.on_p1_format_sql(move || {
-            let text = panes[1].ed_state.borrow().text();
-            if !text.trim().is_empty() {
-                load_editor_text(1, &sql_format::format(&text));
+            let mut ed = panes[1].ed_state.borrow_mut();
+            if !ed.current_line().trim().is_empty() {
+                let formatted = sql_format::format(ed.current_line());
+                ed.replace_current_line(&formatted);
+                sync_editor(1);
             }
         });
     }

--- a/app/src/self_update.rs
+++ b/app/src/self_update.rs
@@ -1,0 +1,431 @@
+//! In-app "Restart to Update": download the matching release asset, swap it
+//! into place, relaunch. Only ever reached for `InstallMethod::Other` installs
+//! (see `update.rs`) — Homebrew/Scoop keep the existing hint-only behavior.
+//!
+//! Integrity note: release assets have no published checksum today, so the
+//! only check here is "did we receive the number of bytes the server said we
+//! would" (catches truncated downloads, not tampering). Publishing a
+//! `checksums.txt` release asset would let this verify a real hash; until
+//! then, don't claim more than size-matching actually proves.
+
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+#[derive(Clone)]
+pub struct ReleaseAsset {
+    pub name: String,
+    pub browser_download_url: String,
+}
+
+// Some variants are only ever constructed inside the macOS/Windows-specific
+// swap code below — legitimately unconstructed (not dead) on Linux builds,
+// which never reach a swap flow (`is_swappable` is always false there).
+#[derive(Debug)]
+#[allow(dead_code)]
+pub enum SelfUpdateError {
+    Network(String),
+    NoMatchingAsset,
+    SizeMismatch { expected: u64, actual: u64 },
+    Io(std::io::Error),
+    NotSwappable,
+    ExternalTool(String),
+    RelaunchFailed(String),
+}
+
+impl std::fmt::Display for SelfUpdateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Network(e) => write!(f, "network error: {e}"),
+            Self::NoMatchingAsset => write!(f, "no matching release asset for this platform"),
+            Self::SizeMismatch { expected, actual } => {
+                write!(f, "download incomplete: got {actual} of {expected} bytes")
+            }
+            Self::Io(e) => write!(f, "{e}"),
+            Self::NotSwappable => write!(f, "this install can't be updated in place"),
+            Self::ExternalTool(e) => write!(f, "{e}"),
+            Self::RelaunchFailed(e) => write!(f, "update installed, but relaunch failed: {e}"),
+        }
+    }
+}
+
+impl From<std::io::Error> for SelfUpdateError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+const RELEASES_LATEST: &str = "https://api.github.com/repos/suiflex/rdb/releases/latest";
+
+/// `None` on any OS/arch this feature doesn't cover — the caller's signal to
+/// fall back to the existing "open the release page" behavior.
+fn target_triple() -> Option<&'static str> {
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("macos", "aarch64") => Some("aarch64-apple-darwin"),
+        ("macos", "x86_64") => Some("x86_64-apple-darwin"),
+        ("windows", "x86_64") => Some("x86_64-pc-windows-msvc"),
+        ("windows", "aarch64") => Some("aarch64-pc-windows-msvc"),
+        _ => None,
+    }
+}
+
+fn wanted_asset_name() -> Option<String> {
+    let triple = target_triple()?;
+    Some(match std::env::consts::OS {
+        "macos" => format!("rdb-{triple}.dmg"),
+        "windows" => format!("rdb-{triple}.exe"),
+        _ => return None,
+    })
+}
+
+/// Full release JSON (including assets), fetched only when the user actually
+/// starts the update flow — the daily background check (`update::fetch_latest_tag`)
+/// stays a separate, lighter call that only reads the tag name.
+pub fn fetch_latest_assets() -> Result<Vec<ReleaseAsset>, SelfUpdateError> {
+    let mut response = ureq::get(RELEASES_LATEST)
+        .header("User-Agent", "rdb-self-update")
+        .header("Accept", "application/vnd.github+json")
+        .config()
+        .timeout_global(Some(Duration::from_secs(15)))
+        .build()
+        .call()
+        .map_err(|e| SelfUpdateError::Network(e.to_string()))?;
+    let body = response
+        .body_mut()
+        .read_to_string()
+        .map_err(|e| SelfUpdateError::Network(e.to_string()))?;
+    let json: serde_json::Value =
+        serde_json::from_str(&body).map_err(|e| SelfUpdateError::Network(e.to_string()))?;
+    let assets = json
+        .get("assets")
+        .and_then(|a| a.as_array())
+        .ok_or(SelfUpdateError::NoMatchingAsset)?;
+    Ok(assets
+        .iter()
+        .filter_map(|a| {
+            Some(ReleaseAsset {
+                name: a.get("name")?.as_str()?.to_string(),
+                browser_download_url: a.get("browser_download_url")?.as_str()?.to_string(),
+            })
+        })
+        .collect())
+}
+
+pub fn pick_asset(assets: &[ReleaseAsset]) -> Option<ReleaseAsset> {
+    let name = wanted_asset_name()?;
+    assets.iter().find(|a| a.name == name).cloned()
+}
+
+fn work_dir() -> PathBuf {
+    std::env::temp_dir().join("rdb-self-update")
+}
+
+/// Downloads `asset` into the self-update work dir, reporting 0.0..=1.0
+/// progress as it goes, and returns the local path once fully verified.
+/// Writes to a `.part` file first and only renames to the final name once
+/// the byte count matches `Content-Length` — a leftover `.part` file always
+/// means "don't trust this download." This is the "idle -> downloading"
+/// step; swapping it into place is a separate, later step (`perform_swap`)
+/// so the user gets an explicit second confirmation before anything is
+/// actually replaced.
+pub fn download_asset(
+    asset: &ReleaseAsset,
+    mut on_progress: impl FnMut(f32),
+) -> Result<PathBuf, SelfUpdateError> {
+    let work = work_dir();
+    std::fs::create_dir_all(&work)?;
+    let dest = work.join(&asset.name);
+
+    let mut response = ureq::get(&asset.browser_download_url)
+        .header("User-Agent", "rdb-self-update")
+        .config()
+        .timeout_global(Some(Duration::from_secs(120)))
+        .build()
+        .call()
+        .map_err(|e| SelfUpdateError::Network(e.to_string()))?;
+    let content_length = response.body_mut().content_length();
+    let mut reader = response.into_body().into_reader();
+
+    let tmp = dest.with_extension("part");
+    let mut file = std::fs::File::create(&tmp)?;
+    let mut buf = [0u8; 64 * 1024];
+    let mut total = 0u64;
+    loop {
+        let n = reader.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        file.write_all(&buf[..n])?;
+        total += n as u64;
+        on_progress(
+            content_length
+                .map(|t| total as f32 / t as f32)
+                .unwrap_or(0.0),
+        );
+    }
+    file.sync_all()?;
+    drop(file);
+
+    if let Some(expected) = content_length {
+        if total != expected {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(SelfUpdateError::SizeMismatch {
+                expected,
+                actual: total,
+            });
+        }
+    }
+    std::fs::rename(&tmp, &dest)?;
+    Ok(dest)
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::*;
+
+    /// `exe` = `.../RDB.app/Contents/MacOS/rdb` -> `.../RDB.app`. `None` for
+    /// anything that isn't a real bundle install (dev build, `cargo run`) —
+    /// the caller falls back to opening the release page instead of
+    /// attempting a swap it can't reason about.
+    pub fn bundle_root(exe: &Path) -> Option<PathBuf> {
+        let macos_dir = exe.parent()?;
+        if macos_dir.file_name()? != "MacOS" {
+            return None;
+        }
+        let contents_dir = macos_dir.parent()?;
+        if contents_dir.file_name()? != "Contents" {
+            return None;
+        }
+        let bundle_root = contents_dir.parent()?;
+        if bundle_root.extension()? != "app" {
+            return None;
+        }
+        Some(bundle_root.to_path_buf())
+    }
+
+    fn find_dot_app(dir: &Path) -> Option<PathBuf> {
+        std::fs::read_dir(dir)
+            .ok()?
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .find(|p| p.extension().is_some_and(|e| e == "app"))
+    }
+
+    fn run_checked(cmd: &str, args: &[&str]) -> Result<(), SelfUpdateError> {
+        let output = std::process::Command::new(cmd)
+            .args(args)
+            .output()
+            .map_err(|e| SelfUpdateError::ExternalTool(format!("{cmd}: {e}")))?;
+        if !output.status.success() {
+            return Err(SelfUpdateError::ExternalTool(format!(
+                "{cmd} {args:?} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
+        Ok(())
+    }
+
+    /// Mounts the already-downloaded `.dmg`, stages the `.app` next to the
+    /// running bundle, swaps it in (never deleting the old one until the new
+    /// one is confirmed in place, rolling back on any failure), clears
+    /// quarantine, and relaunches. On success the caller quits the event
+    /// loop right after.
+    pub fn perform_update(dmg_path: &Path) -> Result<(), SelfUpdateError> {
+        let exe = std::env::current_exe()?;
+        let bundle_root = bundle_root(&exe).ok_or(SelfUpdateError::NotSwappable)?;
+        let bundle_name = bundle_root
+            .file_name()
+            .ok_or(SelfUpdateError::NotSwappable)?
+            .to_string_lossy()
+            .to_string();
+
+        let work = work_dir();
+        let mnt = work.join("mnt");
+        std::fs::create_dir_all(&mnt)?;
+        let mnt_str = mnt.to_string_lossy().to_string();
+        let dmg_str = dmg_path.to_string_lossy().to_string();
+        run_checked(
+            "hdiutil",
+            &[
+                "attach",
+                "-nobrowse",
+                "-readonly",
+                "-mountpoint",
+                &mnt_str,
+                &dmg_str,
+            ],
+        )?;
+        let mounted_app = find_dot_app(&mnt).ok_or(SelfUpdateError::NoMatchingAsset)?;
+
+        let staged = bundle_root.with_file_name(format!("{bundle_name}.new"));
+        let _ = std::fs::remove_dir_all(&staged);
+        let staged_result = run_checked(
+            "cp",
+            &[
+                "-R",
+                &mounted_app.to_string_lossy(),
+                &staged.to_string_lossy(),
+            ],
+        );
+        let _ = run_checked("hdiutil", &["detach", &mnt_str]);
+        staged_result?;
+        let _ = run_checked(
+            "xattr",
+            &["-dr", "com.apple.quarantine", &staged.to_string_lossy()],
+        );
+
+        let backup = bundle_root.with_file_name(format!("{bundle_name}.old"));
+        let _ = std::fs::remove_dir_all(&backup);
+        std::fs::rename(&bundle_root, &backup)?;
+        match std::fs::rename(&staged, &bundle_root) {
+            Ok(()) => {
+                let _ = std::fs::remove_dir_all(&backup);
+            }
+            Err(e) => {
+                // Old bundle wasn't touched beyond the rename-out above — put
+                // it back so the app is never left in a broken state.
+                let _ = std::fs::rename(&backup, &bundle_root);
+                return Err(SelfUpdateError::Io(e));
+            }
+        }
+
+        std::process::Command::new("open")
+            .args(["-n", &bundle_root.to_string_lossy()])
+            .spawn()
+            .map_err(|e| SelfUpdateError::RelaunchFailed(e.to_string()))?;
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod windows {
+    use super::*;
+    use std::os::windows::process::CommandExt;
+
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+    const FINISH_SCRIPT: &str = r#"
+param([int]$Pid, [string]$OldPath, [string]$NewPath)
+try { Wait-Process -Id $Pid -Timeout 15 -ErrorAction SilentlyContinue } catch {}
+$ok = $false
+for ($i = 0; $i -lt 10; $i++) {
+    try { Move-Item -Path $NewPath -Destination $OldPath -Force; $ok = $true; break }
+    catch { Start-Sleep -Milliseconds 500 }
+}
+if ($ok) { Start-Process -FilePath $OldPath }
+Remove-Item -Path $NewPath -ErrorAction SilentlyContinue
+Remove-Item -Path $PSCommandPath -ErrorAction SilentlyContinue
+"#;
+
+    /// Spawns a detached helper script that waits for this process to exit
+    /// (Windows can't overwrite a running exe), swaps the already-downloaded
+    /// exe into place, and relaunches. Our process must quit right after this
+    /// returns `Ok` — the swap only happens once we're actually gone.
+    pub fn perform_update(new_exe: &Path) -> Result<(), SelfUpdateError> {
+        let exe = std::env::current_exe()?;
+        let work = work_dir();
+        std::fs::create_dir_all(&work)?;
+
+        let mut head = [0u8; 2];
+        std::fs::File::open(new_exe)?.read_exact(&mut head)?;
+        if &head != b"MZ" {
+            let _ = std::fs::remove_file(new_exe);
+            return Err(SelfUpdateError::NoMatchingAsset);
+        }
+
+        let script_path = work.join("finish-update.ps1");
+        std::fs::write(&script_path, FINISH_SCRIPT)?;
+
+        let pid = std::process::id();
+        std::process::Command::new("powershell")
+            .args([
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-WindowStyle",
+                "Hidden",
+                "-File",
+            ])
+            .arg(&script_path)
+            .args([
+                "-Pid",
+                &pid.to_string(),
+                "-OldPath",
+                &exe.to_string_lossy(),
+                "-NewPath",
+                &new_exe.to_string_lossy(),
+            ])
+            .creation_flags(CREATE_NO_WINDOW)
+            .spawn()
+            .map_err(|e| SelfUpdateError::RelaunchFailed(e.to_string()))?;
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub use macos::bundle_root as macos_bundle_root;
+
+/// Whether this specific install can be updated in place: `Other` install
+/// method (checked by the caller) on a platform/layout we know how to swap.
+pub fn is_swappable(_exe: Option<&Path>) -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        _exe.and_then(macos_bundle_root).is_some()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        target_triple().is_some()
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        false
+    }
+}
+
+/// Swaps the already-downloaded asset (from `download_asset`) into place and
+/// relaunches. On success the caller should quit the event loop right after
+/// — the old process's job is done. Never reached in practice on a platform
+/// where `is_swappable` is false, but stays a plain cross-platform function
+/// (rather than `#[cfg]`-gated) so callers don't need their own per-platform
+/// branching.
+pub fn perform_swap(downloaded: &Path) -> Result<(), SelfUpdateError> {
+    #[cfg(target_os = "macos")]
+    {
+        macos::perform_update(downloaded)
+    }
+    #[cfg(target_os = "windows")]
+    {
+        windows::perform_update(downloaded)
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        let _ = downloaded;
+        Err(SelfUpdateError::NotSwappable)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pick_asset_never_partial_matches() {
+        // A name that is a superstring of any real target's asset name (e.g.
+        // a published checksum sidecar file) must never be picked in place
+        // of the exact match — regardless of which platform runs this test.
+        let bogus = vec![ReleaseAsset {
+            name: "rdb-aarch64-apple-darwin.dmg.sha256".into(),
+            browser_download_url: "https://example.com/c".into(),
+        }];
+        assert!(pick_asset(&bogus).is_none());
+    }
+
+    #[test]
+    fn size_mismatch_display_is_readable() {
+        let err = SelfUpdateError::SizeMismatch {
+            expected: 100,
+            actual: 40,
+        };
+        assert_eq!(err.to_string(), "download incomplete: got 40 of 100 bytes");
+    }
+}

--- a/app/src/sql_format.rs
+++ b/app/src/sql_format.rs
@@ -98,6 +98,11 @@ pub fn format(sql: &str) -> String {
     out.trim().to_string()
 }
 
+/// Format one physical editor line without introducing new editor lines.
+pub fn format_line(sql: &str) -> String {
+    format(sql).replace('\n', " ")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -123,6 +128,14 @@ mod tests {
         assert_eq!(
             format("select 'from x' as \"From\" -- from here\nfrom t"),
             "SELECT 'from x' AS \"From\" -- from here\nFROM t"
+        );
+    }
+
+    #[test]
+    fn format_line_keeps_a_query_on_one_physical_line() {
+        assert_eq!(
+            format_line("select * from users where active = true"),
+            "SELECT * FROM users WHERE active = true"
         );
     }
 }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -5,6 +5,7 @@ export { Tokens }
 import {
     SearchCommandPill, BreadcrumbChip, DbBadge, GlyphButton, IconButton, PrimaryButton, SecondaryButton, SelectBox, TextButton, Toggle, ToggleRow, Tooltip, Shortcut
 } from "components.slint";
+export { Shortcut }
 import { NavCluster } from "nav-cluster.slint";
 import { ConnPicker } from "picker.slint";
 import { WorkArea } from "workarea.slint";

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -270,7 +270,6 @@ callback create-table-commit();
     in-out property <string> mongo-filter;
     in property <[length]> grid-col-widths;
     callback run-query();
-    callback run-selection();
     callback format-sql();
     callback explain-query();
     callback copy-results();
@@ -472,7 +471,6 @@ callback create-table-commit();
     callback p1-add-row();
     callback p1-mark-delete();
     callback p1-run();
-    callback p1-run-selection();
     callback p1-format-sql();
     callback p1-explain-query();
     callback p1-cancel-stream();
@@ -1538,7 +1536,6 @@ callback create-table-commit();
                         p1-add-row() => { root.p1-add-row(); }
                         p1-mark-delete() => { root.p1-mark-delete(); }
                         p1-run() => { root.p1-run(); }
-                        p1-run-selection() => { root.p1-run-selection(); }
                         p1-format-sql() => { root.p1-format-sql(); }
                         p1-explain-query() => { root.p1-explain-query(); }
                         p1-cancel-stream() => { root.p1-cancel-stream(); }
@@ -1672,9 +1669,6 @@ callback create-table-commit();
                         limit-text <=> root.limit-text;
                         run => {
                             root.run-query();
-                        }
-                        run-selection() => {
-                            root.run-selection();
                         }
                         format-sql() => {
                             root.format-sql();

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -200,7 +200,6 @@ callback create-table-commit();
     callback reorder-conn(int, int);        // (dragged store index, row-step delta)
     callback open-table(string, string);   // (database, container)
     callback pin-table(string, string);    // double-click pins the object tab
-    callback pin-tab(int);                 // double-click pins a preview tab
     callback toggle-fields(string, string); // (database, table) — expand columns inline
     callback toggle-schema-node(string);
     callback select-schema(string);
@@ -1151,17 +1150,10 @@ callback create-table-commit();
                                         }
                                     }
                                     double-clicked => {
-                                        root.pin-tab(i);
-                                    }
-                                    changed has-hover => {
-                                        if (self.has-hover && tab.connection-name != "") {
-                                            Tooltip.text = tab.connection-name;
-                                            Tooltip.x = self.absolute-position.x + self.width / 2;
-                                            Tooltip.y = self.absolute-position.y + self.height + 4px;
-                                            Tooltip.shown = true;
-                                        } else if Tooltip.text == tab.connection-name {
-                                            Tooltip.shown = false;
-                                        }
+                                        root.rename-target = i;
+                                        root.rename-group = 0;
+                                        root.rename-text = tab.title;
+                                        root.rename-modal-open = true;
                                     }
                                 }
 
@@ -1177,22 +1169,6 @@ callback create-table-commit();
                                     padding-left: Tokens.sp3;
                                     padding-right: Tokens.sp1;
                                     spacing: Tokens.sp2;
-                                    if tab.engine != "": VerticalLayout {
-                                        alignment: center;
-                                        DbBadge {
-                                            engine: tab.engine;
-                                            size: 13px;
-                                            fill: tab.has-custom-color ? tab.color : Tokens.db-color(tab.engine);
-                                        }
-                                    }
-                                    if tab.engine != "" && !left-group.tabs-compact: Text {
-                                        text: tab.connection-name;
-                                        vertical-alignment: center;
-                                        color: Tokens.text-faint;
-                                        font-size: 9px;
-                                        max-width: 60px;
-                                        overflow: elide;
-                                    }
                                     if tab.kind == "table": VerticalLayout {
                                         alignment: center;
                                         Rectangle {
@@ -1346,15 +1322,11 @@ callback create-table-commit();
                                             root.select-p1-tab(i);
                                         }
                                     }
-                                    changed has-hover => {
-                                        if (self.has-hover && tab.connection-name != "") {
-                                            Tooltip.text = tab.connection-name;
-                                            Tooltip.x = self.absolute-position.x + self.width / 2;
-                                            Tooltip.y = self.absolute-position.y + self.height + 4px;
-                                            Tooltip.shown = true;
-                                        } else if Tooltip.text == tab.connection-name {
-                                            Tooltip.shown = false;
-                                        }
+                                    double-clicked => {
+                                        root.rename-target = i;
+                                        root.rename-group = 1;
+                                        root.rename-text = tab.title;
+                                        root.rename-modal-open = true;
                                     }
                                 }
                                 if i == root.p1-active-tab: Rectangle {
@@ -1366,22 +1338,6 @@ callback create-table-commit();
                                 p1-tab-content := HorizontalLayout {
                                     padding-left: Tokens.sp3;
                                     padding-right: Tokens.sp2;
-                                    if tab.engine != "": VerticalLayout {
-                                        alignment: center;
-                                        DbBadge {
-                                            engine: tab.engine;
-                                            size: 13px;
-                                            fill: tab.has-custom-color ? tab.color : Tokens.db-color(tab.engine);
-                                        }
-                                    }
-                                    if tab.engine != "" && !right-group.tabs-compact: Text {
-                                        text: tab.connection-name;
-                                        vertical-alignment: center;
-                                        color: Tokens.text-faint;
-                                        font-size: 9px;
-                                        max-width: 60px;
-                                        overflow: elide;
-                                    }
                                     Text {
                                         vertical-alignment: center;
                                         text: tab.kind == "sql" ? ">_" : tab.kind == "function" ? "ƒ" : "▦";

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -25,6 +25,7 @@ import {
     ChartBar,
     IndexRow,
     DocRow,
+    ResultTabItem,
 } from "structs.slint";
 
 export component MainWindow inherits Window {
@@ -430,7 +431,7 @@ callback create-table-commit();
     in-out property <bool> p1-show-structure: false;
     in property <string> p1-query-label;
     in property <string> p1-results-meta;
-    in property <[string]> p1-result-tabs;
+    in property <[ResultTabItem]> p1-result-tabs;
     in property <int> p1-active-result;
     in-out property <int> p1-sql-view-mode;
     in-out property <bool> p1-filter-open;
@@ -508,7 +509,7 @@ callback create-table-commit();
     in property <[PaletteItem]> palette-items;
     callback new-tab();
     callback run-new-tab();   // ⌘\: run current statement into a new result tab
-    in property <[string]> result-tabs;   // "Result 1", "Result 2", …
+    in property <[ResultTabItem]> result-tabs;   // "Result 1", "Result 2", …
     in property <int> active-result;
     callback select-result-tab(int);
     callback close-result-tab(int);

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -3,7 +3,7 @@ export { Theme }
 import { Tokens } from "tokens.slint";
 export { Tokens }
 import {
-    SearchCommandPill, BreadcrumbChip, DbBadge, GlyphButton, IconButton, PrimaryButton, SecondaryButton, SelectBox, TextButton, Toggle, ToggleRow, Tooltip
+    SearchCommandPill, BreadcrumbChip, DbBadge, GlyphButton, IconButton, PrimaryButton, SecondaryButton, SelectBox, TextButton, Toggle, ToggleRow, Tooltip, Shortcut
 } from "components.slint";
 import { NavCluster } from "nav-cluster.slint";
 import { ConnPicker } from "picker.slint";
@@ -650,7 +650,10 @@ callback create-table-commit();
                     return accept;
                 }
                 if (e.text == "r") {
-                    root.refresh-result();
+                    if (root.active-pane == 1) {
+                        if (root.p1-active-table != "") { root.p1-refresh-page(); }
+                        else { root.p1-run(); }
+                    } else { root.refresh-result(); }
                     return accept;
                 }
                 if (e.text == "f") {
@@ -677,39 +680,39 @@ callback create-table-commit();
                     return accept;
                 }
                 if (e.text == "1") {
-                    root.select-tab(0);
+                    if (root.active-pane == 1) { root.select-p1-tab(0); } else { root.select-tab(0); }
                     return accept;
                 }
                 if (e.text == "2") {
-                    root.select-tab(1);
+                    if (root.active-pane == 1) { root.select-p1-tab(1); } else { root.select-tab(1); }
                     return accept;
                 }
                 if (e.text == "3") {
-                    root.select-tab(2);
+                    if (root.active-pane == 1) { root.select-p1-tab(2); } else { root.select-tab(2); }
                     return accept;
                 }
                 if (e.text == "4") {
-                    root.select-tab(3);
+                    if (root.active-pane == 1) { root.select-p1-tab(3); } else { root.select-tab(3); }
                     return accept;
                 }
                 if (e.text == "5") {
-                    root.select-tab(4);
+                    if (root.active-pane == 1) { root.select-p1-tab(4); } else { root.select-tab(4); }
                     return accept;
                 }
                 if (e.text == "6") {
-                    root.select-tab(5);
+                    if (root.active-pane == 1) { root.select-p1-tab(5); } else { root.select-tab(5); }
                     return accept;
                 }
                 if (e.text == "7") {
-                    root.select-tab(6);
+                    if (root.active-pane == 1) { root.select-p1-tab(6); } else { root.select-tab(6); }
                     return accept;
                 }
                 if (e.text == "8") {
-                    root.select-tab(7);
+                    if (root.active-pane == 1) { root.select-p1-tab(7); } else { root.select-tab(7); }
                     return accept;
                 }
                 if (e.text == "9") {
-                    root.select-tab(8);
+                    if (root.active-pane == 1) { root.select-p1-tab(8); } else { root.select-tab(8); }
                     return accept;
                 }
             }
@@ -867,7 +870,7 @@ callback create-table-commit();
                         alignment: center;
                         SecondaryButton {
                             text: "SQL";
-                            tooltip: "New query tab  ⌘T";
+                            tooltip: "New query tab  " + Shortcut.primary + Shortcut.separator + "T";
                             height: 28px;
                             clicked => { root.new-tab(); }
                         }
@@ -1773,7 +1776,7 @@ callback create-table-commit();
                                 horizontal-alignment: center;
                             }
                             Text {
-                                text: "Choose a table, or press ⌘T to start a query";
+                            text: "Choose a table, or press " + Shortcut.primary + Shortcut.separator + "T to start a query";
                                 color: Tokens.text-dim;
                                 font-size: Tokens.font-sm;
                                 horizontal-alignment: center;
@@ -2739,22 +2742,22 @@ callback create-table-commit();
                 }
 
                 for row in [
-                    { k: "⌘K", a: "Command palette" },
-                    { k: "⌘T", a: "New tab" },
-                    { k: "⌘W", a: "Close tab" },
-                    { k: "⌘1–9", a: "Switch to tab" },
-                    { k: "⌘↩", a: "Run query" },
-                    { k: "⌘\\", a: "Run in new tab" },
-                    { k: "⌘S", a: "Save / commit edits" },
-                    { k: "⌘R", a: "Refresh result" },
-                    { k: "⌘⇧R", a: "Reconnect" },
-                    { k: "⌘+ / ⌘-", a: "Zoom in / out" },
-                    { k: "⌘F", a: "Find" },
-                    { k: "⌘O", a: "Open connection" },
-                    { k: "⌘⇧O", a: "Open database" },
-                    { k: "⌘P", a: "Filter sidebar" },
+                    { k: Shortcut.primary + Shortcut.separator + "K", a: "Command palette" },
+                    { k: Shortcut.primary + Shortcut.separator + "T", a: "New tab" },
+                    { k: Shortcut.primary + Shortcut.separator + "W", a: "Close tab" },
+                    { k: Shortcut.primary + Shortcut.separator + "1–9", a: "Switch to tab" },
+                    { k: Shortcut.primary + Shortcut.separator + Shortcut.enter, a: "Run query" },
+                    { k: Shortcut.primary + Shortcut.separator + "\\", a: "Run in new tab" },
+                    { k: Shortcut.primary + Shortcut.separator + "S", a: "Save / commit edits" },
+                    { k: Shortcut.primary + Shortcut.separator + "R", a: "Refresh result" },
+                    { k: Shortcut.primary + Shortcut.separator + Shortcut.shift + Shortcut.separator + "R", a: "Reconnect" },
+                    { k: Shortcut.primary + Shortcut.separator + "+ / " + Shortcut.primary + Shortcut.separator + "-", a: "Zoom in / out" },
+                    { k: Shortcut.primary + Shortcut.separator + "F", a: "Find" },
+                    { k: Shortcut.primary + Shortcut.separator + "O", a: "Open connection" },
+                    { k: Shortcut.primary + Shortcut.separator + Shortcut.shift + Shortcut.separator + "O", a: "Open database" },
+                    { k: Shortcut.primary + Shortcut.separator + "P", a: "Filter sidebar" },
                     { k: "J / K", a: "Grid: next / previous row" },
-                    { k: "⌫ / Del", a: "Grid: mark row for deletion" },
+                    { k: Shortcut.backspace + " / Del", a: "Grid: mark row for deletion" },
                     { k: "Esc", a: "Close dialog" },
                 ]: HorizontalLayout {
                     spacing: Tokens.sp3;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -54,6 +54,17 @@ export component MainWindow inherits Window {
                 enabled: root.connected && root.active-tab >= 0;
                 activated => { root.close-tab(root.active-tab); }
             }
+            MenuSeparator {}
+            MenuItem {
+                title: "Open Connection…";
+                shortcut: @keys(Control + O);
+                activated => { root.open-conn-modal(); }
+            }
+            MenuItem {
+                title: "Open Database…";
+                shortcut: @keys(Control + Shift + O);
+                activated => { root.open-db-modal(); }
+            }
             MenuItem {
                 title: "Save Changes";
                 // Slint maps Control to the platform primary modifier:
@@ -616,11 +627,11 @@ callback create-table-commit();
                     root.toggle-palette();
                     return accept;
                 }
-                if (e.text == "o" && e.modifiers.shift) {
+                if ((e.text == "o" || e.text == "O") && e.modifiers.shift) {
                     root.open-db-modal();
                     return accept;
                 }
-                if (e.text == "o") {
+                if (e.text == "o" || e.text == "O") {
                     root.open-conn-modal();
                     return accept;
                 }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -471,6 +471,7 @@ callback create-table-commit();
     callback p1-add-row();
     callback p1-mark-delete();
     callback p1-run();
+    callback p1-run-new-tab();
     callback p1-format-sql();
     callback p1-explain-query();
     callback p1-cancel-stream();
@@ -1536,6 +1537,7 @@ callback create-table-commit();
                         p1-add-row() => { root.p1-add-row(); }
                         p1-mark-delete() => { root.p1-mark-delete(); }
                         p1-run() => { root.p1-run(); }
+                        p1-run-new-tab() => { root.p1-run-new-tab(); }
                         p1-format-sql() => { root.p1-format-sql(); }
                         p1-explain-query() => { root.p1-explain-query(); }
                         p1-cancel-stream() => { root.p1-cancel-stream(); }
@@ -1669,6 +1671,9 @@ callback create-table-commit();
                         limit-text <=> root.limit-text;
                         run => {
                             root.run-query();
+                        }
+                        run-new-tab() => {
+                            root.run-new-tab();
                         }
                         format-sql() => {
                             root.format-sql();

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -3,7 +3,7 @@ export { Theme }
 import { Tokens } from "tokens.slint";
 export { Tokens }
 import {
-    SearchCommandPill, BreadcrumbChip, GlyphButton, IconButton, PrimaryButton, SecondaryButton, SelectBox, TextButton, Toggle, ToggleRow, Tooltip
+    SearchCommandPill, BreadcrumbChip, DbBadge, GlyphButton, IconButton, PrimaryButton, SecondaryButton, SelectBox, TextButton, Toggle, ToggleRow, Tooltip
 } from "components.slint";
 import { NavCluster } from "nav-cluster.slint";
 import { ConnPicker } from "picker.slint";
@@ -1093,6 +1093,9 @@ callback create-table-commit();
                                 ? (parent.width - 6px) * root.split-ratio : parent.width;
                             height: parent.height;
                             clip: true;
+                            // Below this avg-width-per-tab, drop the inline
+                            // connection name and keep only the badge + tooltip.
+                            property <bool> tabs-compact: self.width / max(1, root.tabs.length) < 110px;
                             HorizontalLayout {
                                 padding-left: Tokens.sp2;
                                 padding-top: Tokens.doc-tab-row-h - Tokens.doc-tab-h;
@@ -1135,6 +1138,16 @@ callback create-table-commit();
                                     double-clicked => {
                                         root.pin-tab(i);
                                     }
+                                    changed has-hover => {
+                                        if (self.has-hover && tab.connection-name != "") {
+                                            Tooltip.text = tab.connection-name;
+                                            Tooltip.x = self.absolute-position.x + self.width / 2;
+                                            Tooltip.y = self.absolute-position.y + self.height + 4px;
+                                            Tooltip.shown = true;
+                                        } else if Tooltip.text == tab.connection-name {
+                                            Tooltip.shown = false;
+                                        }
+                                    }
                                 }
 
                                 // active tab: 2px accent top inset
@@ -1149,6 +1162,21 @@ callback create-table-commit();
                                     padding-left: Tokens.sp3;
                                     padding-right: Tokens.sp1;
                                     spacing: Tokens.sp2;
+                                    if tab.engine != "": VerticalLayout {
+                                        alignment: center;
+                                        DbBadge {
+                                            engine: tab.engine;
+                                            size: 13px;
+                                        }
+                                    }
+                                    if tab.engine != "" && !left-group.tabs-compact: Text {
+                                        text: tab.connection-name;
+                                        vertical-alignment: center;
+                                        color: Tokens.text-faint;
+                                        font-size: 9px;
+                                        max-width: 60px;
+                                        overflow: elide;
+                                    }
                                     if tab.kind == "table": VerticalLayout {
                                         alignment: center;
                                         Rectangle {
@@ -1250,12 +1278,13 @@ callback create-table-commit();
                                 Rectangle { horizontal-stretch: 1; }
                             }
                         }
-                        if root.split || root.tab-drag-source == 0: Rectangle {
+                        if root.split || root.tab-drag-source == 0: right-group := Rectangle {
                             x: (parent.width - 6px) * root.split-ratio + 6px;
                             width: (parent.width - 6px) * (1 - root.split-ratio);
                             height: parent.height;
                             clip: true;
                             background: root.tab-drag-source == 0 ? Tokens.accent-tint : Tokens.chrome;
+                            property <bool> tabs-compact: self.width / max(1, root.p1-tabs.length) < 110px;
                             if !root.split: Text {
                                 text: "Drop tab here";
                                 color: Tokens.accent;
@@ -1301,6 +1330,16 @@ callback create-table-commit();
                                             root.select-p1-tab(i);
                                         }
                                     }
+                                    changed has-hover => {
+                                        if (self.has-hover && tab.connection-name != "") {
+                                            Tooltip.text = tab.connection-name;
+                                            Tooltip.x = self.absolute-position.x + self.width / 2;
+                                            Tooltip.y = self.absolute-position.y + self.height + 4px;
+                                            Tooltip.shown = true;
+                                        } else if Tooltip.text == tab.connection-name {
+                                            Tooltip.shown = false;
+                                        }
+                                    }
                                 }
                                 if i == root.p1-active-tab: Rectangle {
                                     y: 0;
@@ -1311,6 +1350,21 @@ callback create-table-commit();
                                 p1-tab-content := HorizontalLayout {
                                     padding-left: Tokens.sp3;
                                     padding-right: Tokens.sp2;
+                                    if tab.engine != "": VerticalLayout {
+                                        alignment: center;
+                                        DbBadge {
+                                            engine: tab.engine;
+                                            size: 13px;
+                                        }
+                                    }
+                                    if tab.engine != "" && !right-group.tabs-compact: Text {
+                                        text: tab.connection-name;
+                                        vertical-alignment: center;
+                                        color: Tokens.text-faint;
+                                        font-size: 9px;
+                                        max-width: 60px;
+                                        overflow: elide;
+                                    }
                                     Text {
                                         vertical-alignment: center;
                                         text: tab.kind == "sql" ? ">_" : tab.kind == "function" ? "ƒ" : "▦";

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -1172,6 +1172,7 @@ callback create-table-commit();
                                         DbBadge {
                                             engine: tab.engine;
                                             size: 13px;
+                                            fill: tab.has-custom-color ? tab.color : Tokens.db-color(tab.engine);
                                         }
                                     }
                                     if tab.engine != "" && !left-group.tabs-compact: Text {
@@ -1360,6 +1361,7 @@ callback create-table-commit();
                                         DbBadge {
                                             engine: tab.engine;
                                             size: 13px;
+                                            fill: tab.has-custom-color ? tab.color : Tokens.db-color(tab.engine);
                                         }
                                     }
                                     if tab.engine != "" && !right-group.tabs-compact: Text {

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -2421,9 +2421,9 @@ callback create-table-commit();
             TouchArea {
                 width: 20px;
                 clicked => { root.update-dismiss(); }
-                Text {
-                    text: "✕";
-                    font-size: 13px;
+                AppIcon {
+                    name: "close";
+                    size: 11px;
                     color: parent.has-hover ? Tokens.text : Tokens.text-dim;
                 }
             }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -1118,9 +1118,6 @@ callback create-table-commit();
                                 ? (parent.width - 6px) * root.split-ratio : parent.width;
                             height: parent.height;
                             clip: true;
-                            // Below this avg-width-per-tab, drop the inline
-                            // connection name and keep only the badge + tooltip.
-                            property <bool> tabs-compact: self.width / max(1, root.tabs.length) < 110px;
                             HorizontalLayout {
                                 padding-left: Tokens.sp2;
                                 padding-top: Tokens.doc-tab-row-h - Tokens.doc-tab-h;
@@ -1287,7 +1284,6 @@ callback create-table-commit();
                             height: parent.height;
                             clip: true;
                             background: root.tab-drag-source == 0 ? Tokens.accent-tint : Tokens.chrome;
-                            property <bool> tabs-compact: self.width / max(1, root.p1-tabs.length) < 110px;
                             if !root.split: Text {
                                 text: "Drop tab here";
                                 color: Tokens.accent;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -645,7 +645,7 @@ callback create-table-commit();
                     root.commit-edits();
                     return accept;
                 }
-                if (e.text == "r" && e.modifiers.shift) {
+                if ((e.text == "r" || e.text == "R") && e.modifiers.shift) {
                     root.reconnect();
                     return accept;
                 }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -533,6 +533,13 @@ callback create-table-commit();
     callback check-updates-now();          // manual check from settings
     in property <string> update-check-status; // settings feedback line
 
+    // ----- in-app "Restart to Update" (Other installs only — see update.rs) -----
+    in property <bool> update-self-update-supported: false;
+    in property <string> update-stage: "idle"; // idle | downloading | ready | restarting | error
+    in property <float> update-progress: 0.0;  // 0.0..1.0, valid while downloading
+    in property <string> update-error;         // populated while stage == error
+    callback restart-to-update();              // idle/error: download; ready: swap + relaunch
+
     // ----- app settings modal -----
     in-out property <bool> settings-open: false;
     in property <bool> update-check-enabled: true;
@@ -2373,23 +2380,41 @@ callback create-table-commit();
                     color: Tokens.text;
                 }
                 Text {
-                    text: root.update-hint;
+                    text: !root.update-self-update-supported ? root.update-hint
+                        : root.update-stage == "downloading" ? "Downloading… " + round(root.update-progress * 100) + "%"
+                        : root.update-stage == "ready" ? "Ready to install"
+                        : root.update-stage == "restarting" ? "Restarting…"
+                        : root.update-stage == "error" ? root.update-error
+                        : "Click to download";
                     font-size: 11px;
-                    color: Tokens.text-dim;
+                    color: root.update-stage == "error" ? Tokens.error : Tokens.text-dim;
+                    overflow: elide;
                 }
             }
 
             TouchArea {
-                width: 62px;
-                clicked => { root.update-open(); }
+                width: root.update-self-update-supported ? 116px : 62px;
+                clicked => {
+                    if root.update-self-update-supported {
+                        root.restart-to-update();
+                    } else {
+                        root.update-open();
+                    }
+                }
                 Rectangle {
                     background: parent.has-hover ? Tokens.accent-hover : Tokens.accent;
                     border-radius: Tokens.radius;
                     Text {
-                        text: "Update";
+                        text: !root.update-self-update-supported ? "Update"
+                            : root.update-stage == "ready" ? "Restart to Update"
+                            : root.update-stage == "downloading" ? "Downloading…"
+                            : root.update-stage == "restarting" ? "Restarting…"
+                            : root.update-stage == "error" ? "Retry"
+                            : "Download";
                         font-size: 12px;
                         font-weight: 600;
                         color: #FFFFFF;
+                        horizontal-alignment: center;
                     }
                 }
             }
@@ -2586,22 +2611,48 @@ callback create-table-commit();
                                 font-size: 13px;
                                 font-weight: 600;
                             }
-                            Text {
+                            if !root.update-self-update-supported: Text {
                                 text: root.update-hint;
                                 color: Tokens.text-dim;
+                                font-size: 12px;
+                                wrap: word-wrap;
+                            }
+                            if root.update-self-update-supported && root.update-stage == "downloading": Rectangle {
+                                height: 6px;
+                                border-radius: 3px;
+                                background: Tokens.card;
+                                Rectangle {
+                                    x: 0;
+                                    width: parent.width * root.update-progress;
+                                    height: parent.height;
+                                    border-radius: parent.border-radius;
+                                    background: Tokens.accent;
+                                }
+                            }
+                            if root.update-self-update-supported && root.update-stage == "error": Text {
+                                text: root.update-error;
+                                color: Tokens.error;
                                 font-size: 12px;
                                 wrap: word-wrap;
                             }
                             HorizontalLayout {
                                 spacing: Tokens.sp2;
                                 alignment: start;
-                                PrimaryButton {
+                                if !root.update-self-update-supported: PrimaryButton {
                                     text: "Open";
                                     clicked => { root.update-open(); }
                                 }
-                                SecondaryButton {
+                                if !root.update-self-update-supported: SecondaryButton {
                                     text: "Copy";
                                     clicked => { root.update-copy-hint(); }
+                                }
+                                if root.update-self-update-supported: PrimaryButton {
+                                    text: root.update-stage == "ready" ? "Restart to Update"
+                                        : root.update-stage == "downloading" ? "Downloading…"
+                                        : root.update-stage == "restarting" ? "Restarting…"
+                                        : root.update-stage == "error" ? "Retry"
+                                        : "Download";
+                                    clicked => { root.restart-to-update(); }
                                 }
                             }
                         }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -219,6 +219,8 @@ callback create-table-commit();
     // ----- connections screen detail panel -----
     in property <string> sel-name;
     in property <string> sel-engine;
+    in property <color> sel-color;
+    in property <bool> sel-has-custom-color;
     in property <string> sel-sub;
     in property <bool> sel-local;
     in property <[KvRow]> sel-rows;
@@ -1005,6 +1007,8 @@ callback create-table-commit();
             connecting: root.connecting;
             sel-name: root.sel-name;
             sel-engine: root.sel-engine;
+            sel-color: root.sel-color;
+            sel-has-custom-color: root.sel-has-custom-color;
             sel-sub: root.sel-sub;
             sel-local: root.sel-local;
             sel-rows: root.sel-rows;

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -134,10 +134,13 @@ export component SelectBox inherits Rectangle {
 export component DbBadge inherits Rectangle {
     in property <string> engine; // "postgres" | "mysql" | "redis" | "sqlite" | "mongo" | "cassandra"
     in property <length> size: 24px;
+    // Callers with a per-connection custom accent can override this; the
+    // default keeps every existing call site's engine-colored look as-is.
+    in property <brush> fill: Tokens.db-color(engine);
     width: self.size;
     height: self.size;
     border-radius: self.size * 0.28;
-    background: Tokens.db-color(engine);
+    background: self.fill;
     // Known engine → white brand glyph (icons/db-<engine>.svg via AppIcon).
     property <bool> known: engine == "postgres" || engine == "mysql"
         || engine == "redis" || engine == "sqlite" || engine == "mongo"

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -59,6 +59,16 @@ export global Tooltip {
     in-out property <bool> shown;
 }
 
+// Display labels follow the desktop convention while the input handlers use
+// Slint's platform-independent Control/Meta modifier checks.
+export global Shortcut {
+    in-out property <string> primary: "⌘";
+    in-out property <string> shift: "⇧";
+    in-out property <string> separator: "";
+    in-out property <string> enter: "↩";
+    in-out property <string> backspace: "⌫";
+}
+
 // Dropdown select: shows the current value + a ▾ caret so it reads as a
 // picker even when closed, then a click opens a themed option list. Replaces
 // std-widgets ComboBox, which rendered as a blank borderless box in this theme.
@@ -433,7 +443,7 @@ export component SearchCommandPill inherits Rectangle {
         }
         VerticalLayout {
             alignment: center;
-            KeyCap { text: "⌘K"; }
+            KeyCap { text: Shortcut.primary + Shortcut.separator + "K"; }
         }
     }
     ta := TouchArea { clicked => { root.activated(); } }

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -181,6 +181,7 @@ export component OutlineChip inherits Rectangle {
 export component PrimaryButton inherits Rectangle {
     in property <string> text;
     in property <bool> enabled: true;
+    in property <string> tooltip;            // optional hover label
     callback clicked;
     height: Tokens.button-h;
     width: label.preferred-width + 2 * Tokens.sp4;
@@ -197,6 +198,16 @@ export component PrimaryButton inherits Rectangle {
     ta := TouchArea {
         enabled: root.enabled;
         clicked => { root.clicked(); }
+        changed has-hover => {
+            if self.has-hover && root.tooltip != "" {
+                Tooltip.text = root.tooltip;
+                Tooltip.x = root.absolute-position.x + root.width / 2;
+                Tooltip.y = root.absolute-position.y + root.height + 4px;
+                Tooltip.shown = true;
+            } else if Tooltip.text == root.tooltip {
+                Tooltip.shown = false;
+            }
+        }
     }
 }
 

--- a/app/src/ui/palette.slint
+++ b/app/src/ui/palette.slint
@@ -13,6 +13,9 @@ export struct PaletteItem {
     kind: string,
     sub: string,
     local: bool,
+    // Per-connection custom accent (connection rows only; ignored elsewhere).
+    color: color,
+    has-custom-color: bool,
 }
 
 export component ListModal inherits Rectangle {
@@ -173,6 +176,7 @@ export component ListModal inherits Rectangle {
                                     if it.kind == "postgres" || it.kind == "mysql" || it.kind == "redis" || it.kind == "mongo" || it.kind == "sqlite" || it.kind == "cassandra": DbBadge {
                                         engine: it.kind;
                                         size: 24px;
+                                        fill: it.has-custom-color ? it.color : Tokens.db-color(it.kind);
                                     }
                                 }
 

--- a/app/src/ui/picker.slint
+++ b/app/src/ui/picker.slint
@@ -20,6 +20,8 @@ export component ConnPicker inherits Rectangle {
     // Detail panel (filled by Rust when a row is selected).
     in property <string> sel-name;
     in property <string> sel-engine;
+    in property <color> sel-color;
+    in property <bool> sel-has-custom-color;
     in property <string> sel-sub;      // "PostgreSQL · grup profin"
     in property <bool> sel-local;
     in property <[KvRow]> sel-rows;
@@ -149,7 +151,7 @@ export component ConnPicker inherits Rectangle {
                                 // so it dominates the list (CodexBar-style). Idle
                                 // rows stay plain (engine color still reads from
                                 // the badge square); hover gets a faint tint.
-                                property <color> tint: Tokens.db-color(item.engine);
+                                property <color> tint: item.has-custom-color ? item.color : Tokens.db-color(item.engine);
                                 property <bool> selected: item.index == root.selected-conn;
                                 border-radius: Tokens.radius-lg;
                                 background: selected ? tint
@@ -218,6 +220,7 @@ export component ConnPicker inherits Rectangle {
                                         DbBadge {
                                             engine: item.engine;
                                             size: 24px;
+                                            fill: item.has-custom-color ? item.color : Tokens.db-color(item.engine);
                                             border-width: selected ? 1px : 0;
                                             border-color: white.with-alpha(0.5);
                                         }
@@ -500,7 +503,11 @@ export component ConnPicker inherits Rectangle {
                     // ----- header row -----
                     HorizontalLayout {
                         spacing: Tokens.sp4;
-                        DbBadge { engine: root.sel-engine; size: 44px; }
+                        DbBadge {
+                            engine: root.sel-engine;
+                            size: 44px;
+                            fill: root.sel-has-custom-color ? root.sel-color : Tokens.db-color(root.sel-engine);
+                        }
                         VerticalLayout {
                             alignment: center;
                             spacing: Tokens.sp1;

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -602,6 +602,7 @@ export component QueryPane inherits Rectangle {
                                         DbBadge {
                                             engine: item.engine;
                                             size: 13px;
+                                            fill: item.has-custom-color ? item.color : Tokens.db-color(item.engine);
                                         }
                                     }
                                     rl := Text {

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -39,6 +39,7 @@ export component QueryPane inherits Rectangle {
     in-out property <string> limit-text;
     in property <string> query-label;
     callback run();
+    callback run-new-tab();
     callback format-sql();
     callback explain-query();
     callback cancel-stream();
@@ -354,6 +355,14 @@ export component QueryPane inherits Rectangle {
                             height: 28px;
                             enabled: !root.query-running;
                             clicked => { root.run(); }
+                        }
+                    }
+                    VerticalLayout {
+                        alignment: center;
+                        SecondaryButton {
+                            text: "Run New  ⌘\\";
+                            height: 28px;
+                            clicked => { root.run-new-tab(); }
                         }
                     }
                     VerticalLayout {

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -557,72 +557,70 @@ export component QueryPane inherits Rectangle {
                     ExportButton { export(i) => { root.export-results(i); } }
                     TextButton { text: "Chart"; clicked => { root.sql-view-mode = 2; } }
                 }
-                // result tabs — appear once ⌘\ has spawned a second result
-                if root.result-tabs.length > 1: result-strip := HorizontalLayout {
+                // result tabs — appear once ⌘\ has spawned a second result.
+                // Wrapped in a ScrollView since the row can outgrow the panel
+                // width once several runs pile up; the label already reads
+                // "{connection} {n}", so nothing needs to hide when crowded.
+                if root.result-tabs.length > 1: Rectangle {
                     height: 30px;
-                    padding-left: Tokens.sp3;
-                    padding-right: Tokens.sp3;
-                    spacing: Tokens.sp1;
-                    alignment: start;
-                    // Below this avg-width-per-chip, drop the inline connection
-                    // name and keep only the badge + tooltip (mirrors the
-                    // document tab strip's tabs-compact in app-window.slint).
-                    property <bool> results-compact: self.width / max(1, root.result-tabs.length) < 110px;
-                    for item[i] in root.result-tabs: Rectangle {
-                        height: 24px;
-                        width: rl.preferred-width + 2 * Tokens.sp2 + 18px
-                            + (item.engine != "" ? 15px + Tokens.sp1 : 0px)
-                            + (item.engine != "" && !result-strip.results-compact ? 60px + Tokens.sp1 : 0px);
-                        border-radius: Tokens.radius;
-                        background: i == root.active-result ? Tokens.accent-tint
-                            : rta.has-hover ? Tokens.chrome : transparent;
-                        rta := TouchArea {
-                            clicked => { root.select-result-tab(i); }
-                            changed has-hover => {
-                                if (self.has-hover && item.connection-name != "") {
-                                    Tooltip.text = item.connection-name;
-                                    Tooltip.x = self.absolute-position.x + self.width / 2;
-                                    Tooltip.y = self.absolute-position.y + self.height + 4px;
-                                    Tooltip.shown = true;
-                                } else if Tooltip.text == item.connection-name {
-                                    Tooltip.shown = false;
-                                }
-                            }
-                        }
+                    result-scroll := ScrollView {
+                        width: parent.width;
+                        height: parent.height;
+                        vertical-scrollbar-policy: ScrollBarPolicy.always-off;
                         HorizontalLayout {
-                            padding-left: Tokens.sp2;
-                            padding-right: Tokens.sp1;
+                            height: result-scroll.visible-height;
+                            padding-left: Tokens.sp3;
+                            padding-right: Tokens.sp3;
                             spacing: Tokens.sp1;
-                            if item.engine != "": VerticalLayout {
-                                alignment: center;
-                                DbBadge {
-                                    engine: item.engine;
-                                    size: 13px;
+                            alignment: start;
+                            for item[i] in root.result-tabs: Rectangle {
+                                height: 24px;
+                                width: rl.preferred-width + 2 * Tokens.sp2 + 18px
+                                    + (item.engine != "" ? 15px + Tokens.sp1 : 0px);
+                                border-radius: Tokens.radius;
+                                background: i == root.active-result ? Tokens.accent-tint
+                                    : rta.has-hover ? Tokens.chrome : transparent;
+                                rta := TouchArea {
+                                    clicked => { root.select-result-tab(i); }
+                                    changed has-hover => {
+                                        if (self.has-hover && item.connection-name != "") {
+                                            Tooltip.text = item.connection-name;
+                                            Tooltip.x = self.absolute-position.x + self.width / 2;
+                                            Tooltip.y = self.absolute-position.y + self.height + 4px;
+                                            Tooltip.shown = true;
+                                        } else if Tooltip.text == item.connection-name {
+                                            Tooltip.shown = false;
+                                        }
+                                    }
                                 }
-                            }
-                            if item.engine != "" && !result-strip.results-compact: Text {
-                                text: item.connection-name;
-                                vertical-alignment: center;
-                                color: Tokens.text-faint;
-                                font-size: 9px;
-                                max-width: 60px;
-                                overflow: elide;
-                            }
-                            rl := Text {
-                                text: item.label;
-                                color: i == root.active-result ? Tokens.on-tint : Tokens.text-dim;
-                                font-size: Tokens.font-sm;
-                                vertical-alignment: center;
-                            }
-                            Rectangle {
-                                width: 16px;
-                                Text {
-                                    text: "×";
-                                    color: Tokens.text-faint;
-                                    vertical-alignment: center;
-                                    horizontal-alignment: center;
+                                HorizontalLayout {
+                                    padding-left: Tokens.sp2;
+                                    padding-right: Tokens.sp1;
+                                    spacing: Tokens.sp1;
+                                    if item.engine != "": VerticalLayout {
+                                        alignment: center;
+                                        DbBadge {
+                                            engine: item.engine;
+                                            size: 13px;
+                                        }
+                                    }
+                                    rl := Text {
+                                        text: item.label;
+                                        color: i == root.active-result ? Tokens.on-tint : Tokens.text-dim;
+                                        font-size: Tokens.font-sm;
+                                        vertical-alignment: center;
+                                    }
+                                    Rectangle {
+                                        width: 16px;
+                                        Text {
+                                            text: "×";
+                                            color: Tokens.text-faint;
+                                            vertical-alignment: center;
+                                            horizontal-alignment: center;
+                                        }
+                                        TouchArea { clicked => { root.close-result-tab(i); } }
+                                    }
                                 }
-                                TouchArea { clicked => { root.close-result-tab(i); } }
                             }
                         }
                     }

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -9,7 +9,7 @@ import { GridColumn, GridCell, StructField, Span, ChartBar, IndexRow, DocRow, Re
 import { CodeEditor } from "code-editor.slint";
 import { TabularGrid } from "tabular-grid.slint";
 import { PaletteItem } from "palette.slint";
-import { SecondaryButton, PrimaryButton, TextButton, ExportButton, DangerButton, FilterField, UnderlineSegment, DbBadge, Tooltip } from "components.slint";
+import { SecondaryButton, PrimaryButton, TextButton, ExportButton, DangerButton, FilterField, UnderlineSegment, DbBadge, Tooltip, Shortcut } from "components.slint";
 import { ScrollView, TextEdit, ComboBox } from "std-widgets.slint";
 import { AppIcon } from "icons.slint";
 
@@ -351,8 +351,8 @@ export component QueryPane inherits Rectangle {
                     VerticalLayout {
                         alignment: center;
                         PrimaryButton {
-                            text: root.query-running ? "Running…" : "▶ Run  ⌘⏎";
-                            tooltip: "Run selected SQL or the current statement  ⌘↩";
+                            text: root.query-running ? "Running…" : "▶ Run  " + Shortcut.primary + Shortcut.separator + Shortcut.enter;
+                            tooltip: "Run selected SQL or the current statement  " + Shortcut.primary + Shortcut.separator + Shortcut.enter;
                             height: 28px;
                             enabled: !root.query-running;
                             clicked => { root.run(); }
@@ -361,8 +361,8 @@ export component QueryPane inherits Rectangle {
                     VerticalLayout {
                         alignment: center;
                         SecondaryButton {
-                            text: "Run New  ⌘\\";
-                            tooltip: "Run the current statement in a new result tab  ⌘\\";
+                            text: "Run New  " + Shortcut.primary + Shortcut.separator + "\\";
+                            tooltip: "Run the current statement in a new result tab  " + Shortcut.primary + Shortcut.separator + "\\";
                             height: 28px;
                             clicked => { root.run-new-tab(); }
                         }
@@ -1170,7 +1170,7 @@ export component QueryPane inherits Rectangle {
                         vertical-alignment: center;
                     }
                     Text {
-                        text: "⌘C to copy · Esc to close";
+                        text: Shortcut.primary + Shortcut.separator + "C to copy · Esc to close";
                         color: Tokens.text-faint;
                         font-size: Tokens.font-xs;
                         vertical-alignment: center;

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -39,7 +39,6 @@ export component QueryPane inherits Rectangle {
     in-out property <string> limit-text;
     in property <string> query-label;
     callback run();
-    callback run-selection();
     callback format-sql();
     callback explain-query();
     callback cancel-stream();
@@ -356,10 +355,6 @@ export component QueryPane inherits Rectangle {
                             enabled: !root.query-running;
                             clicked => { root.run(); }
                         }
-                    }
-                    VerticalLayout {
-                        alignment: center;
-                        SecondaryButton { text: "Run Selection"; height: 28px; clicked => { root.run-selection(); } }
                     }
                     VerticalLayout {
                         alignment: center;

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -352,6 +352,7 @@ export component QueryPane inherits Rectangle {
                         alignment: center;
                         PrimaryButton {
                             text: root.query-running ? "Running…" : "▶ Run  ⌘⏎";
+                            tooltip: "Run selected SQL or the current statement  ⌘↩";
                             height: 28px;
                             enabled: !root.query-running;
                             clicked => { root.run(); }
@@ -361,6 +362,7 @@ export component QueryPane inherits Rectangle {
                         alignment: center;
                         SecondaryButton {
                             text: "Run New  ⌘\\";
+                            tooltip: "Run the current statement in a new result tab  ⌘\\";
                             height: 28px;
                             clicked => { root.run-new-tab(); }
                         }
@@ -368,13 +370,19 @@ export component QueryPane inherits Rectangle {
                     VerticalLayout {
                         alignment: center;
                         visible: root.sql-capable;
-                        SecondaryButton { text: "Format"; height: 28px; clicked => { root.format-sql(); } }
+                        SecondaryButton {
+                            text: "Format";
+                            tooltip: "Format the active editor line";
+                            height: 28px;
+                            clicked => { root.format-sql(); }
+                        }
                     }
                     VerticalLayout {
                         alignment: center;
                         visible: root.sql-capable;
                         SecondaryButton {
                             text: "Explain";
+                            tooltip: "Run EXPLAIN for the active editor line";
                             height: 28px;
                             clicked => { root.explain-query(); }
                         }

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -5,11 +5,11 @@
 // WorkArea. Lifted verbatim from workarea.slint — property names match 1:1 so
 // the moved markup's `root.<prop>` references resolve to this component.
 import { Tokens } from "tokens.slint";
-import { GridColumn, GridCell, StructField, Span, ChartBar, IndexRow, DocRow } from "structs.slint";
+import { GridColumn, GridCell, StructField, Span, ChartBar, IndexRow, DocRow, ResultTabItem } from "structs.slint";
 import { CodeEditor } from "code-editor.slint";
 import { TabularGrid } from "tabular-grid.slint";
 import { PaletteItem } from "palette.slint";
-import { SecondaryButton, PrimaryButton, TextButton, ExportButton, DangerButton, FilterField, UnderlineSegment } from "components.slint";
+import { SecondaryButton, PrimaryButton, TextButton, ExportButton, DangerButton, FilterField, UnderlineSegment, DbBadge, Tooltip } from "components.slint";
 import { ScrollView, TextEdit, ComboBox } from "std-widgets.slint";
 import { AppIcon } from "icons.slint";
 
@@ -80,7 +80,7 @@ export component QueryPane inherits Rectangle {
     in property <string> results-meta;
     in-out property <bool> filter-open: false;
     in-out property <int> sql-view-mode: 0;
-    in property <[string]> result-tabs;
+    in property <[ResultTabItem]> result-tabs;
     in property <int> active-result;
     callback select-result-tab(int);
     callback close-result-tab(int);
@@ -558,25 +558,58 @@ export component QueryPane inherits Rectangle {
                     TextButton { text: "Chart"; clicked => { root.sql-view-mode = 2; } }
                 }
                 // result tabs — appear once ⌘\ has spawned a second result
-                if root.result-tabs.length > 1: HorizontalLayout {
+                if root.result-tabs.length > 1: result-strip := HorizontalLayout {
                     height: 30px;
                     padding-left: Tokens.sp3;
                     padding-right: Tokens.sp3;
                     spacing: Tokens.sp1;
                     alignment: start;
-                    for name[i] in root.result-tabs: Rectangle {
+                    // Below this avg-width-per-chip, drop the inline connection
+                    // name and keep only the badge + tooltip (mirrors the
+                    // document tab strip's tabs-compact in app-window.slint).
+                    property <bool> results-compact: self.width / max(1, root.result-tabs.length) < 110px;
+                    for item[i] in root.result-tabs: Rectangle {
                         height: 24px;
-                        width: rl.preferred-width + 2 * Tokens.sp2 + 18px;
+                        width: rl.preferred-width + 2 * Tokens.sp2 + 18px
+                            + (item.engine != "" ? 15px + Tokens.sp1 : 0px)
+                            + (item.engine != "" && !result-strip.results-compact ? 60px + Tokens.sp1 : 0px);
                         border-radius: Tokens.radius;
                         background: i == root.active-result ? Tokens.accent-tint
                             : rta.has-hover ? Tokens.chrome : transparent;
-                        rta := TouchArea { clicked => { root.select-result-tab(i); } }
+                        rta := TouchArea {
+                            clicked => { root.select-result-tab(i); }
+                            changed has-hover => {
+                                if (self.has-hover && item.connection-name != "") {
+                                    Tooltip.text = item.connection-name;
+                                    Tooltip.x = self.absolute-position.x + self.width / 2;
+                                    Tooltip.y = self.absolute-position.y + self.height + 4px;
+                                    Tooltip.shown = true;
+                                } else if Tooltip.text == item.connection-name {
+                                    Tooltip.shown = false;
+                                }
+                            }
+                        }
                         HorizontalLayout {
                             padding-left: Tokens.sp2;
                             padding-right: Tokens.sp1;
                             spacing: Tokens.sp1;
+                            if item.engine != "": VerticalLayout {
+                                alignment: center;
+                                DbBadge {
+                                    engine: item.engine;
+                                    size: 13px;
+                                }
+                            }
+                            if item.engine != "" && !result-strip.results-compact: Text {
+                                text: item.connection-name;
+                                vertical-alignment: center;
+                                color: Tokens.text-faint;
+                                font-size: 9px;
+                                max-width: 60px;
+                                overflow: elide;
+                            }
                             rl := Text {
-                                text: name;
+                                text: item.label;
                                 color: i == root.active-result ? Tokens.on-tint : Tokens.text-dim;
                                 font-size: Tokens.font-sm;
                                 vertical-alignment: center;

--- a/app/src/ui/sidebar.slint
+++ b/app/src/ui/sidebar.slint
@@ -3,7 +3,7 @@
 // Reference: design/2-workspace.png (left column).
 import { Tokens } from "tokens.slint";
 import { TreeNode } from "structs.slint";
-import { FilterField, KeyCap, Tooltip } from "components.slint";
+import { FilterField, KeyCap, Tooltip, Shortcut } from "components.slint";
 import { AppIcon } from "icons.slint";
 import { ScrollView, Spinner } from "std-widgets.slint";
 
@@ -108,7 +108,7 @@ export component Sidebar inherits Rectangle {
             fld := FilterField {
                 height: 28px;
                 placeholder: root.mode == 1 ? "Filter queries..." : "Filter items...";
-                trailing-cap: root.mode == 0 ? "⌘P" : "";
+                trailing-cap: root.mode == 0 ? Shortcut.primary + Shortcut.separator + "P" : "";
                 edited(t) => { root.filter-tree(t); }
             }
         }

--- a/app/src/ui/structs.slint
+++ b/app/src/ui/structs.slint
@@ -41,7 +41,10 @@ export struct StructField { name: string, type-name: string, nullable: bool }
 // One editable row of the new-table designer.
 export struct TableCol { name: string, type-name: string, nullable: bool, pk: bool }
 // `kind` picks the tab glyph; preview table tabs are italic until pinned.
-export struct TabItem { title: string, kind: string, preview: bool }
+// `engine` is the DbBadge key ("postgres" etc, empty when no connection was
+// active when the tab was created); `connection-name` is the full name shown
+// via tooltip / inline label.
+export struct TabItem { title: string, kind: string, preview: bool, engine: string, connection-name: string }
 // One lexed editor token; `kind`: 0 plain · 1 keyword · 2 string ·
 // 3 function · 4 comment · 5 number (mirrors app/src/editor.rs).
 // `sel` = inside the selection (background highlight). `cols` = char count, so

--- a/app/src/ui/structs.slint
+++ b/app/src/ui/structs.slint
@@ -45,6 +45,11 @@ export struct TableCol { name: string, type-name: string, nullable: bool, pk: bo
 // active when the tab was created); `connection-name` is the full name shown
 // via tooltip / inline label.
 export struct TabItem { title: string, kind: string, preview: bool, engine: string, connection-name: string }
+// One "Result N" chip in the results panel (a tab can accumulate several runs).
+// `engine`/`connection-name` identify which connection produced that specific
+// run — distinct from the connection on the owning TabItem, since a long-lived
+// SQL tab can be re-run after switching the active connection.
+export struct ResultTabItem { label: string, engine: string, connection-name: string }
 // One lexed editor token; `kind`: 0 plain · 1 keyword · 2 string ·
 // 3 function · 4 comment · 5 number (mirrors app/src/editor.rs).
 // `sel` = inside the selection (background highlight). `cols` = char count, so

--- a/app/src/ui/structs.slint
+++ b/app/src/ui/structs.slint
@@ -49,12 +49,12 @@ export struct TableCol { name: string, type-name: string, nullable: bool, pk: bo
 // `engine` is the DbBadge key ("postgres" etc, empty when no connection was
 // active when the tab was created); `connection-name` is the full name shown
 // via tooltip / inline label.
-export struct TabItem { title: string, kind: string, preview: bool, engine: string, connection-name: string }
+export struct TabItem { title: string, kind: string, preview: bool, engine: string, connection-name: string, color: color, has-custom-color: bool }
 // One "Result N" chip in the results panel (a tab can accumulate several runs).
 // `engine`/`connection-name` identify which connection produced that specific
 // run — distinct from the connection on the owning TabItem, since a long-lived
 // SQL tab can be re-run after switching the active connection.
-export struct ResultTabItem { label: string, engine: string, connection-name: string }
+export struct ResultTabItem { label: string, engine: string, connection-name: string, color: color, has-custom-color: bool }
 // One lexed editor token; `kind`: 0 plain · 1 keyword · 2 string ·
 // 3 function · 4 comment · 5 number (mirrors app/src/editor.rs).
 // `sel` = inside the selection (background highlight). `cols` = char count, so

--- a/app/src/ui/structs.slint
+++ b/app/src/ui/structs.slint
@@ -22,6 +22,11 @@ export struct ConnItem {
     name: string,
     engine: string,
     color: color,
+    // Whether `color` is a user-picked accent vs. just the generic fallback
+    // `theme::accent_or_default` returns when no color was ever set — lets
+    // the UI fall back to the per-engine palette instead of that generic
+    // color for connections that never touched the color picker.
+    has-custom-color: bool,
     is-header: bool,
     expanded: bool,
     index: int,

--- a/app/src/ui/tabular-grid.slint
+++ b/app/src/ui/tabular-grid.slint
@@ -4,6 +4,7 @@
 import { Tokens } from "tokens.slint";
 import { GridColumn, GridCell } from "structs.slint";
 import { ComboBox, DatePickerPopup, ScrollView, TextEdit } from "std-widgets.slint";
+import { Shortcut } from "components.slint";
 
 export component TabularGrid inherits Rectangle {
     in property <[GridColumn]> columns;
@@ -509,7 +510,7 @@ export component TabularGrid inherits Rectangle {
                         vertical-alignment: center;
                     }
                     Text {
-                        text: "⌘C to copy · Esc to close";
+                        text: Shortcut.primary + Shortcut.separator + "C to copy · Esc to close";
                         color: Tokens.text-faint;
                         font-size: Tokens.font-xs;
                         vertical-alignment: center;

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -200,6 +200,7 @@ export component WorkArea inherits Rectangle {
     // Pane 1 callbacks carry no pane arg here; they are wired to pane-1 handlers
     // on MainWindow (a later step). Left unhandled = no-op until then.
     callback p1-run();
+    callback p1-run-new-tab();
     callback p1-format-sql();
     callback p1-explain-query();
     callback p1-cancel-stream();
@@ -247,6 +248,7 @@ export component WorkArea inherits Rectangle {
     in property <int> scroll-grid-tick;
 
     callback run();
+    callback run-new-tab();
     callback format-sql();
     callback explain-query();
     callback copy-results();
@@ -387,6 +389,7 @@ export component WorkArea inherits Rectangle {
             limit-text <=> root.limit-text;
             query-label: root.query-label;
             run() => { root.run(); }
+            run-new-tab() => { root.run-new-tab(); }
             format-sql() => { root.format-sql(); }
             explain-query() => { root.explain-query(); }
             cancel-stream() => { root.cancel-stream(); }
@@ -518,6 +521,7 @@ export component WorkArea inherits Rectangle {
                 limit-text <=> root.p1-limit-text;
                 query-label: root.p1-query-label;
                 run() => { root.p1-run(); }
+                run-new-tab() => { root.p1-run-new-tab(); }
                 format-sql() => { root.p1-format-sql(); }
                 explain-query() => { root.p1-explain-query(); }
                 cancel-stream() => { root.p1-cancel-stream(); }

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -200,7 +200,6 @@ export component WorkArea inherits Rectangle {
     // Pane 1 callbacks carry no pane arg here; they are wired to pane-1 handlers
     // on MainWindow (a later step). Left unhandled = no-op until then.
     callback p1-run();
-    callback p1-run-selection();
     callback p1-format-sql();
     callback p1-explain-query();
     callback p1-cancel-stream();
@@ -248,7 +247,6 @@ export component WorkArea inherits Rectangle {
     in property <int> scroll-grid-tick;
 
     callback run();
-    callback run-selection();
     callback format-sql();
     callback explain-query();
     callback copy-results();
@@ -389,7 +387,6 @@ export component WorkArea inherits Rectangle {
             limit-text <=> root.limit-text;
             query-label: root.query-label;
             run() => { root.run(); }
-            run-selection() => { root.run-selection(); }
             format-sql() => { root.format-sql(); }
             explain-query() => { root.explain-query(); }
             cancel-stream() => { root.cancel-stream(); }
@@ -521,7 +518,6 @@ export component WorkArea inherits Rectangle {
                 limit-text <=> root.p1-limit-text;
                 query-label: root.p1-query-label;
                 run() => { root.p1-run(); }
-                run-selection() => { root.p1-run-selection(); }
                 format-sql() => { root.p1-format-sql(); }
                 explain-query() => { root.p1-explain-query(); }
                 cancel-stream() => { root.p1-cancel-stream(); }

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -7,7 +7,7 @@ import { CodeEditor } from "code-editor.slint";
 import { TabularGrid } from "tabular-grid.slint";
 import { PaletteItem } from "palette.slint";
 import {
-    UnderlineSegment, SecondaryButton, PrimaryButton, TextButton, ExportButton, FilterField, KeyCap
+    UnderlineSegment, SecondaryButton, PrimaryButton, TextButton, ExportButton, FilterField, KeyCap, Shortcut
 } from "components.slint";
 import { ScrollView, ComboBox } from "std-widgets.slint";
 import { AppIcon } from "icons.slint";
@@ -616,7 +616,7 @@ export component WorkArea inherits Rectangle {
                 TextButton { text: "Discard"; clicked => { root.discard-edits(); } }
                 VerticalLayout {
                     alignment: center;
-                    PrimaryButton { text: "Commit  ⌘S"; height: 22px; clicked => { root.commit-edits(); } }
+                    PrimaryButton { text: "Commit  " + Shortcut.primary + Shortcut.separator + "S"; height: 22px; clicked => { root.commit-edits(); } }
                 }
             }
         }

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -2,7 +2,7 @@
 // editor + results split. References: design/2-workspace.png,
 // design/3-sql-editor.png, design/11-filter-edit-t2.png.
 import { Tokens } from "tokens.slint";
-import { GridColumn, GridCell, StructField, Span, ChartBar, IndexRow, DocRow } from "structs.slint";
+import { GridColumn, GridCell, StructField, Span, ChartBar, IndexRow, DocRow, ResultTabItem } from "structs.slint";
 import { CodeEditor } from "code-editor.slint";
 import { TabularGrid } from "tabular-grid.slint";
 import { PaletteItem } from "palette.slint";
@@ -85,7 +85,7 @@ export component WorkArea inherits Rectangle {
     in property <string> query-label;    // "emiten-per-sektor.sql · saved"
     in property <string> results-meta;   // "10 rows · 38 ms"
     // result tabs (SQL): ⌘⏎ replaces the active one, ⌘\ appends
-    in property <[string]> result-tabs;
+    in property <[ResultTabItem]> result-tabs;
     in property <int> active-result;
     callback select-result-tab(int);
     callback close-result-tab(int);
@@ -158,7 +158,7 @@ export component WorkArea inherits Rectangle {
     in-out property <bool> p1-show-structure: false;
     in property <string> p1-query-label;
     in property <string> p1-results-meta;
-    in property <[string]> p1-result-tabs;
+    in property <[ResultTabItem]> p1-result-tabs;
     in property <int> p1-active-result;
     in-out property <int> p1-sql-view-mode;
     in-out property <bool> p1-filter-open;

--- a/app/src/update.rs
+++ b/app/src/update.rs
@@ -49,12 +49,25 @@ impl InstallMethod {
             InstallMethod::Other => "Open the download page",
         }
     }
+
+    /// Whether the in-app "Restart to Update" flow (`self_update.rs`) can run
+    /// for this install. Homebrew/Scoop are never eligible — self-updating a
+    /// package-manager-owned install would fight `brew upgrade`/`scoop
+    /// update`, so those keep the plain hint + release-page link below.
+    /// `Other` still needs `self_update::is_swappable` to confirm this
+    /// specific binary is actually a layout we know how to swap (a real
+    /// `.app` bundle on macOS, a recognized target on Windows) — a dev build
+    /// or unsupported platform falls back to the same hint-only behavior.
+    pub fn self_update_supported(self, exe: Option<&std::path::Path>) -> bool {
+        self == InstallMethod::Other && crate::self_update::is_swappable(exe)
+    }
 }
 
-/// Clicking the banner opens the release page for every install method —
-/// self-updating a brew/scoop install from inside the app would fight the
-/// package manager, and the banner text already shows the exact command.
-/// ponytail: no self-update machinery until asked.
+/// Clicking the banner opens the release page — still the only action for
+/// Homebrew/Scoop (fighting the package manager) and for any `Other` install
+/// this build can't safely swap in place. Installs where
+/// `InstallMethod::self_update_supported` is true get the "Restart to
+/// Update" flow instead (see `self_update.rs`).
 pub fn release_page() -> &'static str {
     RELEASES_PAGE
 }


### PR DESCRIPTION
## Summary
- Give tabs and results a visible link back to their source connection (engine badge + custom accent color), since multi-connection workflows made it easy to lose track of which DB a query/result belonged to.
- Let direct-download (curl/.dmg/.exe) installs update in place with "Restart to Update" instead of always sending users to manually redownload.
- Round out several editor/shortcut/toolbar papercuts found while dogfooding the above.

## Changes

**Connection identity**
- Document tabs and Result-N chips show an engine-colored badge for their source connection; later removed from document tabs only (kept on Result-N chips) so it stops obscuring the tab title.
- Result-N chip row scrolls horizontally and reads `"{connection} {n}"` instead of `"Result n"`.
- Custom per-connection accent color (the Color picker) now actually renders everywhere a connection shows up: sidebar, detail header, ⌘K palette, ⌘O modal, and tab/result badges — previously saved fine but never drawn anywhere.
- Removed a `tabs-compact` property left dead after the document-tab badge was removed.

**In-app self-update**
- "Restart to Update": download the new release asset, swap it into place, relaunch — scoped to direct-download installs only; Homebrew/Scoop keep opening the release page exactly as before.
- New `self_update.rs` handles macOS (mount `.dmg`, stage + swap the `.app`, clear quarantine, relaunch) and Windows (download exe, hand off to a detached PowerShell helper that waits for the process to exit, swap, relaunch).
- Known gaps called out in code rather than hidden: no published checksum for release assets yet (size-only integrity check for now); Windows path is written from documented conventions but untested on real hardware.

**Editor / shortcuts / toolbar**
- `⌘\` routes to the pane that owns the caret; removed the redundant Run Selection button; Format/Explain scoped to the active line only, without introducing stray newlines.
- Added a visible "Run New ⌘\" button; fixed a panic from a stale editor borrow.
- Shifted reconnect (`⌘⇧R`) now triggers correctly; shortcut labels render `⌘`/`Ctrl` per platform and route to the active split pane.
- Query toolbar buttons show hover tooltips describing their action/shortcut.
- Update dialog's dismiss control uses the shared close icon instead of a text glyph that rendered as a missing-glyph box.
- Native File-menu entries for `⌘O`/`⌘⇧O` so editor focus can no longer swallow those shortcuts.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo test -p rdb` — 161 passed
- [x] `make fe-build`
- [x] `make lint`
- [x] `make be-test`
- [ ] `make test-it` — skipped, requires Docker (not run this session)
- [x] Manual via `make fe-run`: document/result tabs, connection colors, query toolbar, shortcuts, update banner/settings fallback
- [ ] Real macOS swap-and-relaunch — needs a real `.app` install at `/Applications`, not exercised via `make fe-run`
- [ ] Windows self-update path end-to-end — no Windows machine available this session
- [ ] `self_update_supported` gating against a simulated Homebrew/Scoop binary path
- [ ] Swap rollback path under a forced failure