### PR TITLE
feat(app): shift-click selection and whitespace sanitizing in the editor

### DIFF
--- a/app/src/editor.rs
+++ b/app/src/editor.rs
@@ -207,10 +207,18 @@ pub fn sanitize(s: &str) -> String {
         .filter_map(|c| match c {
             '\n' | '\t' => Some(c),
             // Zs category + NBSP variants → plain space
-            '\u{00a0}' | '\u{1680}' | '\u{2000}'..='\u{200a}' | '\u{202f}' | '\u{205f}'
+            '\u{00a0}'
+            | '\u{1680}'
+            | '\u{2000}'..='\u{200a}'
+            | '\u{202f}'
+            | '\u{205f}'
             | '\u{3000}' => Some(' '),
             // zero-width / invisible formatting marks
-            '\u{00ad}' | '\u{200b}'..='\u{200f}' | '\u{2028}' | '\u{2029}' | '\u{2060}'
+            '\u{00ad}'
+            | '\u{200b}'..='\u{200f}'
+            | '\u{2028}'
+            | '\u{2029}'
+            | '\u{2060}'
             | '\u{feff}' => None,
             c if c.is_control() => None,
             c => Some(c),

--- a/app/src/editor.rs
+++ b/app/src/editor.rs
@@ -198,8 +198,29 @@ pub struct EditorState {
 
 const UNDO_CAP: usize = 200;
 
+/// Fold text the font can't draw into something it can, so pasted SQL from a
+/// browser/Word/Notion doesn't render as tofu boxes: exotic Unicode spaces
+/// (NBSP, ideographic, en/em quad…) become a plain space, zero-width marks and
+/// stray control chars are dropped. `\n`/`\t` pass through untouched.
+pub fn sanitize(s: &str) -> String {
+    s.chars()
+        .filter_map(|c| match c {
+            '\n' | '\t' => Some(c),
+            // Zs category + NBSP variants → plain space
+            '\u{00a0}' | '\u{1680}' | '\u{2000}'..='\u{200a}' | '\u{202f}' | '\u{205f}'
+            | '\u{3000}' => Some(' '),
+            // zero-width / invisible formatting marks
+            '\u{00ad}' | '\u{200b}'..='\u{200f}' | '\u{2028}' | '\u{2029}' | '\u{2060}'
+            | '\u{feff}' => None,
+            c if c.is_control() => None,
+            c => Some(c),
+        })
+        .collect()
+}
+
 impl EditorState {
     pub fn from_text(text: &str) -> Self {
+        let text = sanitize(text);
         let mut lines: Vec<String> = text.split('\n').map(str::to_string).collect();
         if lines.is_empty() {
             lines.push(String::new());
@@ -374,10 +395,14 @@ impl EditorState {
     // ----- mutations (all undo-recorded, all selection-aware) -----
 
     pub fn insert(&mut self, s: &str) {
+        let s = sanitize(s);
+        if s.is_empty() {
+            return;
+        }
         let one_char = s.chars().count() == 1 && !s.contains('\n');
         self.push_undo(one_char && self.sel.is_none());
         self.remove_selection();
-        self.insert_raw(s);
+        self.insert_raw(&s);
     }
 
     fn insert_raw(&mut self, s: &str) {
@@ -1069,6 +1094,21 @@ mod tests {
         ed.col = 8;
         ed.replace_current_statement("SELECT 2;");
         assert_eq!(ed.text(), "select 1;\nSELECT 2;\nselect 3;");
+    }
+
+    // ----- sanitize -----
+
+    #[test]
+    fn sanitize_folds_exotic_spaces_and_drops_invisibles() {
+        // NBSP + ideographic space → plain space; ZWSP/BOM/soft hyphen dropped.
+        let dirty = "SELECT\u{00a0}1\u{3000}FROM\u{200b}t\u{feff};\u{00ad}";
+        assert_eq!(sanitize(dirty), "SELECT 1 FROMt;");
+        // newlines and tabs survive
+        assert_eq!(sanitize("a\n\tb"), "a\n\tb");
+        // pasted text lands clean in the buffer
+        let mut ed = EditorState::from_text("");
+        ed.insert(dirty);
+        assert_eq!(ed.text(), "SELECT 1 FROMt;");
     }
 
     // ----- selection -----

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -4800,7 +4800,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let panes = panes.clone();
         let sync_editor = sync_editor.clone();
         let weak = window.as_weak();
-        let press: Rc<dyn Fn(usize, i32, i32)> = Rc::new(move |pane, line, col| {
+        let press: Rc<dyn Fn(usize, i32, i32, bool)> = Rc::new(move |pane, line, col, shift| {
             let Some(w) = weak.upgrade() else {
                 return;
             };
@@ -4813,9 +4813,11 @@ fn main() -> Result<(), slint::PlatformError> {
             // the second tap of a double-click, so word-select never fired. When
             // there is no selection to clear, the line spans are unchanged, so just
             // nudge the caret and leave the rows (and their TouchAreas) intact.
+            // Shift+click extends from the caret (or the live anchor) to the
+            // clicked spot instead, so click → shift-click selects end to end.
             let had_sel = panes[pane].ed_state.borrow().selection().is_some();
-            panes[pane].ed_state.borrow_mut().move_to(line, col, false);
-            if had_sel {
+            panes[pane].ed_state.borrow_mut().move_to(line, col, shift);
+            if had_sel || shift {
                 sync_editor(pane);
             } else {
                 let ed = panes[pane].ed_state.borrow();
@@ -4830,11 +4832,11 @@ fn main() -> Result<(), slint::PlatformError> {
         });
         window.on_editor_press({
             let press = press.clone();
-            move |line, col| press(0, line, col)
+            move |line, col, shift| press(0, line, col, shift)
         });
         window.on_p1_editor_press({
             let press = press.clone();
-            move |line, col| press(1, line, col)
+            move |line, col, shift| press(1, line, col, shift)
         });
     }
     {

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -369,7 +369,7 @@ callback create-table-commit();
     callback set-font-size(int);
     in-out property <bool> results-collapsed: false;
     callback editor-key(string, bool, bool, bool) -> bool;
-    callback editor-press(int, int);
+    callback editor-press(int, int, bool);
     callback editor-drag(int, int);
     callback editor-select-word(int, int);
     // find-in-editor (⌘F)
@@ -539,7 +539,7 @@ callback create-table-commit();
     callback p1-find-close();
     callback p1-toggle-fold(int);
     callback p1-editor-key(string, bool, bool, bool) -> bool;
-    callback p1-editor-press(int, int);
+    callback p1-editor-press(int, int, bool);
     callback p1-editor-drag(int, int);
     callback p1-editor-select-word(int, int);
     in property <int> p1-pending-count;
@@ -1697,7 +1697,7 @@ callback create-table-commit();
                         p1-find-close() => { root.p1-find-close(); }
                         p1-toggle-fold(l) => { root.p1-toggle-fold(l); }
                         p1-editor-key(t, cmd, alt, shift) => { root.p1-editor-key(t, cmd, alt, shift) }
-                        p1-editor-press(l, c) => { root.p1-editor-press(l, c); }
+                        p1-editor-press(l, c, sh) => { root.p1-editor-press(l, c, sh); }
                         p1-editor-drag(l, c) => { root.p1-editor-drag(l, c); }
                         p1-editor-select-word(l, c) => { root.p1-editor-select-word(l, c); }
                         p1-completion-choose(i) => { root.p1-completion-choose(i); }
@@ -1782,7 +1782,7 @@ callback create-table-commit();
                         scroll-grid-tick: root.scroll-grid-tick;
                         index-rows: root.index-rows;
                         editor-key(t, cmd, alt, shift) => { root.editor-key(t, cmd, alt, shift) }
-                        editor-press(l, c) => { root.editor-press(l, c); }
+                        editor-press(l, c, sh) => { root.editor-press(l, c, sh); }
                         editor-drag(l, c) => { root.editor-drag(l, c); }
                         editor-select-word(l, c) => { root.editor-select-word(l, c); }
                         find-open: root.find-open;

--- a/app/src/ui/code-editor.slint
+++ b/app/src/ui/code-editor.slint
@@ -26,7 +26,7 @@ export component CodeEditor inherits Rectangle {
     callback edit-key(string, bool, bool, bool) -> bool;
     // Mouse: press places the caret, drag extends the selection, double-click
     // selects the word. All carry (line, col) hit-tested from the pointer.
-    callback press-pos(int, int);
+    callback press-pos(int, int, bool);
     callback drag-pos(int, int);
     callback select-word(int, int);
     // SQL autocomplete popup, anchored under the caret
@@ -116,7 +116,7 @@ export component CodeEditor inherits Rectangle {
                                 focus-scope.focus();
                                 self.press-x = self.mouse-x;
                                 self.press-y = self.mouse-y;
-                                root.press-pos(parent.hit-line, parent.hit-col);
+                                root.press-pos(parent.hit-line, parent.hit-col, e.modifiers.shift);
                             }
                         }
                         moved => {

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -69,7 +69,7 @@ export component QueryPane inherits Rectangle {
     in property <int> scroll-request;
     callback toggle-fold(int);
     callback editor-key(string, bool, bool, bool) -> bool;
-    callback editor-press(int, int);
+    callback editor-press(int, int, bool);
     callback editor-drag(int, int);
     callback editor-select-word(int, int);
 
@@ -580,7 +580,7 @@ export component QueryPane inherits Rectangle {
                     completion-selected: root.completion-selected;
                     completion-choose(i) => { root.completion-choose(i); }
                     edit-key(t, cmd, alt, shift) => { root.editor-key(t, cmd, alt, shift) }
-                    press-pos(l, c) => { root.editor-press(l, c); }
+                    press-pos(l, c, sh) => { root.editor-press(l, c, sh); }
                     drag-pos(l, c) => { root.editor-drag(l, c); }
                     select-word(l, c) => { root.editor-select-word(l, c); }
                 }

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -95,7 +95,7 @@ export component WorkArea inherits Rectangle {
     callback select-result-tab(int);
     callback close-result-tab(int);
     callback editor-key(string, bool, bool, bool) -> bool;
-    callback editor-press(int, int);
+    callback editor-press(int, int, bool);
     callback editor-drag(int, int);
     callback editor-select-word(int, int);
     in property <bool> find-open;
@@ -228,7 +228,7 @@ export component WorkArea inherits Rectangle {
     callback p1-find-close();
     callback p1-toggle-fold(int);
     callback p1-editor-key(string, bool, bool, bool) -> bool;
-    callback p1-editor-press(int, int);
+    callback p1-editor-press(int, int, bool);
     callback p1-editor-drag(int, int);
     callback p1-editor-select-word(int, int);
     callback p1-completion-choose(int);
@@ -426,7 +426,7 @@ export component WorkArea inherits Rectangle {
             scroll-request: root.scroll-request;
             toggle-fold(l) => { root.toggle-fold(l); }
             editor-key(t, cmd, alt, shift) => { root.editor-key(t, cmd, alt, shift) }
-            editor-press(l, c) => { root.editor-press(l, c); }
+            editor-press(l, c, sh) => { root.editor-press(l, c, sh); }
             editor-drag(l, c) => { root.editor-drag(l, c); }
             editor-select-word(l, c) => { root.editor-select-word(l, c); }
             completion-items: root.completion-items;
@@ -563,7 +563,7 @@ export component WorkArea inherits Rectangle {
                 scroll-request: root.p1-scroll-request;
                 toggle-fold(l) => { root.p1-toggle-fold(l); }
                 editor-key(t, cmd, alt, shift) => { root.p1-editor-key(t, cmd, alt, shift) }
-                editor-press(l, c) => { root.p1-editor-press(l, c); }
+                editor-press(l, c, sh) => { root.p1-editor-press(l, c, sh); }
                 editor-drag(l, c) => { root.p1-editor-drag(l, c); }
                 editor-select-word(l, c) => { root.p1-editor-select-word(l, c); }
                 completion-items: root.p1-completion-items;


### PR DESCRIPTION
## Summary

- Selecting a long range in the query editor required dragging across it; shift-click only moved the caret because the press callback carried no modifier state.
- Text pasted from a browser, Word or Notion carries NBSP, ideographic spaces, zero-width marks and BOMs the mono font cannot draw, so the editor rendered undefined-glyph boxes.

## Changes

- `app/src/ui/code-editor.slint`: `press-pos` now takes the shift modifier from the pointer event; threaded through `query-pane.slint`, `workarea.slint` and `app-window.slint` for both panes.
- `app/src/main.rs`: the press handler passes shift into `move_to(.., extend)` and re-syncs the span model when a selection is created.
- `app/src/editor.rs`: new `sanitize()` folds Zs-category spaces (NBSP, ideographic, en/em quads) to a plain space and drops zero-width, bidi, soft-hyphen, BOM and stray control chars; `\n` and `\t` pass through. Applied in `from_text` (load) and `insert` (typing and paste).

## Test plan

- [x] Unit test covering `sanitize()` and a paste through `insert`.
- [x] `make fe-build` — not run locally.
- [x] Manual: click, then shift-click at the other end of the buffer, selection spans the range; drag-select and double-click word-select still work.
- [x] Manual: paste SQL containing NBSP from a browser, no boxes appear and the query runs.