### PR TITLE
fix(app): fold pasted smart punctuation to ASCII

### DIFF
--- a/app/src/editor.rs
+++ b/app/src/editor.rs
@@ -220,6 +220,11 @@ pub fn sanitize(s: &str) -> String {
             | '\u{2029}'
             | '\u{2060}'
             | '\u{feff}' => None,
+            // typographic punctuation (WhatsApp/Word/Notion) → ASCII, so it
+            // both renders and parses as SQL
+            '\u{2018}' | '\u{2019}' | '\u{201a}' | '\u{201b}' | '\u{2032}' => Some('\''),
+            '\u{201c}' | '\u{201d}' | '\u{201e}' | '\u{201f}' | '\u{2033}' => Some('"'),
+            '\u{2010}'..='\u{2015}' | '\u{2212}' => Some('-'),
             c if c.is_control() => None,
             c => Some(c),
         })
@@ -1113,6 +1118,11 @@ mod tests {
         assert_eq!(sanitize(dirty), "SELECT 1 FROMt;");
         // newlines and tabs survive
         assert_eq!(sanitize("a\n\tb"), "a\n\tb");
+        // smart quotes / dashes from WhatsApp fold to ASCII
+        assert_eq!(
+            sanitize("WHERE name = \u{2018}a\u{2019} \u{2013}\u{2014} \u{201c}b\u{201d}"),
+            "WHERE name = 'a' -- \"b\""
+        );
         // pasted text lands clean in the buffer
         let mut ed = EditorState::from_text("");
         ed.insert(dirty);


### PR DESCRIPTION
## Summary

- Text pasted into the query editor from WhatsApp, Jira or Word carries typographic punctuation: curly quotes, en/em dashes, prime marks. They render fine, so the failure is silent — it is the statement that fails to parse, because no SQL dialect accepts `U+2018` as a string delimiter.
- Extends the paste sanitizer that already exists rather than adding a new mechanism.

## Changes

- `app/src/editor.rs` — `sanitize()` now folds `‘’‚‛′` → `'`, `“”„‟″` → `"`, `‐–—―−` → `-`, alongside the exotic-space and zero-width folding already there. Applies to both paste and text load, since everything routes through `insert`/`from_text`.
- Extended `sanitize_folds_exotic_spaces_and_drops_invisibles` with the typographic punctuation cases.

## Notes

Bundled IBM Plex Mono already covers every one of these codepoints, so this change is purely about parseability, not rendering. Tofu for CJK/emoji is a separate concern and is untouched here — Slint 1.16 uses fontique with `system_fonts: true`, so fallback to system fonts is already active on desktop.

## Test plan

- [x] `cargo test -p rdb --bin rdb sanitize`
- [ ] `make lint` (left to the `rdb-app` CI job)
- [ ] Paste manually from Jira/WhatsApp into the query editor and run the statement