### PR TITLE
fix(ci): read the release version from the generated changelog

### DIFF
--- a/.github/scripts/fold_changelog.py
+++ b/.github/scripts/fold_changelog.py
@@ -39,10 +39,26 @@ def strip_top_heading(text):
     return "".join(lines)
 
 
-def fold(src_text, dst_text, version, product):
+def parse_version(section):
+    """Read the released version off the generated section's heading.
+
+    The action's `app--version` output is only populated when a release is
+    created, not when the release PR is opened, so it can't be used here.
+    The generated file is rewritten from scratch every run and holds exactly
+    one section, making its first heading the released version.
+    """
+    match = re.match(r"## (?:.+: )?\[([^\]]+)\]", section)
+    if not match:
+        raise SystemExit("generated changelog has no version heading")
+    return match.group(1)
+
+
+def fold(src_text, dst_text, version=None, product="RDB"):
     section = strip_top_heading(src_text).strip("\n")
     if not section:
-        raise SystemExit(f"no changelog section found for {version}")
+        raise SystemExit("generated changelog is empty")
+
+    version = version or parse_version(section)
 
     # Target the exact released version, not "whichever heading is first" —
     # a rebased release branch can otherwise carry an unrelated block on top.
@@ -74,7 +90,6 @@ def fold(src_text, dst_text, version, product):
 
 
 def main():
-    version = os.environ["RELEASED_VERSION"]
     product = os.environ.get("PRODUCT_NAME", "RDB")
     src = sys.argv[1] if len(sys.argv) > 1 else "app/CHANGELOG.md"
     dst = sys.argv[2] if len(sys.argv) > 2 else "CHANGELOG.md"
@@ -88,9 +103,10 @@ def main():
     with open(dst, encoding="utf-8") as fh:
         dst_text = fh.read()
 
+    folded = fold(src_text, dst_text, product=product)
     with open(dst, "w", encoding="utf-8") as fh:
-        fh.write(fold(src_text, dst_text, version, product))
-    print(f"folded {version} into {dst}")
+        fh.write(folded)
+    print(f"folded {parse_version(strip_top_heading(src_text).strip())} into {dst}")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_fold_changelog.py
+++ b/.github/scripts/test_fold_changelog.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Self-check for fold-changelog.py. Run: python3 test_fold_changelog.py"""
 
-from fold_changelog import fold
+from fold_changelog import fold, parse_version
 
 ROOT = """# Changelog
 
@@ -54,6 +54,23 @@ def test_is_idempotent():
     once = fold(GENERATED, ROOT, "0.31.0", "RDB")
     twice = fold(GENERATED, once, "0.31.0", "RDB")
     assert once == twice
+
+
+def test_derives_the_version_when_none_is_given():
+    # The action's version output is empty on the release-PR path, so the
+    # real workflow always takes this branch.
+    assert parse_version("## [0.31.0](https://example.com/x) (2026-08-03)") == "0.31.0"
+    out = fold(GENERATED, ROOT)
+    assert out.startswith("# Changelog\n\n## RDB: [0.31.0]"), out[:80]
+    assert out == fold(GENERATED, ROOT, "0.31.0", "RDB")
+
+
+def test_rejects_a_source_with_no_version_heading():
+    try:
+        fold("# Changelog\n\nnot a release section at all\n", ROOT)
+    except SystemExit:
+        return
+    raise AssertionError("expected a missing version heading to be rejected")
 
 
 def test_rejects_a_section_for_the_wrong_version():

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -45,15 +45,18 @@ jobs:
       # `changelog-path` relative to its package dir and rejects `..`, so it
       # writes app/CHANGELOG.md and this step folds that into the root file
       # (prefixing the heading to match the release title) and drops the
-      # package copy. Targets the exact version release-please just built
-      # the PR for, not "whichever heading comes first" — a stale/rebased
-      # PR branch can otherwise prefix the wrong block.
+      # package copy. app/CHANGELOG.md is rewritten from scratch every run,
+      # so it holds exactly the section being released — that's what the
+      # version is taken from, rather than the root file where a rebased
+      # branch could leave an unrelated block on top.
       - name: Fold CHANGELOG into the repo root
         if: ${{ steps.release.outputs.pr }}
         env:
-          # Keep generated PR JSON out of the shell script body.
+          # Keep generated PR JSON out of the shell script body. The version
+          # is read off the generated changelog rather than an action output:
+          # the `app--*` outputs are only populated when a release is created,
+          # not on this (release-PR) path, where they're all empty.
           RELEASE_PR: ${{ steps.release.outputs.pr }}
-          RELEASED_VERSION: ${{ steps.release.outputs['app--version'] }}
         run: |
           branch=$(printf '%s' "$RELEASE_PR" | jq -r '.headBranchName')
           git fetch origin "$branch"


### PR DESCRIPTION
## Summary
- #174 fixed the `illegal pathing characters` failure — release-please itself now runs green and opened release PR #175. But the new fold step failed, so #175 still carries `app/CHANGELOG.md` instead of updating the root `CHANGELOG.md`.
- Cause: the step read the version from `steps.release.outputs['app--version']`, which is only populated when a **release** is created. The fold step runs on the **release-PR** path (`if: steps.release.outputs.pr`) — the mutually exclusive branch, where every `app--*` output is empty:
  ```
  RELEASED_VERSION:
  ...
  generated section does not start with a  heading
  ```
- The previous `awk` step read that same empty variable and matched `^## \[\]`, which never matches — so it silently rewrote nothing and exited 0. That, not heading ordering, is why an unprefixed heading slipped through before.

## Changes
- `.github/scripts/fold_changelog.py`: new `parse_version()` reads the version off the generated section's own heading; `fold()` derives it when no version is passed. `app/CHANGELOG.md` is rewritten from scratch each run and holds exactly the section being released, so its heading is unambiguous — and it's a safer source than the root file, where a rebased branch could leave an unrelated block on top.
- `.github/scripts/test_fold_changelog.py`: added cases for deriving the version and for rejecting a source with no version heading.
- `.github/workflows/release-please.yml`: dropped the always-empty `RELEASED_VERSION` env var and corrected the surrounding comments.

The `Prefix release title with product name` step is untouched — it's gated on `app--release_created`, the merge-time path where those outputs *are* populated.

## Note on #175
No need to close it. Once this lands, the next release-please run rebuilds #175's branch off the new `develop` HEAD, picking up the fixed script, and the fold step rewrites it in place — root `CHANGELOG.md` gains the section, `app/CHANGELOG.md` is deleted.

## Test plan
- [x] `python3 .github/scripts/test_fold_changelog.py` — 6/6 pass
- [x] Replayed the exact failing input: pulled the real 36-line `app/CHANGELOG.md` off #175's branch, ran the workflow's shell sequence verbatim with `RELEASED_VERSION` explicitly unset
- [x] Result: root `CHANGELOG.md` gains `## RDB: [0.31.0]` under `# Changelog`, `app/CHANGELOG.md` deleted and untracked, exit 0
- [x] Everything from the `0.30.0` heading down is byte-identical to develop's changelog; section count 31 → 32; exactly one `0.31.0` heading
- [x] Re-run with the branch recreated — short-circuits with no empty commit, still one heading
- [ ] After merge: next `release-please` run on `develop` goes green and #175 shows `CHANGELOG.md` instead of `app/CHANGELOG.md`