### PR TITLE
chore(deps): bump event-listener to 5.4.2 for RUSTSEC-2026-0221

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1807,11 +1807,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]


### PR DESCRIPTION
## Summary
- Resolves the `event-listener` unsoundness advisory flagged by the weekly `audit` workflow.
- Transitive-only dependency and an in-range patch bump, so this is a lockfile-only change with no `Cargo.toml` edits.

Fixes #171

## Changes
- `Cargo.lock`: `event-listener` 5.4.1 → 5.4.2.

`event-listener` is never a direct dependency of any workspace crate — it arrives through two paths:

```
event-listener 5.4.1
├── zbus 5.16.0 ← keyring / notify-rust / i-slint-backend-winit / rfd
└── event-listener-strategy → async-lock → redis → rdb-driver-redis
```

RUSTSEC-2026-0221: affected versions unconditionally implement `Send`/`Sync` for `StackSlot<'_, T>`, which lets a `!Send` tag set via `Event::with_tag` be moved to another thread and accessed through `StackSlot::wait` — a data race reachable from safe code.

## Notes
`cargo audit` still reports two unrelated `quick-xml` 0.39.4 advisories (RUSTSEC-2026-0194 / RUSTSEC-2026-0195), reachable only via `wayland-scanner ← smithay-clipboard ← copypasta`/`slint`. There is no in-range upgrade for those — they need an upstream bump, so they're left out of this PR.

## Test plan
- [x] `cargo audit` — RUSTSEC-2026-0221 no longer reported
- [x] `cargo build --workspace`
- [x] `cargo test --workspace --lib` — all 8 crates pass, 0 failures