### PR TITLE
fix(ci): unbreak release-please, keep CHANGELOG.md at the repo root

### DIFF
--- a/.github/scripts/fold_changelog.py
+++ b/.github/scripts/fold_changelog.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Fold release-please's package changelog into the repo-root CHANGELOG.md.
+
+release-please resolves `changelog-path` relative to its package directory
+and rejects `..`, so it can't be pointed at the repo root directly. Instead
+it writes its default `app/CHANGELOG.md` and this script splices that
+section into the root file, prefixes the heading with the product name, and
+removes the package copy so the changelog only ever lives at the root.
+
+Re-runnable: release-please recreates its release branch as new commits land
+on develop, so a section for the same version is replaced rather than
+duplicated or left stale.
+"""
+
+import os
+import re
+import sys
+
+HEADING = "# Changelog"
+
+
+def split_sections(body):
+    """Split markdown into (preamble, [section, ...]) on `## ` headings."""
+    parts = re.split(r"^(?=## )", body, flags=re.MULTILINE)
+    if not parts:
+        return "", []
+    if parts[0].startswith("## "):
+        return "", parts
+    return parts[0], parts[1:]
+
+
+def strip_top_heading(text):
+    """Drop a leading `# ...` title and the blank lines under it."""
+    lines = text.splitlines(keepends=True)
+    if lines and lines[0].startswith("# "):
+        lines = lines[1:]
+        while lines and not lines[0].strip():
+            lines = lines[1:]
+    return "".join(lines)
+
+
+def fold(src_text, dst_text, version, product):
+    section = strip_top_heading(src_text).strip("\n")
+    if not section:
+        raise SystemExit(f"no changelog section found for {version}")
+
+    # Target the exact released version, not "whichever heading is first" —
+    # a rebased release branch can otherwise carry an unrelated block on top.
+    marker = f"## [{version}]"
+    prefixed = f"## {product}: [{version}]"
+    if section.startswith(marker):
+        section = prefixed + section[len(marker):]
+    elif not section.startswith(prefixed):
+        raise SystemExit(
+            f"generated section does not start with a {version} heading"
+        )
+
+    preamble, sections = split_sections(strip_top_heading(dst_text))
+    # Drop any existing block for this version so a regenerated release
+    # branch replaces it instead of stacking a second copy.
+    sections = [
+        s
+        for s in sections
+        if not (s.startswith(marker) or s.startswith(prefixed))
+    ]
+
+    body = "".join(sections).lstrip("\n")
+    out = f"{HEADING}\n\n{section}\n\n"
+    if preamble.strip():
+        out = f"{HEADING}\n\n{preamble.strip()}\n\n{section}\n\n"
+    if body:
+        out += body
+    return out.rstrip("\n") + "\n"
+
+
+def main():
+    version = os.environ["RELEASED_VERSION"]
+    product = os.environ.get("PRODUCT_NAME", "RDB")
+    src = sys.argv[1] if len(sys.argv) > 1 else "app/CHANGELOG.md"
+    dst = sys.argv[2] if len(sys.argv) > 2 else "CHANGELOG.md"
+
+    if not os.path.exists(src):
+        print(f"{src} not present; nothing to fold")
+        return
+
+    with open(src, encoding="utf-8") as fh:
+        src_text = fh.read()
+    with open(dst, encoding="utf-8") as fh:
+        dst_text = fh.read()
+
+    with open(dst, "w", encoding="utf-8") as fh:
+        fh.write(fold(src_text, dst_text, version, product))
+    print(f"folded {version} into {dst}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_fold_changelog.py
+++ b/.github/scripts/test_fold_changelog.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Self-check for fold-changelog.py. Run: python3 test_fold_changelog.py"""
+
+from fold_changelog import fold
+
+ROOT = """# Changelog
+
+## RDB: [0.30.0](https://example.com/compare/v0.29.0...v0.30.0) (2026-08-01)
+
+
+### App Features
+
+* **app:** something old ([aaa](https://example.com/commit/aaa))
+
+## RDB: [0.29.0](https://example.com/compare/v0.28.0...v0.29.0) (2026-07-01)
+
+
+### Bug Fixes
+
+* **app:** older still ([bbb](https://example.com/commit/bbb))
+"""
+
+GENERATED = """# Changelog
+
+## [0.31.0](https://example.com/compare/v0.30.0...v0.31.0) (2026-08-03)
+
+
+### Bug Fixes
+
+* **ci:** the new thing ([ccc](https://example.com/commit/ccc))
+"""
+
+
+def test_prepends_under_header_and_prefixes_heading():
+    out = fold(GENERATED, ROOT, "0.31.0", "RDB")
+    assert out.startswith("# Changelog\n\n## RDB: [0.31.0]"), out[:80]
+    assert "the new thing" in out
+    # older releases survive, in order
+    assert out.index("[0.31.0]") < out.index("[0.30.0]") < out.index("[0.29.0]")
+    assert "something old" in out and "older still" in out
+
+
+def test_replaces_stale_section_for_same_version():
+    once = fold(GENERATED, ROOT, "0.31.0", "RDB")
+    regenerated = GENERATED.replace("the new thing", "the regenerated thing")
+    twice = fold(regenerated, once, "0.31.0", "RDB")
+    assert twice.count("## RDB: [0.31.0]") == 1, twice
+    assert "the regenerated thing" in twice
+    assert "the new thing" not in twice
+    assert "something old" in twice
+
+
+def test_is_idempotent():
+    once = fold(GENERATED, ROOT, "0.31.0", "RDB")
+    twice = fold(GENERATED, once, "0.31.0", "RDB")
+    assert once == twice
+
+
+def test_rejects_a_section_for_the_wrong_version():
+    try:
+        fold(GENERATED, ROOT, "9.9.9", "RDB")
+    except SystemExit:
+        return
+    raise AssertionError("expected a mismatched version to be rejected")
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_"):
+            fn()
+            print(f"ok {name}")
+    print("all checks passed")

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,11 +41,14 @@ jobs:
           gh release edit "${{ steps.release.outputs['app--tag_name'] }}" \
             --title "RDB ${{ steps.release.outputs['app--tag_name'] }}"
 
-      # Match the CHANGELOG to the release title. Target the exact version
-      # release-please just built the PR for, not "whichever heading comes
-      # first" — a stale/rebased PR branch can otherwise prefix the wrong
-      # block (this is what put 0.28.0's heading out of place).
-      - name: Prefix CHANGELOG heading with product name
+      # We keep CHANGELOG.md at the repo root, but release-please resolves
+      # `changelog-path` relative to its package dir and rejects `..`, so it
+      # writes app/CHANGELOG.md and this step folds that into the root file
+      # (prefixing the heading to match the release title) and drops the
+      # package copy. Targets the exact version release-please just built
+      # the PR for, not "whichever heading comes first" — a stale/rebased
+      # PR branch can otherwise prefix the wrong block.
+      - name: Fold CHANGELOG into the repo root
         if: ${{ steps.release.outputs.pr }}
         env:
           # Keep generated PR JSON out of the shell script body.
@@ -55,15 +58,14 @@ jobs:
           branch=$(printf '%s' "$RELEASE_PR" | jq -r '.headBranchName')
           git fetch origin "$branch"
           git checkout "$branch"
-          awk -v ver="$RELEASED_VERSION" \
-            '$0 ~ "^## \\[" ver "\\]" { sub(/^## \[/, "## RDB: ["); } { print }' \
-            CHANGELOG.md > CHANGELOG.md.tmp
-          mv CHANGELOG.md.tmp CHANGELOG.md
-          if git diff --quiet -- CHANGELOG.md; then
-            echo "CHANGELOG heading already prefixed"
+          python3 .github/scripts/fold_changelog.py
+          rm -f app/CHANGELOG.md
+          if git diff --quiet -- CHANGELOG.md app/CHANGELOG.md; then
+            echo "CHANGELOG already folded into the root"
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -am "docs: prefix changelog heading with RDB"
+          git add -A CHANGELOG.md app/CHANGELOG.md
+          git commit -m "docs: fold changelog into the repo root"
           git push origin "$branch"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,6 @@
   "packages": {
     "app": {
       "package-name": "rdb",
-      "changelog-path": "../CHANGELOG.md",
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
## Summary
- `release-please` has failed on every push to `develop` since #172 merged, so no release PR can be opened at all — releases are currently blocked.
- Root cause: `changelog-path` was set to `../CHANGELOG.md` when the changelog moved to the repo root, but release-please resolves that path relative to the **package** directory and rejects `..` outright:
  ```
  release-please failed: illegal pathing characters in path: app/../CHANGELOG.md
  ```
- Fixes it while keeping `CHANGELOG.md` at the repo root, which is where we want it.

## Changes
- `release-please-config.json`: drop the illegal `changelog-path` override so release-please writes its default `app/CHANGELOG.md`.
- `.github/scripts/fold_changelog.py`: new script that splices the generated section into the root `CHANGELOG.md`, prefixes the heading to match the release title, and leaves the package copy to be removed. Replaces an existing section for the same version rather than duplicating it, so it stays correct when release-please recreates its release branch as new commits land on `develop`.
- `.github/scripts/test_fold_changelog.py`: self-check covering placement, stale-section replacement, idempotency, and version-mismatch rejection.
- `.github/workflows/release-please.yml`: the existing heading-prefix step becomes a fold-into-root step — same PR-branch checkout, same exact-version targeting, now also dropping `app/CHANGELOG.md` so the changelog only ever lives at the root.

Considered and rejected: moving the package key from `app` to `.` would make the root path the natural default, but release-please's Rust strategy branches on `workspace.members` and would then bump every `crates/*` crate to the app's version, as well as renaming the `app--*` action outputs this workflow depends on.

## Test plan
- [x] `python3 .github/scripts/test_fold_changelog.py` — 4/4 checks pass
- [x] Dry run against the real root `CHANGELOG.md` with a synthetic generated section: new block lands under `# Changelog` with the `RDB:` prefix, the 0.30.0 block and everything below are byte-identical, section count goes 31 → 32
- [x] Re-run over its own output — idempotent, single `0.31.0` heading
- [x] Regenerated-section case — stale entries replaced, not stacked
- [x] Missing `app/CHANGELOG.md` — safe no-op, exit 0
- [x] Full workflow shell sequence rehearsed in a throwaway git repo: root updated, `app/CHANGELOG.md` deleted and untracked, re-run short-circuits without an empty commit
- [ ] After merge: next `release-please` run on `develop` goes green and its release PR edits the root `CHANGELOG.md` with no `app/CHANGELOG.md`