### PR TITLE
fix: Linux startup panic and unmaintained rustls-pemfile advisory

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -52,4 +52,11 @@ jobs:
           #                           affects code that parses CRLs, which
           #                           this workspace never does. Revisit when
           #                           tiberius bumps its rustls pin.
-          ignore: RUSTSEC-2026-0194,RUSTSEC-2026-0195,RUSTSEC-2024-0436,RUSTSEC-2026-0206,RUSTSEC-2026-0192,RUSTSEC-2025-0141,RUSTSEC-2026-0235,RUSTSEC-2026-0098,RUSTSEC-2026-0099,RUSTSEC-2026-0104
+          #   2025-0134 rustls-pemfile — tiberius (driver-mssql) -> pinned
+          #                           1.0.4; crate is unmaintained (archived
+          #                           upstream, no CVE), and tiberius 0.12.3
+          #                           (latest on crates.io) still depends on
+          #                           it directly. Revisit when tiberius
+          #                           bumps off it (upstream suggests
+          #                           rustls-pki-types' PemObject trait).
+          ignore: RUSTSEC-2026-0194,RUSTSEC-2026-0195,RUSTSEC-2024-0436,RUSTSEC-2026-0206,RUSTSEC-2026-0192,RUSTSEC-2025-0141,RUSTSEC-2026-0235,RUSTSEC-2026-0098,RUSTSEC-2026-0099,RUSTSEC-2026-0104,RUSTSEC-2025-0134

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -3931,6 +3931,11 @@ fn main() -> Result<(), slint::PlatformError> {
         .enable_all()
         .build()
         .expect("tokio runtime");
+    // Kept alive for the rest of main(): Slint's winit backend, rfd, and
+    // notify-rust all pull in zbus on Linux and need an entered runtime the
+    // moment they touch D-Bus during startup, before any of our own async
+    // code runs.
+    let _rt_guard = rt.enter();
     let rt = Arc::new(rt);
 
     let window = MainWindow::new()?;


### PR DESCRIPTION
## Summary
- Fix zbus/tokio panic on Linux startup by entering the tokio runtime before Slint and connstore init
- Ignore RUSTSEC-2025-0134 (rustls-pemfile unmaintained) in the audit workflow, transitive via tiberius with no upgrade path yet

## Changes
- `app/src/main.rs`: keep an entered-runtime guard alive through `MainWindow::new()` and `ConnStore::open_default()`, since Slint's winit backend, rfd, and notify-rust all pull in zbus on Linux and need an ambient tokio context the moment they touch D-Bus
- `.github/workflows/audit.yml`: add `RUSTSEC-2025-0134` to the ignore list with a documented rationale, matching the existing pattern for other transitive tiberius/rustls advisories

## Test plan
- [x] `cargo build -p rdb`
- [x] `cargo fmt -p rdb -- --check`
- [x] `cargo clippy -p rdb --bin rdb -- -D warnings`
- [x] YAML syntax validated for `audit.yml`
- [ ] Linux confirmation from issue reporter that the startup panic is gone

## Related Issue
Fixes #195
Fixes #196