### PR TITLE
fix(app): improve database and Mongo workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,7 +1,11 @@
 name: release-please
 
 on:
-  push:
+  # A maintainer starts release preparation explicitly after batching changes.
+  workflow_dispatch:
+  # A merged release PR is finalized automatically into a tag and release.
+  pull_request:
+    types: [closed]
     branches: [develop]
 
 permissions:
@@ -14,10 +18,17 @@ concurrency:
 
 jobs:
   release-please:
+    # Manual runs prepare/update the release PR. Pull request runs only
+    # finalize a merged Release Please PR, never an application PR.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release-please--'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: develop
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ desktop.ini
 docs/superpowers
 .forgeguard
 .mcp.json
+.pi
 
 # Env & secrets
 .env

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -601,6 +601,52 @@ fn build_conn_items(
     rows
 }
 
+/// Bucket `build_conn_items`'s flat rows into one `TopLevelGroup` per
+/// top-level header, so the sidebar can draw a single continuous outline
+/// around each top-level card (header + every nested subgroup/connection
+/// under it) instead of guessing card boundaries from a flat list. The
+/// no-groups case (every connection ungrouped) never emits a header row at
+/// all — that stays a single header-less group, same as before.
+fn group_conn_items(flat: Vec<ConnItem>) -> Vec<TopLevelGroup> {
+    if flat.first().is_some_and(|first| !first.is_header) {
+        return vec![TopLevelGroup {
+            has_header: false,
+            rows: ModelRc::from(Rc::new(VecModel::from(flat))),
+        }];
+    }
+    let mut groups = Vec::new();
+    let mut cur: Vec<ConnItem> = Vec::new();
+    for item in flat {
+        if item.is_header && item.depth == 0 && !cur.is_empty() {
+            groups.push(TopLevelGroup {
+                has_header: true,
+                rows: ModelRc::from(Rc::new(VecModel::from(std::mem::take(&mut cur)))),
+            });
+        }
+        cur.push(item);
+    }
+    if !cur.is_empty() {
+        groups.push(TopLevelGroup {
+            has_header: true,
+            rows: ModelRc::from(Rc::new(VecModel::from(cur))),
+        });
+    }
+    groups
+}
+
+/// `build_conn_items` + `group_conn_items`, wrapped straight into the
+/// `ModelRc` the sidebar's `set_connections` expects — the one-liner every
+/// call site should use instead of repeating the two-step build+wrap.
+fn build_sidebar_model(
+    store: &rdb_connstore::ConnStore,
+    collapsed: &HashSet<String>,
+    filter: &str,
+) -> ModelRc<TopLevelGroup> {
+    ModelRc::from(Rc::new(VecModel::from(group_conn_items(build_conn_items(
+        store, collapsed, filter,
+    )))))
+}
+
 /// Flatten `build_conn_items`'s output into the ⌘O "Open Connection" modal's
 /// `PaletteItem` list plus a parallel index map (`-1` for a header row, the
 /// real store index for a connection row) — shared by the modal's open
@@ -650,6 +696,45 @@ fn build_conn_palette_items(
         }
     }
     (items, map)
+}
+
+/// Bucket a flat `PaletteItem` list into `PaletteGroup`s for `ListModal`,
+/// same rule as `group_conn_items`: a `"group"`-kind row at depth 0 starts a
+/// new top-level card. Every `ListModal` caller other than the ⌘O connection
+/// picker never emits a `"group"`-kind row at all, so their list's first
+/// item is never `"group"` and this always falls through to the single
+/// `has_header: false` bucket — unaffected, same as before.
+fn group_palette_items(flat: Vec<PaletteItem>) -> Vec<PaletteGroup> {
+    if flat.first().is_some_and(|first| first.kind != "group") {
+        let start_index = 0;
+        return vec![PaletteGroup {
+            has_header: false,
+            start_index,
+            rows: ModelRc::from(Rc::new(VecModel::from(flat))),
+        }];
+    }
+    let mut groups = Vec::new();
+    let mut cur: Vec<PaletteItem> = Vec::new();
+    let mut cur_start = 0i32;
+    for (i, item) in flat.into_iter().enumerate() {
+        if item.kind == "group" && item.depth == 0 && !cur.is_empty() {
+            groups.push(PaletteGroup {
+                has_header: true,
+                start_index: cur_start,
+                rows: ModelRc::from(Rc::new(VecModel::from(std::mem::take(&mut cur)))),
+            });
+            cur_start = i as i32;
+        }
+        cur.push(item);
+    }
+    if !cur.is_empty() {
+        groups.push(PaletteGroup {
+            has_header: true,
+            start_index: cur_start,
+            rows: ModelRc::from(Rc::new(VecModel::from(cur))),
+        });
+    }
+    groups
 }
 
 /// Walk `rendered` (the same list `build_conn_items` produced) accumulating
@@ -4225,9 +4310,11 @@ fn main() -> Result<(), slint::PlatformError> {
             let Some(w) = weak.upgrade() else {
                 return;
             };
-            let items =
-                build_conn_items(&store.borrow(), &collapsed.borrow(), &conn_filter.borrow());
-            w.set_connections(ModelRc::from(Rc::new(VecModel::from(items))));
+            w.set_connections(build_sidebar_model(
+                &store.borrow(),
+                &collapsed.borrow(),
+                &conn_filter.borrow(),
+            ));
         }
     };
     rebuild_sidebar();
@@ -5331,7 +5418,9 @@ fn main() -> Result<(), slint::PlatformError> {
             if items.is_empty() {
                 return;
             }
-            w.set_db_items(ModelRc::from(Rc::new(VecModel::from(items))));
+            w.set_db_items(ModelRc::from(Rc::new(VecModel::from(group_palette_items(
+                items,
+            )))));
             w.set_db_modal_open(true);
         });
     }
@@ -5342,7 +5431,14 @@ fn main() -> Result<(), slint::PlatformError> {
             let Some(w) = weak.upgrade() else {
                 return;
             };
-            let Some(it) = w.get_db_items().row_data(idx.max(0) as usize) else {
+            // `db-items` is always the single-bucket wrap (never real
+            // top-level groups), so its one `PaletteGroup.rows` is the flat
+            // list `idx` was always meant to index into.
+            let Some(it) = w
+                .get_db_items()
+                .row_data(0)
+                .and_then(|g| g.rows.row_data(idx.max(0) as usize))
+            else {
                 return;
             };
             w.set_db_modal_open(false);
@@ -5382,7 +5478,9 @@ fn main() -> Result<(), slint::PlatformError> {
             if items.is_empty() {
                 return;
             }
-            w.set_schema_items(ModelRc::from(Rc::new(VecModel::from(items))));
+            w.set_schema_items(ModelRc::from(Rc::new(VecModel::from(group_palette_items(
+                items,
+            )))));
             w.set_schema_modal_open(true);
         });
     }
@@ -5409,7 +5507,12 @@ fn main() -> Result<(), slint::PlatformError> {
                 return;
             };
             w.set_schema_modal_open(false);
-            let Some(it) = w.get_schema_items().row_data(idx.max(0) as usize) else {
+            // Same single-bucket wrap as `db-items` — see comment there.
+            let Some(it) = w
+                .get_schema_items()
+                .row_data(0)
+                .and_then(|g| g.rows.row_data(idx.max(0) as usize))
+            else {
                 return;
             };
             let schema_name = it.label.to_string();
@@ -5817,7 +5920,9 @@ fn main() -> Result<(), slint::PlatformError> {
             };
             let (items, map) = build_conn_palette_items(&store.borrow(), &collapsed.borrow(), "");
             *conn_modal_map.borrow_mut() = map;
-            w.set_conn_items(ModelRc::from(Rc::new(VecModel::from(items))));
+            w.set_conn_items(ModelRc::from(Rc::new(VecModel::from(group_palette_items(
+                items,
+            )))));
             w.set_conn_modal_open(true);
         });
     }
@@ -6666,15 +6771,19 @@ fn main() -> Result<(), slint::PlatformError> {
             let _ = settings
                 .borrow_mut()
                 .update(|s| s.ui_state.collapsed_groups = groups);
-            let items =
-                build_conn_items(&store.borrow(), &collapsed.borrow(), &conn_filter.borrow());
-            w.set_connections(ModelRc::from(Rc::new(VecModel::from(items))));
+            w.set_connections(build_sidebar_model(
+                &store.borrow(),
+                &collapsed.borrow(),
+                &conn_filter.borrow(),
+            ));
             // Keep the ⌘O modal in sync too, whichever surface triggered this.
             if w.get_conn_modal_open() {
                 let (items, map) =
                     build_conn_palette_items(&store.borrow(), &collapsed.borrow(), "");
                 *conn_modal_map.borrow_mut() = map;
-                w.set_conn_items(ModelRc::from(Rc::new(VecModel::from(items))));
+                w.set_conn_items(ModelRc::from(Rc::new(VecModel::from(group_palette_items(
+                    items,
+                )))));
             }
         });
     }
@@ -6718,9 +6827,11 @@ fn main() -> Result<(), slint::PlatformError> {
             let _ = settings
                 .borrow_mut()
                 .update(|s| s.ui_state.collapsed_groups = groups);
-            let items =
-                build_conn_items(&store.borrow(), &collapsed.borrow(), &conn_filter.borrow());
-            w.set_connections(ModelRc::from(Rc::new(VecModel::from(items))));
+            w.set_connections(build_sidebar_model(
+                &store.borrow(),
+                &collapsed.borrow(),
+                &conn_filter.borrow(),
+            ));
         });
     }
 
@@ -6783,9 +6894,11 @@ fn main() -> Result<(), slint::PlatformError> {
             let _ = settings
                 .borrow_mut()
                 .update(|s| s.ui_state.collapsed_groups = groups);
-            let items =
-                build_conn_items(&store.borrow(), &collapsed.borrow(), &conn_filter.borrow());
-            w.set_connections(ModelRc::from(Rc::new(VecModel::from(items))));
+            w.set_connections(build_sidebar_model(
+                &store.borrow(),
+                &collapsed.borrow(),
+                &conn_filter.borrow(),
+            ));
         });
     }
 
@@ -6800,9 +6913,11 @@ fn main() -> Result<(), slint::PlatformError> {
                 return;
             };
             *conn_filter.borrow_mut() = t.to_string();
-            let items =
-                build_conn_items(&store.borrow(), &collapsed.borrow(), &conn_filter.borrow());
-            w.set_connections(ModelRc::from(Rc::new(VecModel::from(items))));
+            w.set_connections(build_sidebar_model(
+                &store.borrow(),
+                &collapsed.borrow(),
+                &conn_filter.borrow(),
+            ));
         });
     }
 
@@ -6825,9 +6940,11 @@ fn main() -> Result<(), slint::PlatformError> {
             };
             let (id, was_fav) = id;
             let _ = store.borrow_mut().set_favorite(&id, !was_fav);
-            let items =
-                build_conn_items(&store.borrow(), &collapsed.borrow(), &conn_filter.borrow());
-            w.set_connections(ModelRc::from(Rc::new(VecModel::from(items))));
+            w.set_connections(build_sidebar_model(
+                &store.borrow(),
+                &collapsed.borrow(),
+                &conn_filter.borrow(),
+            ));
         });
     }
 
@@ -6875,12 +6992,11 @@ fn main() -> Result<(), slint::PlatformError> {
                         };
                         let _ = store.borrow_mut().update(sc);
                     }
-                    let items = build_conn_items(
+                    w.set_connections(build_sidebar_model(
                         &store.borrow(),
                         &collapsed.borrow(),
                         &conn_filter.borrow(),
-                    );
-                    w.set_connections(ModelRc::from(Rc::new(VecModel::from(items))));
+                    ));
                     return;
                 }
             }
@@ -6916,9 +7032,11 @@ fn main() -> Result<(), slint::PlatformError> {
                 (from.id.clone(), members[target_pos])
             };
             let _ = store.borrow_mut().reorder(&from_id, target_vec_idx);
-            let items =
-                build_conn_items(&store.borrow(), &collapsed.borrow(), &conn_filter.borrow());
-            w.set_connections(ModelRc::from(Rc::new(VecModel::from(items))));
+            w.set_connections(build_sidebar_model(
+                &store.borrow(),
+                &collapsed.borrow(),
+                &conn_filter.borrow(),
+            ));
         });
     }
 
@@ -11931,7 +12049,9 @@ fn main() -> Result<(), slint::PlatformError> {
                         &recent_queries.borrow(),
                         "",
                     );
-                    w.set_palette_items(ModelRc::from(Rc::new(VecModel::from(items))));
+                    w.set_palette_items(ModelRc::from(Rc::new(VecModel::from(
+                        group_palette_items(items),
+                    ))));
                     PALETTE_ACTIONS.with(|s| *s.borrow_mut() = actions);
                 }
             }
@@ -11976,7 +12096,9 @@ fn main() -> Result<(), slint::PlatformError> {
                     &recent_queries.borrow(),
                     &q.to_lowercase(),
                 );
-                w.set_palette_items(ModelRc::from(Rc::new(VecModel::from(items))));
+                w.set_palette_items(ModelRc::from(Rc::new(VecModel::from(group_palette_items(
+                    items,
+                )))));
                 PALETTE_ACTIONS.with(|s| *s.borrow_mut() = actions);
             }
         });
@@ -12658,12 +12780,11 @@ fn main() -> Result<(), slint::PlatformError> {
             let conn_filter = conn_filter.clone();
             move || {
                 if let Some(w) = weak.upgrade() {
-                    let items = build_conn_items(
+                    w.set_connections(build_sidebar_model(
                         &store.borrow(),
                         &collapsed.borrow(),
                         &conn_filter.borrow(),
-                    );
-                    w.set_connections(ModelRc::from(Rc::new(VecModel::from(items))));
+                    ));
                 }
             }
         };
@@ -12820,9 +12941,11 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_form_open(false);
             w.set_selected_conn(-1);
             w.set_schema_tree(ModelRc::from(Rc::new(VecModel::<TreeNode>::default())));
-            let items =
-                build_conn_items(&store.borrow(), &collapsed.borrow(), &conn_filter.borrow());
-            w.set_connections(ModelRc::from(Rc::new(VecModel::from(items))));
+            w.set_connections(build_sidebar_model(
+                &store.borrow(),
+                &collapsed.borrow(),
+                &conn_filter.borrow(),
+            ));
         });
     }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -12705,9 +12705,14 @@ fn main() -> Result<(), slint::PlatformError> {
                 (host, port)
             };
             let sslmode = match w.get_f_sslmode().to_string().as_str() {
-                "Disable" => rdb_core::conn::SslMode::Disable,
                 "Require" => rdb_core::conn::SslMode::Require,
-                _ => rdb_core::conn::SslMode::Prefer,
+                "Prefer" => rdb_core::conn::SslMode::Prefer,
+                // Empty/unset (the SSL mode field is hidden for engines
+                // like Redis that never populate `f-sslmode`) must not
+                // silently become `Prefer` — that maps to `rediss://` and
+                // hangs a TLS handshake against a plain server instead of
+                // failing fast or connecting at all.
+                _ => rdb_core::conn::SslMode::Disable,
             };
             let database = {
                 let d = w.get_f_database().to_string();
@@ -12824,9 +12829,14 @@ fn main() -> Result<(), slint::PlatformError> {
                 (host, port)
             };
             let sslmode = match w.get_f_sslmode().to_string().as_str() {
-                "Disable" => rdb_core::conn::SslMode::Disable,
                 "Require" => rdb_core::conn::SslMode::Require,
-                _ => rdb_core::conn::SslMode::Prefer,
+                "Prefer" => rdb_core::conn::SslMode::Prefer,
+                // Empty/unset (the SSL mode field is hidden for engines
+                // like Redis that never populate `f-sslmode`) must not
+                // silently become `Prefer` — that maps to `rediss://` and
+                // hangs a TLS handshake against a plain server instead of
+                // failing fast or connecting at all.
+                _ => rdb_core::conn::SslMode::Disable,
             };
             let database = {
                 let d = w.get_f_database().to_string();

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -8000,9 +8000,10 @@ fn main() -> Result<(), slint::PlatformError> {
                                 w.set_connected(false);
                                 w.set_connecting(false);
                                 w.set_tree_loading(false);
-                                w.set_picker_error(SharedString::from(format!(
-                                    "connection failed: {e}"
-                                )));
+                                // `e` is `RdbError`, whose own `Display` already
+                                // reads "connection failed: …" — don't prefix it
+                                // again.
+                                w.set_picker_error(SharedString::from(format!("{e}")));
                             }
                         });
                     }
@@ -12658,7 +12659,9 @@ fn main() -> Result<(), slint::PlatformError> {
                     if let Some(w) = weak2.upgrade() {
                         w.set_sel_footer(SharedString::from(match result {
                             Ok(ms) => format!("connection ok · {}", model::format_latency(ms)),
-                            Err(e) => format!("connection failed: {e}"),
+                            // `RdbError`'s own `Display` already reads
+                            // "connection failed: …" — don't prefix it again.
+                            Err(e) => format!("{e}"),
                         }));
                     }
                 });
@@ -12758,9 +12761,9 @@ fn main() -> Result<(), slint::PlatformError> {
                             }
                             Err(e) => {
                                 w.set_test_ok(false);
-                                w.set_test_result(SharedString::from(format!(
-                                    "connection failed: {e}"
-                                )));
+                                // `RdbError`'s own `Display` already reads
+                                // "connection failed: …" — don't prefix it again.
+                                w.set_test_result(SharedString::from(format!("{e}")));
                             }
                         }
                     }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2136,6 +2136,13 @@ fn default_split_ratio() -> f32 {
     0.5
 }
 
+/// Disk restore is only for the first connection of an app session. Reconnecting
+/// with a different database must keep the in-memory workspace: it contains tabs
+/// and results that may have been created since the last persistence write.
+fn should_restore_query_tabs(tabs_restored: bool) -> bool {
+    !tabs_restored
+}
+
 #[derive(serde::Serialize, serde::Deserialize, Default)]
 struct PersistedTabs {
     tabs: Vec<PersistedTab>,
@@ -7467,7 +7474,7 @@ fn main() -> Result<(), slint::PlatformError> {
             // persisted SQL scratch tabs; a later switch to another connection
             // keeps the SQL scratch tabs so the user can hop between connections
             // without losing their queries.
-            let restore = !tabs_restored.get() || db_ovr.is_some();
+            let restore = should_restore_query_tabs(tabs_restored.get());
             tabs_restored.set(true);
             let (init_tabs, init_active, init_active_p1, init_active_group) = if restore {
                 let (tabs, active, active_p1, active_group, max_number) = load_query_tabs();
@@ -13101,6 +13108,12 @@ mod tests {
             pk: false,
         }];
         assert!(build_create_table(None, "t", &no_type, rdb_connstore::Engine::Postgres).is_err());
+    }
+
+    #[test]
+    fn query_tabs_restore_only_on_first_connection() {
+        assert!(should_restore_query_tabs(false));
+        assert!(!should_restore_query_tabs(true));
     }
 
     #[test]

--- a/app/src/model.rs
+++ b/app/src/model.rs
@@ -745,7 +745,11 @@ mod tests {
     fn documents_render_as_json_text_block() {
         let rs = ResultSet::Documents(vec![serde_json::json!({"a": 1})]);
         match to_result_view(&rs) {
-            ResultView::Documents(d) => assert!(d.json.contains("\"a\"")),
+            ResultView::Documents(d) => {
+                assert!(d.json.contains("\"a\""));
+                assert_eq!(d.tree.len(), 2);
+                assert_eq!(d.tree[1].key, "a");
+            }
             other => panic!("expected Documents, got {other:?}"),
         }
     }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -9,7 +9,7 @@ export { Shortcut }
 import { NavCluster } from "nav-cluster.slint";
 import { ConnPicker } from "picker.slint";
 import { WorkArea } from "workarea.slint";
-import { CommandPalette, ListModal, PaletteItem } from "palette.slint";
+import { CommandPalette, ListModal, PaletteItem, PaletteGroup } from "palette.slint";
 import { ConnForm } from "conn-form.slint";
 import { AppIcon } from "icons.slint";
 import { ScrollView, Spinner } from "std-widgets.slint";
@@ -18,6 +18,7 @@ import {
     GridCell,
     TreeNode,
     ConnItem,
+    TopLevelGroup,
     KvRow,
     TabItem,
     StructField,
@@ -176,7 +177,7 @@ export component MainWindow inherits Window {
     in property <bool> tree-loading;
 
     // ----- sidebar models -----
-    in property <[ConnItem]> connections;
+    in property <[TopLevelGroup]> connections;
     in property <[TreeNode]> schema-tree;
     in property <int> selected-conn: -1;
     in property <string> active-table;
@@ -390,10 +391,10 @@ callback create-table-commit();
     // ----- open-database / open-connection modals -----
     in-out property <bool> db-modal-open: false;
     in-out property <bool> conn-modal-open: false;
-    in property <[PaletteItem]> db-items;
+    in property <[PaletteGroup]> db-items;
     // Databases the current connection can switch to; empty hides the switcher.
     in property <[string]> db-list;
-    in property <[PaletteItem]> conn-items;
+    in property <[PaletteGroup]> conn-items;
     callback db-choose(int);
     callback conn-choose(int);
     callback open-db-modal();
@@ -401,7 +402,7 @@ callback create-table-commit();
 
     // ----- schema switcher modal -----
     in-out property <bool> schema-modal-open: false;
-    in property <[PaletteItem]> schema-items;
+    in property <[PaletteGroup]> schema-items;
     callback schema-choose(int);
 
     // ----- pagination + edit footer -----
@@ -562,7 +563,7 @@ callback create-table-commit();
     callback p1-edit-cancelled();
     callback p1-toggle-doc-node(string);
     in property <bool> palette-open;
-    in property <[PaletteItem]> palette-items;
+    in property <[PaletteGroup]> palette-items;
     callback new-tab();
     callback run-new-tab();   // ⌘\: run current statement into a new result tab
     in property <[ResultTabItem]> result-tabs;   // "Result 1", "Result 2", …

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -582,6 +582,13 @@ export component UnderlineSegment inherits Rectangle {
     in property <bool> active: false;
     callback clicked;
     width: label.preferred-width;
+    // Explicit and constant — without it this auto-sizes from `label`'s own
+    // box, and since `active` also switches font-weight, the active and
+    // inactive segments end up with very slightly different glyph metrics
+    // and therefore different auto-heights, throwing off any alignment
+    // that assumes every instance shares one height (siblings in a row,
+    // this segment vs. its own pair).
+    height: Tokens.font-sm + 2 * Tokens.sp1;
     label := Text {
         text: root.text;
         color: active ? Tokens.accent : (ta.has-hover ? Tokens.text : Tokens.text-dim);

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -368,6 +368,7 @@ export component TextButton inherits Rectangle {
         color: active ? Tokens.accent : Tokens.text-dim;
         font-size: Tokens.font-sm;
         font-weight: 500;
+        vertical-alignment: center;
     }
     ta := TooltipArea {
         tip: root.tooltip;
@@ -391,6 +392,7 @@ export component ExportButton inherits Rectangle {
         color: Tokens.text-dim;
         font-size: Tokens.font-sm;
         font-weight: 500;
+        vertical-alignment: center;
     }
     menu := PopupWindow {
         // Default close-on-click swallows the press and closes before the inner
@@ -588,7 +590,7 @@ export component UnderlineSegment inherits Rectangle {
     // and therefore different auto-heights, throwing off any alignment
     // that assumes every instance shares one height (siblings in a row,
     // this segment vs. its own pair).
-    height: Tokens.font-sm + 2 * Tokens.sp1;
+    height: Tokens.button-h;
     label := Text {
         text: root.text;
         color: active ? Tokens.accent : (ta.has-hover ? Tokens.text : Tokens.text-dim);
@@ -603,6 +605,60 @@ export component UnderlineSegment inherits Rectangle {
         background: active ? Tokens.accent : transparent;
     }
     ta := TouchArea { clicked => { root.clicked(); } }
+}
+
+// Result view toggle (Grid/Tree) with the same geometry as toolbar buttons.
+export component ResultModeButton inherits Rectangle {
+    in property <string> text;
+    in property <bool> active: false;
+    in property <string> tooltip;
+    callback clicked;
+    height: Tokens.button-h;
+    width: label.preferred-width + 2 * Tokens.sp2;
+    label := Text {
+        text: root.text;
+        color: root.active ? Tokens.accent : (ta.has-hover ? Tokens.text : Tokens.text-dim);
+        font-size: Tokens.font-sm;
+        font-weight: root.active ? Tokens.weight-emphasis : 500;
+        vertical-alignment: center;
+    }
+    if root.active: Rectangle {
+        y: parent.height - self.height;
+        height: 2px;
+        width: parent.width;
+        background: Tokens.accent;
+    }
+    ta := TooltipArea {
+        tip: root.tooltip;
+        clicked => { root.clicked(); }
+    }
+}
+
+// Grid/Tree toggle used by both query results and direct collection browsing.
+// The component owns its toolbar slot geometry so both parent toolbars place it
+// identically without extra layout wrappers.
+export component ResultModeToggle inherits Rectangle {
+    in property <int> mode: 0;
+    callback changed(int);
+    height: Tokens.button-h;
+    width: row.preferred-width;
+
+    row := HorizontalLayout {
+        height: Tokens.button-h;
+        spacing: Tokens.sp3;
+        ResultModeButton {
+            text: "Grid";
+            active: root.mode == 0;
+            tooltip: "Show the result as a grid";
+            clicked => { root.changed(0); }
+        }
+        ResultModeButton {
+            text: "Tree";
+            active: root.mode == 1;
+            tooltip: "Show the result as a tree";
+            clicked => { root.changed(1); }
+        }
+    }
 }
 
 // Grey tag chip (mono text: profin, fintech).

--- a/app/src/ui/conn-form.slint
+++ b/app/src/ui/conn-form.slint
@@ -361,6 +361,7 @@ export component ConnForm inherits Rectangle {
                 color: Tokens.error;
                 font-size: Tokens.font-sm;
                 horizontal-alignment: center;
+                wrap: word-wrap;
             }
 
             if root.test-busy || root.test-result != "": Text {
@@ -368,6 +369,7 @@ export component ConnForm inherits Rectangle {
                 color: root.test-ok ? Tokens.ok : Tokens.text-dim;
                 font-size: Tokens.font-sm;
                 horizontal-alignment: center;
+                wrap: word-wrap;
             }
 
             HorizontalLayout {

--- a/app/src/ui/palette.slint
+++ b/app/src/ui/palette.slint
@@ -28,12 +28,27 @@ export struct PaletteItem {
     // Nesting depth of this row's group (0 = top-level). Mirrors `ConnItem.depth`.
     depth: int,
 }
+// One top-level card of grouped items: the ⌘O "Open Connection" picker's own
+// header + nested subgroups + connections, boxed with a continuous outline
+// (mirrors `TopLevelGroup` in the sidebar). Every other `ListModal` user
+// (⌘K, ⌘⇧O, schema switcher) never has real top-level groups, so their flat
+// row list is wrapped as a single `has-header: false` bucket — no border,
+// same rendering as before.
+export struct PaletteGroup {
+    has-header: bool,
+    // Position of `rows[0]` in the original flat list — lets a row inside
+    // this group recover its true global index (`start-index + local i`)
+    // for `root.selected`/`root.choose(...)`, which Rust still treats as a
+    // single flat position across every group.
+    start-index: int,
+    rows: [PaletteItem],
+}
 
 export component ListModal inherits Rectangle {
     in property <bool> open;
     in property <string> title;
     in property <string> placeholder: "Search...";
-    in property <[PaletteItem]> items;
+    in property <[PaletteGroup]> items;
     in-out property <int> selected: 0;
     in property <length> card-width: 520px;
     in property <string> confirm-label: "Open";
@@ -100,9 +115,32 @@ export component ListModal inherits Rectangle {
                 Flickable {
                     viewport-height: list.preferred-height;
                     list := VerticalLayout {
-                        spacing: 1px;
+                        // Gap *between* top-level group cards (⌘O connection
+                        // picker only — every other caller has a single
+                        // `has-header: false` bucket, so this never applies).
+                        spacing: Tokens.sp2;
                         alignment: start;
-                        for it[i] in root.items: Rectangle {
+                        for grp[gi] in root.items: Rectangle {
+                            // One continuous card around a whole top-level
+                            // connection group (⌘O picker only), mirroring
+                            // the sidebar's `TopLevelGroup` outline. Every
+                            // other caller's single flat bucket draws no
+                            // border/background here at all.
+                            height: gwrap.preferred-height;
+                            background: grp.has-header ? Tokens.card : transparent;
+                            border-width: grp.has-header ? 1px : 0px;
+                            border-color: Tokens.border-strong;
+                            border-radius: Tokens.radius-lg;
+
+                            gwrap := VerticalLayout {
+                                padding: grp.has-header ? 1px : 0px;
+                                // Non-conn-group callers keep their original
+                                // uniform hairline gap between every row; the
+                                // conn-group card stays flush (its own
+                                // sibling-subgroup gap is added per-row below).
+                                spacing: grp.has-header ? 0px : 1px;
+                                alignment: start;
+                                for it[i] in grp.rows: Rectangle {
                             // Non-selectable group header (GitHub-style sections).
                             property <bool> is-section: it.kind == "section";
                             property <bool> is-group: it.kind == "group";
@@ -113,24 +151,45 @@ export component ListModal inherits Rectangle {
                             // unaffected.
                             property <bool> in-conn-group: is-group || it.group != "";
                             property <bool> two-line: it.sub != "";
-                            height: is-section ? 28px : two-line ? 44px : 34px;
-                            border-top-left-radius: is-group ? Tokens.radius-lg : Tokens.radius;
-                            border-top-right-radius: is-group ? Tokens.radius-lg : Tokens.radius;
-                            border-bottom-left-radius: it.is-group-end ? Tokens.radius-lg : Tokens.radius;
-                            border-bottom-right-radius: it.is-group-end ? Tokens.radius-lg : Tokens.radius;
+                            property <length> content-h: is-section ? 28px : two-line ? 44px : 34px;
+                            // True flat position — what `root.selected`/
+                            // `root.choose(...)` actually mean to Rust.
+                            property <int> global-i: grp.start-index + i;
+                            // Same box-boundary rule as the sidebar, scoped to
+                            // conn-group rows only — every other caller keeps
+                            // its original always-`Tokens.radius` pill style.
+                            property <bool> box-top: is-group || i == 0
+                                || (in-conn-group && it.depth > 0 && grp.rows[i - 1].depth != it.depth);
+                            property <bool> box-bottom: i == grp.rows.length - 1
+                                || (in-conn-group && grp.rows[i + 1].depth < it.depth)
+                                || (in-conn-group && grp.rows[i + 1].depth == it.depth && grp.rows[i + 1].kind == "group");
+                            property <bool> needs-gap: in-conn-group && box-top && i > 0
+                                && grp.rows[i - 1].depth >= it.depth;
+                            height: needs-gap ? content-h + Tokens.sp2 : content-h;
+                            background: transparent;
+
+                            card-box := Rectangle {
+                                y: parent.height - content-h;
+                                height: content-h;
+                                x: in-conn-group ? it.depth * Tokens.sp2 : 0px;
+                                width: parent.width - 2 * self.x;
+                                border-top-left-radius: in-conn-group ? (box-top ? Tokens.radius-lg : 0px) : Tokens.radius;
+                                border-top-right-radius: in-conn-group ? (box-top ? Tokens.radius-lg : 0px) : Tokens.radius;
+                                border-bottom-left-radius: in-conn-group ? (box-bottom ? Tokens.radius-lg : 0px) : Tokens.radius;
+                                border-bottom-right-radius: in-conn-group ? (box-bottom ? Tokens.radius-lg : 0px) : Tokens.radius;
                             background: is-section ? transparent
-                                : i == root.selected ? Tokens.chrome
+                                : global-i == root.selected ? Tokens.chrome
                                 : it-ta.has-hover ? Tokens.canvas
-                                : in-conn-group ? Tokens.card : transparent;
+                                : in-conn-group ? (it.depth > 0 ? Tokens.canvas : Tokens.card) : transparent;
                             it-ta := TouchArea {
                                 clicked => {
                                     if (is-group) {
                                         root.toggle-group(it.group);
                                     } else if (!is-section) {
-                                        root.selected = i;
+                                        root.selected = global-i;
                                     }
                                 }
-                                double-clicked => { if (!is-section && !is-group) { root.choose(i); } }
+                                double-clicked => { if (!is-section && !is-group) { root.choose(global-i); } }
                             }
                             // Section header: small dim caps, no icon.
                             if is-section: HorizontalLayout {
@@ -246,6 +305,9 @@ export component ListModal inherits Rectangle {
                                     }
                                 }
                             }
+                            } // card-box
+                                }
+                            } // gwrap
                         }
                     }
                 }

--- a/app/src/ui/picker.slint
+++ b/app/src/ui/picker.slint
@@ -4,14 +4,14 @@
 import { Tokens } from "tokens.slint";
 import {
     DbBadge, OutlineChip, PrimaryButton, SecondaryButton, TextButton,
-    TagChip, FilterField, Tooltip, FloatingCard
+    TagChip, FilterField, Tooltip, FloatingCard, DangerButton
 } from "components.slint";
 import { AppIcon } from "icons.slint";
-import { ConnItem, KvRow } from "structs.slint";
+import { ConnItem, KvRow, TopLevelGroup } from "structs.slint";
 import { ScrollView } from "std-widgets.slint";
 
 export component ConnPicker inherits Rectangle {
-    in property <[ConnItem]> connections;
+    in property <[TopLevelGroup]> connections;
     in property <int> selected-conn: -1;
     in property <string> error;
     // True while a connect attempt is in flight (button shows a spinner label).
@@ -65,6 +65,8 @@ export component ConnPicker inherits Rectangle {
     property <bool> rename-modal-open: false;
     property <string> rename-old: "";
     property <string> rename-text: "";
+    property <bool> delete-confirm-open: false;
+    property <string> delete-confirm-target: "";
 
     background: Tokens.canvas;
 
@@ -121,39 +123,85 @@ export component ConnPicker inherits Rectangle {
                     list-content := VerticalLayout {
                         padding-left: Tokens.sp3;
                         padding-right: Tokens.sp3;
-                        // No uniform spacing here — that's what left a visible
-                        // gap between every row, including within one card
-                        // (header to its first member, member to member). The
-                        // only gap wanted is *between* cards, which the header
-                        // row's own extra height (added above, `i > 0`) already
-                        // provides.
-                        spacing: 0px;
+                        // Spacing here is *between* top-level group cards only
+                        // — each card below is its own element now, so this
+                        // is the one place that gap needs to be expressed.
+                        spacing: Tokens.sp2;
                         alignment: start;
 
-                        for item[i] in root.connections: Rectangle {
-                            // Only top-level groups start a new card. Subgroups
-                            // stay attached to their parent card; adding the same
-                            // gap before them makes the hierarchy look broken.
-                            // The inner header Rectangle is anchored to the
-                            // bottom when a top-level gap is present.
-                            height: item.is-header
-                                ? (item.depth == 0 && i > 0 ? 28px + Tokens.sp2 : 28px)
-                                : 40px;
-                            background: item.is-header ? transparent : Tokens.card;
-                            border-top-left-radius: !item.is-header && i == 0 ? Tokens.radius-lg : 0px;
-                            border-top-right-radius: !item.is-header && i == 0 ? Tokens.radius-lg : 0px;
-                            border-bottom-left-radius: !item.is-header && item.is-group-end ? Tokens.radius-lg : 0px;
-                            border-bottom-right-radius: !item.is-header && item.is-group-end ? Tokens.radius-lg : 0px;
+                        for grp[gi] in root.connections: Rectangle {
+                            // One continuous card around a whole top-level
+                            // group — its header, every nested subgroup, and
+                            // any of its own direct connections — so all of
+                            // it reads as belonging to the same group no
+                            // matter how a nested subgroup's own distinct
+                            // color breaks up the fill inside. The no-groups
+                            // case (`has-header` false, nothing ever put in a
+                            // group) has nothing to outline — it's just the
+                            // bare connection list on the canvas, as before.
+                            height: gwrap.preferred-height;
+                            background: grp.has-header ? Tokens.card : transparent;
+                            border-width: grp.has-header ? 1px : 0px;
+                            border-color: Tokens.border-strong;
+                            border-radius: Tokens.radius-lg;
+
+                            gwrap := VerticalLayout {
+                                padding: grp.has-header ? 1px : 0px;
+                                spacing: 0px;
+                                alignment: start;
+
+                                for item[i] in grp.rows: Rectangle {
+                            // A box "starts" on a header row (top-level group or
+                            // nested subgroup alike), or on a *nested* row whose
+                            // depth differs from the row before it (a subgroup's
+                            // own connections resuming after a deeper nested
+                            // subgroup ends). A depth-0 row never starts its own
+                            // box this way — a group's direct connections
+                            // resuming after a subgroup must stay flush and same
+                            // color as their header, or they read as detached
+                            // from the group instead of still belonging to it.
+                            // A box "ends" on the last row before depth drops
+                            // back out of it, or before a sibling header at the
+                            // same depth begins — which also naturally closes a
+                            // collapsed (childless) header's box on itself. This
+                            // one rule generalizes the old depth-0-only
+                            // `is-group-end` special case to any nesting depth.
+                            property <bool> box-top: item.is-header || i == 0
+                                || (item.depth > 0 && grp.rows[i - 1].depth != item.depth);
+                            property <bool> box-bottom: i == grp.rows.length - 1
+                                || grp.rows[i + 1].depth < item.depth
+                                || (grp.rows[i + 1].depth == item.depth && grp.rows[i + 1].is-header);
+                            property <length> content-h: item.is-header ? 28px : 40px;
+                            // A gap only belongs *between* sibling boxes at the
+                            // same-or-shallower level (a new subgroup starting,
+                            // or a parent's own rows resuming after one ends) —
+                            // never between a header and the first row of its
+                            // own box, which must stay visually attached.
+                            property <bool> needs-gap: box-top && i > 0
+                                && grp.rows[i - 1].depth >= item.depth;
+
+                            height: needs-gap ? content-h + Tokens.sp2 : content-h;
+                            background: transparent;
+
+                            // Card surface: the top-level group's card keeps its
+                            // usual full-width fill; a subgroup gets an inset,
+                            // differently-shaded surface so it reads as its own
+                            // card nested inside the parent group's card.
+                            card-box := Rectangle {
+                                y: parent.height - content-h;
+                                height: content-h;
+                                x: item.depth * Tokens.sp2;
+                                width: parent.width - 2 * self.x;
+                                background: item.depth > 0 ? Tokens.canvas : Tokens.card;
+                                border-top-left-radius: box-top ? Tokens.radius-lg : 0px;
+                                border-top-right-radius: box-top ? Tokens.radius-lg : 0px;
+                                border-bottom-left-radius: box-bottom ? Tokens.radius-lg : 0px;
+                                border-bottom-right-radius: box-bottom ? Tokens.radius-lg : 0px;
 
                             // --- group header row ---
                             if item.is-header: Rectangle {
-                                y: parent.height - 28px;
-                                height: 28px;
-                                background: Tokens.card;
-                                border-top-left-radius: item.depth == 0 ? Tokens.radius-lg : 0px;
-                                border-top-right-radius: item.depth == 0 ? Tokens.radius-lg : 0px;
-                                border-bottom-left-radius: item.is-group-end ? Tokens.radius-lg : 0px;
-                                border-bottom-right-radius: item.is-group-end ? Tokens.radius-lg : 0px;
+                                width: parent.width;
+                                height: parent.height;
                                 hdr-ta := TouchArea {
                                     // `item.group` is the raw-case key stored on
                                     // SavedConnection; `item.name` is uppercased
@@ -433,6 +481,9 @@ export component ConnPicker inherits Rectangle {
                                     }
                                 }
                             }
+                            } // card-box
+                                }
+                            } // gwrap
                         }
                     }
                 }
@@ -895,7 +946,8 @@ export component ConnPicker inherits Rectangle {
                                 root.rename-text = root.group-menu-target;
                                 root.rename-modal-open = true;
                             } else {
-                                root.group-delete(root.group-menu-target);
+                                root.delete-confirm-target = root.group-menu-target;
+                                root.delete-confirm-open = true;
                             }
                             group-menu.close();
                         }
@@ -970,6 +1022,62 @@ export component ConnPicker inherits Rectangle {
                         clicked => {
                             root.group-rename(root.rename-old, root.rename-text);
                             root.rename-modal-open = false;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ----- Delete group confirmation -----
+    Rectangle {
+        visible: root.delete-confirm-open;
+        background: Tokens.veil;
+        TouchArea { clicked => { root.delete-confirm-open = false; } }
+        Rectangle {
+            width: 340px;
+            x: (parent.width - self.width) / 2;
+            y: 140px;
+            height: dbox.preferred-height;
+            border-radius: Tokens.modal-radius;
+            background: Tokens.card;
+            border-width: 1px;
+            border-color: Tokens.border;
+            drop-shadow-blur: 42px;
+            drop-shadow-offset-y: 12px;
+            drop-shadow-color: #1C191426;
+            TouchArea {}
+            dbox := VerticalLayout {
+                padding: Tokens.sp4;
+                spacing: Tokens.sp3;
+                Text {
+                    text: "Delete group?";
+                    color: Tokens.text;
+                    font-size: 15px;
+                    font-weight: 700;
+                    horizontal-alignment: center;
+                }
+                Text {
+                    text: "\"" + root.delete-confirm-target + "\" will be deleted. Connections inside move up to the parent group — nothing is destroyed.";
+                    color: Tokens.text-dim;
+                    font-size: Tokens.font-sm;
+                    horizontal-alignment: center;
+                    wrap: word-wrap;
+                }
+                HorizontalLayout {
+                    spacing: Tokens.sp2;
+                    alignment: end;
+                    SecondaryButton {
+                        text: "Cancel";
+                        height: 30px;
+                        clicked => { root.delete-confirm-open = false; }
+                    }
+                    DangerButton {
+                        text: "Delete";
+                        height: 30px;
+                        clicked => {
+                            root.group-delete(root.delete-confirm-target);
+                            root.delete-confirm-open = false;
                         }
                     }
                 }

--- a/app/src/ui/picker.slint
+++ b/app/src/ui/picker.slint
@@ -131,16 +131,14 @@ export component ConnPicker inherits Rectangle {
                         alignment: start;
 
                         for item[i] in root.connections: Rectangle {
-                            // Headers (except the very first) carry a little
-                            // extra height above their real 28px content so a
-                            // gap opens up before each new group's card; the
-                            // inner content Rectangle anchors to the bottom of
-                            // that extra space rather than filling it. Row
-                            // items carry the card background directly on this
-                            // outer shell instead (no gap to work around), so
-                            // the existing selected/hover Rectangle underneath
-                            // stays untouched and just composites over it.
-                            height: item.is-header ? (i > 0 ? 28px + Tokens.sp2 : 28px) : 40px;
+                            // Only top-level groups start a new card. Subgroups
+                            // stay attached to their parent card; adding the same
+                            // gap before them makes the hierarchy look broken.
+                            // The inner header Rectangle is anchored to the
+                            // bottom when a top-level gap is present.
+                            height: item.is-header
+                                ? (item.depth == 0 && i > 0 ? 28px + Tokens.sp2 : 28px)
+                                : 40px;
                             background: item.is-header ? transparent : Tokens.card;
                             border-top-left-radius: !item.is-header && i == 0 ? Tokens.radius-lg : 0px;
                             border-top-right-radius: !item.is-header && i == 0 ? Tokens.radius-lg : 0px;
@@ -152,8 +150,8 @@ export component ConnPicker inherits Rectangle {
                                 y: parent.height - 28px;
                                 height: 28px;
                                 background: Tokens.card;
-                                border-top-left-radius: Tokens.radius-lg;
-                                border-top-right-radius: Tokens.radius-lg;
+                                border-top-left-radius: item.depth == 0 ? Tokens.radius-lg : 0px;
+                                border-top-right-radius: item.depth == 0 ? Tokens.radius-lg : 0px;
                                 border-bottom-left-radius: item.is-group-end ? Tokens.radius-lg : 0px;
                                 border-bottom-right-radius: item.is-group-end ? Tokens.radius-lg : 0px;
                                 hdr-ta := TouchArea {

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -9,7 +9,7 @@ import { GridColumn, GridCell, StructField, Span, ChartBar, IndexRow, DocRow, Re
 import { CodeEditor } from "code-editor.slint";
 import { TabularGrid } from "tabular-grid.slint";
 import { PaletteItem } from "palette.slint";
-import { SecondaryButton, PrimaryButton, TextButton, ExportButton, DangerButton, FilterField, UnderlineSegment, DbBadge, Tooltip, TooltipArea, Shortcut } from "components.slint";
+import { SecondaryButton, PrimaryButton, TextButton, ExportButton, DangerButton, FilterField, ResultModeToggle, DbBadge, Tooltip, TooltipArea, Shortcut } from "components.slint";
 import { ScrollView, TextEdit, ComboBox } from "std-widgets.slint";
 import { AppIcon } from "icons.slint";
 
@@ -224,21 +224,12 @@ export component QueryPane inherits Rectangle {
                         clicked => { root.browse-editor-open = !root.browse-editor-open; }
                     }
                 }
-                // Mongo document view switch (grid table ⇄ JSON tree)
+                // Mongo document view switch (grid table ⇄ JSON tree).
                 if root.result-kind == 1: VerticalLayout {
                     alignment: center;
-                    HorizontalLayout {
-                        spacing: Tokens.sp3;
-                        UnderlineSegment {
-                            text: "Grid";
-                            active: root.doc-view == 0;
-                            clicked => { root.doc-view = 0; }
-                        }
-                        UnderlineSegment {
-                            text: "Tree";
-                            active: root.doc-view == 1;
-                            clicked => { root.doc-view = 1; }
-                        }
+                    ResultModeToggle {
+                        mode: root.doc-view;
+                        changed(mode) => { root.doc-view = mode; }
                     }
                 }
                 VerticalLayout {
@@ -618,39 +609,10 @@ export component QueryPane inherits Rectangle {
                         clicked => { root.filter-open = !root.filter-open; }
                     }
                     // Mongo query results use the same Grid/Tree document view as
-                    // collection browsing; keep the switch available in this header
-                    // too. `UnderlineSegment` has no explicit height (it sizes to
-                    // its label text), unlike the `TextButton` siblings around it
-                    // (fixed `Tokens.button-h`) — a `VerticalLayout{alignment:center}`
-                    // wrapper still left it a hair off (nested-layout auto-sizing
-                    // through this row's own stretch cross-axis-alignment isn't
-                    // reliable here), so this centers it with an explicit `y`
-                    // instead: a plain `Rectangle` (not a layout, so `y`/`height` on
-                    // its child are respected literally) stretches to the row's full
-                    // height like every sibling, and the inner row is placed at the
-                    // exact vertical center of that height, no auto-sizing involved.
-                    if root.result-kind == 1: Rectangle {
-                        // Explicit width — otherwise this Rectangle has no
-                        // natural size and the row's default stretch along
-                        // its main (horizontal) axis hands it all the
-                        // leftover space, shoving Copy/Export/Chart to the
-                        // far right.
-                        width: gt-row.preferred-width;
-                        gt-row := HorizontalLayout {
-                            y: (parent.height - self.preferred-height) / 2;
-                            height: self.preferred-height;
-                            spacing: Tokens.sp3;
-                            UnderlineSegment {
-                                text: "Grid";
-                                active: root.doc-view == 0;
-                                clicked => { root.doc-view = 0; }
-                            }
-                            UnderlineSegment {
-                                text: "Tree";
-                                active: root.doc-view == 1;
-                                clicked => { root.doc-view = 1; }
-                            }
-                        }
+                    // collection browsing.
+                    if root.result-kind == 1: ResultModeToggle {
+                        mode: root.doc-view;
+                        changed(mode) => { root.doc-view = mode; }
                     }
                     TextButton {
                         text: "Copy";

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -621,12 +621,18 @@ export component QueryPane inherits Rectangle {
                     // collection browsing; keep the switch available in this header
                     // too. `UnderlineSegment` has no explicit height (it sizes to
                     // its label text), unlike the `TextButton` siblings around it
-                    // (fixed `Tokens.button-h`) — without this `VerticalLayout`
-                    // wrapper to center it, the row's default stretch alignment
-                    // pulls it out of line with them.
-                    if root.result-kind == 1: VerticalLayout {
-                        alignment: center;
-                        HorizontalLayout {
+                    // (fixed `Tokens.button-h`) — a `VerticalLayout{alignment:center}`
+                    // wrapper still left it a hair off (nested-layout auto-sizing
+                    // through this row's own stretch cross-axis-alignment isn't
+                    // reliable here), so this centers it with an explicit `y`
+                    // instead: a plain `Rectangle` (not a layout, so `y`/`height` on
+                    // its child are respected literally) stretches to the row's full
+                    // height like every sibling, and the inner row is placed at the
+                    // exact vertical center of that height, no auto-sizing involved.
+                    if root.result-kind == 1: Rectangle {
+                        gt-row := HorizontalLayout {
+                            y: (parent.height - self.preferred-height) / 2;
+                            height: self.preferred-height;
                             spacing: Tokens.sp3;
                             UnderlineSegment {
                                 text: "Grid";

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -617,6 +617,21 @@ export component QueryPane inherits Rectangle {
                         tooltip: "Toggle the per-column filter row";
                         clicked => { root.filter-open = !root.filter-open; }
                     }
+                    // Mongo query results use the same Grid/Tree document view as
+                    // collection browsing; keep the switch available in this header too.
+                    if root.result-kind == 1: HorizontalLayout {
+                        spacing: Tokens.sp3;
+                        UnderlineSegment {
+                            text: "Grid";
+                            active: root.doc-view == 0;
+                            clicked => { root.doc-view = 0; }
+                        }
+                        UnderlineSegment {
+                            text: "Tree";
+                            active: root.doc-view == 1;
+                            clicked => { root.doc-view = 1; }
+                        }
+                    }
                     TextButton {
                         text: "Copy";
                         tooltip: "Copy every loaded row to the clipboard as TSV";

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -630,6 +630,12 @@ export component QueryPane inherits Rectangle {
                     // height like every sibling, and the inner row is placed at the
                     // exact vertical center of that height, no auto-sizing involved.
                     if root.result-kind == 1: Rectangle {
+                        // Explicit width — otherwise this Rectangle has no
+                        // natural size and the row's default stretch along
+                        // its main (horizontal) axis hands it all the
+                        // leftover space, shoving Copy/Export/Chart to the
+                        // far right.
+                        width: gt-row.preferred-width;
                         gt-row := HorizontalLayout {
                             y: (parent.height - self.preferred-height) / 2;
                             height: self.preferred-height;

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -618,18 +618,26 @@ export component QueryPane inherits Rectangle {
                         clicked => { root.filter-open = !root.filter-open; }
                     }
                     // Mongo query results use the same Grid/Tree document view as
-                    // collection browsing; keep the switch available in this header too.
-                    if root.result-kind == 1: HorizontalLayout {
-                        spacing: Tokens.sp3;
-                        UnderlineSegment {
-                            text: "Grid";
-                            active: root.doc-view == 0;
-                            clicked => { root.doc-view = 0; }
-                        }
-                        UnderlineSegment {
-                            text: "Tree";
-                            active: root.doc-view == 1;
-                            clicked => { root.doc-view = 1; }
+                    // collection browsing; keep the switch available in this header
+                    // too. `UnderlineSegment` has no explicit height (it sizes to
+                    // its label text), unlike the `TextButton` siblings around it
+                    // (fixed `Tokens.button-h`) — without this `VerticalLayout`
+                    // wrapper to center it, the row's default stretch alignment
+                    // pulls it out of line with them.
+                    if root.result-kind == 1: VerticalLayout {
+                        alignment: center;
+                        HorizontalLayout {
+                            spacing: Tokens.sp3;
+                            UnderlineSegment {
+                                text: "Grid";
+                                active: root.doc-view == 0;
+                                clicked => { root.doc-view = 0; }
+                            }
+                            UnderlineSegment {
+                                text: "Tree";
+                                active: root.doc-view == 1;
+                                clicked => { root.doc-view = 1; }
+                            }
                         }
                     }
                     TextButton {

--- a/app/src/ui/structs.slint
+++ b/app/src/ui/structs.slint
@@ -57,6 +57,18 @@ export struct ConnItem {
     // mirrors `TreeNode.depth`.
     depth: int,
 }
+// One top-level card in the sidebar: its own header row plus every row
+// nested under it (subgroup headers, direct connections), so the sidebar
+// can draw one continuous outline around the whole card. `has-header` is
+// false only in the no-groups-at-all case, where the store's connections
+// render as a single flat, header-less list (no card/outline drawn).
+export struct TopLevelGroup {
+    has-header: bool,
+    // Includes the top-level header row itself as the first element when
+    // `has-header` is true — one flat list lets the sidebar reuse its
+    // per-row header/connection rendering unchanged, just scoped per group.
+    rows: [ConnItem],
+}
 // One Host/Port/… row of the connection-detail card.
 export struct KvRow { k: string, v: string }
 export struct StructField { name: string, type-name: string, nullable: bool }


### PR DESCRIPTION
## Summary

- Improve database connection management and Mongo result browsing across the app.
- Fix Mongo Grid/Tree controls so they remain aligned in both query results and direct collection views.
- Improve connection-group layout, error handling, Redis connection defaults, and release workflow automation.

## Changes

- **Mongo results and browsing**
  - Add Grid/Tree rendering and controls for Mongo query results.
  - Refactor the Grid/Tree controls into shared Slint components used by query results and direct collection browsing.
  - Keep the controls aligned with Editor, Filter, Copy, Export, and Chart actions.
  - Add regression coverage for Mongo document tree conversion.

- **Connection and workspace behavior**
  - Preserve query tabs when switching databases and restore persisted tabs only on the first connection.
  - Improve top-level and nested connection-group spacing and outlines.
  - Add confirmation before deleting connection groups or subgroups.
  - Prevent Redis connections from defaulting to TLS when SSL is not explicitly selected.
  - Remove duplicated connection-error prefixes and allow long error messages to wrap correctly.

- **Release workflow**
  - Make Release Please preparation manually triggered by a maintainer.
  - Automatically finalize the tag and GitHub Release after a Release Please PR is merged.
  - Keep semantic version calculation driven by Conventional Commits.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p rdb`
- [x] `cargo test -p rdb --bin rdb` — 215 passed
- [x] `cargo build -p rdb`
- [x] `cargo clippy -p rdb --all-targets`
- [x] `git diff --check`
- [x] YAML parsed successfully with Ruby YAML parser
- [x] YAML parsed successfully with PyYAML
- [x] `forgeguard gate --changed --output compact` — 0 errors, 0 warnings, 0 failed checks
- [ ] `actionlint` — unavailable locally because it is not installed
