### PR TITLE
Improve query feedback, grid range copy, and global search

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -193,9 +193,11 @@ jobs:
               --body "Automated release-data refresh for ${{ github.ref_name }}.")"
             pr_number="${pr_url##*/}"
           fi
-          # Merge once GitHub has computed mergeability (no auto-merge on this repo).
+          # Merge once GitHub has computed mergeability (no auto-merge on this
+          # repo). Plain merge commit, not --squash: this repo's ruleset has
+          # squash merges disabled entirely (allow_squash_merge: false).
           for i in 1 2 3 4 5 6; do
-            if gh pr merge "$pr_number" --squash --delete-branch; then
+            if gh pr merge "$pr_number" --merge --delete-branch; then
               exit 0
             fi
             echo "merge not ready yet, retrying…"; sleep 5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "rdb"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/app/src/editor.rs
+++ b/app/src/editor.rs
@@ -736,12 +736,21 @@ impl EditorState {
 
     /// Statement under the cursor: the `;`-delimited segment containing the
     /// cursor, ignoring semicolons inside single-quoted literals. Falls back
-    /// to the current line when the segment is empty.
+    /// to the current line when the segment is empty. A leading `-- comment`
+    /// block with no `;` of its own is transparent to `statement_bounds`'s
+    /// segment scan, so it can ride along as a prefix on whichever real
+    /// statement follows — trimmed off here so Run/the query console only
+    /// see the real SQL, not unrelated commented-out lines above it.
+    /// `statement_bounds` itself is left untrimmed — it's shared with
+    /// `replace_current_statement`, and changing its bounds here would also
+    /// change what gets spliced out on Format SQL / autocomplete-accept,
+    /// which is a separate, pre-existing behavior this fix doesn't touch.
     pub fn current_statement(&self) -> String {
         let (s, e) = self.statement_bounds();
         let text = self.text();
         let chars: Vec<char> = text.chars().collect();
-        chars[s..e].iter().collect::<String>().trim().to_string()
+        let stmt: String = chars[s..e].iter().collect::<String>().trim().to_string();
+        trim_leading_comments(&stmt).to_string()
     }
 
     /// Replace the `;`-delimited statement under the cursor with `text`,
@@ -894,6 +903,28 @@ fn is_blank_sql(seg: &str) -> bool {
         .all(|l| l.is_empty())
 }
 
+/// Strip leading blank lines and full `-- comment` lines from `stmt`.
+/// Returns `stmt` unchanged if trimming would consume it entirely (cursor
+/// genuinely sitting inside a comment-only block, nothing real to show).
+fn trim_leading_comments(stmt: &str) -> &str {
+    let mut rest = stmt;
+    loop {
+        let trimmed = rest.trim_start();
+        match trimmed.strip_prefix("--") {
+            Some(after) => rest = after.split_once('\n').map_or("", |(_, tail)| tail),
+            None => {
+                rest = trimmed;
+                break;
+            }
+        }
+    }
+    if rest.is_empty() {
+        stmt
+    } else {
+        rest
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1030,6 +1061,27 @@ mod tests {
     fn statement_without_semicolons_is_whole_text() {
         let ed = EditorState::from_text("SELECT *\nFROM t");
         assert_eq!(ed.current_statement(), "SELECT *\nFROM t");
+    }
+
+    #[test]
+    fn statement_drops_leading_comment_block_glued_by_bounds() {
+        // Reproduces the reported buffer shape: a leading comment block with
+        // no `;` of its own gets glued onto the following statement by
+        // statement_bounds' segment scan; current_statement() must trim it
+        // off so Run/the console only show the SELECT the cursor is on.
+        let text = "-- update t\n-- set x = 1\n-- where y = 2;\n\nselect * from t;\n-- where z = 3;\n\nupdate t set x = 1;";
+        let mut ed = EditorState::from_text(text);
+        ed.line = 4; // the `select * from t;` line
+        ed.col = 0;
+        assert_eq!(ed.current_statement(), "select * from t;");
+    }
+
+    #[test]
+    fn statement_in_pure_comment_block_keeps_comments() {
+        // Cursor sitting inside a comment-only segment (nothing real to
+        // trim to) still returns the comment text rather than empty.
+        let ed = EditorState::from_text("-- just a note\n-- nothing else");
+        assert_eq!(ed.current_statement(), "-- just a note\n-- nothing else");
     }
 
     #[test]

--- a/app/src/editor.rs
+++ b/app/src/editor.rs
@@ -708,18 +708,24 @@ impl EditorState {
         // segment's end, which also equals the next segment's start) runs the
         // statement it just closed, not the following one. `find` yields the
         // earliest match, so the closing segment wins.
-        let (s, e) = segments
+        let matched = segments
             .iter()
             .copied()
-            .find(|&(s, e)| offset >= s && offset <= e)
-            .or_else(|| segments.last().copied())
-            .unwrap_or((0, chars.len()));
-        let stmt: String = chars[s..e].iter().collect();
-        if !stmt.trim().is_empty() {
-            return (s, e);
+            .find(|&(s, e)| offset >= s && offset <= e);
+        if let Some((s, e)) = matched {
+            let stmt: String = chars[s..e].iter().collect();
+            if !stmt.trim().is_empty() {
+                return (s, e);
+            }
         }
-        // Blank segment (e.g. cursor sits in trailing whitespace after the
-        // last statement) — fall back to the current line's own range.
+        // No segment contains the cursor, or the one that does is blank
+        // (e.g. cursor sits in trailing whitespace after the last
+        // statement) — fall back to the current line's own range. Never
+        // fall back to "the last statement in the buffer": if the
+        // offset/segment match ever misses, that would silently run an
+        // unrelated statement elsewhere in the buffer — including one the
+        // user never selected — instead of the harmless no-op/syntax-error
+        // a current-line fallback gives.
         let mut line_start = 0;
         for l in &self.lines[..self.line] {
             line_start += l.chars().count() + 1;

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -7362,6 +7362,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 // is what the grid shows (TablePlus semantics). Redis/Mongo
                 // take the whole text as a single command.
                 let mut split_views: Vec<model::ResultView> = Vec::new();
+                let mut split_verbs: Vec<Option<&'static str>> = Vec::new();
                 let (outcome, n_stmts, last_stmt) = match picked.as_ref() {
                     Some((engine, driver)) => {
                         let stmts = if matches!(
@@ -7422,6 +7423,7 @@ fn main() -> Result<(), slint::PlatformError> {
                             if split {
                                 if let Ok(rs) = &out {
                                     split_views.push(model::to_result_view(rs));
+                                    split_verbs.push(model::sql_verb(&s));
                                 }
                             }
                         }
@@ -7440,6 +7442,21 @@ fn main() -> Result<(), slint::PlatformError> {
                 let view = outcome.as_ref().ok().map(model::to_result_view);
                 let model_ms = model_started.elapsed().as_millis() as u64;
                 let elapsed_ms = started.elapsed().as_millis().max(1) as u64;
+                // Only a genuine `Ok(rs)` reaches here — the "error: ..." Affected
+                // variant used elsewhere for failures is built on a separate path
+                // that never calls `to_result_view`, so any Affected we see below
+                // is always a real "N rows affected" from a successful mutation.
+                let view = view.map(|v| match v {
+                    model::ResultView::Affected(status) => {
+                        let verb = last_stmt.as_deref().and_then(model::sql_verb);
+                        model::ResultView::Affected(model::format_affected(
+                            &status,
+                            verb,
+                            &format!("{elapsed_ms} ms"),
+                        ))
+                    }
+                    other => other,
+                });
                 let err = outcome.err();
                 // A hand-typed `SELECT ... FROM t` result has no row identity by
                 // default. When it's an unambiguous single-table select (no
@@ -7515,7 +7532,8 @@ fn main() -> Result<(), slint::PlatformError> {
                                 if split && split_views.len() >= 2 {
                                     let stored: Vec<StoredResult> = split_views
                                         .iter()
-                                        .map(|vw| {
+                                        .zip(split_verbs.iter())
+                                        .map(|(vw, verb)| {
                                             let rows = match vw {
                                                 model::ResultView::Table(g) => g.rows.len(),
                                                 model::ResultView::Documents(d) => {
@@ -7524,8 +7542,20 @@ fn main() -> Result<(), slint::PlatformError> {
                                                 model::ResultView::Affected(_) => 0,
                                             }
                                                 as u64;
+                                            let vw = match vw {
+                                                model::ResultView::Affected(status) => {
+                                                    model::ResultView::Affected(
+                                                        model::format_affected(
+                                                            status,
+                                                            *verb,
+                                                            &format!("{elapsed_ms} ms"),
+                                                        ),
+                                                    )
+                                                }
+                                                other => other.clone(),
+                                            };
                                             StoredResult {
-                                                view: vw.clone(),
+                                                view: vw,
                                                 meta: query_timing_meta(
                                                     rows, 1, elapsed_ms, queue_ms, driver_ms,
                                                     model_ms,

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2470,6 +2470,31 @@ fn set_p_selected_row(w: &MainWindow, pane: usize, row: i32) {
         w.set_p1_selected_row(row);
     }
 }
+fn set_p_range_anchor(w: &MainWindow, pane: usize, row: i32) {
+    if pane == 0 {
+        w.set_range_anchor_row(row);
+    } else {
+        w.set_p1_range_anchor_row(row);
+    }
+}
+/// Slice `grid` down to the pane's finalized drag/shift-click row range, if
+/// any is active and still in bounds; otherwise return the grid unchanged.
+fn range_sliced_grid(
+    grid: &model::GridModel,
+    pane: usize,
+) -> (model::GridModel, Option<(usize, usize)>) {
+    let range = SELECTED_RANGE.with(|s| s.borrow()[pane]);
+    match range {
+        Some((start, end)) if end < grid.rows.len() => (
+            model::GridModel {
+                columns: grid.columns.clone(),
+                rows: grid.rows[start..=end].to_vec(),
+            },
+            Some((start, end)),
+        ),
+        _ => (grid.clone(), None),
+    }
+}
 /// Per-column indented JSON for one grid row, empty where the value isn't JSON.
 /// Feeds the Details panel so a JSON cell reads as formatted text there too.
 fn detail_pretty_row(g: &model::GridModel, row: usize) -> Vec<SharedString> {
@@ -3101,6 +3126,12 @@ thread_local! {
     /// thread_local suffices; no cross-tab persistence is needed.
     static DOC_TREES: std::cell::RefCell<[(Vec<model::DocNode>, HashSet<String>); 2]> =
         std::cell::RefCell::new(Default::default());
+    /// Finalized (start, end) row range from the last drag/shift-click in the
+    /// results grid, per pane. `None` once a plain click lands with no range,
+    /// or once a fresh result is presented — Copy falls back to the full grid
+    /// then.
+    static SELECTED_RANGE: std::cell::RefCell<[Option<(usize, usize)>; 2]> =
+        std::cell::RefCell::new(Default::default());
 }
 
 /// Compute the visible JSON-tree rows for the current collapse state and push
@@ -3279,6 +3310,8 @@ fn present_view(
     // Details gate `(selected-row + 1) * col-count <= cells.length` then evaluates
     // false — so the panel silently vanishes even while its toggle is on.
     set_p_selected_row(w, pane, 0);
+    set_p_range_anchor(w, pane, -1);
+    SELECTED_RANGE.with(|s| s.borrow_mut()[pane] = None);
     // Seed the Details JSON preview for the first row of the new result.
     if let Some(g) = displayed_grid.lock().unwrap().as_ref() {
         refresh_detail_pretty(w, pane, g, 0);
@@ -8581,11 +8614,17 @@ fn main() -> Result<(), slint::PlatformError> {
             let Some(grid) = displayed_grid.lock().unwrap().clone() else {
                 return;
             };
+            let (to_copy, range) = range_sliced_grid(&grid, 0);
             use copypasta::ClipboardProvider;
             let msg = match copypasta::ClipboardContext::new()
-                .and_then(|mut cb| cb.set_contents(export::to_tsv(&grid)))
+                .and_then(|mut cb| cb.set_contents(export::to_tsv(&to_copy)))
             {
-                Ok(()) => format!("copied {} rows", grid.rows.len()),
+                Ok(()) => match range {
+                    Some((start, end)) => {
+                        format!("copied {} of {} rows", end - start + 1, grid.rows.len())
+                    }
+                    None => format!("copied {} rows", grid.rows.len()),
+                },
                 Err(e) => format!("copy failed: {e}"),
             };
             w.set_results_meta(SharedString::from(msg));
@@ -8752,6 +8791,31 @@ fn main() -> Result<(), slint::PlatformError> {
                 if let Some(g) = panes[1].displayed_grid.lock().unwrap().as_ref() {
                     refresh_detail_pretty(&w, 1, g, row);
                 }
+            }
+        });
+    }
+    {
+        let weak = window.as_weak();
+        window.on_p1_row_press(move |row, shift| {
+            if let Some(w) = weak.upgrade() {
+                if !shift || w.get_p1_range_anchor_row() < 0 {
+                    set_p_range_anchor(&w, 1, row);
+                }
+                set_p_selected_row(&w, 1, row);
+                SELECTED_RANGE.with(|s| s.borrow_mut()[1] = None);
+            }
+        });
+    }
+    {
+        let weak = window.as_weak();
+        window.on_p1_row_drag(move |row| {
+            if let Some(w) = weak.upgrade() {
+                set_p_selected_row(&w, 1, row);
+                let anchor = w.get_p1_range_anchor_row();
+                SELECTED_RANGE.with(|s| {
+                    s.borrow_mut()[1] = (anchor >= 0 && anchor != row)
+                        .then(|| (anchor.min(row) as usize, anchor.max(row) as usize));
+                });
             }
         });
     }
@@ -9033,11 +9097,17 @@ fn main() -> Result<(), slint::PlatformError> {
             let Some(grid) = panes[1].displayed_grid.lock().unwrap().clone() else {
                 return;
             };
+            let (to_copy, range) = range_sliced_grid(&grid, 1);
             use copypasta::ClipboardProvider;
             let msg = match copypasta::ClipboardContext::new()
-                .and_then(|mut cb| cb.set_contents(export::to_tsv(&grid)))
+                .and_then(|mut cb| cb.set_contents(export::to_tsv(&to_copy)))
             {
-                Ok(()) => format!("copied {} rows", grid.rows.len()),
+                Ok(()) => match range {
+                    Some((start, end)) => {
+                        format!("copied {} of {} rows", end - start + 1, grid.rows.len())
+                    }
+                    None => format!("copied {} rows", grid.rows.len()),
+                },
                 Err(e) => format!("copy failed: {e}"),
             };
             set_p_results_meta(&w, 1, SharedString::from(msg));
@@ -10598,6 +10668,31 @@ fn main() -> Result<(), slint::PlatformError> {
                 if let Some(g) = displayed_grid.lock().unwrap().as_ref() {
                     refresh_detail_pretty(&w, 0, g, r);
                 }
+            }
+        });
+    }
+    {
+        let weak = window.as_weak();
+        window.on_row_press(move |row, shift| {
+            if let Some(w) = weak.upgrade() {
+                if !shift || w.get_range_anchor_row() < 0 {
+                    set_p_range_anchor(&w, 0, row);
+                }
+                set_p_selected_row(&w, 0, row);
+                SELECTED_RANGE.with(|s| s.borrow_mut()[0] = None);
+            }
+        });
+    }
+    {
+        let weak = window.as_weak();
+        window.on_row_drag(move |row| {
+            if let Some(w) = weak.upgrade() {
+                set_p_selected_row(&w, 0, row);
+                let anchor = w.get_range_anchor_row();
+                SELECTED_RANGE.with(|s| {
+                    s.borrow_mut()[0] = (anchor >= 0 && anchor != row)
+                        .then(|| (anchor.min(row) as usize, anchor.max(row) as usize));
+                });
             }
         });
     }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2477,20 +2477,32 @@ fn set_p_range_anchor(w: &MainWindow, pane: usize, row: i32) {
         w.set_p1_range_anchor_row(row);
     }
 }
-/// Slice `grid` down to the pane's finalized drag/shift-click row range, if
-/// any is active and still in bounds; otherwise return the grid unchanged.
+fn set_p_range_anchor_col(w: &MainWindow, pane: usize, col: i32) {
+    if pane == 0 {
+        w.set_range_anchor_col(col);
+    } else {
+        w.set_p1_range_anchor_col(col);
+    }
+}
+/// Slice `grid` down to the pane's finalized drag/shift-click range, if any
+/// is active and still in bounds; otherwise return the grid unchanged. A
+/// range is always exactly one column wide (the column the drag started
+/// in) — see the `range-anchor-col` doc comment in tabular-grid.slint.
 fn range_sliced_grid(
     grid: &model::GridModel,
     pane: usize,
-) -> (model::GridModel, Option<(usize, usize)>) {
+) -> (model::GridModel, Option<(usize, usize, usize)>) {
     let range = SELECTED_RANGE.with(|s| s.borrow()[pane]);
     match range {
-        Some((start, end)) if end < grid.rows.len() => (
+        Some((start, end, col)) if end < grid.rows.len() && col < grid.columns.len() => (
             model::GridModel {
-                columns: grid.columns.clone(),
-                rows: grid.rows[start..=end].to_vec(),
+                columns: vec![grid.columns[col].clone()],
+                rows: grid.rows[start..=end]
+                    .iter()
+                    .map(|row| vec![row[col].clone()])
+                    .collect(),
             },
-            Some((start, end)),
+            Some((start, end, col)),
         ),
         _ => (grid.clone(), None),
     }
@@ -3248,7 +3260,7 @@ thread_local! {
     /// results grid, per pane. `None` once a plain click lands with no range,
     /// or once a fresh result is presented — Copy falls back to the full grid
     /// then.
-    static SELECTED_RANGE: std::cell::RefCell<[Option<(usize, usize)>; 2]> =
+    static SELECTED_RANGE: std::cell::RefCell<[Option<(usize, usize, usize)>; 2]> =
         std::cell::RefCell::new(Default::default());
     /// What each row of the currently displayed ⌘K palette list does when
     /// chosen, rebuilt alongside `palette_items` every open/filter — see
@@ -3434,6 +3446,7 @@ fn present_view(
     // false — so the panel silently vanishes even while its toggle is on.
     set_p_selected_row(w, pane, 0);
     set_p_range_anchor(w, pane, -1);
+    set_p_range_anchor_col(w, pane, -1);
     SELECTED_RANGE.with(|s| s.borrow_mut()[pane] = None);
     // Seed the Details JSON preview for the first row of the new result.
     if let Some(g) = displayed_grid.lock().unwrap().as_ref() {
@@ -8743,9 +8756,12 @@ fn main() -> Result<(), slint::PlatformError> {
                 .and_then(|mut cb| cb.set_contents(export::to_tsv(&to_copy)))
             {
                 Ok(()) => match range {
-                    Some((start, end)) => {
-                        format!("copied {} of {} rows", end - start + 1, grid.rows.len())
-                    }
+                    Some((start, end, col)) => format!(
+                        "copied {} of {} rows, column {}",
+                        end - start + 1,
+                        grid.rows.len(),
+                        grid.columns[col].name
+                    ),
                     None => format!("copied {} rows", grid.rows.len()),
                 },
                 Err(e) => format!("copy failed: {e}"),
@@ -8919,12 +8935,14 @@ fn main() -> Result<(), slint::PlatformError> {
     }
     {
         let weak = window.as_weak();
-        window.on_p1_row_press(move |row, shift| {
+        window.on_p1_row_press(move |row, col, shift| {
             if let Some(w) = weak.upgrade() {
                 if !shift || w.get_p1_range_anchor_row() < 0 {
                     set_p_range_anchor(&w, 1, row);
+                    set_p_range_anchor_col(&w, 1, col);
                 }
                 set_p_selected_row(&w, 1, row);
+                w.set_p1_selected_col(col);
                 SELECTED_RANGE.with(|s| s.borrow_mut()[1] = None);
             }
         });
@@ -8935,9 +8953,16 @@ fn main() -> Result<(), slint::PlatformError> {
             if let Some(w) = weak.upgrade() {
                 set_p_selected_row(&w, 1, row);
                 let anchor = w.get_p1_range_anchor_row();
+                let anchor_col = w.get_p1_range_anchor_col();
                 SELECTED_RANGE.with(|s| {
-                    s.borrow_mut()[1] = (anchor >= 0 && anchor != row)
-                        .then(|| (anchor.min(row) as usize, anchor.max(row) as usize));
+                    s.borrow_mut()[1] =
+                        (anchor >= 0 && anchor != row && anchor_col >= 0).then(|| {
+                            (
+                                anchor.min(row) as usize,
+                                anchor.max(row) as usize,
+                                anchor_col as usize,
+                            )
+                        });
                 });
             }
         });
@@ -9226,9 +9251,12 @@ fn main() -> Result<(), slint::PlatformError> {
                 .and_then(|mut cb| cb.set_contents(export::to_tsv(&to_copy)))
             {
                 Ok(()) => match range {
-                    Some((start, end)) => {
-                        format!("copied {} of {} rows", end - start + 1, grid.rows.len())
-                    }
+                    Some((start, end, col)) => format!(
+                        "copied {} of {} rows, column {}",
+                        end - start + 1,
+                        grid.rows.len(),
+                        grid.columns[col].name
+                    ),
                     None => format!("copied {} rows", grid.rows.len()),
                 },
                 Err(e) => format!("copy failed: {e}"),
@@ -10796,12 +10824,14 @@ fn main() -> Result<(), slint::PlatformError> {
     }
     {
         let weak = window.as_weak();
-        window.on_row_press(move |row, shift| {
+        window.on_row_press(move |row, col, shift| {
             if let Some(w) = weak.upgrade() {
                 if !shift || w.get_range_anchor_row() < 0 {
                     set_p_range_anchor(&w, 0, row);
+                    set_p_range_anchor_col(&w, 0, col);
                 }
                 set_p_selected_row(&w, 0, row);
+                w.set_selected_col(col);
                 SELECTED_RANGE.with(|s| s.borrow_mut()[0] = None);
             }
         });
@@ -10812,9 +10842,16 @@ fn main() -> Result<(), slint::PlatformError> {
             if let Some(w) = weak.upgrade() {
                 set_p_selected_row(&w, 0, row);
                 let anchor = w.get_range_anchor_row();
+                let anchor_col = w.get_range_anchor_col();
                 SELECTED_RANGE.with(|s| {
-                    s.borrow_mut()[0] = (anchor >= 0 && anchor != row)
-                        .then(|| (anchor.min(row) as usize, anchor.max(row) as usize));
+                    s.borrow_mut()[0] =
+                        (anchor >= 0 && anchor != row && anchor_col >= 0).then(|| {
+                            (
+                                anchor.min(row) as usize,
+                                anchor.max(row) as usize,
+                                anchor_col as usize,
+                            )
+                        });
                 });
             }
         });

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2605,9 +2605,24 @@ fn restore_grid_state(w: &MainWindow, pane: usize, g: &GroupRuntime, sr: &Stored
     *g.displayed_grid.lock().unwrap() = view_grid(&filtered);
     apply_result(w, pane, filtered);
 }
+/// What activating (choose/double-click) a non-section palette row does.
+/// Index-aligned with the `Vec<PaletteItem>` `build_palette_items` returns —
+/// section header rows get `None`.
+#[derive(Debug, Clone)]
+enum PaletteAction {
+    None,
+    Connect(usize),
+    OpenTable(SharedString, SharedString),
+    OpenFunction(SharedString),
+    OpenSavedQuery(String, usize),
+    OpenRecent(usize),
+}
+
 /// Build the ⌘K palette model, grouped GitHub-style under non-selectable
 /// "section" header rows. `needle` (lowercase) filters both groups; empty
-/// shows everything. Empty groups drop their header.
+/// shows everything. Empty groups drop their header. Returns the flat item
+/// list alongside an index-aligned action list `on_palette_choose` dispatches
+/// on.
 fn build_palette_items(
     names: &[(
         String,
@@ -2618,8 +2633,10 @@ fn build_palette_items(
         slint::Color,
     )],
     w: &MainWindow,
+    saved_queries: &[(String, String)],
+    recent_queries: &[HistoryEntry],
     needle: &str,
-) -> Vec<PaletteItem> {
+) -> (Vec<PaletteItem>, Vec<PaletteAction>) {
     let section = |t: &str| PaletteItem {
         label: t.into(),
         kind: "section".into(),
@@ -2634,13 +2651,16 @@ fn build_palette_items(
         is_group_end: false,
     };
     let mut items: Vec<PaletteItem> = Vec::new();
+    let mut actions: Vec<PaletteAction> = Vec::new();
     let conns: Vec<_> = names
         .iter()
-        .filter(|(n, ..)| needle.is_empty() || n.to_lowercase().contains(needle))
+        .enumerate()
+        .filter(|(_, (n, ..))| needle.is_empty() || n.to_lowercase().contains(needle))
         .collect();
     if !conns.is_empty() {
         items.push(section("Connections"));
-        for (n, badge, color, has_custom_color, env_tag_label, env_tag_color) in conns {
+        actions.push(PaletteAction::None);
+        for (idx, (n, badge, color, has_custom_color, env_tag_label, env_tag_color)) in conns {
             items.push(PaletteItem {
                 label: n.clone().into(),
                 kind: (*badge).into(),
@@ -2654,21 +2674,26 @@ fn build_palette_items(
                 expanded: false,
                 is_group_end: false,
             });
+            actions.push(PaletteAction::Connect(idx));
         }
     }
-    let tables: Vec<SharedString> = w
-        .get_schema_tree()
-        .iter()
-        .filter(|n| {
-            n.kind == "table" && (needle.is_empty() || n.label.to_lowercase().contains(needle))
-        })
-        .map(|n| n.label.clone())
-        .collect();
+    let schema_tree = w.get_schema_tree();
+    let by_kind = |kind: &'static str| -> Vec<(SharedString, SharedString)> {
+        schema_tree
+            .iter()
+            .filter(|n| {
+                n.kind == kind && (needle.is_empty() || n.label.to_lowercase().contains(needle))
+            })
+            .map(|n| (n.db.clone(), n.label.clone()))
+            .collect()
+    };
+    let tables = by_kind("table");
     if !tables.is_empty() {
         items.push(section("Tables"));
-        for label in tables {
+        actions.push(PaletteAction::None);
+        for (db, label) in tables {
             items.push(PaletteItem {
-                label,
+                label: label.clone(),
                 kind: "table".into(),
                 sub: SharedString::default(),
                 local: false,
@@ -2680,9 +2705,102 @@ fn build_palette_items(
                 expanded: false,
                 is_group_end: false,
             });
+            actions.push(PaletteAction::OpenTable(db, label));
         }
     }
-    items
+    let views = by_kind("view");
+    if !views.is_empty() {
+        items.push(section("Views"));
+        actions.push(PaletteAction::None);
+        for (db, label) in views {
+            items.push(PaletteItem {
+                label: label.clone(),
+                kind: "view".into(),
+                sub: SharedString::default(),
+                local: false,
+                color: theme::accent_or_default(""),
+                has_custom_color: false,
+                env_tag_label: SharedString::default(),
+                env_tag_color: theme::accent_or_default(""),
+                group: SharedString::default(),
+                expanded: false,
+                is_group_end: false,
+            });
+            actions.push(PaletteAction::OpenTable(db, label));
+        }
+    }
+    let functions = by_kind("function");
+    if !functions.is_empty() {
+        items.push(section("Functions"));
+        actions.push(PaletteAction::None);
+        for (_db, label) in functions {
+            items.push(PaletteItem {
+                label: label.clone(),
+                kind: "function".into(),
+                sub: SharedString::default(),
+                local: false,
+                color: theme::accent_or_default(""),
+                has_custom_color: false,
+                env_tag_label: SharedString::default(),
+                env_tag_color: theme::accent_or_default(""),
+                group: SharedString::default(),
+                expanded: false,
+                is_group_end: false,
+            });
+            actions.push(PaletteAction::OpenFunction(label));
+        }
+    }
+    let saved: Vec<_> = saved_queries
+        .iter()
+        .enumerate()
+        .filter(|(_, (n, _))| needle.is_empty() || n.to_lowercase().contains(needle))
+        .collect();
+    if !saved.is_empty() {
+        items.push(section("Saved Queries"));
+        actions.push(PaletteAction::None);
+        for (idx, (name, sql)) in saved {
+            items.push(PaletteItem {
+                label: name.clone().into(),
+                kind: "command".into(),
+                sub: recent_preview(sql).into(),
+                local: false,
+                color: theme::accent_or_default(""),
+                has_custom_color: false,
+                env_tag_label: SharedString::default(),
+                env_tag_color: theme::accent_or_default(""),
+                group: SharedString::default(),
+                expanded: false,
+                is_group_end: false,
+            });
+            actions.push(PaletteAction::OpenSavedQuery(name.clone(), idx));
+        }
+    }
+    let recent: Vec<_> = recent_queries
+        .iter()
+        .enumerate()
+        .filter(|(_, e)| needle.is_empty() || e.sql.to_lowercase().contains(needle))
+        .collect();
+    if !recent.is_empty() {
+        items.push(section("Recent History"));
+        actions.push(PaletteAction::None);
+        for (idx, entry) in recent {
+            items.push(PaletteItem {
+                label: recent_preview(&entry.sql).into(),
+                kind: "command".into(),
+                sub: entry.engine.clone().unwrap_or_default().into(),
+                local: false,
+                color: theme::accent_or_default(""),
+                has_custom_color: false,
+                env_tag_label: SharedString::default(),
+                env_tag_color: theme::accent_or_default(""),
+                group: SharedString::default(),
+                expanded: false,
+                is_group_end: false,
+            });
+            actions.push(PaletteAction::OpenRecent(idx));
+        }
+    }
+    (items, actions)
 }
 fn set_p_editing(w: &MainWindow, pane: usize, row: i32, col: i32) {
     if pane == 0 {
@@ -3132,6 +3250,11 @@ thread_local! {
     /// then.
     static SELECTED_RANGE: std::cell::RefCell<[Option<(usize, usize)>; 2]> =
         std::cell::RefCell::new(Default::default());
+    /// What each row of the currently displayed ⌘K palette list does when
+    /// chosen, rebuilt alongside `palette_items` every open/filter — see
+    /// `build_palette_items`.
+    static PALETTE_ACTIONS: std::cell::RefCell<Vec<PaletteAction>> =
+        const { std::cell::RefCell::new(Vec::new()) };
 }
 
 /// Compute the visible JSON-tree rows for the current collapse state and push
@@ -11224,6 +11347,8 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let weak = window.as_weak();
         let store = store.clone();
+        let saved_queries = saved_queries.clone();
+        let recent_queries = recent_queries.clone();
         window.on_toggle_palette(move || {
             if let Some(w) = weak.upgrade() {
                 let opening = !w.get_palette_open();
@@ -11252,8 +11377,15 @@ fn main() -> Result<(), slint::PlatformError> {
                             )
                         })
                         .collect();
-                    let items = build_palette_items(&names, &w, "");
+                    let (items, actions) = build_palette_items(
+                        &names,
+                        &w,
+                        &saved_queries.borrow(),
+                        &recent_queries.borrow(),
+                        "",
+                    );
                     w.set_palette_items(ModelRc::from(Rc::new(VecModel::from(items))));
+                    PALETTE_ACTIONS.with(|s| *s.borrow_mut() = actions);
                 }
             }
         });
@@ -11263,6 +11395,8 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let weak = window.as_weak();
         let store = store.clone();
+        let saved_queries = saved_queries.clone();
+        let recent_queries = recent_queries.clone();
         window.on_palette_filter(move |q| {
             if let Some(w) = weak.upgrade() {
                 let names: Vec<(
@@ -11288,18 +11422,40 @@ fn main() -> Result<(), slint::PlatformError> {
                         )
                     })
                     .collect();
-                let items = build_palette_items(&names, &w, &q.to_lowercase());
+                let (items, actions) = build_palette_items(
+                    &names,
+                    &w,
+                    &saved_queries.borrow(),
+                    &recent_queries.borrow(),
+                    &q.to_lowercase(),
+                );
                 w.set_palette_items(ModelRc::from(Rc::new(VecModel::from(items))));
+                PALETTE_ACTIONS.with(|s| *s.borrow_mut() = actions);
             }
         });
     }
 
-    // ----- palette choose (MVP: just closes) -----
+    // ----- palette choose -----
     {
         let weak = window.as_weak();
-        window.on_palette_choose(move |_idx| {
+        window.on_palette_choose(move |idx| {
             if let Some(w) = weak.upgrade() {
                 w.set_palette_open(false);
+                let action = PALETTE_ACTIONS
+                    .with(|s| s.borrow().get(idx.max(0) as usize).cloned())
+                    .unwrap_or(PaletteAction::None);
+                match action {
+                    PaletteAction::None => {}
+                    PaletteAction::Connect(i) => w.invoke_connect_clicked(i as i32),
+                    PaletteAction::OpenTable(db, label) => w.invoke_open_table(db, label),
+                    PaletteAction::OpenFunction(name) => w.invoke_open_function(name),
+                    PaletteAction::OpenSavedQuery(name, idx) => {
+                        w.invoke_open_query(SharedString::from(name), idx as i32)
+                    }
+                    PaletteAction::OpenRecent(idx) => {
+                        w.invoke_open_query(SharedString::default(), idx as i32)
+                    }
+                }
             }
         });
     }

--- a/app/src/model.rs
+++ b/app/src/model.rs
@@ -360,10 +360,16 @@ fn dedupe_column_names(mut cols: Vec<VmColumn>) -> Vec<VmColumn> {
 /// "N rows affected" toast. `None` for anything else (SELECT, DDL, NoSQL
 /// commands) so the toast falls back to its plain form.
 pub fn sql_verb(sql: &str) -> Option<&'static str> {
-    let word = sql
-        .trim_start()
-        .split(|c: char| c.is_whitespace() || c == '(')
-        .next()?;
+    let mut s = sql;
+    loop {
+        s = s.trim_start();
+        if let Some(rest) = s.strip_prefix("--") {
+            s = rest.split_once('\n').map_or("", |(_, after)| after);
+            continue;
+        }
+        break;
+    }
+    let word = s.split(|c: char| c.is_whitespace() || c == '(').next()?;
     match word.to_ascii_uppercase().as_str() {
         "INSERT" => Some("INSERT"),
         "UPDATE" => Some("UPDATE"),
@@ -673,6 +679,14 @@ mod tests {
         assert_eq!(sql_verb("delete from t"), Some("DELETE"));
         assert_eq!(sql_verb("select * from t"), None);
         assert_eq!(sql_verb(""), None);
+        assert_eq!(
+            sql_verb("-- where taint = 'T11T';\n\nupdate t set x = 1"),
+            Some("UPDATE")
+        );
+        assert_eq!(
+            sql_verb("-- one\n-- two\n\n  delete from t"),
+            Some("DELETE")
+        );
     }
 
     #[test]

--- a/app/src/model.rs
+++ b/app/src/model.rs
@@ -356,6 +356,31 @@ fn dedupe_column_names(mut cols: Vec<VmColumn>) -> Vec<VmColumn> {
     cols
 }
 
+/// First keyword of a SQL statement (INSERT/UPDATE/DELETE), used to label the
+/// "N rows affected" toast. `None` for anything else (SELECT, DDL, NoSQL
+/// commands) so the toast falls back to its plain form.
+pub fn sql_verb(sql: &str) -> Option<&'static str> {
+    let word = sql
+        .trim_start()
+        .split(|c: char| c.is_whitespace() || c == '(')
+        .next()?;
+    match word.to_ascii_uppercase().as_str() {
+        "INSERT" => Some("INSERT"),
+        "UPDATE" => Some("UPDATE"),
+        "DELETE" => Some("DELETE"),
+        _ => None,
+    }
+}
+
+/// Enrich a bare "N rows affected" status with the statement verb and query
+/// latency, e.g. `"UPDATE — 3 rows affected · 12 ms"`.
+pub fn format_affected(status: &str, verb: Option<&str>, latency: &str) -> String {
+    match verb {
+        Some(verb) => format!("{verb} — {status} · {latency}"),
+        None => format!("{status} · {latency}"),
+    }
+}
+
 /// Convert any ResultSet into its presentation-ready view. Each variant keeps
 /// its own shape instead of collapsing to a single grid.
 pub fn to_result_view(rs: &ResultSet) -> ResultView {
@@ -639,6 +664,27 @@ mod tests {
             ResultView::Affected(s) => assert_eq!(s, "3 rows affected"),
             other => panic!("expected Affected, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn sql_verb_detects_mutations() {
+        assert_eq!(sql_verb("  update t set x = 1"), Some("UPDATE"));
+        assert_eq!(sql_verb("INSERT INTO t VALUES (1)"), Some("INSERT"));
+        assert_eq!(sql_verb("delete from t"), Some("DELETE"));
+        assert_eq!(sql_verb("select * from t"), None);
+        assert_eq!(sql_verb(""), None);
+    }
+
+    #[test]
+    fn format_affected_includes_verb_and_latency() {
+        assert_eq!(
+            format_affected("3 rows affected", Some("UPDATE"), "12 ms"),
+            "UPDATE — 3 rows affected · 12 ms"
+        );
+        assert_eq!(
+            format_affected("3 rows affected", None, "12 ms"),
+            "3 rows affected · 12 ms"
+        );
     }
 
     #[test]

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -295,6 +295,9 @@ callback create-table-commit();
     in property <string> result-status;
     in-out property <int> selected-row: 0;
     in-out property <int> selected-col: -1;
+    in-out property <int> range-anchor-row: -1;
+    callback row-press(int, bool);
+    callback row-drag(int);
     in property <int> editing-row: -1;
     in property <int> editing-col: -1;
     in-out property <string> editing-value;
@@ -489,6 +492,9 @@ callback create-table-commit();
     in property <[string]> p1-grid-col-filters;
     in-out property <int> p1-selected-row;
     in-out property <int> p1-selected-col: -1;
+    in-out property <int> p1-range-anchor-row: -1;
+    callback p1-row-press(int, bool);
+    callback p1-row-drag(int);
     in property <int> p1-editing-row: -1;
     in property <int> p1-editing-col: -1;
     in-out property <string> p1-editing-value;
@@ -1621,6 +1627,9 @@ callback create-table-commit();
                         p1-detail-pretty: root.p1-detail-pretty;
                         p1-selected-row <=> root.p1-selected-row;
                         p1-selected-col <=> root.p1-selected-col;
+                        p1-range-anchor-row <=> root.p1-range-anchor-row;
+                        p1-row-press(r, shift) => { root.p1-row-press(r, shift); }
+                        p1-row-drag(r) => { root.p1-row-drag(r); }
                         p1-editing-row: root.p1-editing-row;
                         p1-editing-col: root.p1-editing-col;
                         p1-editing-value <=> root.p1-editing-value;
@@ -1755,6 +1764,9 @@ callback create-table-commit();
                         find-close() => { root.find-close(); }
                         selected-row: root.selected-row;
                         selected-col: root.selected-col;
+                        range-anchor-row: root.range-anchor-row;
+                        row-press(r, shift) => { root.row-press(r, shift); }
+                        row-drag(r) => { root.row-drag(r); }
                         editing-row: root.editing-row;
                         editing-col: root.editing-col;
                         editing-value <=> root.editing-value;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -296,7 +296,8 @@ callback create-table-commit();
     in-out property <int> selected-row: 0;
     in-out property <int> selected-col: -1;
     in-out property <int> range-anchor-row: -1;
-    callback row-press(int, bool);
+    in-out property <int> range-anchor-col: -1;
+    callback row-press(int, int, bool);
     callback row-drag(int);
     in property <int> editing-row: -1;
     in property <int> editing-col: -1;
@@ -493,7 +494,8 @@ callback create-table-commit();
     in-out property <int> p1-selected-row;
     in-out property <int> p1-selected-col: -1;
     in-out property <int> p1-range-anchor-row: -1;
-    callback p1-row-press(int, bool);
+    in-out property <int> p1-range-anchor-col: -1;
+    callback p1-row-press(int, int, bool);
     callback p1-row-drag(int);
     in property <int> p1-editing-row: -1;
     in property <int> p1-editing-col: -1;
@@ -1638,7 +1640,8 @@ callback create-table-commit();
                         p1-selected-row <=> root.p1-selected-row;
                         p1-selected-col <=> root.p1-selected-col;
                         p1-range-anchor-row <=> root.p1-range-anchor-row;
-                        p1-row-press(r, shift) => { root.p1-row-press(r, shift); }
+                        p1-range-anchor-col <=> root.p1-range-anchor-col;
+                        p1-row-press(r, c, shift) => { root.p1-row-press(r, c, shift); }
                         p1-row-drag(r) => { root.p1-row-drag(r); }
                         p1-editing-row: root.p1-editing-row;
                         p1-editing-col: root.p1-editing-col;
@@ -1775,7 +1778,8 @@ callback create-table-commit();
                         selected-row: root.selected-row;
                         selected-col: root.selected-col;
                         range-anchor-row: root.range-anchor-row;
-                        row-press(r, shift) => { root.row-press(r, shift); }
+                        range-anchor-col: root.range-anchor-col;
+                        row-press(r, c, shift) => { root.row-press(r, c, shift); }
                         row-drag(r) => { root.row-drag(r); }
                         editing-row: root.editing-row;
                         editing-col: root.editing-col;

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -792,6 +792,10 @@ callback create-table-commit();
                     if (root.active-pane == 1) { root.select-p1-tab(8); } else { root.select-tab(8); }
                     return accept;
                 }
+                if (e.text == "c") {
+                    if (root.active-pane == 1) { root.p1-copy-results(); } else { root.copy-results(); }
+                    return accept;
+                }
             }
             // Plain j/k (vim-style row nav) vs Cmd/Ctrl+K (palette) don't
             // collide: every branch in the ctrl/meta block above returns

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -793,6 +793,12 @@ callback create-table-commit();
                     return accept;
                 }
             }
+            // Plain j/k (vim-style row nav) vs Cmd/Ctrl+K (palette) don't
+            // collide: every branch in the ctrl/meta block above returns
+            // accept, so ⌘K is consumed before falling through here. Keep
+            // that early-return-before-fallthrough order if this handler
+            // grows — reordering the two blocks would make ⌘K also move
+            // the row selection.
             if (e.text == "j") {
                 root.move-row(1);
                 return accept;

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -107,6 +107,7 @@ export component QueryPane inherits Rectangle {
     in property <[string]> detail-pretty;
     in-out property <int> selected-row: 0;
     in-out property <int> selected-col: -1;
+    in property <int> range-anchor-row: -1;
     in property <int> editing-row: -1;
     in property <int> editing-col: -1;
     in-out property <string> editing-value;
@@ -119,6 +120,8 @@ export component QueryPane inherits Rectangle {
     callback set-col-filter(int, string);
     callback resize-col(int, length);
     callback select-cell(int, int);
+    callback row-press(int, bool);
+    callback row-drag(int);
     callback edit-cell(int, int);
     callback cell-edited(int, int, string);
     callback cell-advance(int, int, string, bool);
@@ -754,11 +757,14 @@ export component QueryPane inherits Rectangle {
                 set-col-filter(i, t) => { root.set-col-filter(i, t); }
                 selected-row <=> root.selected-row;
                 selected-col <=> root.selected-col;
+                range-anchor-row: root.range-anchor-row;
                 editing-row: root.editing-row;
                 editing-col: root.editing-col;
                 editing-value <=> root.editing-value;
                 resize-col(i, d) => { root.resize-col(i, d); }
                 select-cell(r, c) => { root.select-cell(r, c); }
+                row-press(r, shift) => { root.row-press(r, shift); }
+                row-drag(r) => { root.row-drag(r); }
                 edit-cell(r, c) => { root.edit-cell(r, c); }
                 cell-edited(r, c, t) => { root.cell-edited(r, c, t); }
                 cell-advance(r, c, t, fwd) => { root.cell-advance(r, c, t, fwd); }

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -765,6 +765,7 @@ export component QueryPane inherits Rectangle {
                 select-cell(r, c) => { root.select-cell(r, c); }
                 row-press(r, shift) => { root.row-press(r, shift); }
                 row-drag(r) => { root.row-drag(r); }
+                copy-request() => { root.copy-results(); }
                 edit-cell(r, c) => { root.edit-cell(r, c); }
                 cell-edited(r, c, t) => { root.cell-edited(r, c, t); }
                 cell-advance(r, c, t, fwd) => { root.cell-advance(r, c, t, fwd); }

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -108,6 +108,7 @@ export component QueryPane inherits Rectangle {
     in-out property <int> selected-row: 0;
     in-out property <int> selected-col: -1;
     in property <int> range-anchor-row: -1;
+    in property <int> range-anchor-col: -1;
     in property <int> editing-row: -1;
     in property <int> editing-col: -1;
     in-out property <string> editing-value;
@@ -120,7 +121,7 @@ export component QueryPane inherits Rectangle {
     callback set-col-filter(int, string);
     callback resize-col(int, length);
     callback select-cell(int, int);
-    callback row-press(int, bool);
+    callback row-press(int, int, bool);
     callback row-drag(int);
     callback edit-cell(int, int);
     callback cell-edited(int, int, string);
@@ -758,12 +759,13 @@ export component QueryPane inherits Rectangle {
                 selected-row <=> root.selected-row;
                 selected-col <=> root.selected-col;
                 range-anchor-row: root.range-anchor-row;
+                range-anchor-col: root.range-anchor-col;
                 editing-row: root.editing-row;
                 editing-col: root.editing-col;
                 editing-value <=> root.editing-value;
                 resize-col(i, d) => { root.resize-col(i, d); }
                 select-cell(r, c) => { root.select-cell(r, c); }
-                row-press(r, shift) => { root.row-press(r, shift); }
+                row-press(r, c, shift) => { root.row-press(r, c, shift); }
                 row-drag(r) => { root.row-drag(r); }
                 copy-request() => { root.copy-results(); }
                 edit-cell(r, c) => { root.edit-cell(r, c); }

--- a/app/src/ui/tabular-grid.slint
+++ b/app/src/ui/tabular-grid.slint
@@ -23,6 +23,12 @@ export component TabularGrid inherits Rectangle {
     callback set-col-filter(int, string);   // (display col, raw filter text)
     in-out property <int> selected-row: 0;
     in-out property <int> selected-col: -1;
+    // Row where the current drag/shift-click range started, -1 = no range
+    // active. Rust owns the value (mirrors selected-row); a range is drawn
+    // whenever this differs from selected-row.
+    in property <int> range-anchor-row: -1;
+    callback row-press(int, bool);          // (row, shift-held) → mouse/touch down on a cell
+    callback row-drag(int);                 // row currently under the pointer while dragging
     // inline edit overlay: row/col currently being edited, -1 = none
     in property <int> editing-row: -1;
     in property <int> editing-col: -1;
@@ -223,9 +229,13 @@ export component TabularGrid inherits Rectangle {
             height: Tokens.grid-row-h;
             property <bool> row-deleted: root.cells[r * root.col-count].state == 2;
             property <bool> row-inserted: root.cells[r * root.col-count].state == 3;
+            property <bool> in-range: root.range-anchor-row >= 0
+                && r >= min(root.range-anchor-row, root.selected-row)
+                && r <= max(root.range-anchor-row, root.selected-row);
             background: row-deleted ? Tokens.error-tint
                 : row-inserted ? Tokens.ok-tint
                 : r == root.selected-row ? Tokens.accent-tint.with-alpha(0.55)
+                : in-range ? Tokens.accent-tint.with-alpha(0.3)
                 : row-ta.has-hover ? Tokens.chrome.with-alpha(0.6)
                 : transparent;
             // Empty: the Flickables own the wheel now; this only tracks hover.
@@ -258,10 +268,27 @@ export component TabularGrid inherits Rectangle {
                     clip: !(r == root.editing-row && c == root.editing-col);
                     background: transparent;
                     cell-ta := TouchArea {
+                        // Row under the pointer, even once the drag has moved past
+                        // this cell's own row bounds (mouse-y then falls outside
+                        // 0..grid-row-h) — same idea as the header drag/resize math
+                        // above, just row-indexed instead of pixel-indexed.
+                        property <int> drag-row: clamp(
+                            r + floor(self.mouse-y / Tokens.grid-row-h),
+                            0, root.row-count - 1);
                         clicked => { root.select-cell(r, c); }
                         // Stash the value so the read-only inspector card can show
                         // it directly (editable grids reopen the inline overlay).
                         double-clicked => { root.editing-value = cell.text; root.edit-cell(r, c); }
+                        pointer-event(e) => {
+                            if (e.kind == PointerEventKind.down) {
+                                root.row-press(r, e.modifiers.shift);
+                            }
+                        }
+                        moved => {
+                            if (self.pressed) {
+                                root.row-drag(self.drag-row);
+                            }
+                        }
                     }
                     if !is-bar: Text {
                         vertical-alignment: center;

--- a/app/src/ui/tabular-grid.slint
+++ b/app/src/ui/tabular-grid.slint
@@ -23,11 +23,15 @@ export component TabularGrid inherits Rectangle {
     callback set-col-filter(int, string);   // (display col, raw filter text)
     in-out property <int> selected-row: 0;
     in-out property <int> selected-col: -1;
-    // Row where the current drag/shift-click range started, -1 = no range
-    // active. Rust owns the value (mirrors selected-row); a range is drawn
-    // whenever this differs from selected-row.
+    // Row/col where the current drag/shift-click range started, -1 = no
+    // range active. Rust owns both (mirrors selected-row); a range is drawn
+    // whenever range-anchor-row differs from selected-row. The column is
+    // fixed at press time and never updated during drag — range copy is
+    // scoped to that one column, not a full row×col rectangle (dragging
+    // into another column visually doesn't widen the copied range).
     in property <int> range-anchor-row: -1;
-    callback row-press(int, bool);          // (row, shift-held) → mouse/touch down on a cell
+    in property <int> range-anchor-col: -1;
+    callback row-press(int, int, bool);     // (row, col, shift-held) → mouse/touch down on a cell
     callback row-drag(int);                 // row currently under the pointer while dragging
     // inline edit overlay: row/col currently being edited, -1 = none
     in property <int> editing-row: -1;
@@ -242,13 +246,9 @@ export component TabularGrid inherits Rectangle {
             height: Tokens.grid-row-h;
             property <bool> row-deleted: root.cells[r * root.col-count].state == 2;
             property <bool> row-inserted: root.cells[r * root.col-count].state == 3;
-            property <bool> in-range: root.range-anchor-row >= 0
-                && r >= min(root.range-anchor-row, root.selected-row)
-                && r <= max(root.range-anchor-row, root.selected-row);
             background: row-deleted ? Tokens.error-tint
                 : row-inserted ? Tokens.ok-tint
                 : r == root.selected-row ? Tokens.accent-tint.with-alpha(0.55)
-                : in-range ? Tokens.accent-tint.with-alpha(0.3)
                 : row-ta.has-hover ? Tokens.chrome.with-alpha(0.6)
                 : transparent;
             // Empty: the Flickables own the wheel now; this only tracks hover.
@@ -277,9 +277,17 @@ export component TabularGrid inherits Rectangle {
                     property <bool> is-num: root.columns[c].type-name == "int4"
                         || root.columns[c].type-name == "int8"
                         || root.columns[c].type-name == "numeric";
+                    // Range copy is scoped to the anchor column only (see
+                    // range-anchor-col doc comment), so the tint highlights
+                    // just that column's cells across the row range, not the
+                    // whole row.
+                    property <bool> in-range: root.range-anchor-col >= 0
+                        && c == root.range-anchor-col
+                        && r >= min(root.range-anchor-row, root.selected-row)
+                        && r <= max(root.range-anchor-row, root.selected-row);
                     width: root.col-widths.length > c ? root.col-widths[c] : 140px;
                     clip: !(r == root.editing-row && c == root.editing-col);
-                    background: transparent;
+                    background: in-range ? Tokens.accent-tint.with-alpha(0.3) : transparent;
                     cell-ta := TouchArea {
                         // Row under the pointer, even once the drag has moved past
                         // this cell's own row bounds (mouse-y then falls outside
@@ -295,7 +303,7 @@ export component TabularGrid inherits Rectangle {
                         pointer-event(e) => {
                             if (e.kind == PointerEventKind.down) {
                                 grid-focus.focus();
-                                root.row-press(r, e.modifiers.shift);
+                                root.row-press(r, c, e.modifiers.shift);
                             }
                         }
                         moved => {

--- a/app/src/ui/tabular-grid.slint
+++ b/app/src/ui/tabular-grid.slint
@@ -39,6 +39,7 @@ export component TabularGrid inherits Rectangle {
     callback cell-edited(int, int, string); // Enter in the inline editor
     callback cell-advance(int, int, string, bool); // Tab/Shift+Tab → commit + edit neighbour
     callback edit-cancelled();
+    callback copy-request();               // Cmd/Ctrl+C while the grid has focus
     in property <int> scroll-grid-tick;
     property <int> date-row: -1;
     property <int> date-col: -1;
@@ -65,6 +66,18 @@ export component TabularGrid inherits Rectangle {
         flick.viewport-y = min(0px, flick.height - flick.viewport-height);
     }
 
+    // Claims keyboard focus on any row/cell interaction (see cell-ta below) so
+    // Cmd/Ctrl+C copies the grid's row-range selection instead of whatever
+    // the SQL editor last had focused — the editor's own FocusScope never
+    // releases focus on its own, so the grid has to explicitly take it back.
+    grid-focus := FocusScope {
+        key-pressed(e) => {
+            if ((e.modifiers.control || e.modifiers.meta) && e.text == "c") {
+                root.copy-request();
+                return accept;
+            }
+            return reject;
+        }
     // One two-axis Flickable scrolls both ways (trackpad smooth on both), and
     // rows are manually windowed — only the on-screen slice exists — so it stays
     // light on large results. The header sits above and pans with viewport-x.
@@ -281,6 +294,7 @@ export component TabularGrid inherits Rectangle {
                         double-clicked => { root.editing-value = cell.text; root.edit-cell(r, c); }
                         pointer-event(e) => {
                             if (e.kind == PointerEventKind.down) {
+                                grid-focus.focus();
                                 root.row-press(r, e.modifiers.shift);
                             }
                         }
@@ -522,6 +536,7 @@ export component TabularGrid inherits Rectangle {
                 }
             }
         }
+    }
     }
 
     date-picker := DatePickerPopup {

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -51,6 +51,9 @@ export component WorkArea inherits Rectangle {
     in property <string> conn-status;
     in-out property <int> selected-row: 0;
     in-out property <int> selected-col: -1;
+    in property <int> range-anchor-row: -1;
+    callback row-press(int, bool);
+    callback row-drag(int);
     in property <int> editing-row: -1;
     in property <int> editing-col: -1;
     in-out property <bool> show-structure: false;
@@ -177,6 +180,9 @@ export component WorkArea inherits Rectangle {
     in property <[string]> p1-detail-pretty;
     in-out property <int> p1-selected-row;
     in-out property <int> p1-selected-col: -1;
+    in property <int> p1-range-anchor-row: -1;
+    callback p1-row-press(int, bool);
+    callback p1-row-drag(int);
     in property <int> p1-editing-row: -1;
     in property <int> p1-editing-col: -1;
     in-out property <string> p1-editing-value;
@@ -448,6 +454,7 @@ export component WorkArea inherits Rectangle {
             detail-pretty: root.grid-detail-pretty;
             selected-row <=> root.selected-row;
             selected-col <=> root.selected-col;
+            range-anchor-row: root.range-anchor-row;
             editing-row: root.editing-row;
             editing-col: root.editing-col;
             editing-value <=> root.editing-value;
@@ -457,6 +464,8 @@ export component WorkArea inherits Rectangle {
             set-col-filter(i, t) => { root.set-col-filter(i, t); }
             resize-col(i, d) => { root.resize-col(i, d); }
             select-cell(r, c) => { root.select-cell(r, c); }
+            row-press(r, shift) => { root.row-press(r, shift); }
+            row-drag(r) => { root.row-drag(r); }
             edit-cell(r, c) => { root.edit-cell(r, c); }
             cell-edited(r, c, t) => { root.cell-edited(r, c, t); }
             cell-advance(r, c, t, fwd) => { root.cell-advance(r, c, t, fwd); }
@@ -581,6 +590,7 @@ export component WorkArea inherits Rectangle {
                 detail-pretty: root.p1-detail-pretty;
                 selected-row <=> root.p1-selected-row;
                 selected-col <=> root.p1-selected-col;
+                range-anchor-row: root.p1-range-anchor-row;
                 editing-row: root.p1-editing-row;
                 editing-col: root.p1-editing-col;
                 editing-value <=> root.p1-editing-value;
@@ -590,6 +600,8 @@ export component WorkArea inherits Rectangle {
                 set-col-filter(i, t) => { root.p1-set-col-filter(i, t); }
                 resize-col(i, d) => { root.p1-resize-col(i, d); }
                 select-cell(r, c) => { root.p1-select-cell(r, c); }
+                row-press(r, shift) => { root.p1-row-press(r, shift); }
+                row-drag(r) => { root.p1-row-drag(r); }
                 edit-cell(r, c) => { root.p1-edit-cell(r, c); }
                 cell-edited(r, c, t) => { root.p1-cell-edited(r, c, t); }
                 cell-advance(r, c, t, fwd) => { root.p1-cell-advance(r, c, t, fwd); }

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -52,7 +52,8 @@ export component WorkArea inherits Rectangle {
     in-out property <int> selected-row: 0;
     in-out property <int> selected-col: -1;
     in property <int> range-anchor-row: -1;
-    callback row-press(int, bool);
+    in property <int> range-anchor-col: -1;
+    callback row-press(int, int, bool);
     callback row-drag(int);
     in property <int> editing-row: -1;
     in property <int> editing-col: -1;
@@ -181,7 +182,8 @@ export component WorkArea inherits Rectangle {
     in-out property <int> p1-selected-row;
     in-out property <int> p1-selected-col: -1;
     in property <int> p1-range-anchor-row: -1;
-    callback p1-row-press(int, bool);
+    in property <int> p1-range-anchor-col: -1;
+    callback p1-row-press(int, int, bool);
     callback p1-row-drag(int);
     in property <int> p1-editing-row: -1;
     in property <int> p1-editing-col: -1;
@@ -455,6 +457,7 @@ export component WorkArea inherits Rectangle {
             selected-row <=> root.selected-row;
             selected-col <=> root.selected-col;
             range-anchor-row: root.range-anchor-row;
+            range-anchor-col: root.range-anchor-col;
             editing-row: root.editing-row;
             editing-col: root.editing-col;
             editing-value <=> root.editing-value;
@@ -464,7 +467,7 @@ export component WorkArea inherits Rectangle {
             set-col-filter(i, t) => { root.set-col-filter(i, t); }
             resize-col(i, d) => { root.resize-col(i, d); }
             select-cell(r, c) => { root.select-cell(r, c); }
-            row-press(r, shift) => { root.row-press(r, shift); }
+            row-press(r, c, shift) => { root.row-press(r, c, shift); }
             row-drag(r) => { root.row-drag(r); }
             edit-cell(r, c) => { root.edit-cell(r, c); }
             cell-edited(r, c, t) => { root.cell-edited(r, c, t); }
@@ -591,6 +594,7 @@ export component WorkArea inherits Rectangle {
                 selected-row <=> root.p1-selected-row;
                 selected-col <=> root.p1-selected-col;
                 range-anchor-row: root.p1-range-anchor-row;
+                range-anchor-col: root.p1-range-anchor-col;
                 editing-row: root.p1-editing-row;
                 editing-col: root.p1-editing-col;
                 editing-value <=> root.p1-editing-value;
@@ -600,7 +604,7 @@ export component WorkArea inherits Rectangle {
                 set-col-filter(i, t) => { root.p1-set-col-filter(i, t); }
                 resize-col(i, d) => { root.p1-resize-col(i, d); }
                 select-cell(r, c) => { root.p1-select-cell(r, c); }
-                row-press(r, shift) => { root.p1-row-press(r, shift); }
+                row-press(r, c, shift) => { root.p1-row-press(r, c, shift); }
                 row-drag(r) => { root.p1-row-drag(r); }
                 edit-cell(r, c) => { root.p1-edit-cell(r, c); }
                 cell-edited(r, c, t) => { root.p1-cell-edited(r, c, t); }


### PR DESCRIPTION
## Summary
- Mutation query results now show the statement verb and latency alongside the row count (e.g. `UPDATE — 3 rows affected · 12 ms`) instead of a bare row count.
- The results grid supports drag/shift-click row selection with column-scoped copy, and Cmd+C now works for it regardless of which pane last had keyboard focus.
- The ⌘K palette is a real global search now — Connections, Tables, Views, Functions, Saved Queries, and Recent History, with each result actually navigating instead of just closing the modal.
- Two safety/correctness fixes surfaced during manual testing: Run could silently execute an unselected statement elsewhere in the buffer under a rare cursor-desync condition, and the query console showed unrelated commented-out lines glued onto the statement that actually ran.

## Changes
- **Rows-affected toast**: `sql_verb()` detects the statement verb (including past leading `--` comments) and merges it with the already-computed latency into the toast text.
- **Grid range select + copy**: drag or shift-click a row range in one column; the highlight and Cmd+C/Copy button both scope to that column across the selected rows. The grid now claims keyboard focus on interaction so Cmd+C follows whichever area (editor or grid) was last used.
- **Global search palette**: `build_palette_items` adds Views, Functions, Saved Queries, and Recent History sections; choosing an item now opens/navigates to it by reusing the existing open-table/open-function/open-query/connect handlers.
- **Editor safety fix**: `EditorState::statement_bounds()` no longer falls back to "the last statement in the buffer" when the cursor/segment match misses — it falls back to the current line instead, so a desync can no longer cause Run to execute an unrelated (possibly destructive) statement.
- **Query console fix**: leading `-- comment` blocks glued onto a statement by the segment scan are trimmed from what `current_statement()` returns, so the console and the driver only see the statement that was actually meant to run. (A comment in the *middle* of an already-open statement is still shown as-is — it's genuinely part of that one statement, not a separate boundary to trim.)
- `chore`: synced a stale `Cargo.lock` version entry, split into its own commit.

## Test plan
- [x] `cargo build -p rdb`
- [x] `cargo test -p rdb model::` (20 passed)
- [x] `cargo test -p rdb editor::` (44 passed)
- [x] `cargo clippy -p rdb -- -D warnings` clean on every commit
- [x] Manual: run an UPDATE preceded by a comment line, confirm the toast shows verb + latency
- [x] Manual: drag-select rows within one column, confirm the highlight and Cmd+C/Copy only cover that column
- [x] Manual: run "current statement" with a leading commented-out statement above it, confirm only the intended statement runs and shows in the console
- [x] Manual: ⌘K palette shows and navigates Views/Functions/Saved Queries/Recent History