### PR TITLE
fix(app): silence macOS eh_frame linker warning

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(target_os = "macos")']
+rustflags = ["-C", "link-arg=-Wl,-no_compact_unwind"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5594,7 +5594,7 @@ dependencies = [
 
 [[package]]
 name = "rdb"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "async-trait",
  "copypasta",


### PR DESCRIPTION
## Summary
- `cargo build -p rdb` on macOS CI emits a linker warning (`__eh_frame section too large`) because linking every driver crate into one binary pushes unwind metadata past ld's 16MB compact-unwind table limit.
- `ld` already falls back to DWARF CFI unwind on overflow; this just skips the failed attempt so the warning stops appearing. Same runtime behavior, no functional change.

## Changes
- Add `.cargo/config.toml` with `-Wl,-no_compact_unwind` linker flag for `cfg(target_os = "macos")`.
- Sync `Cargo.lock` to `app` v0.29.0 (lockfile was stale relative to `app/Cargo.toml`).

## Test plan
- [x] `cargo build -p rdb` locally — warning no longer appears
- [x] `make fmt-check` passes
- [x] CI `rdb-app / check (macos-latest)` job log clean of `eh_frame` warning