### PR TITLE
feat: mongo query completion, per-engine docs, issue template fix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,9 +44,16 @@ body:
       label: Operating system
       options:
         - macOS
+        - Windows
         - Linux
+        - Other
     validations:
       required: true
+  - type: input
+    id: os-detail
+    attributes:
+      label: OS version / distro (optional)
+      placeholder: e.g. macOS 15.2, Ubuntu 24.04, Windows 11, FreeBSD 14
   - type: input
     id: version
     attributes:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5885,7 +5885,7 @@ dependencies = [
 
 [[package]]
 name = "rdb"
-version = "0.33.0"
+version = "0.34.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -221,9 +221,21 @@ The release binary lands at `target/release/rdb`.
 ### Connect & query
 
 1. Click a saved connection → connects, schema loads in sidebar.
-2. Type SQL (PostgreSQL/MySQL/SQL Server/ClickHouse), CQL (Cassandra), a Redis command (e.g. `GET key`), or a MongoDB JSON operation in the query editor.
+2. Type a query for the connected engine — syntax differs per engine, see below.
 3. `Cmd+Enter` (macOS) / `Ctrl+Enter` (Linux) to run.
 4. Click a table/collection in the sidebar to auto-generate and run a `SELECT *` / `find` query.
+
+### Query syntax per engine
+
+| Engine | Language | Example |
+| --- | --- | --- |
+| PostgreSQL, MySQL, SQLite, SQL Server, ClickHouse | SQL | `SELECT * FROM users` |
+| Cassandra | CQL (no JOIN/subquery/HAVING) | `SELECT * FROM keyspace.table` |
+| Redis | command tokens | `GET user:1`, `SET user:1 value` |
+| MongoDB | mongosh chain, or a JSON envelope | `db.users.find({ age: { $gt: 20 } }).limit(5)`<br>`{"collection":"users","op":"find","body":{}}` |
+
+More detail (including MongoDB's supported methods/modifiers) is on the
+[docs page](https://rdb.suiflex.dev/docs).
 
 ### Command palette
 

--- a/app/src/completion.rs
+++ b/app/src/completion.rs
@@ -331,6 +331,15 @@ pub fn suggest(
         } else if is_mongo && mongo::is_collection(nodes, owner_word) {
             // MongoDB: `db.<collection>.` — offer collection methods.
             mongo::methods()
+        } else if is_mongo
+            && owner_word.is_empty()
+            && matches!(mongo::call_context(before_dot), Some(ctx) if ctx.depth == 0)
+        {
+            // MongoDB: `db.coll.find().` — the call closed (every `{`/`[` it
+            // opened is matched), so offer chained modifiers instead of
+            // falling through to column completion (there's no owner name
+            // right before this dot to look up columns for anyway).
+            mongo::chain_modifiers()
         } else {
             let cols = columns_of(nodes, &owner);
             if !cols.is_empty() {
@@ -579,6 +588,26 @@ mod tests {
         );
         assert!(c.iter().any(|x| x.label == "find"));
         assert!(!c.iter().any(|x| x.label == "source"));
+    }
+
+    #[test]
+    fn mongo_closed_call_dot_offers_chain_modifiers() {
+        // `db.coll.find().s` — the call already closed, so `.` should offer
+        // limit/skip/sort, not fall through to (empty) column completion.
+        let mut ns = nodes();
+        ns.push(VmTreeNode {
+            label: "log_inbound".into(),
+            kind: "collection".into(),
+        });
+        let (n, c) = sug(
+            "db.log_inbound.find().s",
+            &ns,
+            "public",
+            rdb_connstore::QueryLanguage::Mongo,
+        );
+        assert_eq!(n, 1);
+        assert!(c.iter().any(|x| x.label == "sort"));
+        assert!(!c.iter().any(|x| x.label == "limit"));
     }
 
     #[test]

--- a/app/src/completion.rs
+++ b/app/src/completion.rs
@@ -298,15 +298,23 @@ pub fn suggest(
     // Default table/column suggestions come from the active schema only, so the
     // popup follows the connected schema without the user picking it first.
     let scope = schema_scope(nodes, active_schema);
-    let word = trailing_word(before_cursor);
-    let head = before_cursor.strip_suffix(word).unwrap_or(before_cursor);
+    let is_mongo = language == rdb_connstore::QueryLanguage::Mongo;
+    let mut word = trailing_word(before_cursor);
+    let mut head = before_cursor.strip_suffix(word).unwrap_or(before_cursor);
+    // Mongo operator/stage names are `$`-prefixed, but `$` isn't an identifier
+    // char, so `trailing_word` stops right after it — extend the word (and
+    // its replace length) back over the `$` so matching/insertion land on
+    // the whole `$eq`-style token instead of duplicating the `$`.
+    if is_mongo && head.ends_with('$') {
+        word = &before_cursor[before_cursor.len() - word.len() - 1..];
+        head = before_cursor.strip_suffix(word).unwrap_or(before_cursor);
+    }
     // Type-triggered: don't pop up on an empty line or right after whitespace —
     // only once the user has typed at least one char of a word. `table.`/`alias.`
-    // is an explicit request for that table's columns, so it still fires.
+    // (or a bare Mongo `$`) is an explicit request, so it still fires.
     if word.is_empty() && !head.ends_with('.') {
         return (0, Vec::new());
     }
-    let is_mongo = language == rdb_connstore::QueryLanguage::Mongo;
     let mut cands = if let Some(before_dot) = head.strip_suffix('.') {
         // `table.` / `alias.` → that table's columns. When the name before the
         // dot is a schema/database, offer that schema's tables instead.
@@ -328,7 +336,10 @@ pub fn suggest(
             cols
         }
     } else if is_mongo {
-        mongo::bare_word(scope)
+        match mongo::call_context(before_cursor) {
+            Some(ctx) if ctx.depth >= 1 => mongo::in_call(&ctx, nodes),
+            _ => mongo::bare_word(scope),
+        }
     } else {
         // Keyword context comes from the current line; `before_cursor` may span
         // several lines (alias resolution needs the whole statement).
@@ -538,6 +549,45 @@ mod tests {
         );
         assert!(c.iter().any(|x| x.label == "find"));
         assert!(c.iter().any(|x| x.label == "findOne"));
+    }
+
+    #[test]
+    fn mongo_find_filter_offers_field_names() {
+        let mut ns = nodes();
+        ns.push(VmTreeNode {
+            label: "log_inbound".into(),
+            kind: "collection".into(),
+        });
+        ns.push(VmTreeNode {
+            label: "source".into(),
+            kind: "field".into(),
+        });
+        let (_, c) = sug(
+            "db.log_inbound.find({ sou",
+            &ns,
+            "public",
+            rdb_connstore::QueryLanguage::Mongo,
+        );
+        assert!(c.iter().any(|x| x.label == "source"));
+    }
+
+    #[test]
+    fn mongo_dollar_offers_query_operators_and_replaces_whole_token() {
+        let mut ns = nodes();
+        ns.push(VmTreeNode {
+            label: "log_inbound".into(),
+            kind: "collection".into(),
+        });
+        let (n, c) = sug(
+            "db.log_inbound.find({ age: { $g",
+            &ns,
+            "public",
+            rdb_connstore::QueryLanguage::Mongo,
+        );
+        // Replace length covers the `$` too, so accepting "$gt" doesn't
+        // duplicate the `$` the user already typed.
+        assert_eq!(n, 2);
+        assert!(c.iter().any(|x| x.label == "$gt"));
     }
 
     #[test]

--- a/app/src/completion.rs
+++ b/app/src/completion.rs
@@ -321,19 +321,25 @@ pub fn suggest(
         // Explicit `schema.` uses the whole tree so other schemas stay reachable.
         let owner_word = trailing_word(before_dot);
         let owner = resolve_alias(stmt, owner_word, language);
-        let cols = columns_of(nodes, &owner);
-        if !cols.is_empty() {
-            cols
-        } else if is_mongo && owner_word.eq_ignore_ascii_case("db") {
+        // MongoDB's `db.` / `db.<collection>.` shapes are unambiguous and must
+        // win over column completion: a collection's sampled fields (from
+        // Driver::sample_fields) would otherwise satisfy the `!cols.is_empty()`
+        // check below and hide the method list.
+        if is_mongo && owner_word.eq_ignore_ascii_case("db") {
             // MongoDB: `db.` is the current database — offer its collections.
             tables(scope)
         } else if is_mongo && mongo::is_collection(nodes, owner_word) {
             // MongoDB: `db.<collection>.` — offer collection methods.
             mongo::methods()
-        } else if is_database(nodes, owner_word) {
-            tables(schema_scope(nodes, owner_word))
         } else {
-            cols
+            let cols = columns_of(nodes, &owner);
+            if !cols.is_empty() {
+                cols
+            } else if is_database(nodes, owner_word) {
+                tables(schema_scope(nodes, owner_word))
+            } else {
+                cols
+            }
         }
     } else if is_mongo {
         match mongo::call_context(before_cursor) {
@@ -549,6 +555,30 @@ mod tests {
         );
         assert!(c.iter().any(|x| x.label == "find"));
         assert!(c.iter().any(|x| x.label == "findOne"));
+    }
+
+    /// Regression: once `Driver::sample_fields` populates a collection's
+    /// fields, `db.<collection>.` must still offer methods, not those fields
+    /// (the `!cols.is_empty()` check must not win over the Mongo dot-branch).
+    #[test]
+    fn mongo_collection_dot_with_sampled_fields_still_suggests_methods() {
+        let mut ns = nodes();
+        ns.push(VmTreeNode {
+            label: "log_inbound".into(),
+            kind: "collection".into(),
+        });
+        ns.push(VmTreeNode {
+            label: "source".into(),
+            kind: "field".into(),
+        });
+        let (_, c) = sug(
+            "db.log_inbound.fi",
+            &ns,
+            "public",
+            rdb_connstore::QueryLanguage::Mongo,
+        );
+        assert!(c.iter().any(|x| x.label == "find"));
+        assert!(!c.iter().any(|x| x.label == "source"));
     }
 
     #[test]

--- a/app/src/completion/mongo.rs
+++ b/app/src/completion/mongo.rs
@@ -33,6 +33,17 @@ pub fn methods() -> Vec<Candidate> {
         .collect()
 }
 
+/// mongosh's chained result modifiers, offered after a closed
+/// `db.<collection>.<method>(...)` call (`db.coll.find().<here>`) — see
+/// `call_context`'s `depth == 0` case. Matches `query_parse.rs`'s
+/// `parse_mongo_line`, which parses this chain permissively after any method
+/// (not just `find`), so offered the same way here rather than gating on it.
+const CHAIN_MODIFIERS: &[&str] = &["limit", "skip", "sort"];
+
+pub fn chain_modifiers() -> Vec<Candidate> {
+    keyword_candidates(CHAIN_MODIFIERS)
+}
+
 /// Does `name` match a collection node in the tree?
 pub fn is_collection(nodes: &[VmTreeNode], name: &str) -> bool {
     let nl = name.to_lowercase();

--- a/app/src/completion/mongo.rs
+++ b/app/src/completion/mongo.rs
@@ -4,7 +4,7 @@
 
 use crate::model::VmTreeNode;
 
-use super::{tables, Candidate};
+use super::{columns_of, tables, Candidate};
 
 /// mongosh collection methods, offered after `db.<collection>.` so Mongo
 /// completion reaches parity with SQL column completion.
@@ -50,4 +50,293 @@ pub fn bare_word(scope: &[VmTreeNode]) -> Vec<Candidate> {
     }];
     c.extend(tables(scope));
     c
+}
+
+/// Cursor position relative to the nearest `db.<coll>.<method>(...)` call
+/// before it. Best-effort text scan, not a JSON parser — matches the rest of
+/// this module's heuristic style (see `query_parse.rs`'s own stance on this).
+/// Misfires on unusual nesting (e.g. `$or: [ { <here> } ]`) are acceptable;
+/// extend the scan rather than reaching for a real parser.
+pub struct CallCtx {
+    pub collection: String,
+    pub method: String,
+    /// Unmatched `{`/`[` opened after the method's `(`.
+    pub depth: u32,
+    /// Key text immediately preceding the innermost still-open `{`/`[`, if
+    /// any (e.g. `$set` in `{ $set: { |`).
+    pub open_key: Option<String>,
+    /// Top-level (`depth == 0`) commas seen since the method's `(` — which
+    /// positional argument the cursor is in.
+    pub arg_index: u32,
+}
+
+/// Cursor position, anchored at the last `db.` before it so an earlier,
+/// unrelated call in the same document can't pollute the scan.
+pub fn call_context(before_cursor: &str) -> Option<CallCtx> {
+    let anchor = before_cursor.rfind("db.")?;
+    let mut rest = &before_cursor[anchor + 3..];
+    let collection = take_ident(&mut rest)?;
+    rest = rest.strip_prefix('.')?;
+    let method = take_ident(&mut rest)?;
+    let rest = rest.strip_prefix('(')?;
+    let (depth, open_key, arg_index) = scan_call_body(rest);
+    Some(CallCtx {
+        collection,
+        method,
+        depth,
+        open_key,
+        arg_index,
+    })
+}
+
+fn take_ident(rest: &mut &str) -> Option<String> {
+    let end = rest
+        .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+        .unwrap_or(rest.len());
+    if end == 0 {
+        return None;
+    }
+    let ident = rest[..end].to_string();
+    *rest = &rest[end..];
+    Some(ident)
+}
+
+/// Scans everything after a method's `(` up to the cursor: brace/bracket
+/// depth, the key that precedes the innermost still-open one, and how many
+/// top-level commas (argument separators) have been seen. String-literal
+/// aware so `{`/`}`/`,`/`:` inside a quoted value don't confuse the scan.
+fn scan_call_body(rest: &str) -> (u32, Option<String>, u32) {
+    let mut stack: Vec<Option<String>> = Vec::new();
+    let mut pending = String::new();
+    let mut pending_key: Option<String> = None;
+    let mut arg_index: u32 = 0;
+    let mut in_string: Option<char> = None;
+    let mut escape = false;
+    for c in rest.chars() {
+        if let Some(q) = in_string {
+            if escape {
+                escape = false;
+            } else if c == '\\' {
+                escape = true;
+            } else if c == q {
+                in_string = None;
+            }
+            continue;
+        }
+        match c {
+            '"' | '\'' => {
+                in_string = Some(c);
+                pending.clear();
+            }
+            '{' | '[' => {
+                stack.push(pending_key.take());
+                pending.clear();
+            }
+            '}' | ']' => {
+                stack.pop();
+                pending.clear();
+                pending_key = None;
+            }
+            ':' => {
+                let key = pending.trim().to_string();
+                pending_key = if key.is_empty() { None } else { Some(key) };
+                pending.clear();
+            }
+            ',' => {
+                if stack.is_empty() {
+                    arg_index += 1;
+                }
+                pending.clear();
+                pending_key = None;
+            }
+            c if c.is_ascii_alphanumeric() || c == '_' || c == '$' || c == '.' => {
+                pending.push(c);
+            }
+            _ => pending.clear(),
+        }
+    }
+    (
+        stack.len() as u32,
+        stack.last().cloned().flatten(),
+        arg_index,
+    )
+}
+
+/// MongoDB query operators, offered as filter values (`{ field: { <here> } }`).
+const QUERY_OPS: &[&str] = &[
+    "$eq",
+    "$ne",
+    "$gt",
+    "$gte",
+    "$lt",
+    "$lte",
+    "$in",
+    "$nin",
+    "$exists",
+    "$regex",
+    "$and",
+    "$or",
+    "$not",
+    "$nor",
+    "$type",
+    "$size",
+    "$all",
+    "$elemMatch",
+];
+
+/// Update operators, offered as the top-level keys of an update document.
+const UPDATE_OPS: &[&str] = &[
+    "$set",
+    "$unset",
+    "$inc",
+    "$push",
+    "$pull",
+    "$addToSet",
+    "$rename",
+    "$currentDate",
+    "$min",
+    "$max",
+];
+
+/// Aggregation pipeline stage names, offered inside a pipeline stage object.
+const STAGE_NAMES: &[&str] = &[
+    "$match",
+    "$group",
+    "$project",
+    "$sort",
+    "$limit",
+    "$skip",
+    "$unwind",
+    "$lookup",
+    "$count",
+    "$addFields",
+    "$facet",
+    "$replaceRoot",
+];
+
+fn keyword_candidates(words: &[&str]) -> Vec<Candidate> {
+    words
+        .iter()
+        .map(|w| Candidate {
+            label: (*w).to_string(),
+            kind: "keyword".into(),
+            sub: String::new(),
+        })
+        .collect()
+}
+
+/// Filter-shaped keys: an open object under one of these offers field names
+/// again rather than another operator (`{ $match: { <here> } }`).
+fn is_filter_shaped(key: &str) -> bool {
+    matches!(key, "$match" | "$set" | "$or" | "$and" | "$nor")
+}
+
+/// Completions once the cursor is inside a `db.<coll>.<method>(...)` call
+/// (`ctx.depth >= 1`). Heuristic dispatch mirroring the SQL/CQL clause-
+/// position `bare_word` functions: best real guess for the position, not a
+/// guarantee.
+pub fn in_call(ctx: &CallCtx, nodes: &[VmTreeNode]) -> Vec<Candidate> {
+    let is_filter_method = matches!(
+        ctx.method.as_str(),
+        "find"
+            | "findOne"
+            | "countDocuments"
+            | "deleteOne"
+            | "deleteMany"
+            | "updateOne"
+            | "updateMany"
+    );
+    match &ctx.open_key {
+        None if is_filter_method && ctx.arg_index == 0 => columns_of(nodes, &ctx.collection),
+        None if matches!(ctx.method.as_str(), "updateOne" | "updateMany") && ctx.arg_index == 1 => {
+            keyword_candidates(UPDATE_OPS)
+        }
+        None if ctx.method == "aggregate" && ctx.depth == 2 => keyword_candidates(STAGE_NAMES),
+        Some(key) if is_filter_shaped(key) => columns_of(nodes, &ctx.collection),
+        Some(key) if UPDATE_OPS.contains(&key.as_str()) => columns_of(nodes, &ctx.collection),
+        _ => keyword_candidates(QUERY_OPS),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn nodes() -> Vec<VmTreeNode> {
+        let mk = |l: &str, k: &str| VmTreeNode {
+            label: l.into(),
+            kind: k.into(),
+        };
+        vec![
+            mk("users", "collection"),
+            mk("name", "field"),
+            mk("age", "field"),
+        ]
+    }
+
+    #[test]
+    fn find_filter_position_offers_fields() {
+        let ctx = call_context("db.users.find({ ").unwrap();
+        assert_eq!(ctx.method, "find");
+        assert_eq!(ctx.depth, 1);
+        assert_eq!(ctx.open_key, None);
+        let labels: Vec<String> = in_call(&ctx, &nodes())
+            .into_iter()
+            .map(|c| c.label)
+            .collect();
+        assert!(labels.iter().any(|l| l == "name"));
+        assert!(labels.iter().any(|l| l == "age"));
+    }
+
+    #[test]
+    fn update_second_arg_offers_update_operators() {
+        let ctx = call_context("db.users.updateOne({ _id: 1 }, { ").unwrap();
+        assert_eq!(ctx.arg_index, 1);
+        assert_eq!(ctx.open_key, None);
+        let labels: Vec<String> = in_call(&ctx, &nodes())
+            .into_iter()
+            .map(|c| c.label)
+            .collect();
+        assert!(labels.iter().any(|l| l == "$set"));
+        assert!(!labels.iter().any(|l| l == "name"));
+    }
+
+    #[test]
+    fn set_key_offers_fields_again() {
+        let ctx = call_context("db.users.updateOne({}, { $set: { ").unwrap();
+        assert_eq!(ctx.open_key, Some("$set".to_string()));
+        let labels: Vec<String> = in_call(&ctx, &nodes())
+            .into_iter()
+            .map(|c| c.label)
+            .collect();
+        assert!(labels.iter().any(|l| l == "name"));
+    }
+
+    #[test]
+    fn aggregate_pipeline_stage_offers_stage_names() {
+        let ctx = call_context("db.users.aggregate([{ ").unwrap();
+        assert_eq!(ctx.depth, 2);
+        let labels: Vec<String> = in_call(&ctx, &nodes())
+            .into_iter()
+            .map(|c| c.label)
+            .collect();
+        assert!(labels.iter().any(|l| l == "$match"));
+    }
+
+    #[test]
+    fn match_stage_offers_fields() {
+        let ctx = call_context("db.users.aggregate([{ $match: { ").unwrap();
+        assert_eq!(ctx.open_key, Some("$match".to_string()));
+        let labels: Vec<String> = in_call(&ctx, &nodes())
+            .into_iter()
+            .map(|c| c.label)
+            .collect();
+        assert!(labels.iter().any(|l| l == "name"));
+    }
+
+    #[test]
+    fn no_call_in_progress_returns_none() {
+        assert!(call_context("db.users.find").is_none());
+        assert!(call_context("db.").is_none());
+    }
 }

--- a/app/src/dispatch.rs
+++ b/app/src/dispatch.rs
@@ -10,7 +10,7 @@ use rdb_core::driver::Driver;
 use rdb_core::error::Result;
 use rdb_core::query::Query;
 use rdb_core::result::ResultSet;
-use rdb_core::schema::{Container, Schema};
+use rdb_core::schema::{Container, Field, Schema};
 use rdb_core::write::{TableRef, WriteOp};
 use rdb_driver_cassandra::CassandraDriver;
 use rdb_driver_clickhouse::ClickhouseDriver;
@@ -186,6 +186,26 @@ impl AnyDriver {
             AnyDriver::Clickhouse(d) => d.containers(database).await,
             #[cfg(feature = "mock")]
             AnyDriver::Mock(d) => d.containers(database).await,
+        }
+    }
+
+    pub async fn sample_fields(
+        &self,
+        database: &str,
+        container: &str,
+        sample_size: u32,
+    ) -> Result<Vec<Field>> {
+        match self {
+            AnyDriver::Postgres(d) => d.sample_fields(database, container, sample_size).await,
+            AnyDriver::Mysql(d) => d.sample_fields(database, container, sample_size).await,
+            AnyDriver::Redis(d) => d.sample_fields(database, container, sample_size).await,
+            AnyDriver::Mongo(d) => d.sample_fields(database, container, sample_size).await,
+            AnyDriver::Sqlite(d) => d.sample_fields(database, container, sample_size).await,
+            AnyDriver::Cassandra(d) => d.sample_fields(database, container, sample_size).await,
+            AnyDriver::Mssql(d) => d.sample_fields(database, container, sample_size).await,
+            AnyDriver::Clickhouse(d) => d.sample_fields(database, container, sample_size).await,
+            #[cfg(feature = "mock")]
+            AnyDriver::Mock(d) => d.sample_fields(database, container, sample_size).await,
         }
     }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1639,6 +1639,55 @@ async fn try_connect(
     }
 }
 
+/// Build the query editor's completion seed for one schema/database. Mongo
+/// has no real schema, so this samples each collection's fields first (see
+/// `Driver::sample_fields`) and completes only the seed with them — the
+/// sidebar tree keeps the real, unsampled schema so it doesn't start
+/// rendering field rows under every collection. Every other engine just
+/// converts the schema tree directly. Shared by the connect flow and the
+/// schema/database switcher, which both need to (re)populate this seed.
+async fn build_completion_seed(
+    driver: &Arc<AnyDriver>,
+    engine: rdb_connstore::Engine,
+    schema_current: &str,
+    schema: &rdb_core::schema::Schema,
+) -> Vec<model::VmTreeNode> {
+    if !matches!(engine, rdb_connstore::Engine::Mongo) {
+        return model::to_completion_nodes(schema_current, schema);
+    }
+    let Some(dbase) = schema.databases.first() else {
+        return model::to_completion_nodes(schema_current, schema);
+    };
+    let mut set = tokio::task::JoinSet::new();
+    for cont in &dbase.containers {
+        let driver = driver.clone();
+        let db = dbase.name.clone();
+        let name = cont.name.clone();
+        set.spawn(async move {
+            let fields = driver
+                .sample_fields(&db, &name, MONGO_FIELD_SAMPLE_SIZE)
+                .await
+                .unwrap_or_default();
+            (name, fields)
+        });
+    }
+    let mut sampled: HashMap<String, Vec<rdb_core::schema::Field>> = HashMap::new();
+    while let Some(res) = set.join_next().await {
+        if let Ok((name, fields)) = res {
+            sampled.insert(name, fields);
+        }
+    }
+    let mut cloned = schema.clone();
+    if let Some(d) = cloned.databases.first_mut() {
+        for cont in &mut d.containers {
+            if let Some(fields) = sampled.remove(&cont.name) {
+                cont.fields = fields;
+            }
+        }
+    }
+    model::to_completion_nodes(schema_current, &cloned)
+}
+
 /// Kind of the active tab ("table" | "sql" | "function"), empty when none.
 fn active_tab_kind(w: &MainWindow) -> String {
     use slint::Model;
@@ -5333,6 +5382,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let rt = rt.clone();
         let current = current.clone();
         let raw_nodes = raw_nodes.clone();
+        let completion_nodes = completion_nodes.clone();
         let cur_engine = cur_engine.clone();
         let expanded_tables = expanded_tables.clone();
         let collapsed_categories = collapsed_categories.clone();
@@ -5413,6 +5463,7 @@ fn main() -> Result<(), slint::PlatformError> {
             let weak2 = weak.clone();
             let current = current.clone();
             let raw_nodes = raw_nodes.clone();
+            let completion_nodes = completion_nodes.clone();
             let expanded_tables = expanded_tables.clone();
             let loaded_dbs = loaded_dbs.clone();
             let query_console = query_console.clone();
@@ -5442,6 +5493,12 @@ fn main() -> Result<(), slint::PlatformError> {
                     clear_loading();
                     return;
                 };
+                // Completion previously stayed seeded from whatever schema was
+                // scoped at connect (possibly empty, if the connection had no
+                // default database) — refresh it for the schema/database the
+                // user just switched to.
+                let seed = build_completion_seed(&driver, engine, &schema_name, &schema).await;
+                *completion_nodes.lock().unwrap() = seed;
                 let nodes = model::to_tree_model(&schema);
                 // Nested engines (Mongo/Redis/Cassandra) now scope to the one
                 // chosen database; open it so its collections show at once.
@@ -7723,54 +7780,14 @@ fn main() -> Result<(), slint::PlatformError> {
                         // and columns fill in from the background load below.
                         let all_schema_names: Vec<String> =
                             schema_names.iter().map(|s| s.to_string()).collect();
-                        // Mongo has no real schema, so sample a few documents per
-                        // collection to seed field-name completion (`find({ | })`).
-                        // Only the completion seed gets the sampled fields — the
-                        // sidebar tree (`raw_nodes`, above) keeps the real,
-                        // unsampled schema so it doesn't start rendering field
-                        // rows under every collection.
-                        let completion_schema = if matches!(engine, rdb_connstore::Engine::Mongo) {
-                            if let Some(dbase) = schema.databases.first() {
-                                let mut set = tokio::task::JoinSet::new();
-                                for cont in &dbase.containers {
-                                    let driver = driver.clone();
-                                    let db = dbase.name.clone();
-                                    let name = cont.name.clone();
-                                    set.spawn(async move {
-                                        let fields = driver
-                                            .sample_fields(&db, &name, MONGO_FIELD_SAMPLE_SIZE)
-                                            .await
-                                            .unwrap_or_default();
-                                        (name, fields)
-                                    });
-                                }
-                                let mut sampled: HashMap<String, Vec<rdb_core::schema::Field>> =
-                                    HashMap::new();
-                                while let Some(res) = set.join_next().await {
-                                    if let Ok((name, fields)) = res {
-                                        sampled.insert(name, fields);
-                                    }
-                                }
-                                let mut cloned = schema.clone();
-                                if let Some(d) = cloned.databases.first_mut() {
-                                    for cont in &mut d.containers {
-                                        if let Some(fields) = sampled.remove(&cont.name) {
-                                            cont.fields = fields;
-                                        }
-                                    }
-                                }
-                                cloned
-                            } else {
-                                schema.clone()
-                            }
-                        } else {
-                            schema.clone()
-                        };
                         {
-                            let mut seed = model::to_completion_nodes(
+                            let mut seed = build_completion_seed(
+                                &driver,
+                                engine,
                                 schema_current.as_str(),
-                                &completion_schema,
-                            );
+                                &schema,
+                            )
+                            .await;
                             for name in &all_schema_names {
                                 if name != schema_current.as_str() {
                                     seed.push(model::VmTreeNode {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -7811,6 +7811,9 @@ fn main() -> Result<(), slint::PlatformError> {
                             if let Some(w) = weak2.upgrade() {
                                 w.set_schema_tree(ModelRc::from(Rc::new(VecModel::from(rows))));
                                 w.set_sql_capable(sql_capable);
+                                w.set_new_tab_label(
+                                    crate::query_parse::language_label(engine).into(),
+                                );
                                 w.set_schema_name(schema_current);
                                 w.set_schema_list(ModelRc::from(Rc::new(VecModel::from(
                                     schema_names,

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -29,7 +29,7 @@ mod theme;
 mod update;
 
 use std::cell::{Cell, RefCell};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -41,6 +41,8 @@ use dispatch::AnyDriver;
 const UNGROUPED: &str = "Ungrouped";
 const MIN_FONT_SIZE: i32 = 10;
 const MAX_FONT_SIZE: i32 = 18;
+/// Documents sampled per Mongo collection to seed field-name completion.
+const MONGO_FIELD_SAMPLE_SIZE: u32 = 20;
 
 fn clamp_font_size(size: i32) -> i32 {
     size.clamp(MIN_FONT_SIZE, MAX_FONT_SIZE)
@@ -7645,7 +7647,8 @@ fn main() -> Result<(), slint::PlatformError> {
                             .into_iter()
                             .map(SharedString::from)
                             .collect();
-                        *slot = Some((engine, Arc::new(driver)));
+                        let driver = Arc::new(driver);
+                        *slot = Some((engine, driver.clone()));
                         drop(slot);
                         let nodes = model::to_tree_model(&schema);
                         let fields = model::to_structure_model(&schema);
@@ -7720,9 +7723,54 @@ fn main() -> Result<(), slint::PlatformError> {
                         // and columns fill in from the background load below.
                         let all_schema_names: Vec<String> =
                             schema_names.iter().map(|s| s.to_string()).collect();
+                        // Mongo has no real schema, so sample a few documents per
+                        // collection to seed field-name completion (`find({ | })`).
+                        // Only the completion seed gets the sampled fields — the
+                        // sidebar tree (`raw_nodes`, above) keeps the real,
+                        // unsampled schema so it doesn't start rendering field
+                        // rows under every collection.
+                        let completion_schema = if matches!(engine, rdb_connstore::Engine::Mongo) {
+                            if let Some(dbase) = schema.databases.first() {
+                                let mut set = tokio::task::JoinSet::new();
+                                for cont in &dbase.containers {
+                                    let driver = driver.clone();
+                                    let db = dbase.name.clone();
+                                    let name = cont.name.clone();
+                                    set.spawn(async move {
+                                        let fields = driver
+                                            .sample_fields(&db, &name, MONGO_FIELD_SAMPLE_SIZE)
+                                            .await
+                                            .unwrap_or_default();
+                                        (name, fields)
+                                    });
+                                }
+                                let mut sampled: HashMap<String, Vec<rdb_core::schema::Field>> =
+                                    HashMap::new();
+                                while let Some(res) = set.join_next().await {
+                                    if let Ok((name, fields)) = res {
+                                        sampled.insert(name, fields);
+                                    }
+                                }
+                                let mut cloned = schema.clone();
+                                if let Some(d) = cloned.databases.first_mut() {
+                                    for cont in &mut d.containers {
+                                        if let Some(fields) = sampled.remove(&cont.name) {
+                                            cont.fields = fields;
+                                        }
+                                    }
+                                }
+                                cloned
+                            } else {
+                                schema.clone()
+                            }
+                        } else {
+                            schema.clone()
+                        };
                         {
-                            let mut seed =
-                                model::to_completion_nodes(schema_current.as_str(), &schema);
+                            let mut seed = model::to_completion_nodes(
+                                schema_current.as_str(),
+                                &completion_schema,
+                            );
                             for name in &all_schema_names {
                                 if name != schema_current.as_str() {
                                     seed.push(model::VmTreeNode {

--- a/app/src/query_parse.rs
+++ b/app/src/query_parse.rs
@@ -109,6 +109,19 @@ pub fn editor_hint(engine: Engine) -> &'static str {
     }
 }
 
+/// Short label for the "new query tab" button, naming the connected
+/// engine's query language.
+pub fn language_label(engine: Engine) -> &'static str {
+    match engine {
+        Engine::Postgres | Engine::MySql | Engine::Sqlite | Engine::Mssql | Engine::Clickhouse => {
+            "SQL"
+        }
+        Engine::Cassandra => "CQL",
+        Engine::Redis => "Redis",
+        Engine::Mongo => "Mongo",
+    }
+}
+
 /// Line-comment marker for the engine's query language. Used by the editor's
 /// Cmd+/ toggle and to strip commented lines before a query runs.
 pub fn comment_prefix(engine: Engine) -> &'static str {

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -292,6 +292,9 @@ callback create-table-commit();
     // result shape: 0 Table, 1 Documents, 2 KeyValue, 3 Affected
     in property <int> result-kind: 0;
     in property <bool> sql-capable: true;
+    // Label for the "+ new query tab" button — names the connected engine's
+    // query language (SQL/CQL/Redis/Mongo) instead of a hardcoded "SQL".
+    in property <string> new-tab-label: "SQL";
     in property <string> result-status;
     in-out property <int> selected-row: 0;
     in-out property <int> selected-col: -1;
@@ -984,7 +987,7 @@ callback create-table-commit();
                     VerticalLayout {
                         alignment: center;
                         SecondaryButton {
-                            text: "SQL";
+                            text: root.new-tab-label;
                             tooltip: "New query tab  " + Shortcut.primary + Shortcut.separator + "T";
                             height: 28px;
                             clicked => { root.new-tab(); }

--- a/crates/core/src/driver.rs
+++ b/crates/core/src/driver.rs
@@ -51,6 +51,21 @@ pub trait Driver: Send + Sync {
         Ok(Vec::new())
     }
 
+    /// Best-effort field discovery for schema-less engines (Mongo): sample up
+    /// to `sample_size` documents from `container` and union their keys into
+    /// [`Field`](crate::schema::Field)s, for the query editor's completion
+    /// popup. Engines with a real schema already get fields from
+    /// [`Driver::schema`]/[`Driver::containers`] and can ignore this — default
+    /// is empty, no sampling.
+    async fn sample_fields(
+        &self,
+        _database: &str,
+        _container: &str,
+        _sample_size: u32,
+    ) -> Result<Vec<crate::schema::Field>> {
+        Ok(Vec::new())
+    }
+
     /// Run a query. Drivers handle the `Query` variant(s) they support and
     /// return `RdbError::UnsupportedQuery` for the rest.
     async fn query(&self, q: &Query) -> Result<ResultSet>;

--- a/crates/driver-mongo/src/driver.rs
+++ b/crates/driver-mongo/src/driver.rs
@@ -32,10 +32,6 @@ pub struct MongoDriver {
 /// Fallback collection cap when the UI has not pushed a limit yet.
 const DEFAULT_COLLECTION_LIMIT: usize = 200;
 
-/// Documents sampled per collection for field-name completion. Cheap: one
-/// `find().limit(n)` round trip, no full scan, no index required.
-const FIELD_SAMPLE_SIZE: u32 = 20;
-
 /// Mongo's internal databases. Hidden from the sidebar so the user's own
 /// databases aren't buried, matching Compass/TablePlus defaults.
 fn is_system_db(name: &str) -> bool {
@@ -557,7 +553,14 @@ mod tests {
         );
         assert_eq!(
             order,
-            vec!["name", "age", "address", "address.city", "email", "address.zip"]
+            vec![
+                "name",
+                "age",
+                "address",
+                "address.city",
+                "email",
+                "address.zip"
+            ]
         );
         assert_eq!(types["age"], "int32");
         assert_eq!(types["address"], "object");

--- a/crates/driver-mongo/src/driver.rs
+++ b/crates/driver-mongo/src/driver.rs
@@ -13,7 +13,7 @@ use rdb_core::driver::Driver;
 use rdb_core::error::{RdbError, Result};
 use rdb_core::query::{MongoKind, MongoOp, Query};
 use rdb_core::result::{Cell, ResultSet};
-use rdb_core::schema::{Container, ContainerKind, Database, Schema};
+use rdb_core::schema::{Container, ContainerKind, Database, Field, Schema};
 use rdb_core::write::{TableRef, WriteOp};
 
 use crate::convert::{document_to_json, json_to_document};
@@ -31,6 +31,10 @@ pub struct MongoDriver {
 
 /// Fallback collection cap when the UI has not pushed a limit yet.
 const DEFAULT_COLLECTION_LIMIT: usize = 200;
+
+/// Documents sampled per collection for field-name completion. Cheap: one
+/// `find().limit(n)` round trip, no full scan, no index required.
+const FIELD_SAMPLE_SIZE: u32 = 20;
 
 /// Mongo's internal databases. Hidden from the sidebar so the user's own
 /// databases aren't buried, matching Compass/TablePlus defaults.
@@ -216,6 +220,43 @@ impl Driver for MongoDriver {
             .collect())
     }
 
+    /// Mongo has no real schema, so completion falls back to sampling: union
+    /// the top-level keys (plus one level of nested-object dot notation,
+    /// e.g. `address.city`) across up to `sample_size` documents.
+    async fn sample_fields(
+        &self,
+        database: &str,
+        container: &str,
+        sample_size: u32,
+    ) -> Result<Vec<Field>> {
+        let coll: Collection<Document> = self.client.database(database).collection(container);
+        let mut cursor = coll
+            .find(doc! {})
+            .limit(sample_size as i64)
+            .await
+            .map_err(|e| RdbError::Schema(e.to_string()))?;
+        let mut order: Vec<String> = Vec::new();
+        let mut types: std::collections::HashMap<String, &'static str> =
+            std::collections::HashMap::new();
+        while let Some(d) = cursor
+            .try_next()
+            .await
+            .map_err(|e| RdbError::Schema(e.to_string()))?
+        {
+            collect_keys(&d, "", &mut order, &mut types);
+        }
+        Ok(order
+            .into_iter()
+            .map(|name| Field {
+                type_name: types.get(&name).copied().unwrap_or("mixed").to_string(),
+                name,
+                nullable: true,
+                pk: false,
+                fk: false,
+            })
+            .collect())
+    }
+
     async fn query(&self, q: &Query) -> Result<ResultSet> {
         let op: &MongoOp = match q {
             Query::Mongo(op) => op,
@@ -355,6 +396,43 @@ fn pk_id(pk: &[(String, Cell)]) -> Result<mongodb::bson::Bson> {
     Ok(cell_to_bson(cell))
 }
 
+/// Insert-order union of a document's keys into `order`/`types`, one level
+/// of nested objects deep (`address.city`), used by [`MongoDriver::sample_fields`].
+fn collect_keys(
+    doc: &Document,
+    prefix: &str,
+    order: &mut Vec<String>,
+    types: &mut std::collections::HashMap<String, &'static str>,
+) {
+    for (key, value) in doc {
+        let full = format!("{prefix}{key}");
+        if !types.contains_key(&full) {
+            order.push(full.clone());
+        }
+        types.insert(full.clone(), bson_type_name(value));
+        if let mongodb::bson::Bson::Document(sub) = value {
+            collect_keys(sub, &format!("{full}."), order, types);
+        }
+    }
+}
+
+fn bson_type_name(b: &mongodb::bson::Bson) -> &'static str {
+    use mongodb::bson::Bson;
+    match b {
+        Bson::Double(_) => "double",
+        Bson::String(_) => "string",
+        Bson::Array(_) => "array",
+        Bson::Document(_) => "object",
+        Bson::Boolean(_) => "bool",
+        Bson::Null => "null",
+        Bson::Int32(_) => "int32",
+        Bson::Int64(_) => "int64",
+        Bson::ObjectId(_) => "objectId",
+        Bson::DateTime(_) => "date",
+        _ => "mixed",
+    }
+}
+
 fn cell_to_bson(c: &Cell) -> mongodb::bson::Bson {
     use mongodb::bson::Bson;
     match c {
@@ -459,6 +537,31 @@ mod tests {
     fn build_uri_full_uri_override_is_verbatim() {
         let srv = "mongodb+srv://user:pass@cluster0.abc.mongodb.net/app?retryWrites=true";
         assert_eq!(build_uri(&cfg(Some(srv), SslMode::Require)), srv);
+    }
+
+    #[test]
+    fn collect_keys_unions_top_level_and_one_nested_level() {
+        let mut order = Vec::new();
+        let mut types = std::collections::HashMap::new();
+        collect_keys(
+            &doc! { "name": "a", "age": 1, "address": { "city": "x" } },
+            "",
+            &mut order,
+            &mut types,
+        );
+        collect_keys(
+            &doc! { "name": "b", "email": "b@x.com", "address": { "zip": "1" } },
+            "",
+            &mut order,
+            &mut types,
+        );
+        assert_eq!(
+            order,
+            vec!["name", "age", "address", "address.city", "email", "address.zip"]
+        );
+        assert_eq!(types["age"], "int32");
+        assert_eq!(types["address"], "object");
+        assert_eq!(types["address.city"], "string");
     }
 
     #[test]

--- a/website/src/pages/docs.astro
+++ b/website/src/pages/docs.astro
@@ -10,7 +10,7 @@ const guides = [
   },
   {
     title: "Connect and query",
-    body: "Click a saved connection and the schema loads in the sidebar. Type a query for the connected engine — see Query syntax below — then press Cmd+Enter (Ctrl+Enter on Windows and Linux) to run.",
+    body: "Click a saved connection and the schema loads in the sidebar. Type a query for the connected engine (see Query syntax below), then press Cmd+Enter (Ctrl+Enter on Windows and Linux) to run.",
   },
   {
     title: "Browse a table",
@@ -32,7 +32,7 @@ const querySyntax = [
     engines: "Cassandra",
     language: "CQL",
     examples: ["SELECT * FROM keyspace.table ALLOW FILTERING"],
-    note: "No JOIN, subquery, or HAVING — CQL is a narrower dialect than SQL.",
+    note: "No JOIN, subquery, or HAVING: CQL is a narrower dialect than SQL.",
   },
   {
     engines: "Redis",
@@ -89,8 +89,8 @@ const querySyntax = [
     <div class="mx-auto max-w-4xl px-4 py-14 sm:px-6">
       <h2 class="font-display text-2xl font-semibold tracking-tight">Query syntax per engine</h2>
       <p class="mt-3 max-w-xl text-sm leading-relaxed text-fg-2">
-        Each engine's query editor tab speaks that engine's native language
-        — there's no single unified query syntax across all of them.
+        Each engine's query editor tab speaks that engine's native language;
+        there's no single unified query syntax across all of them.
       </p>
       <div class="mt-6 grid gap-4 sm:grid-cols-2">
         {

--- a/website/src/pages/docs.astro
+++ b/website/src/pages/docs.astro
@@ -10,7 +10,7 @@ const guides = [
   },
   {
     title: "Connect and query",
-    body: "Click a saved connection and the schema loads in the sidebar. Type SQL, a Redis command, or a MongoDB JSON operation, then press Cmd+Enter (Ctrl+Enter on Windows and Linux) to run.",
+    body: "Click a saved connection and the schema loads in the sidebar. Type a query for the connected engine — see Query syntax below — then press Cmd+Enter (Ctrl+Enter on Windows and Linux) to run.",
   },
   {
     title: "Browse a table",
@@ -19,6 +19,33 @@ const guides = [
   {
     title: "Jump anywhere",
     body: "Cmd+K opens the command palette: fuzzy-search every saved connection and schema object without touching the mouse.",
+  },
+];
+
+const querySyntax = [
+  {
+    engines: "PostgreSQL, MySQL, SQLite, SQL Server, ClickHouse",
+    language: "SQL",
+    examples: ["SELECT * FROM users WHERE active = true"],
+  },
+  {
+    engines: "Cassandra",
+    language: "CQL",
+    examples: ["SELECT * FROM keyspace.table ALLOW FILTERING"],
+    note: "No JOIN, subquery, or HAVING — CQL is a narrower dialect than SQL.",
+  },
+  {
+    engines: "Redis",
+    language: "command tokens",
+    examples: ["GET user:1", "SET user:1 value", "HGETALL user:1"],
+  },
+  {
+    engines: "MongoDB",
+    language: "mongosh chain, or a JSON envelope",
+    examples: [
+      "db.users.find({ age: { $gt: 20 } }).limit(5)",
+      '{"collection":"users","op":"find","body":{}}',
+    ],
   },
 ];
 ---
@@ -56,6 +83,32 @@ const guides = [
         ))
       }
     </ol>
+  </section>
+
+  <section class="border-t border-line" aria-label="Query syntax">
+    <div class="mx-auto max-w-4xl px-4 py-14 sm:px-6">
+      <h2 class="font-display text-2xl font-semibold tracking-tight">Query syntax per engine</h2>
+      <p class="mt-3 max-w-xl text-sm leading-relaxed text-fg-2">
+        Each engine's query editor tab speaks that engine's native language
+        — there's no single unified query syntax across all of them.
+      </p>
+      <div class="mt-6 grid gap-4 sm:grid-cols-2">
+        {
+          querySyntax.map((row) => (
+            <div class="rounded-xl border border-line bg-panel px-4 py-4">
+              <span class="block text-sm font-medium">{row.engines}</span>
+              <span class="block text-xs text-fg-3">{row.language}</span>
+              <div class="mt-3 space-y-2">
+                {row.examples.map((ex) => (
+                  <pre class="overflow-x-auto rounded-lg border border-line bg-code px-3 py-2 font-mono text-[13px] text-fg-2"><code>{ex}</code></pre>
+                ))}
+              </div>
+              {row.note && <p class="mt-2 text-xs text-fg-3">{row.note}</p>}
+            </div>
+          ))
+        }
+      </div>
+    </div>
   </section>
 
   <section class="border-t border-line">


### PR DESCRIPTION
## Summary
- Improve MongoDB query completion: field names, `$`-operators, aggregation stage names, and chained `.limit()/.skip()/.sort()`, seeded by sampling a few documents per collection since Mongo has no static schema.
- Fix completion going stale after a schema/database switch (affected any engine connected without a default database, not just Mongo).
- Document per-engine query syntax in the README and website docs page.
- Broaden the bug report issue template's OS dropdown (add Windows/Other + optional version field).
- New query tab button now names the connected engine's query language instead of a hardcoded "SQL".

## Changes
- `crates/core/src/driver.rs`, `crates/driver-mongo/src/driver.rs`: `Driver::sample_fields` (default no-op; Mongo samples up to 20 docs per collection and unions their keys).
- `app/src/dispatch.rs`, `app/src/main.rs`: wire sampling into the connect flow and the schema/database switcher via a shared `build_completion_seed` helper.
- `app/src/completion.rs`, `app/src/completion/mongo.rs`: bracket-depth-aware `call_context`, field/operator/stage-name dispatch, chained-modifier completion, and a priority fix so `db.<collection>.` still offers methods once fields are sampled.
- `app/src/query_parse.rs`, `app/src/ui/app-window.slint`: dynamic new-tab button label per engine.
- `README.md`, `website/src/pages/docs.astro`: per-engine query syntax section.
- `.github/ISSUE_TEMPLATE/bug_report.yml`: OS dropdown + optional version/distro field.

## Test plan
- [x] `make all` (fmt-check + lint + test + build) passes on the full workspace
- [x] `cargo test -p rdb --bin rdb completion` — 41 completion tests pass, including new Mongo regression tests
- [x] `cargo test -p rdb-driver-mongo --lib` — field-sampling unit test passes
- [x] Manual: connected to a live Mongo instance without a default database, switched schema, verified collection/field/operator/stage/chained-modifier completion all work and the sidebar tree is unaffected by field sampling
- [x] Manual: new-tab button reads "Mongo" while connected to Mongo, "SQL" for Postgres
- [x] `website` Astro build passes (`npm run build`)