### PR TITLE
fix: editor auto-pair, cell edit sizing, filter debounce, cask Gatekeeper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "rdb"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -138,6 +138,15 @@ brew install suiflex/tap/rdb
 
 Upgrade later with `brew upgrade rdb`.
 
+> **macOS Gatekeeper note:** the `.app` is ad-hoc signed (no paid Apple
+> Developer notarization). The cask and `install.sh` both strip the
+> quarantine flag automatically, so a normal install just works. If you
+> downloaded the `.dmg` straight from a GitHub Release and macOS says the
+> app is damaged / rejected, clear it yourself:
+> ```bash
+> xattr -dr com.apple.quarantine /Applications/RDB.app
+> ```
+
 ### Windows
 
 ```powershell

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -4068,7 +4068,25 @@ fn main() -> Result<(), slint::PlatformError> {
                     match (it.next(), it.next()) {
                         (Some(c), None) => match c {
                             '\u{8}' => {
+                                // Delete both sides of an empty pair in one
+                                // keystroke, mirroring the auto-close below.
+                                let before = ed.col.checked_sub(1).and_then(|c| {
+                                    ed.lines[ed.line].chars().nth(c)
+                                });
+                                let after = ed.lines[ed.line].chars().nth(ed.col);
+                                let is_empty_pair = ed.selection().is_none()
+                                    && matches!(
+                                        (before, after),
+                                        (Some('('), Some(')'))
+                                            | (Some('['), Some(']'))
+                                            | (Some('{'), Some('}'))
+                                            | (Some('"'), Some('"'))
+                                            | (Some('\''), Some('\''))
+                                    );
                                 ed.backspace();
+                                if is_empty_pair {
+                                    ed.delete();
+                                }
                                 true
                             }
                             '\u{7f}' => {
@@ -4111,6 +4129,26 @@ fn main() -> Result<(), slint::PlatformError> {
                             }
                             '\u{f72b}' => {
                                 ed.end();
+                                true
+                            }
+                            // Skip over an already-typed closer/quote instead
+                            // of inserting a duplicate.
+                            c @ (')' | ']' | '}' | '"' | '\'')
+                                if ed.selection().is_none()
+                                    && ed.lines[ed.line].chars().nth(ed.col) == Some(c) =>
+                            {
+                                ed.move_cursor(0, 1);
+                                true
+                            }
+                            c @ ('(' | '[' | '{' | '"' | '\'') => {
+                                let closer = match c {
+                                    '(' => ')',
+                                    '[' => ']',
+                                    '{' => '}',
+                                    other => other, // quotes close themselves
+                                };
+                                ed.insert(&format!("{c}{closer}"));
+                                ed.move_cursor(0, -1);
                                 true
                             }
                             c if !c.is_control() => {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -4070,9 +4070,10 @@ fn main() -> Result<(), slint::PlatformError> {
                             '\u{8}' => {
                                 // Delete both sides of an empty pair in one
                                 // keystroke, mirroring the auto-close below.
-                                let before = ed.col.checked_sub(1).and_then(|c| {
-                                    ed.lines[ed.line].chars().nth(c)
-                                });
+                                let before = ed
+                                    .col
+                                    .checked_sub(1)
+                                    .and_then(|c| ed.lines[ed.line].chars().nth(c));
                                 let after = ed.lines[ed.line].chars().nth(ed.col);
                                 let is_empty_pair = ed.selection().is_none()
                                     && matches!(

--- a/app/src/ui/tabular-grid.slint
+++ b/app/src/ui/tabular-grid.slint
@@ -304,7 +304,10 @@ export component TabularGrid inherits Rectangle {
                         // face — an estimate, not a measurement, so the editor can
                         // size itself to the value without a layout round-trip.
                         // Bump the constant if short values start wrapping.
-                        property <length> text-w: cell.text.character-count * 7px + 2 * Tokens.sp2;
+                        // Tracks the live in-progress text (root.editing-value),
+                        // not the last-committed cell.text, so the box keeps
+                        // growing as the user types instead of clipping input.
+                        property <length> text-w: root.editing-value.character-count * 7px + 2 * Tokens.sp2;
                         // Never narrower than the cell, never wider than the value
                         // needs, still capped so a huge JSON blob can't span the pane.
                         property <length> editor-w: self.compact-editor ? parent.width

--- a/app/src/ui/tabular-grid.slint
+++ b/app/src/ui/tabular-grid.slint
@@ -155,10 +155,22 @@ export component TabularGrid inherits Rectangle {
         if root.filter-open: HorizontalLayout {
             height: 26px;
             Rectangle { width: 44px; background: Tokens.chrome; }
-            for col[c] in root.columns: Rectangle {
+            for col[c] in root.columns: col-filter-box := Rectangle {
                 width: root.col-widths.length > c ? root.col-widths[c] : 140px;
                 background: Tokens.chrome;
                 clip: true;
+                property <string> pending-text: "";
+                // Debounce so a full re-query doesn't fire on every keystroke
+                // (was noticeable as input lag, worst on high-latency
+                // connections regardless of engine).
+                debounce := Timer {
+                    interval: 300ms;
+                    running: false;
+                    triggered => {
+                        self.running = false;
+                        root.set-col-filter(c, col-filter-box.pending-text);
+                    }
+                }
                 Rectangle {
                     x: 2px;
                     y: 2px;
@@ -177,8 +189,13 @@ export component TabularGrid inherits Rectangle {
                         font-family: Tokens.mono;
                         font-size: Tokens.font-xs;
                         single-line: true;
-                        // filter live as the user types (no Enter needed)
-                        edited => { root.set-col-filter(c, self.text); }
+                        // filter live as the user types (no Enter needed),
+                        // but debounced so it queries after a short pause
+                        edited => {
+                            col-filter-box.pending-text = self.text;
+                            debounce.running = true;
+                            debounce.restart();
+                        }
                     }
                 }
             }

--- a/packaging/rdb-cask.rb.tmpl
+++ b/packaging/rdb-cask.rb.tmpl
@@ -21,4 +21,15 @@ cask "rdb" do
   homepage "https://github.com/suiflex/rdb"
 
   app "RDB.app"
+
+  # The .app is ad-hoc signed (no Apple Developer cert), so Gatekeeper
+  # rejects it as "damaged"/"rejected by OS" once macOS re-checks the
+  # quarantine flag Homebrew leaves on the download (e.g. opening via
+  # Spotlight). Stripping it here is the standard cask workaround short
+  # of paid notarization. See suiflex/rdb#184.
+  postflight do
+    system_command "/usr/bin/xattr",
+                    args: ["-cr", "#{appdir}/RDB.app"],
+                    sudo: false
+  end
 end


### PR DESCRIPTION
## Summary
- SQL editor didn't auto-close brackets/quotes, making manual typing tedious
- Inline grid cell editor sized itself off the pre-edit value, so longer input got clipped/hidden
- Per-column filter row fired a full re-query on every keystroke with no debounce, on every engine
- Homebrew cask install could hit macOS Gatekeeper rejection (ad-hoc signed app, #184)

## Changes
- Auto-close matching `"` `'` `(` `[` `{` pairs while typing in the SQL editor, with skip-over on a typed closer and paired backspace delete (`app/src/main.rs`)
- Size the inline cell editor overlay off the live `editing-value` instead of the stale pre-edit `cell.text` (`app/src/ui/tabular-grid.slint`)
- Debounce the per-column filter query by 300ms so it fires once typing pauses, not per keystroke (`app/src/ui/tabular-grid.slint`)
- Strip the quarantine attribute in a cask `postflight` block so Gatekeeper doesn't flag the ad-hoc signed app (`packaging/rdb-cask.rb.tmpl`), plus a README note on the workaround for direct `.dmg` downloads
- `cargo fmt` cleanup and a `Cargo.lock` version sync

## Test plan
- [x] `cargo build -p rdb` clean on each commit
- [x] `make fmt-check` / `make lint` pass
- [x] `cargo test --workspace --lib` pass (175+ unit tests)
- [x] Manual: type `"` `'` `(` `[` `{` in the SQL editor — auto-close/skip-over/paired-backspace work
- [x] Manual: edit a long value in a grid cell — box resizes with input, nothing clipped
- [x] Manual: type quickly in the per-column filter row (Postgres and Mongo) — query no longer fires per keystroke
- [ ] Manual: reinstall via `brew install --cask suiflex/tap/rdb` on a fresh macOS machine and open via Spotlight — no Gatekeeper rejection