### PR TITLE
fix(ci): fold the changelog whenever a release PR is open

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -49,19 +49,32 @@ jobs:
       # so it holds exactly the section being released — that's what the
       # version is taken from, rather than the root file where a rebased
       # branch could leave an unrelated block on top.
+      #
+      # Deliberately NOT gated on `steps.release.outputs.pr`: that output only
+      # appears on runs where release-please actually rewrote the PR, so a run
+      # that reported "PR #N remained the same" (e.g. a commit outside the
+      # `app` package path) would skip the fold and strand a release PR with
+      # the changelog still under app/. Look the PR up by its label instead,
+      # so every push re-checks and heals a PR left behind by an earlier
+      # failure.
       - name: Fold CHANGELOG into the repo root
-        if: ${{ steps.release.outputs.pr }}
         env:
-          # Keep generated PR JSON out of the shell script body. The version
-          # is read off the generated changelog rather than an action output:
-          # the `app--*` outputs are only populated when a release is created,
-          # not on this (release-PR) path, where they're all empty.
-          RELEASE_PR: ${{ steps.release.outputs.pr }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
-          branch=$(printf '%s' "$RELEASE_PR" | jq -r '.headBranchName')
+          branch=$(gh pr list --state open --label "autorelease: pending" \
+            --json headRefName --jq '.[0].headRefName')
+          if [ -z "$branch" ]; then
+            echo "no open release PR; nothing to fold"
+            exit 0
+          fi
+          # Copy the script out before switching branches: the release branch
+          # is only rebuilt when release-please rewrites it, so it can carry an
+          # older copy of this script than the commit that triggered this run.
+          script=$(mktemp)
+          cp .github/scripts/fold_changelog.py "$script"
           git fetch origin "$branch"
           git checkout "$branch"
-          python3 .github/scripts/fold_changelog.py
+          python3 "$script"
           rm -f app/CHANGELOG.md
           if git diff --quiet -- CHANGELOG.md app/CHANGELOG.md; then
             echo "CHANGELOG already folded into the root"


### PR DESCRIPTION
## Summary
- The release-please run after #176 merged was **green, but the fold step never ran** — it shows as skipped (`-`), not passed. #175 therefore still has `app/CHANGELOG.md` instead of the root `CHANGELOG.md`.
- Cause, from the run log:
  ```
  ✔ PR https://github.com/suiflex/rdb/pull/175 remained the same
  ```
  The step was gated on `steps.release.outputs.pr`, which is only emitted on runs where release-please actually rewrote the PR. My CI commits touched only `.github/**`, which is outside the `app` package path, so the PR content didn't change, no `pr` output was produced, and the step was skipped.
- That gating makes any failure permanent: a release PR stranded by one bad run can never be repaired, because the next run has no reason to rewrite it. #175 is exactly that state.

## Changes
- `.github/workflows/release-please.yml`:
  - Look the release PR up by its `autorelease: pending` label instead of gating on the action's `pr` output, so every push to `develop` re-checks and heals a stranded PR.
  - Copy `fold_changelog.py` to a temp path *before* `git checkout "$branch"`. The release branch is only rebuilt when release-please rewrites it, so it can carry an older copy of the script than the commit that triggered the run — which is the case for #175 right now, whose branch still has the pre-#176 script that reads the always-empty `RELEASED_VERSION`. Without this, the healing run would crash on the stale copy.

## Effect on #175
Merging this is itself a push to `develop`, which triggers the workflow, which now finds #175 by label and folds it — root `CHANGELOG.md` gains the `0.31.0` section, `app/CHANGELOG.md` is deleted. Still no need to close it.

## Test plan
- [x] Rehearsed the exact situation in a throwaway repo with a real remote: a release branch carrying the **old** script plus `develop` carrying the new one, using #175's real 36-line `app/CHANGELOG.md`
- [x] The new script runs (`folded 0.31.0 into CHANGELOG.md`) rather than the stale one, confirming the temp-copy pin — without it the old copy raises on the missing env var
- [x] Result: root gains `## RDB: [0.31.0]`, exactly one heading, `app/CHANGELOG.md` deleted and untracked
- [x] No-open-release-PR path exits 0 cleanly
- [x] Re-run on an already-folded branch short-circuits with no empty commit
- [x] `python3 .github/scripts/test_fold_changelog.py` — 6/6 still pass
- [ ] After merge: the triggered run shows the fold step as executed (not skipped) and #175's file list shows `CHANGELOG.md`