### PR TITLE
feat(app): nested connection groups, tab/sidebar polish, tab-collision fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "rdb"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5618,6 +5618,7 @@ dependencies = [
  "serde_json",
  "slint",
  "slint-build",
+ "tempfile",
  "tokio",
  "ureq",
 ]

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -55,3 +55,6 @@ objc2-foundation = { version = "0.3.2", default-features = false, features = ["s
 
 [build-dependencies]
 slint-build = "1.8"
+
+[dev-dependencies]
+tempfile = "3"

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -196,82 +196,256 @@ fn existing_groups(store: &rdb_connstore::ConnStore) -> Vec<String> {
     groups
 }
 
-/// Options for the New/Edit dialog's Group dropdown: "None" + every
-/// distinct group already in use + a trailing "create new" entry.
+/// Distinct top-level group names (the first path segment of every entry
+/// `existing_groups` returns), sorted.
+fn top_level_groups(store: &rdb_connstore::ConnStore) -> Vec<String> {
+    let mut tops: Vec<String> = existing_groups(store)
+        .iter()
+        .map(|g| g.split('/').next().unwrap_or(g).to_string())
+        .collect();
+    tops.sort();
+    tops.dedup();
+    tops
+}
+
+/// Options for the New/Edit dialog's top-level Group dropdown: "None" +
+/// every distinct top-level group already in use + a trailing "create new"
+/// entry. Nesting under a chosen group is a separate Subgroup dropdown, see
+/// `subgroup_picker_options`.
 fn group_picker_options(store: &rdb_connstore::ConnStore) -> Vec<String> {
     let mut opts = vec!["None".to_string()];
-    opts.extend(existing_groups(store));
+    opts.extend(top_level_groups(store));
     opts.push("+ New group…".to_string());
     opts
 }
 
-/// Build the grouped sidebar row model: a header row per group followed by its
-/// connection rows (unless the group is collapsed). `index` on each connection
-/// row is its position in the store list, so connect/edit callbacks stay correct
-/// regardless of grouping or ordering. `collapsed` holds the set of group labels
-/// currently folded shut.
-fn build_conn_items(
-    store: &rdb_connstore::ConnStore,
-    collapsed: &HashSet<String>,
-    filter: &str,
-) -> Vec<ConnItem> {
-    let needle = filter.trim().to_lowercase();
-    // Bucket store indices by group label, preserving first-seen group order.
-    let mut order: Vec<String> = Vec::new();
-    let mut buckets: std::collections::HashMap<String, Vec<usize>> =
-        std::collections::HashMap::new();
-    for (i, sc) in store.list().iter().enumerate() {
-        if !needle.is_empty() && !sc.name.to_lowercase().contains(&needle) {
-            continue;
-        }
-        let g = sc
-            .group
-            .as_deref()
-            .filter(|s| !s.trim().is_empty())
-            .unwrap_or(UNGROUPED)
-            .to_string();
-        if !buckets.contains_key(&g) {
-            order.push(g.clone());
-        }
-        buckets.entry(g).or_default().push(i);
+/// Options for the Subgroup dropdown once `parent` is picked as the top
+/// group: "None" + every direct child of `parent` already in use (by leaf
+/// name) + a trailing "create new" entry. Grandchildren (anything nested
+/// two or more levels under `parent`) are not listed here — the guided
+/// picker is two levels deep; deeper nesting still works by typing a
+/// `/`-containing name into the "create new" free-text field.
+fn subgroup_picker_options(store: &rdb_connstore::ConnStore, parent: &str) -> Vec<String> {
+    let mut leaves: Vec<String> = existing_groups(store)
+        .iter()
+        .filter(|g| rdb_connstore::group_parent(g) == Some(parent))
+        .map(|g| rdb_connstore::group_leaf(g).to_string())
+        .collect();
+    leaves.sort();
+    leaves.dedup();
+    let mut opts = vec!["None".to_string()];
+    opts.extend(leaves);
+    opts.push("+ New subgroup…".to_string());
+    opts
+}
+
+/// Where a connection/subfolder currently at `sc_group` (a descendant of
+/// `deleted`, itself included) lands once `deleted` is removed: a direct
+/// member promotes to `deleted`'s parent (`None` if `deleted` was
+/// top-level); a deeper descendant has `deleted`'s own segment spliced out
+/// and is reparented one level up, same as a file manager deleting a folder.
+fn cascade_delete_group(deleted: &str, sc_group: &str) -> Option<String> {
+    if sc_group == deleted {
+        return rdb_connstore::group_parent(deleted).map(str::to_string);
+    }
+    let suffix = &sc_group[deleted.len() + 1..]; // past "deleted/"
+    Some(match rdb_connstore::group_parent(deleted) {
+        Some(parent) => format!("{parent}/{suffix}"),
+        None => suffix.to_string(),
+    })
+}
+
+/// Where a connection/subfolder currently at `sc_group` (a descendant of
+/// `old`, itself included) lands once `old` is renamed to `new`: the `old`
+/// prefix is swapped for `new`, keeping whatever nested suffix followed it.
+fn cascade_rename_group(old: &str, new: &str, sc_group: &str) -> String {
+    if sc_group == old {
+        new.to_string()
+    } else {
+        format!("{new}{}", &sc_group[old.len()..]) // keeps the "/suffix" tail
+    }
+}
+
+#[cfg(test)]
+mod group_cascade_tests {
+    use super::*;
+
+    #[test]
+    fn delete_direct_member_promotes_to_parent() {
+        assert_eq!(cascade_delete_group("OSS", "OSS"), None);
+        assert_eq!(
+            cascade_delete_group("OSS/Production", "OSS/Production"),
+            Some("OSS".to_string())
+        );
     }
 
-    let mut rows: Vec<ConnItem> = Vec::new();
-    for g in &order {
-        // Ungrouped connections list flat (no header) when they are the only
-        // bucket; once real groups exist they get their own UNGROUPED header.
-        let is_ungrouped = g == UNGROUPED && order.len() == 1;
-        let expanded = is_ungrouped || !collapsed.contains(g);
-        if !is_ungrouped {
-            rows.push(ConnItem {
-                id: SharedString::default(),
-                name: g.to_uppercase().into(),
-                engine: SharedString::default(),
-                color: theme::accent_or_default(""),
-                has_custom_color: false,
-                is_header: true,
-                expanded,
-                index: -1,
-                group: g.clone().into(),
-                subline: SharedString::default(),
-                local: false,
-                count: buckets[g].len() as i32,
-                favorite: false,
-                env_tag_label: SharedString::default(),
-                env_tag_color: theme::accent_or_default(""),
-                is_group_end: false,
-            });
+    #[test]
+    fn delete_descendant_splices_out_the_deleted_segment() {
+        assert_eq!(
+            cascade_delete_group("OSS/Production", "OSS/Production/DB"),
+            Some("OSS/DB".to_string())
+        );
+        assert_eq!(
+            cascade_delete_group("OSS", "OSS/Production/DB"),
+            Some("Production/DB".to_string())
+        );
+    }
+
+    #[test]
+    fn rename_direct_member_and_descendant_suffix() {
+        assert_eq!(
+            cascade_rename_group("OSS", "OSS-Legacy", "OSS"),
+            "OSS-Legacy"
+        );
+        assert_eq!(
+            cascade_rename_group("OSS", "OSS-Legacy", "OSS/Production"),
+            "OSS-Legacy/Production"
+        );
+        assert_eq!(
+            cascade_rename_group("OSS/Production", "OSS/Prod", "OSS/Production/DB"),
+            "OSS/Prod/DB"
+        );
+    }
+}
+
+#[cfg(test)]
+mod build_conn_items_tests {
+    use super::*;
+    use rdb_connstore::{ConnStore, EncryptedFileBackend, Engine, SavedConnection};
+
+    /// A throwaway `ConnStore` backed by a temp dir, seeded with connections
+    /// at the given group paths (`None` = ungrouped). Never touches the real
+    /// platform config dir.
+    fn store_with_groups(groups: &[Option<&str>]) -> (tempfile::TempDir, ConnStore) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let backend = EncryptedFileBackend::new(dir.path()).expect("file secret backend");
+        let mut store = ConnStore::new(dir.path().join("connections.json"), Box::new(backend));
+        for (i, g) in groups.iter().enumerate() {
+            let mut sc = SavedConnection::new(format!("conn{i}"), Engine::Postgres, "h", 5432, "u");
+            sc.group = g.map(str::to_string);
+            store.add(sc).expect("add");
         }
-        if !expanded {
-            // Collapsed: the header is the only (and thus last) visible row.
-            if let Some(last) = rows.last_mut() {
-                last.is_group_end = true;
-            }
-            continue;
+        (dir, store)
+    }
+
+    #[test]
+    fn implied_ancestor_header_renders_with_zero_direct_members() {
+        let (_dir, store) = store_with_groups(&[Some("OSS/Production")]);
+        let rows = build_conn_items(&store, &HashSet::new(), "");
+        // OSS (0 direct, 1 nested) -> OSS/Production (1 direct) -> the connection.
+        assert_eq!(rows.len(), 3);
+        assert!(rows[0].is_header);
+        assert_eq!(rows[0].group.as_str(), "OSS");
+        assert_eq!(rows[0].depth, 0);
+        assert_eq!(rows[0].count, 1);
+        assert!(rows[1].is_header);
+        assert_eq!(rows[1].group.as_str(), "OSS/Production");
+        assert_eq!(rows[1].depth, 1);
+        assert_eq!(rows[1].count, 1);
+        assert!(!rows[2].is_header);
+        assert_eq!(rows[2].group.as_str(), "OSS/Production");
+        assert_eq!(rows[2].depth, 1);
+    }
+
+    #[test]
+    fn collapsing_a_parent_hides_the_whole_subtree() {
+        let (_dir, store) = store_with_groups(&[Some("OSS/Production"), Some("OSS")]);
+        let collapsed = HashSet::from(["OSS".to_string()]);
+        let rows = build_conn_items(&store, &collapsed, "");
+        // Only the OSS header itself remains visible.
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].is_header);
+        assert_eq!(rows[0].group.as_str(), "OSS");
+        assert!(!rows[0].expanded);
+        assert!(rows[0].is_group_end);
+    }
+
+    #[test]
+    fn is_group_end_lands_on_the_deepest_last_row_of_each_top_level_group() {
+        let (_dir, store) = store_with_groups(&[Some("OSS/Production"), Some("LOCAL")]);
+        let rows = build_conn_items(&store, &HashSet::new(), "");
+        // OSS, OSS/Production, conn0 (deepest last row of the OSS card),
+        // LOCAL, conn1 (last row of the LOCAL card).
+        assert_eq!(rows.len(), 5);
+        assert!(rows[2].is_group_end, "conn0 should close the OSS card");
+        assert!(
+            !rows[1].is_group_end,
+            "the OSS/Production header is not the card's true end"
+        );
+        assert!(rows[4].is_group_end, "conn1 should close the LOCAL card");
+    }
+}
+
+/// Total connections directly or transitively under `path` (used for a
+/// folder header's count badge).
+fn subtree_conn_count(
+    path: &str,
+    child_folders: &std::collections::HashMap<Option<String>, Vec<String>>,
+    direct_conns: &std::collections::HashMap<String, Vec<usize>>,
+) -> i32 {
+    let mut total = direct_conns.get(path).map_or(0, |v| v.len() as i32);
+    if let Some(children) = child_folders.get(&Some(path.to_string())) {
+        for child in children {
+            total += subtree_conn_count(child, child_folders, direct_conns);
         }
-        // Favorites float to the top of their group, then explicit sort order.
-        // Stable sort keeps store insertion order for equal keys (order == 0).
-        let mut idxs = buckets[g].clone();
+    }
+    total
+}
+
+/// Depth-first: push `path`'s header row, then (unless collapsed) its child
+/// folders followed by its own direct connection rows. Never touches
+/// `is_group_end` — that is only meaningful at the top-level group's true
+/// last visible row, which the caller marks after the whole subtree returns.
+fn emit_group_subtree(
+    path: &str,
+    depth: i32,
+    store: &rdb_connstore::ConnStore,
+    child_folders: &std::collections::HashMap<Option<String>, Vec<String>>,
+    direct_conns: &std::collections::HashMap<String, Vec<usize>>,
+    collapsed: &HashSet<String>,
+    rows: &mut Vec<ConnItem>,
+) {
+    let expanded = !collapsed.contains(path);
+    rows.push(ConnItem {
+        id: SharedString::default(),
+        name: rdb_connstore::group_leaf(path).to_uppercase().into(),
+        engine: SharedString::default(),
+        color: theme::accent_or_default(""),
+        has_custom_color: false,
+        is_header: true,
+        expanded,
+        index: -1,
+        group: path.into(),
+        subline: SharedString::default(),
+        local: false,
+        count: subtree_conn_count(path, child_folders, direct_conns),
+        favorite: false,
+        env_tag_label: SharedString::default(),
+        env_tag_color: theme::accent_or_default(""),
+        is_group_end: false,
+        depth,
+    });
+    if !expanded {
+        // Collapsing a folder hides its whole subtree, not just its direct rows.
+        return;
+    }
+    if let Some(children) = child_folders.get(&Some(path.to_string())) {
+        for child in children {
+            emit_group_subtree(
+                child,
+                depth + 1,
+                store,
+                child_folders,
+                direct_conns,
+                collapsed,
+                rows,
+            );
+        }
+    }
+    if let Some(idxs) = direct_conns.get(path) {
+        // Favorites float to the top, then explicit sort order. Stable sort
+        // keeps store insertion order for equal keys (order == 0).
+        let mut idxs = idxs.clone();
         idxs.sort_by_key(|&i| {
             let s = &store.list()[i];
             (!s.favorite, s.order)
@@ -291,7 +465,7 @@ fn build_conn_items(
                 is_header: false,
                 expanded: true,
                 index: i as i32,
-                group: g.clone().into(),
+                group: path.into(),
                 subline: subline.into(),
                 local: s.local,
                 count: 0,
@@ -300,9 +474,124 @@ fn build_conn_items(
                 env_tag_color: theme::env_tag_color(s.env_tag)
                     .unwrap_or_else(|| theme::accent_or_default("")),
                 is_group_end: false,
+                depth,
             });
         }
-        // Expanded: the last member row just pushed is the group's visible end.
+    }
+}
+
+/// Build the grouped sidebar row model: a header row per group (and, once
+/// nested, per subgroup) followed by its connection rows, depth-first,
+/// unless the group is collapsed. `index` on each connection row is its
+/// position in the store list, so connect/edit callbacks stay correct
+/// regardless of grouping or ordering. `collapsed` holds the set of full
+/// group paths currently folded shut.
+///
+/// `SavedConnection.group` is treated as a `/`-delimited path: `"OSS"` is a
+/// top-level group same as before, `"OSS/Production"` nests under it. A
+/// group's ancestors are registered as folder headers even if they hold no
+/// connections directly, so `"OSS"` still renders when every connection
+/// under it lives at `"OSS/Production"`.
+fn build_conn_items(
+    store: &rdb_connstore::ConnStore,
+    collapsed: &HashSet<String>,
+    filter: &str,
+) -> Vec<ConnItem> {
+    let needle = filter.trim().to_lowercase();
+    // child_folders[None] is the top-level order; child_folders[Some(p)] is
+    // p's direct subfolders, both in first-seen order across the store scan.
+    let mut child_folders: std::collections::HashMap<Option<String>, Vec<String>> =
+        std::collections::HashMap::new();
+    let mut registered: HashSet<String> = HashSet::new();
+    let mut direct_conns: std::collections::HashMap<String, Vec<usize>> =
+        std::collections::HashMap::new();
+    for (i, sc) in store.list().iter().enumerate() {
+        if !needle.is_empty() && !sc.name.to_lowercase().contains(&needle) {
+            continue;
+        }
+        let g = sc
+            .group
+            .as_deref()
+            .and_then(rdb_connstore::normalize_group_path)
+            .unwrap_or_else(|| UNGROUPED.to_string());
+        if g == UNGROUPED {
+            if registered.insert(UNGROUPED.to_string()) {
+                child_folders
+                    .entry(None)
+                    .or_default()
+                    .push(UNGROUPED.to_string());
+            }
+        } else {
+            // Register g and every ancestor, shallowest first, so a parent
+            // is always in child_folders before its child is appended to it.
+            for anc in rdb_connstore::group_ancestors(&g)
+                .map(str::to_string)
+                .chain(std::iter::once(g.clone()))
+            {
+                if registered.insert(anc.clone()) {
+                    let parent = rdb_connstore::group_parent(&anc).map(str::to_string);
+                    child_folders.entry(parent).or_default().push(anc);
+                }
+            }
+        }
+        direct_conns.entry(g).or_default().push(i);
+    }
+
+    let root_order = child_folders.get(&None).cloned().unwrap_or_default();
+    let mut rows: Vec<ConnItem> = Vec::new();
+    for path in &root_order {
+        // Ungrouped connections list flat (no header) when they are the only
+        // top-level bucket; once real groups exist they get their own
+        // UNGROUPED header like any other top-level folder.
+        if path == UNGROUPED && root_order.len() == 1 {
+            if let Some(idxs) = direct_conns.get(UNGROUPED) {
+                let mut idxs = idxs.clone();
+                idxs.sort_by_key(|&i| {
+                    let s = &store.list()[i];
+                    (!s.favorite, s.order)
+                });
+                for &i in &idxs {
+                    let s = &store.list()[i];
+                    let subline = match &s.database {
+                        Some(db) => format!("{} : {}", s.host, db),
+                        None => s.host.clone(),
+                    };
+                    rows.push(ConnItem {
+                        id: s.id.clone().into(),
+                        name: s.name.clone().into(),
+                        engine: AnyDriver::badge(s.engine).into(),
+                        color: theme::accent_or_default(s.color.as_deref().unwrap_or("")),
+                        has_custom_color: s.color.is_some(),
+                        is_header: false,
+                        expanded: true,
+                        index: i as i32,
+                        group: UNGROUPED.into(),
+                        subline: subline.into(),
+                        local: s.local,
+                        count: 0,
+                        favorite: s.favorite,
+                        env_tag_label: theme::env_tag_label(s.env_tag).into(),
+                        env_tag_color: theme::env_tag_color(s.env_tag)
+                            .unwrap_or_else(|| theme::accent_or_default("")),
+                        is_group_end: false,
+                        depth: 0,
+                    });
+                }
+            }
+        } else {
+            emit_group_subtree(
+                path,
+                0,
+                store,
+                &child_folders,
+                &direct_conns,
+                collapsed,
+                &mut rows,
+            );
+        }
+        // Whatever this top-level group's true last visible row ended up
+        // being (its header if collapsed, its deepest descendant otherwise)
+        // is the one that rounds the card's bottom corners.
         if let Some(last) = rows.last_mut() {
             last.is_group_end = true;
         }
@@ -326,7 +615,7 @@ fn build_conn_palette_items(
     for r in rows {
         if r.is_header {
             items.push(PaletteItem {
-                label: r.group.to_lowercase().into(),
+                label: rdb_connstore::group_leaf(&r.group).to_lowercase().into(),
                 kind: "group".into(),
                 sub: SharedString::default(),
                 local: false,
@@ -337,6 +626,7 @@ fn build_conn_palette_items(
                 group: r.group,
                 expanded: r.expanded,
                 is_group_end: r.is_group_end,
+                depth: r.depth,
             });
             map.push(-1);
         } else {
@@ -352,6 +642,7 @@ fn build_conn_palette_items(
                 group: r.group,
                 expanded: r.expanded,
                 is_group_end: r.is_group_end,
+                depth: r.depth,
             });
             map.push(r.index);
         }
@@ -411,6 +702,7 @@ mod row_group_at_y_tests {
             env_tag_label: SharedString::default(),
             env_tag_color: Default::default(),
             is_group_end: false,
+            depth: 0,
         }
     }
 
@@ -2687,6 +2979,7 @@ fn build_palette_items(
         group: SharedString::default(),
         expanded: false,
         is_group_end: false,
+        depth: 0,
     };
     let mut items: Vec<PaletteItem> = Vec::new();
     let mut actions: Vec<PaletteAction> = Vec::new();
@@ -2711,6 +3004,7 @@ fn build_palette_items(
                 group: SharedString::default(),
                 expanded: false,
                 is_group_end: false,
+                depth: 0,
             });
             actions.push(PaletteAction::Connect(idx));
         }
@@ -2742,6 +3036,7 @@ fn build_palette_items(
                 group: SharedString::default(),
                 expanded: false,
                 is_group_end: false,
+                depth: 0,
             });
             actions.push(PaletteAction::OpenTable(db, label));
         }
@@ -2763,6 +3058,7 @@ fn build_palette_items(
                 group: SharedString::default(),
                 expanded: false,
                 is_group_end: false,
+                depth: 0,
             });
             actions.push(PaletteAction::OpenTable(db, label));
         }
@@ -2784,6 +3080,7 @@ fn build_palette_items(
                 group: SharedString::default(),
                 expanded: false,
                 is_group_end: false,
+                depth: 0,
             });
             actions.push(PaletteAction::OpenFunction(label));
         }
@@ -2809,6 +3106,7 @@ fn build_palette_items(
                 group: SharedString::default(),
                 expanded: false,
                 is_group_end: false,
+                depth: 0,
             });
             actions.push(PaletteAction::OpenSavedQuery(name.clone(), idx));
         }
@@ -2834,6 +3132,7 @@ fn build_palette_items(
                 group: SharedString::default(),
                 expanded: false,
                 is_group_end: false,
+                depth: 0,
             });
             actions.push(PaletteAction::OpenRecent(idx));
         }
@@ -4016,6 +4315,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     group: SharedString::default(),
                     expanded: false,
                     is_group_end: false,
+                    depth: 0,
                 })
                 .collect();
             *panes[pane].completion_ctx.borrow_mut() =
@@ -4895,6 +5195,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     group: SharedString::default(),
                     expanded: false,
                     is_group_end: false,
+                    depth: 0,
                 })
                 .collect();
             if items.is_empty() {
@@ -4945,6 +5246,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     group: SharedString::default(),
                     expanded: false,
                     is_group_end: false,
+                    depth: 0,
                 })
                 .collect();
             if items.is_empty() {
@@ -6239,7 +6541,9 @@ fn main() -> Result<(), slint::PlatformError> {
         });
     }
 
-    // ----- delete a group: its connections fall back to Ungrouped -----
+    // ----- delete a group: its connections + descendant subfolders promote
+    // one level up (a top-level folder's members fall back to Ungrouped,
+    // same as before nesting existed) -----
     {
         let weak = window.as_weak();
         let store = store.clone();
@@ -6253,20 +6557,25 @@ fn main() -> Result<(), slint::PlatformError> {
             let g = g.to_string();
             {
                 let mut st = store.borrow_mut();
-                let ids: Vec<String> = st
+                let members: Vec<(String, String)> = st
                     .list()
                     .iter()
-                    .filter(|s| s.group.as_deref() == Some(g.as_str()))
-                    .map(|s| s.id.clone())
+                    .filter_map(|s| {
+                        let grp = s.group.as_deref()?;
+                        rdb_connstore::is_descendant(grp, &g)
+                            .then(|| (s.id.clone(), grp.to_string()))
+                    })
                     .collect();
-                for id in ids {
+                for (id, grp) in members {
                     if let Some(mut sc) = st.get(&id).cloned() {
-                        sc.group = None;
+                        sc.group = cascade_delete_group(&g, &grp);
                         let _ = st.update(sc);
                     }
                 }
             }
-            collapsed.borrow_mut().remove(&g);
+            collapsed
+                .borrow_mut()
+                .retain(|p| !rdb_connstore::is_descendant(p, &g));
             let groups: Vec<String> = collapsed.borrow().iter().cloned().collect();
             let _ = settings
                 .borrow_mut()
@@ -6277,7 +6586,8 @@ fn main() -> Result<(), slint::PlatformError> {
         });
     }
 
-    // ----- rename a group: every member connection follows -----
+    // ----- rename a group: every member connection and descendant subfolder
+    // follows, prefix-replaced -----
     {
         let weak = window.as_weak();
         let store = store.clone();
@@ -6289,31 +6599,46 @@ fn main() -> Result<(), slint::PlatformError> {
                 return;
             };
             let old = old.to_string();
-            let new = new.trim().to_string();
-            if new.is_empty() || new == old {
+            let Some(new) = rdb_connstore::normalize_group_path(&new) else {
+                return;
+            };
+            // Also rejects a no-op rename (new == old counts as its own
+            // descendant) and renaming a folder into its own subtree, which
+            // would otherwise create a cycle.
+            if rdb_connstore::is_descendant(&new, &old) {
                 return;
             }
             {
                 let mut st = store.borrow_mut();
-                let ids: Vec<String> = st
+                let members: Vec<(String, String)> = st
                     .list()
                     .iter()
-                    .filter(|s| s.group.as_deref() == Some(old.as_str()))
-                    .map(|s| s.id.clone())
+                    .filter_map(|s| {
+                        let grp = s.group.as_deref()?;
+                        rdb_connstore::is_descendant(grp, &old)
+                            .then(|| (s.id.clone(), grp.to_string()))
+                    })
                     .collect();
-                for id in ids {
+                for (id, grp) in members {
                     if let Some(mut sc) = st.get(&id).cloned() {
-                        sc.group = Some(new.clone());
+                        sc.group = Some(cascade_rename_group(&old, &new, &grp));
                         let _ = st.update(sc);
                     }
                 }
             }
             // Carry the collapsed state over so renaming doesn't silently
-            // re-expand a group the user had folded shut.
+            // re-expand a group (or one of its subfolders) the user had
+            // folded shut.
             {
                 let mut c = collapsed.borrow_mut();
-                if c.remove(&old) {
-                    c.insert(new.clone());
+                let renamed: Vec<String> = c
+                    .iter()
+                    .filter(|p| rdb_connstore::is_descendant(p, &old))
+                    .cloned()
+                    .collect();
+                for p in renamed {
+                    c.remove(&p);
+                    c.insert(cascade_rename_group(&old, &new, &p));
                 }
             }
             let groups: Vec<String> = collapsed.borrow().iter().cloned().collect();
@@ -11739,10 +12064,68 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_f_params(SharedString::default());
             w.set_f_color(SharedString::from("#2c5fd8"));
             w.set_f_env_tag(SharedString::from("None"));
-            w.set_f_group(SharedString::default());
             w.set_f_group_display(SharedString::from("None"));
+            w.set_f_new_group_text(SharedString::default());
+            w.set_f_subgroup_display(SharedString::from("None"));
+            w.set_f_new_subgroup_text(SharedString::default());
             w.set_group_options(ModelRc::from(Rc::new(VecModel::from(
                 group_picker_options(&store.borrow())
+                    .into_iter()
+                    .map(SharedString::from)
+                    .collect::<Vec<_>>(),
+            ))));
+            w.set_subgroup_options(ModelRc::from(Rc::new(VecModel::from(vec![
+                SharedString::from("None"),
+                SharedString::from("+ New subgroup…"),
+            ]))));
+            w.set_f_import_url(SharedString::default());
+            w.set_form_error(SharedString::default());
+            w.set_test_result(SharedString::default());
+            w.set_test_ok(false);
+            w.set_test_busy(false);
+            w.set_form_open(true);
+        });
+    }
+    // open add form, pre-nested under an existing top-level group ("New
+    // Subgroup" on the picker's group context menu, only offered on
+    // top-level headers — see picker.slint) — same as open-add-form, except
+    // Group starts on `parent` and Subgroup starts on "+ New subgroup…"
+    // with an empty text field, so the user only has to type the leaf name.
+    {
+        let weak = window.as_weak();
+        let store = store.clone();
+        let editing_id = editing_id.clone();
+        window.on_open_add_form_in_group(move |parent| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let parent = parent.to_string();
+            *editing_id.borrow_mut() = String::new();
+            w.set_form_edit_mode(false);
+            w.set_f_name(SharedString::default());
+            w.set_f_engine(SharedString::from("PostgreSQL"));
+            w.set_f_host(SharedString::from("localhost"));
+            w.set_f_port(SharedString::from("5432"));
+            w.set_f_user(SharedString::default());
+            w.set_f_database(SharedString::default());
+            w.set_f_password(SharedString::default());
+            w.set_f_has_password(false);
+            w.set_f_sslmode(SharedString::from("Prefer"));
+            w.set_f_params(SharedString::default());
+            w.set_f_color(SharedString::from("#2c5fd8"));
+            w.set_f_env_tag(SharedString::from("None"));
+            w.set_f_group_display(SharedString::from(parent.clone()));
+            w.set_f_new_group_text(SharedString::default());
+            w.set_f_subgroup_display(SharedString::from("+ New subgroup…"));
+            w.set_f_new_subgroup_text(SharedString::default());
+            w.set_group_options(ModelRc::from(Rc::new(VecModel::from(
+                group_picker_options(&store.borrow())
+                    .into_iter()
+                    .map(SharedString::from)
+                    .collect::<Vec<_>>(),
+            ))));
+            w.set_subgroup_options(ModelRc::from(Rc::new(VecModel::from(
+                subgroup_picker_options(&store.borrow(), &parent)
                     .into_iter()
                     .map(SharedString::from)
                     .collect::<Vec<_>>(),
@@ -11795,10 +12178,43 @@ fn main() -> Result<(), slint::PlatformError> {
                 sc.color.unwrap_or_else(|| "#2c5fd8".into()),
             ));
             w.set_f_env_tag(SharedString::from(sc.env_tag.as_str()));
-            w.set_f_group_display(SharedString::from(
-                sc.group.clone().unwrap_or_else(|| "None".into()),
-            ));
-            w.set_f_group(SharedString::from(sc.group.unwrap_or_default()));
+            w.set_f_new_group_text(SharedString::default());
+            match sc.group.as_deref() {
+                None => {
+                    w.set_f_group_display(SharedString::from("None"));
+                    w.set_f_subgroup_display(SharedString::from("None"));
+                    w.set_f_new_subgroup_text(SharedString::default());
+                    w.set_subgroup_options(ModelRc::from(Rc::new(VecModel::from(vec![
+                        SharedString::from("None"),
+                        SharedString::from("+ New subgroup…"),
+                    ]))));
+                }
+                Some(g) => {
+                    let top = g.split('/').next().unwrap_or(g).to_string();
+                    let rest = g[top.len()..].trim_start_matches('/').to_string();
+                    let sub_opts = subgroup_picker_options(&st, &top);
+                    w.set_f_group_display(SharedString::from(top));
+                    if rest.is_empty() {
+                        w.set_f_subgroup_display(SharedString::from("None"));
+                        w.set_f_new_subgroup_text(SharedString::default());
+                    } else if sub_opts.iter().any(|o| o == &rest) {
+                        w.set_f_subgroup_display(SharedString::from(rest));
+                        w.set_f_new_subgroup_text(SharedString::default());
+                    } else {
+                        // A deeper/irregular path than the guided picker
+                        // covers — surface it as free text so editing never
+                        // silently truncates it.
+                        w.set_f_subgroup_display(SharedString::from("+ New subgroup…"));
+                        w.set_f_new_subgroup_text(SharedString::from(rest));
+                    }
+                    w.set_subgroup_options(ModelRc::from(Rc::new(VecModel::from(
+                        sub_opts
+                            .into_iter()
+                            .map(SharedString::from)
+                            .collect::<Vec<_>>(),
+                    ))));
+                }
+            }
             w.set_group_options(ModelRc::from(Rc::new(VecModel::from(
                 group_picker_options(&st)
                     .into_iter()
@@ -11811,6 +12227,25 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_test_ok(false);
             w.set_test_busy(false);
             w.set_form_open(true);
+        });
+    }
+    // Group dropdown changed -> recompute the Subgroup dropdown's options
+    // for the newly-picked parent.
+    {
+        let weak = window.as_weak();
+        let store = store.clone();
+        window.on_form_group_changed(move |top| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let opts = if top == "None" || top == "+ New group…" {
+                vec!["None".to_string(), "+ New subgroup…".to_string()]
+            } else {
+                subgroup_picker_options(&store.borrow(), &top)
+            };
+            w.set_subgroup_options(ModelRc::from(Rc::new(VecModel::from(
+                opts.into_iter().map(SharedString::from).collect::<Vec<_>>(),
+            ))));
         });
     }
     // engine changed -> default port if port empty/default-ish

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1823,18 +1823,33 @@ fn save_query_tabs(w: &MainWindow, tabs: &[WorkspaceTab], active: Option<&str>) 
     }
 }
 
+/// Tab ids are minted as `query:<connection>:<N>`; pull `N` back out so a
+/// restored tab's number can be folded into the in-memory counter and never
+/// re-handed-out to a freshly created tab.
+fn tab_id_number(id: &str) -> Option<usize> {
+    id.rsplit(':').next()?.parse().ok()
+}
+
 /// Load persisted SQL tabs into fresh `WorkspaceTab`s (empty results/browse).
-/// Returns the tabs, each group's active tab id (if it still exists), and the
-/// focused group.
-fn load_query_tabs() -> (Vec<WorkspaceTab>, Option<String>, Option<String>, usize) {
+/// Returns the tabs, each group's active tab id (if it still exists), the
+/// focused group, and the highest tab number embedded in any restored id (0
+/// if none) — callers fold this into their `query_number` counter so a
+/// newly-created tab can never collide with a restored one.
+fn load_query_tabs() -> (
+    Vec<WorkspaceTab>,
+    Option<String>,
+    Option<String>,
+    usize,
+    usize,
+) {
     let Ok(path) = rdb_connstore::ConnStore::query_tabs_path() else {
-        return (Vec::new(), None, None, 0);
+        return (Vec::new(), None, None, 0, 0);
     };
     let Some(payload): Option<PersistedTabs> = std::fs::read_to_string(path)
         .ok()
         .and_then(|s| serde_json::from_str(&s).ok())
     else {
-        return (Vec::new(), None, None, 0);
+        return (Vec::new(), None, None, 0, 0);
     };
     let tabs: Vec<WorkspaceTab> = payload
         .tabs
@@ -1853,10 +1868,21 @@ fn load_query_tabs() -> (Vec<WorkspaceTab>, Option<String>, Option<String>, usiz
             t
         })
         .collect();
+    let max_number = tabs
+        .iter()
+        .filter_map(|t| tab_id_number(&t.id))
+        .max()
+        .unwrap_or(0);
     let exists = |id: &String| tabs.iter().any(|t| t.id == *id);
     let active = payload.active.filter(|id| exists(id));
     let active_p1 = payload.active_p1.filter(|id| exists(id));
-    (tabs, active, active_p1, payload.active_group.min(1))
+    (
+        tabs,
+        active,
+        active_p1,
+        payload.active_group.min(1),
+        max_number,
+    )
 }
 
 fn page_bounds(page: u64, limit: u64, total: Option<u64>, shown: u64) -> (u64, u64, bool, bool) {
@@ -6950,6 +6976,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let edit_buf = edit_buf.clone();
         let db_override = db_override.clone();
         let tabs_restored = tabs_restored.clone();
+        let query_number = query_number.clone();
         let restore_tab = restore_tab.clone();
         let save_active_tab = save_active_tab.clone();
         let save_p1_tab = save_p1_tab.clone();
@@ -6987,7 +7014,11 @@ fn main() -> Result<(), slint::PlatformError> {
             let restore = !tabs_restored.get() || db_ovr.is_some();
             tabs_restored.set(true);
             let (init_tabs, init_active, init_active_p1, init_active_group) = if restore {
-                load_query_tabs()
+                let (tabs, active, active_p1, active_group, max_number) = load_query_tabs();
+                // Never let a freshly-minted tab reuse a number a restored tab
+                // already holds — `fetch_max` only ever raises the counter.
+                query_number.fetch_max(max_number, std::sync::atomic::Ordering::Relaxed);
+                (tabs, active, active_p1, active_group)
             } else {
                 // Retain every open tab across the switch so the workspace
                 // behaves like a set of persistent documents — the SQL scratch

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -1227,7 +1227,8 @@ callback create-table-commit();
                                 height: Tokens.doc-tab-h;
                                 background: i == root.active-tab ? Tokens.card
                                     : (tab-ta.has-hover ? Tokens.card.with-alpha(0.5) : transparent);
-                                border-radius: 0;
+                                border-radius: Tokens.radius;
+                                clip: true;
                                 tab-ta := TouchArea {
                                     property <bool> dragging: false;
                                     moved => {
@@ -1428,6 +1429,8 @@ callback create-table-commit();
                                 height: Tokens.doc-tab-h;
                                 background: i == root.p1-active-tab ? Tokens.card
                                     : (p1-tab-ta.has-hover ? Tokens.card.with-alpha(0.5) : transparent);
+                                border-radius: Tokens.radius;
+                                clip: true;
                                 p1-tab-ta := TouchArea {
                                     property <bool> dragging: false;
                                     moved => {

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -620,15 +620,25 @@ callback create-table-commit();
     in-out property <string> f-params;
     in-out property <string> f-color;
     in-out property <string> f-env-tag;
-    in-out property <string> f-group;
+    // Derived by ConnForm from the Group/Subgroup dropdowns — read-only here.
+    out property <string> f-group: conn-form.f-group;
     in-out property <string> f-group-display;
     in property <[string]> group-options;
+    in-out property <string> f-new-group-text;
+    in-out property <string> f-subgroup-display;
+    in property <[string]> subgroup-options;
+    in-out property <string> f-new-subgroup-text;
+    callback form-group-changed(string);
     in-out property <string> f-import-url;
     in property <string> form-error;
     in property <string> test-result;
     in property <bool> test-ok;
     in property <bool> test-busy;
     callback open-add-form();
+    // Same as open-add-form(), but starts the Group dropdown on "+ New
+    // group…" (the text field is left empty — the user types the full path,
+    // e.g. "<parent>/<child>", themselves).
+    callback open-add-form-in-group(string);
     callback open-edit-form(int);
     callback export-conns(int);
     callback form-engine-changed(string);
@@ -1137,6 +1147,7 @@ callback create-table-commit();
             cancel-connect() => { root.cancel-connect(); }
             test-clicked(i) => { root.test-conn-quick(i); }
             add-clicked() => { root.open-add-form(); }
+            add-conn-in-group(g) => { root.open-add-form-in-group(g); }
             edit-clicked(i) => { root.open-edit-form(i); }
             toggle-group(g) => { root.toggle-group(g); }
             group-rename(o, n) => { root.group-rename(o, n); }
@@ -2454,7 +2465,7 @@ callback create-table-commit();
     }
 
     // ----- connection form overlay (drawn on top of palette layer) -----
-    ConnForm {
+    conn-form := ConnForm {
         width: root.width;
         height: root.height;
         open: root.form-open;
@@ -2471,9 +2482,15 @@ callback create-table-commit();
         f-params <=> root.f-params;
         f-color <=> root.f-color;
         f-env-tag <=> root.f-env-tag;
-        f-group <=> root.f-group;
         f-group-display <=> root.f-group-display;
         group-options: root.group-options;
+        f-new-group-text <=> root.f-new-group-text;
+        f-subgroup-display <=> root.f-subgroup-display;
+        subgroup-options: root.subgroup-options;
+        f-new-subgroup-text <=> root.f-new-subgroup-text;
+        group-changed(v) => {
+            root.form-group-changed(v);
+        }
         f-import-url <=> root.f-import-url;
         form-error: root.form-error;
         test-result: root.test-result;

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -2,6 +2,21 @@
 import { Tokens } from "tokens.slint";
 import { AppIcon } from "icons.slint";
 
+// Rounded, bordered, drop-shadowed surface used for panels that should read
+// as floating above the canvas (connection picker, workspace sidebar) rather
+// than flush-filling their column. Callers place it with their own gutter
+// inset (x/y/width/height) since that varies by host layout.
+export component FloatingCard inherits Rectangle {
+    background: Tokens.sidebar;
+    border-radius: Tokens.radius-lg;
+    border-width: 1px;
+    border-color: Tokens.border;
+    drop-shadow-blur: 18px;
+    drop-shadow-color: #00000035;
+    drop-shadow-offset-y: 6px;
+    clip: true;
+}
+
 // iOS-style on/off switch. One place for the pill + sliding knob so every
 // settings toggle stays identical.
 export component Toggle inherits TouchArea {

--- a/app/src/ui/conn-form.slint
+++ b/app/src/ui/conn-form.slint
@@ -57,12 +57,29 @@ export component ConnForm inherits Rectangle {
     in-out property <string> f-params;     // Mongo options query string or full URI
     in-out property <string> f-color;      // selected hex
     in-out property <string> f-env-tag;    // "None"|"Local"|"Dev"|"Staging"|"Testing"|"Production"
-    in-out property <string> f-group;      // sidebar folder label; empty = ungrouped
-    in-out property <string> f-group-display; // text shown in the Group dropdown ("None" when f-group is empty)
-    in property <[string]> group-options;  // ["None", ...distinct groups, "+ New group…"]
+    // Derived, not written to directly (see below) — the two dropdowns and
+    // their free-text fallbacks are the actual source of truth.
+    out property <string> f-group: root.f-group-display == "None" ? ""
+        : root.f-group-display == "+ New group…" ? root.f-new-group-text
+        : root.f-subgroup-display == "None" ? root.f-group-display
+        : root.f-subgroup-display == "+ New subgroup…"
+            ? (root.f-new-subgroup-text == "" ? root.f-group-display : root.f-group-display + "/" + root.f-new-subgroup-text)
+        : root.f-group-display + "/" + root.f-subgroup-display;
+    in-out property <string> f-group-display; // top-level Group dropdown value ("None" when ungrouped)
+    in property <[string]> group-options;  // ["None", ...top-level group names, "+ New group…"]
+    in-out property <string> f-new-group-text; // typed when f-group-display == "+ New group…"
+    in-out property <string> f-subgroup-display; // Subgroup dropdown value; only meaningful once a real group is picked
+    in property <[string]> subgroup-options; // ["None", ...direct-child leaves of f-group-display, "+ New subgroup…"]
+    in-out property <string> f-new-subgroup-text; // typed when f-subgroup-display == "+ New subgroup…"
+    callback group-changed(string);
     // Live-derived (not manually toggled), so a stale true doesn't carry over
     // from a previous dialog session — Rust always resets f-group-display on open.
     property <bool> creating-new-group: root.f-group-display == "+ New group…";
+    // A real existing (or about-to-be-created) top group is selected — the
+    // Subgroup row only ever shows once this is true, no group means
+    // nothing to nest under.
+    property <bool> has-parent-group: root.f-group-display != "None" && root.f-group-display != "+ New group…";
+    property <bool> creating-new-subgroup: root.f-subgroup-display == "+ New subgroup…";
     in-out property <string> f-import-url;  // pasted connection URL
     in property <string> form-error;
     in property <string> test-result;   // test-connection status line
@@ -294,7 +311,13 @@ export component ConnForm inherits Rectangle {
                     model: root.group-options;
                     current-value <=> root.f-group-display;
                     selected(v) => {
-                        root.f-group = (v == "None" || v == "+ New group…") ? "" : v;
+                        // A new parent invalidates whatever subgroup was
+                        // picked for the old one.
+                        root.f-subgroup-display = "None";
+                        root.f-new-subgroup-text = "";
+                        if (v != "+ New group…") {
+                            root.group-changed(v);
+                        }
                     }
                 }
             }
@@ -304,8 +327,29 @@ export component ConnForm inherits Rectangle {
                 FormLabel { text: ""; }
                 FormField {
                     horizontal-stretch: 1;
-                    text <=> root.f-group;
+                    text <=> root.f-new-group-text;
                     placeholder: "New group name";
+                }
+            }
+            // Nothing to nest under until a real group is picked.
+            if root.has-parent-group: HorizontalLayout {
+                height: 30px;
+                spacing: Tokens.sp2;
+                FormLabel { text: "Subgroup"; }
+                SelectBox {
+                    horizontal-stretch: 1;
+                    model: root.subgroup-options;
+                    current-value <=> root.f-subgroup-display;
+                }
+            }
+            if root.has-parent-group && root.creating-new-subgroup: HorizontalLayout {
+                height: 30px;
+                spacing: Tokens.sp2;
+                FormLabel { text: ""; }
+                FormField {
+                    horizontal-stretch: 1;
+                    text <=> root.f-new-subgroup-text;
+                    placeholder: "New subgroup name";
                 }
             }
 

--- a/app/src/ui/palette.slint
+++ b/app/src/ui/palette.slint
@@ -25,6 +25,8 @@ export struct PaletteItem {
     expanded: bool,
     // Last row of a group's visible block — rounds the card's bottom corners.
     is-group-end: bool,
+    // Nesting depth of this row's group (0 = top-level). Mirrors `ConnItem.depth`.
+    depth: int,
 }
 
 export component ListModal inherits Rectangle {
@@ -146,7 +148,7 @@ export component ListModal inherits Rectangle {
                                 }
                             }
                             if !is-section: HorizontalLayout {
-                                padding-left: Tokens.sp2;
+                                padding-left: Tokens.sp2 + it.depth * Tokens.sp3;
                                 padding-right: Tokens.sp2;
                                 spacing: Tokens.sp3;
 

--- a/app/src/ui/picker.slint
+++ b/app/src/ui/picker.slint
@@ -35,6 +35,10 @@ export component ConnPicker inherits Rectangle {
     callback cancel-connect();
     callback test-clicked(int);
     callback add-clicked();
+    // "New Subgroup" on a group's context menu: opens the add-connection
+    // form with the Group field ready for a full path (arg is the parent
+    // group's path, informational only — the text itself starts empty).
+    callback add-conn-in-group(string);
     callback edit-clicked(int);
     // Export saved connections to ~/Downloads. Arg is the format: 0 = JSON, 1 = CSV.
     callback export-conns(int);
@@ -55,6 +59,7 @@ export component ConnPicker inherits Rectangle {
 
     // Group header context menu (Rename/Delete) + its rename modal state.
     property <string> group-menu-target: "";
+    property <int> group-menu-target-depth: 0;
     property <length> group-menu-x: 0px;
     property <length> group-menu-y: 0px;
     property <bool> rename-modal-open: false;
@@ -163,6 +168,7 @@ export component ConnPicker inherits Rectangle {
                                             && e.button == PointerEventButton.right
                                             && item.group != "Ungrouped") {
                                             root.group-menu-target = item.group;
+                                            root.group-menu-target-depth = item.depth;
                                             root.group-menu-x = self.absolute-position.x - root.absolute-position.x;
                                             root.group-menu-y = self.absolute-position.y - root.absolute-position.y;
                                             group-menu.show();
@@ -179,6 +185,7 @@ export component ConnPicker inherits Rectangle {
                                     // position.
                                     width: parent.width;
                                     height: parent.height;
+                                    padding-left: Tokens.sp2 + item.depth * Tokens.sp3;
                                     spacing: Tokens.sp2;
                                     // No `alignment: start` here (deliberately) — that
                                     // mode disables stretch factors entirely, which is
@@ -263,6 +270,7 @@ export component ConnPicker inherits Rectangle {
                                             gmore-ta := TouchArea {
                                                 clicked => {
                                                     root.group-menu-target = item.group;
+                                                    root.group-menu-target-depth = item.depth;
                                                     root.group-menu-x = self.absolute-position.x - root.absolute-position.x;
                                                     root.group-menu-y = self.absolute-position.y - root.absolute-position.y;
                                                     group-menu.show();
@@ -301,7 +309,7 @@ export component ConnPicker inherits Rectangle {
                                 }
 
                                 HorizontalLayout {
-                                    padding-left: Tokens.sp3;
+                                    padding-left: Tokens.sp3 + item.depth * Tokens.sp3;
                                     padding-right: Tokens.sp3;
                                     spacing: Tokens.sp3;
                                     // Drag handle: reorders within the group.
@@ -785,7 +793,7 @@ export component ConnPicker inherits Rectangle {
         // 60px — the reason the menu opened in an unrelated spot). Clamp so
         // it stays on screen if the button sits near the panel's edge.
         x: min(root.group-menu-x, root.width - 148px);
-        y: min(root.group-menu-y, root.height - 96px);
+        y: min(root.group-menu-y, root.height - 124px);
         width: 140px;
         Rectangle {
             background: Tokens.card;
@@ -796,20 +804,28 @@ export component ConnPicker inherits Rectangle {
             drop-shadow-color: Tokens.text.with-alpha(0.25);
             VerticalLayout {
                 padding: 4px;
-                for label[action] in ["Rename", "Delete"]: Rectangle {
-                    height: 28px;
+                // "New Subgroup" only makes sense on a top-level group — the
+                // guided Group/Subgroup picker in the connection form is
+                // two levels deep, not a full tree, so a subfolder header
+                // doesn't offer it.
+                property <bool> target-is-top-level: root.group-menu-target-depth == 0;
+                for label[action] in ["New Subgroup", "Rename", "Delete"]: Rectangle {
+                    visible: action != 0 || target-is-top-level;
+                    height: self.visible ? 28px : 0px;
                     border-radius: Tokens.radius;
-                    background: gmenu-ta.has-hover ? (action == 1 ? Tokens.error-tint : Tokens.accent-tint) : transparent;
+                    background: gmenu-ta.has-hover ? (action == 2 ? Tokens.error-tint : Tokens.accent-tint) : transparent;
                     Text {
                         x: Tokens.sp2;
                         text: label;
-                        color: action == 1 ? Tokens.error : Tokens.text;
+                        color: action == 2 ? Tokens.error : Tokens.text;
                         font-size: Tokens.font-sm;
                         vertical-alignment: center;
                     }
                     gmenu-ta := TouchArea {
                         clicked => {
                             if (action == 0) {
+                                root.add-conn-in-group(root.group-menu-target);
+                            } else if (action == 1) {
                                 root.rename-old = root.group-menu-target;
                                 root.rename-text = root.group-menu-target;
                                 root.rename-modal-open = true;

--- a/app/src/ui/picker.slint
+++ b/app/src/ui/picker.slint
@@ -4,7 +4,7 @@
 import { Tokens } from "tokens.slint";
 import {
     DbBadge, OutlineChip, PrimaryButton, SecondaryButton, TextButton,
-    TagChip, FilterField, Tooltip
+    TagChip, FilterField, Tooltip, FloatingCard
 } from "components.slint";
 import { AppIcon } from "icons.slint";
 import { ConnItem, KvRow } from "structs.slint";
@@ -73,19 +73,11 @@ export component ConnPicker inherits Rectangle {
             width: 560px;
             background: Tokens.canvas;
 
-            card := Rectangle {
+            card := FloatingCard {
                 x: Tokens.sp3;
                 y: Tokens.sp3;
                 width: parent.width - 2 * Tokens.sp3;
                 height: parent.height - 2 * Tokens.sp3;
-                background: Tokens.sidebar;
-                border-radius: Tokens.radius-lg;
-                border-width: 1px;
-                border-color: Tokens.border;
-                drop-shadow-blur: 18px;
-                drop-shadow-color: #00000035;
-                drop-shadow-offset-y: 6px;
-                clip: true;
 
             VerticalLayout {
                 spacing: 0;

--- a/app/src/ui/sidebar.slint
+++ b/app/src/ui/sidebar.slint
@@ -3,7 +3,7 @@
 // Reference: design/2-workspace.png (left column).
 import { Tokens } from "tokens.slint";
 import { TreeNode } from "structs.slint";
-import { DbBadge, FilterField, KeyCap, Tooltip, Shortcut } from "components.slint";
+import { DbBadge, FilterField, KeyCap, Tooltip, Shortcut, FloatingCard } from "components.slint";
 import { AppIcon } from "icons.slint";
 import { ScrollView, Spinner } from "std-widgets.slint";
 
@@ -61,7 +61,15 @@ export component Sidebar inherits Rectangle {
         }
     }
 
-    background: Tokens.sidebar;
+    // Canvas gutter around the card so the sidebar reads as a floating panel
+    // (matches the connection-picker's left column) instead of a flush column.
+    background: Tokens.canvas;
+
+    card := FloatingCard {
+        x: Tokens.sp3;
+        y: Tokens.sp3;
+        width: parent.width - 2 * Tokens.sp3;
+        height: parent.height - 2 * Tokens.sp3;
 
     VerticalLayout {
         spacing: 0;
@@ -422,6 +430,7 @@ export component Sidebar inherits Rectangle {
                 }
             }
         }
+    }
     }
 
     history-menu := PopupWindow {

--- a/app/src/ui/sidebar.slint
+++ b/app/src/ui/sidebar.slint
@@ -66,10 +66,10 @@ export component Sidebar inherits Rectangle {
     background: Tokens.canvas;
 
     card := FloatingCard {
-        x: Tokens.sp3;
-        y: Tokens.sp3;
-        width: parent.width - 2 * Tokens.sp3;
-        height: parent.height - 2 * Tokens.sp3;
+        x: Tokens.sp1;
+        y: Tokens.sp1;
+        width: parent.width - 2 * Tokens.sp1;
+        height: parent.height - 2 * Tokens.sp1;
 
     VerticalLayout {
         spacing: 0;

--- a/app/src/ui/structs.slint
+++ b/app/src/ui/structs.slint
@@ -53,6 +53,9 @@ export struct ConnItem {
     // if expanded, otherwise the header itself) — rounds the card's bottom
     // corners so consecutive groups read as separate cards.
     is-group-end: bool,
+    // Nesting depth of this row's group (0 = top-level). Drives left indent;
+    // mirrors `TreeNode.depth`.
+    depth: int,
 }
 // One Host/Port/… row of the connection-detail card.
 export struct KvRow { k: string, v: string }

--- a/crates/connstore/src/group_path.rs
+++ b/crates/connstore/src/group_path.rs
@@ -1,0 +1,114 @@
+//! Pure helpers for treating `SavedConnection.group` as a `/`-delimited
+//! nested path (`"OSS/Production"`) instead of a flat name. No new storage
+//! or entity: a depth-1 path is exactly today's flat group name, so every
+//! existing `connections.json` is already valid input here.
+
+/// Path separator between nesting levels.
+pub const GROUP_SEP: char = '/';
+
+/// Trim, collapse repeated separators, and strip leading/trailing
+/// separators. An empty result (e.g. `""`, `"/"`, `"  "`) normalizes to
+/// `None` — the same "no group" meaning as today's flat model.
+pub fn normalize_group_path(raw: &str) -> Option<String> {
+    let normalized = raw
+        .split(GROUP_SEP)
+        .map(str::trim)
+        .filter(|seg| !seg.is_empty())
+        .collect::<Vec<_>>()
+        .join(&GROUP_SEP.to_string());
+    if normalized.is_empty() {
+        None
+    } else {
+        Some(normalized)
+    }
+}
+
+/// Parent path one level up, or `None` if `path` is already top-level.
+pub fn group_parent(path: &str) -> Option<&str> {
+    path.rsplit_once(GROUP_SEP).map(|(parent, _)| parent)
+}
+
+/// The final segment of a path (its display label at its own depth).
+pub fn group_leaf(path: &str) -> &str {
+    path.rsplit_once(GROUP_SEP)
+        .map(|(_, leaf)| leaf)
+        .unwrap_or(path)
+}
+
+/// Every proper ancestor of `path`, shallowest first: `"A/B/C"` yields
+/// `"A"`, `"A/B"` (not `"A/B/C"` itself).
+pub fn group_ancestors(path: &str) -> impl Iterator<Item = &str> {
+    path.match_indices(GROUP_SEP).map(move |(i, _)| &path[..i])
+}
+
+/// True if `path` is `ancestor` itself or nested under it.
+pub fn is_descendant(path: &str, ancestor: &str) -> bool {
+    path == ancestor
+        || path
+            .strip_prefix(ancestor)
+            .is_some_and(|rest| rest.starts_with(GROUP_SEP))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_empty_and_whitespace() {
+        assert_eq!(normalize_group_path(""), None);
+        assert_eq!(normalize_group_path("   "), None);
+        assert_eq!(normalize_group_path("/"), None);
+        assert_eq!(normalize_group_path("///"), None);
+    }
+
+    #[test]
+    fn normalize_trims_and_collapses() {
+        assert_eq!(normalize_group_path("OSS"), Some("OSS".into()));
+        assert_eq!(
+            normalize_group_path("/OSS/Production/"),
+            Some("OSS/Production".into())
+        );
+        assert_eq!(
+            normalize_group_path("OSS// Production "),
+            Some("OSS/Production".into())
+        );
+        assert_eq!(
+            normalize_group_path(" OSS / Production / DB "),
+            Some("OSS/Production/DB".into())
+        );
+    }
+
+    #[test]
+    fn parent_and_leaf() {
+        assert_eq!(group_parent("OSS"), None);
+        assert_eq!(group_parent("OSS/Production"), Some("OSS"));
+        assert_eq!(group_parent("OSS/Production/DB"), Some("OSS/Production"));
+
+        assert_eq!(group_leaf("OSS"), "OSS");
+        assert_eq!(group_leaf("OSS/Production"), "Production");
+        assert_eq!(group_leaf("OSS/Production/DB"), "DB");
+    }
+
+    #[test]
+    fn ancestors_are_shallowest_first_and_exclude_self() {
+        assert_eq!(
+            group_ancestors("OSS").collect::<Vec<_>>(),
+            Vec::<&str>::new()
+        );
+        assert_eq!(
+            group_ancestors("OSS/Production/DB").collect::<Vec<_>>(),
+            vec!["OSS", "OSS/Production"]
+        );
+    }
+
+    #[test]
+    fn descendant_check() {
+        assert!(is_descendant("OSS", "OSS"));
+        assert!(is_descendant("OSS/Production", "OSS"));
+        assert!(is_descendant("OSS/Production/DB", "OSS"));
+        assert!(is_descendant("OSS/Production/DB", "OSS/Production"));
+        assert!(!is_descendant("OSS", "OSS/Production"));
+        assert!(!is_descendant("OSSLegacy", "OSS"));
+        assert!(!is_descendant("Other", "OSS"));
+    }
+}

--- a/crates/connstore/src/lib.rs
+++ b/crates/connstore/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod conn_url;
 pub mod error;
+pub mod group_path;
 pub mod model;
 pub mod secret;
 pub mod settings;
@@ -10,6 +11,9 @@ pub mod store;
 
 pub use conn_url::{parse_conn_url, ConnUrlError, ParsedUrl};
 pub use error::{ConnStoreError, Result};
+pub use group_path::{
+    group_ancestors, group_leaf, group_parent, is_descendant, normalize_group_path,
+};
 pub use model::{Engine, EnvTag, SavedConnection};
 pub use secret::{EncryptedFileBackend, KeyringBackend, SecretBackend};
 pub use settings::{AppSettings, EditorPrefs, SettingsStore, ThemeMode, UiState};


### PR DESCRIPTION
## Summary
- Fix a tab-corruption bug where opening a 3rd query tab silently emptied an already-open tab's saved queries after a restart.
- Give the workspace sidebar and query tabs a more polished, floating/rounded look.
- Support nested connection groups (subfolders like `OSS/Production`) with a guided Group/Subgroup picker in the connection form.

## Changes
- `main.rs`: seed the query-tab id counter from restored tab ids so a freshly created tab can never collide with one restored from disk.
- `sidebar.slint` / `components.slint` / `picker.slint`: extract a shared `FloatingCard` component and apply it to the workspace sidebar (matching the connection picker's existing look); tightened the gutter after review.
- `app-window.slint`: rounded-chip query tabs (was a flush square block).
- `crates/connstore/src/group_path.rs` (new): pure helpers treating `SavedConnection.group` as a `/`-delimited path — no persistence migration needed, every existing flat group name is already a valid depth-1 path.
- `main.rs`: `build_conn_items` rewritten depth-first with implied ancestor headers; group delete/rename now cascade through descendants.
- `structs.slint` / `palette.slint`: `ConnItem`/`PaletteItem` gain a `depth` field driving indentation in the sidebar and ⌘O palette.
- `conn-form.slint`: Group field redesigned into a two-tier Group + Subgroup picker — the Subgroup control only appears once a real group is picked; the composed path is a derived value, never something the user types with a `/` in it.
- Picker group context menu: "New Subgroup" entry on top-level group headers, hidden on already-nested groups.

## Test plan
- [x] `cargo build -p rdb`
- [x] `make fmt-check`
- [x] `make lint`
- [x] `cargo test -p rdb` (185 passed)
- [x] `cargo test -p rdb-connstore` (42 passed)
- [x] Manual: multi-tab restart no longer corrupts saved queries
- [x] Manual: sidebar/tab visual changes reviewed in running app
- [x] Manual: create/rename/delete nested groups via guided picker and context menu, verified cascade behavior