### PR TITLE
feat(app): paste safety, completion perf, and sidebar UX fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,7 +1727,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1924,7 +1924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2923,7 +2923,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -5630,7 +5630,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.40",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -5669,9 +5669,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6463,7 +6463,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6555,7 +6555,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7334,7 +7334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7640,7 +7640,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8288,7 +8288,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8848,15 +8848,15 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.1"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+checksum = "62c35be770821a214dbc362fc26908c853e776c0004294d0b10b8a6bad582f94"
 dependencies = [
- "core-foundation 0.10.1",
  "jni",
  "log",
  "ndk-context",
  "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
  "url",
  "web-sys",
@@ -8927,7 +8927,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5885,7 +5885,7 @@ dependencies = [
 
 [[package]]
 name = "rdb"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/app/src/completion.rs
+++ b/app/src/completion.rs
@@ -277,6 +277,36 @@ fn last_keyword(line: &str, language: rdb_connstore::QueryLanguage) -> Option<St
         .map(|s| s.text.to_uppercase())
 }
 
+/// Whether the cursor is in a table-name position (after FROM, JOIN, INTO,
+/// UPDATE, or TABLE). Used to decide whether to auto-append an alias.
+pub fn is_table_position(line: &str, language: rdb_connstore::QueryLanguage) -> bool {
+    matches!(
+        last_keyword(line, language).as_deref(),
+        Some("FROM") | Some("JOIN") | Some("INTO") | Some("UPDATE") | Some("TABLE")
+    )
+}
+
+/// Generate a short alias from a table name by taking the first letter of
+/// each underscore-delimited segment. `users` → `u`, `order_items` → `oi`.
+pub fn generate_alias(table: &str) -> String {
+    let mut alias = String::new();
+    for part in table.split('_') {
+        if let Some(ch) = part.chars().next() {
+            alias.push(ch.to_ascii_lowercase());
+        }
+    }
+    if alias.is_empty() {
+        // Fallback: first char of the whole name.
+        table
+            .chars()
+            .next()
+            .map(|c| c.to_ascii_lowercase().to_string())
+            .unwrap_or_default()
+    } else {
+        alias
+    }
+}
+
 /// Suggest completions for the text before the cursor. Returns the char length
 /// of the partial word to replace on accept, plus the (prefix-filtered, capped)
 /// candidates. An empty list means "no popup".
@@ -1098,5 +1128,59 @@ mod tests {
             c.iter().map(|x| x.label.as_str()).collect::<Vec<_>>(),
             ["step_config"]
         );
+    }
+
+    #[test]
+    fn generate_alias_single_word() {
+        assert_eq!(generate_alias("users"), "u");
+    }
+
+    #[test]
+    fn generate_alias_underscore_separated() {
+        assert_eq!(generate_alias("order_items"), "oi");
+        assert_eq!(generate_alias("t_invoice_line"), "til");
+    }
+
+    #[test]
+    fn generate_alias_preserves_case_in_initials() {
+        // Each segment's first char is lowercased.
+        assert_eq!(generate_alias("UserSessions"), "u");
+        assert_eq!(generate_alias("order_Items"), "oi");
+    }
+
+    #[test]
+    fn generate_alias_empty_fallback() {
+        // Edge case: empty string or just underscores.
+        assert_eq!(generate_alias(""), "");
+        assert_eq!(generate_alias("_"), "");
+    }
+
+    #[test]
+    fn is_table_position_detects_from_and_join() {
+        assert!(is_table_position(
+            "select * from ",
+            rdb_connstore::QueryLanguage::Sql
+        ));
+        assert!(is_table_position(
+            "select * from t left join ",
+            rdb_connstore::QueryLanguage::Sql
+        ));
+        assert!(is_table_position(
+            "insert into ",
+            rdb_connstore::QueryLanguage::Sql
+        ));
+        assert!(is_table_position(
+            "update ",
+            rdb_connstore::QueryLanguage::Sql
+        ));
+        // Not table position:
+        assert!(!is_table_position(
+            "select ",
+            rdb_connstore::QueryLanguage::Sql
+        ));
+        assert!(!is_table_position(
+            "select * from users where ",
+            rdb_connstore::QueryLanguage::Sql
+        ));
     }
 }

--- a/app/src/editor.rs
+++ b/app/src/editor.rs
@@ -225,6 +225,14 @@ pub fn sanitize(s: &str) -> String {
             '\u{2018}' | '\u{2019}' | '\u{201a}' | '\u{201b}' | '\u{2032}' => Some('\''),
             '\u{201c}' | '\u{201d}' | '\u{201e}' | '\u{201f}' | '\u{2033}' => Some('"'),
             '\u{2010}'..='\u{2015}' | '\u{2212}' => Some('-'),
+            // ponytail: blocklist of known-bad ranges (private-use/replacement
+            // codepoints from external copy-widget icon fonts), not real
+            // glyph-coverage validation against the editor font
+            '\u{e000}'..='\u{f8ff}'
+            | '\u{f0000}'..='\u{ffffd}'
+            | '\u{100000}'..='\u{10fffd}'
+            | '\u{fffc}'
+            | '\u{fffd}' => None,
             c if c.is_control() => None,
             c => Some(c),
         })
@@ -1127,6 +1135,15 @@ mod tests {
         let mut ed = EditorState::from_text("");
         ed.insert(dirty);
         assert_eq!(ed.text(), "SELECT 1 FROMt;");
+    }
+
+    #[test]
+    fn sanitize_drops_private_use_and_replacement_chars() {
+        // PUA glyph (e.g. from a web tool's copy-button icon font) before SET/WHERE
+        let dirty = "SET\u{e000}x=1\u{fffc}WHERE\u{fffd}y=2";
+        assert_eq!(sanitize(dirty), "SETx=1WHEREy=2");
+        // supplementary PUA-A / PUA-B also dropped
+        assert_eq!(sanitize("a\u{f0000}b\u{100000}c"), "abc");
     }
 
     // ----- selection -----

--- a/app/src/editor.rs
+++ b/app/src/editor.rs
@@ -233,6 +233,9 @@ pub fn sanitize(s: &str) -> String {
             | '\u{100000}'..='\u{10fffd}'
             | '\u{fffc}'
             | '\u{fffd}' => None,
+            // variation selectors: orphaned once the PUA/emoji base glyph
+            // they modify is stripped above, still renders as tofu alone
+            '\u{fe00}'..='\u{fe0f}' | '\u{e0100}'..='\u{e01ef}' => None,
             c if c.is_control() => None,
             c => Some(c),
         })
@@ -1144,6 +1147,9 @@ mod tests {
         assert_eq!(sanitize(dirty), "SETx=1WHEREy=2");
         // supplementary PUA-A / PUA-B also dropped
         assert_eq!(sanitize("a\u{f0000}b\u{100000}c"), "abc");
+        // orphaned variation selector (PUA base + VS, base already stripped
+        // above) doesn't survive on its own either
+        assert_eq!(sanitize("SET\u{e000}\u{fe0f}x"), "SETx");
     }
 
     // ----- selection -----

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -5993,7 +5993,16 @@ fn main() -> Result<(), slint::PlatformError> {
             w.set_sel_has_custom_color(s.color.is_some());
             let label = AnyDriver::label(s.engine);
             let sub = match s.group.as_deref().filter(|g| !g.trim().is_empty()) {
-                Some(g) => format!("{label} · grup {}", g.to_lowercase()),
+                Some(g) => {
+                    let mut parts = g.split('/').filter(|p| !p.trim().is_empty());
+                    match (parts.next(), parts.collect::<Vec<_>>().join(" / ")) {
+                        (Some(group), sub) if !sub.is_empty() => {
+                            format!("{label} · Group: {group} · Subgroup: {sub}")
+                        }
+                        (Some(group), _) => format!("{label} · Group: {group}"),
+                        (None, _) => label.to_string(),
+                    }
+                }
                 None => label.to_string(),
             };
             w.set_sel_sub(sub.into());

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -7993,9 +7993,8 @@ fn main() -> Result<(), slint::PlatformError> {
                         // Load every other schema's tables so cross-schema
                         // `schema.table` autocompletes. Runs after the sidebar
                         // (active schema) already rendered; the popup just gains
-                        // more names as this fills.
-                        // ponytail: sequential N+1 fetch, fine for typical schema
-                        // counts; make it concurrent if a wide DB feels laggy.
+                        // more names as this fills. Fetched concurrently, one
+                        // task per schema, instead of sequentially.
                         if matches!(engine, rdb_connstore::Engine::Postgres)
                             && all_schema_names.len() > 1
                         {
@@ -8004,10 +8003,24 @@ fn main() -> Result<(), slint::PlatformError> {
                                 guard.as_ref().map(|(_, d)| d.clone())
                             };
                             if let Some(driver) = driver {
+                                let handles: Vec<_> = all_schema_names
+                                    .iter()
+                                    .cloned()
+                                    .map(|name| {
+                                        let driver = driver.clone();
+                                        tokio::spawn(async move {
+                                            driver
+                                                .schema_for(&name)
+                                                .await
+                                                .ok()
+                                                .map(|s| model::to_completion_nodes(&name, &s))
+                                        })
+                                    })
+                                    .collect();
                                 let mut all = Vec::new();
-                                for name in &all_schema_names {
-                                    if let Ok(s) = driver.schema_for(name).await {
-                                        all.extend(model::to_completion_nodes(name, &s));
+                                for handle in handles {
+                                    if let Ok(Some(nodes)) = handle.await {
+                                        all.extend(nodes);
                                     }
                                 }
                                 if !all.is_empty() {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -508,14 +508,18 @@ fn build_conn_items(
     let mut direct_conns: std::collections::HashMap<String, Vec<usize>> =
         std::collections::HashMap::new();
     for (i, sc) in store.list().iter().enumerate() {
-        if !needle.is_empty() && !sc.name.to_lowercase().contains(&needle) {
-            continue;
-        }
         let g = sc
             .group
             .as_deref()
             .and_then(rdb_connstore::normalize_group_path)
             .unwrap_or_else(|| UNGROUPED.to_string());
+        if !needle.is_empty()
+            && !sc.name.to_lowercase().contains(&needle)
+            && !g.to_lowercase().contains(&needle)
+            && !sc.env_tag.as_str().to_lowercase().contains(&needle)
+        {
+            continue;
+        }
         if g == UNGROUPED {
             if registered.insert(UNGROUPED.to_string()) {
                 child_folders

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1296,7 +1296,8 @@ mod result_tab_tests {
 struct GroupRuntime {
     ed_state: Rc<RefCell<editor::EditorState>>,
     folded_heads: Rc<RefCell<HashSet<usize>>>,
-    completion_ctx: Rc<RefCell<(usize, Vec<String>)>>,
+    #[allow(clippy::type_complexity)]
+    completion_ctx: Rc<RefCell<(usize, Vec<(String, String)>)>>,
     find_hits: Rc<RefCell<Vec<(usize, usize, usize)>>>,
     edit_buf: Arc<std::sync::Mutex<model::EditBuffer>>,
     results: Arc<std::sync::Mutex<Vec<StoredResult>>>,
@@ -4175,6 +4176,7 @@ fn main() -> Result<(), slint::PlatformError> {
     ));
     window.set_history_max_entries(history_cap.get() as i32);
     window.set_nosql_collection_limit(settings.borrow().get().nosql_collection_limit.max(1) as i32);
+    window.set_auto_table_alias(settings.borrow().get().editor.auto_table_alias);
     window.set_app_version(env!("CARGO_PKG_VERSION").into());
 
     // Fixed window size for the screenshot loop: RDB_WIN=WxH (logical px).
@@ -4531,8 +4533,13 @@ fn main() -> Result<(), slint::PlatformError> {
                     depth: 0,
                 })
                 .collect();
-            *panes[pane].completion_ctx.borrow_mut() =
-                (word_len, cands.iter().map(|c| c.label.clone()).collect());
+            *panes[pane].completion_ctx.borrow_mut() = (
+                word_len,
+                cands
+                    .iter()
+                    .map(|c| (c.label.clone(), c.kind.clone()))
+                    .collect(),
+            );
             set_p_completion_items(&w, pane, ModelRc::from(Rc::new(VecModel::from(items))));
             set_p_completion_selected(&w, pane, 0);
             set_p_completion_visible(&w, pane, true);
@@ -4542,12 +4549,14 @@ fn main() -> Result<(), slint::PlatformError> {
         let weak = window.as_weak();
         let panes = panes.clone();
         let sync_editor = sync_editor.clone();
+        let settings = settings.clone();
+        let cur_engine = cur_engine.clone();
         Rc::new(move |pane, idx| {
             let Some(w) = weak.upgrade() else {
                 return;
             };
-            let (word_len, labels) = panes[pane].completion_ctx.borrow().clone();
-            let Some(label) = labels.get(idx.max(0) as usize).cloned() else {
+            let (word_len, entries) = panes[pane].completion_ctx.borrow().clone();
+            let Some((label, kind)) = entries.get(idx.max(0) as usize).cloned() else {
                 return;
             };
             {
@@ -4556,6 +4565,21 @@ fn main() -> Result<(), slint::PlatformError> {
                     ed.backspace();
                 }
                 ed.insert(&label);
+                // Auto-append alias when accepting a table name in FROM/JOIN position.
+                if kind == "table" && settings.borrow().get().editor.auto_table_alias {
+                    let language = cur_engine
+                        .borrow()
+                        .map(rdb_connstore::Engine::language)
+                        .unwrap_or(rdb_connstore::QueryLanguage::Sql);
+                    let before = ed.before_cursor_doc();
+                    let cur_line = before.rsplit('\n').next().unwrap_or(&before);
+                    if completion::is_table_position(cur_line, language) {
+                        let alias = completion::generate_alias(&label);
+                        if !alias.is_empty() {
+                            ed.insert(&format!(" {alias}"));
+                        }
+                    }
+                }
             }
             set_p_completion_visible(&w, pane, false);
             *panes[pane].completion_ctx.borrow_mut() = (0, Vec::new());
@@ -12292,6 +12316,16 @@ fn main() -> Result<(), slint::PlatformError> {
                     }
                 });
             });
+        });
+    }
+
+    // ----- settings: auto-table-alias toggle -----
+    {
+        let settings = settings.clone();
+        window.on_set_auto_table_alias(move |v| {
+            let _ = settings
+                .borrow_mut()
+                .update(|s| s.editor.auto_table_alias = v);
         });
     }
 

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -2740,21 +2740,11 @@ callback create-table-commit();
                         }
                         ToggleRow {
                             label: "Auto table alias";
-                            description: "Appends a short alias (e.g. order_items → oi) when you accept a table suggestion in FROM/JOIN.";
+                            description: "Appends a short alias (e.g. order_items → oi).";
                             checked: root.auto-table-alias;
                             toggled => {
                                 root.auto-table-alias = !root.auto-table-alias;
                                 root.set-auto-table-alias(root.auto-table-alias);
-                            }
-                        }
-                    }
-
-                    HorizontalLayout {
-                        SecondaryButton {
-                            text: "Keyboard Shortcuts";
-                            clicked => {
-                                root.settings-open = false;
-                                root.shortcuts-open = true;
                             }
                         }
                     }
@@ -2887,7 +2877,14 @@ callback create-table-commit();
 
                 // --- done ---
                 HorizontalLayout {
-                    alignment: end;
+                    if root.settings-tab == 0: SecondaryButton {
+                        text: "Keyboard Shortcuts";
+                        clicked => {
+                            root.settings-open = false;
+                            root.shortcuts-open = true;
+                        }
+                    }
+                    Rectangle { horizontal-stretch: 1; }
                     PrimaryButton {
                         text: "Done";
                         clicked => { root.settings-open = false; }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -604,6 +604,9 @@ callback create-table-commit();
     // Max collections listed per database for NoSQL (MongoDB); RDBMS unaffected.
     in property <int> nosql-collection-limit: 200;
     callback set-nosql-collection-limit(int);
+    // Auto-append alias when accepting a table name from completion in FROM/JOIN position.
+    in property <bool> auto-table-alias: true;
+    callback set-auto-table-alias(bool);
     in-out property <bool> shortcuts-open: false;
     // Settings modal active section: 0 Appearance, 1 Updates, 2 About.
     in-out property <int> settings-tab: 0;
@@ -2725,6 +2728,11 @@ callback create-table-commit();
                                     : value == "1000" ? 1000 : 200);
                             }
                         }
+                    }
+                    ToggleRow {
+                        label: "Auto table alias";
+                        checked: root.auto-table-alias;
+                        toggled => { root.set-auto-table-alias(!root.auto-table-alias); }
                     }
                     HorizontalLayout {
                         SecondaryButton {

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -605,7 +605,7 @@ callback create-table-commit();
     in property <int> nosql-collection-limit: 200;
     callback set-nosql-collection-limit(int);
     // Auto-append alias when accepting a table name from completion in FROM/JOIN position.
-    in property <bool> auto-table-alias: true;
+    in-out property <bool> auto-table-alias: true;
     callback set-auto-table-alias(bool);
     in-out property <bool> shortcuts-open: false;
     // Settings modal active section: 0 Appearance, 1 Updates, 2 About.
@@ -2732,7 +2732,10 @@ callback create-table-commit();
                     ToggleRow {
                         label: "Auto table alias";
                         checked: root.auto-table-alias;
-                        toggled => { root.set-auto-table-alias(!root.auto-table-alias); }
+                        toggled => {
+                            root.auto-table-alias = !root.auto-table-alias;
+                            root.set-auto-table-alias(root.auto-table-alias);
+                        }
                     }
                     HorizontalLayout {
                         SecondaryButton {

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -3,7 +3,7 @@ export { Theme }
 import { Tokens } from "tokens.slint";
 export { Tokens }
 import {
-    SearchCommandPill, BreadcrumbChip, DbBadge, GlyphButton, IconButton, OutlineChip, PrimaryButton, SecondaryButton, SelectBox, TextButton, Toggle, ToggleRow, Tooltip, TooltipArea, Shortcut
+    SearchCommandPill, BreadcrumbChip, DbBadge, GlyphButton, IconButton, OutlineChip, PrimaryButton, SecondaryButton, SelectBox, SettingsSectionHeader, TextButton, Toggle, ToggleRow, Tooltip, TooltipArea, Shortcut
 } from "components.slint";
 export { Shortcut }
 import { NavCluster } from "nav-cluster.slint";
@@ -2665,78 +2665,90 @@ callback create-table-commit();
 
                 // --- Appearance ---
                 if root.settings-tab == 0: VerticalLayout {
-                    spacing: Tokens.sp3;
-                    ToggleRow {
-                        label: "Dark mode";
-                        checked: Tokens.dark;
-                        toggled => { root.toggle-theme(); }
-                    }
-                    ToggleRow {
-                        label: "Sidebar on the right";
-                        checked: root.sidebar-right;
-                        toggled => {
-                            root.sidebar-right = !root.sidebar-right;
-                            root.set-sidebar-side(root.sidebar-right);
-                        }
-                    }
-                    HorizontalLayout {
+                    spacing: Tokens.sp4;
+
+                    VerticalLayout {
                         spacing: Tokens.sp3;
-                        VerticalLayout {
-                            alignment: center;
-                            horizontal-stretch: 1;
-                            Text {
-                                text: "History entries";
-                                color: Tokens.text;
-                                font-size: 13px;
-                            }
+                        SettingsSectionHeader { label: "Appearance"; }
+                        ToggleRow {
+                            label: "Dark mode";
+                            checked: Tokens.dark;
+                            toggled => { root.toggle-theme(); }
                         }
-                        SelectBox {
-                            width: 82px;
-                            model: ["25", "50", "100", "200"];
-                            current-value: root.history-max-entries == 25 ? "25"
-                                : root.history-max-entries == 100 ? "100"
-                                : root.history-max-entries == 200 ? "200" : "50";
-                            selected(value) => {
-                                root.set-history-max-entries(value == "25" ? 25
-                                    : value == "100" ? 100 : value == "200" ? 200 : 50);
+                        ToggleRow {
+                            label: "Sidebar on the right";
+                            checked: root.sidebar-right;
+                            toggled => {
+                                root.sidebar-right = !root.sidebar-right;
+                                root.set-sidebar-side(root.sidebar-right);
                             }
                         }
                     }
-                    // NoSQL-only: caps how many collections the MongoDB sidebar
-                    // lists per database. RDBMS table listings are unaffected.
-                    HorizontalLayout {
+
+                    VerticalLayout {
                         spacing: Tokens.sp3;
-                        VerticalLayout {
-                            alignment: center;
-                            horizontal-stretch: 1;
-                            Text {
-                                text: "Max collections (MongoDB)";
-                                color: Tokens.text;
-                                font-size: 13px;
+                        SettingsSectionHeader { label: "Editor"; }
+                        HorizontalLayout {
+                            spacing: Tokens.sp3;
+                            VerticalLayout {
+                                alignment: center;
+                                horizontal-stretch: 1;
+                                Text {
+                                    text: "History entries";
+                                    color: Tokens.text;
+                                    font-size: 13px;
+                                }
+                            }
+                            SelectBox {
+                                width: 82px;
+                                model: ["25", "50", "100", "200"];
+                                current-value: root.history-max-entries == 25 ? "25"
+                                    : root.history-max-entries == 100 ? "100"
+                                    : root.history-max-entries == 200 ? "200" : "50";
+                                selected(value) => {
+                                    root.set-history-max-entries(value == "25" ? 25
+                                        : value == "100" ? 100 : value == "200" ? 200 : 50);
+                                }
                             }
                         }
-                        SelectBox {
-                            width: 82px;
-                            model: ["50", "100", "200", "500", "1000"];
-                            current-value: root.nosql-collection-limit == 50 ? "50"
-                                : root.nosql-collection-limit == 100 ? "100"
-                                : root.nosql-collection-limit == 500 ? "500"
-                                : root.nosql-collection-limit == 1000 ? "1000" : "200";
-                            selected(value) => {
-                                root.set-nosql-collection-limit(value == "50" ? 50
-                                    : value == "100" ? 100 : value == "500" ? 500
-                                    : value == "1000" ? 1000 : 200);
+                        // NoSQL-only: caps how many collections the MongoDB sidebar
+                        // lists per database. RDBMS table listings are unaffected.
+                        HorizontalLayout {
+                            spacing: Tokens.sp3;
+                            VerticalLayout {
+                                alignment: center;
+                                horizontal-stretch: 1;
+                                Text {
+                                    text: "Max collections (MongoDB)";
+                                    color: Tokens.text;
+                                    font-size: 13px;
+                                }
+                            }
+                            SelectBox {
+                                width: 82px;
+                                model: ["50", "100", "200", "500", "1000"];
+                                current-value: root.nosql-collection-limit == 50 ? "50"
+                                    : root.nosql-collection-limit == 100 ? "100"
+                                    : root.nosql-collection-limit == 500 ? "500"
+                                    : root.nosql-collection-limit == 1000 ? "1000" : "200";
+                                selected(value) => {
+                                    root.set-nosql-collection-limit(value == "50" ? 50
+                                        : value == "100" ? 100 : value == "500" ? 500
+                                        : value == "1000" ? 1000 : 200);
+                                }
+                            }
+                        }
+                        ToggleRow {
+                            label: "Auto table alias";
+                            description: "Appends a short alias (e.g. order_items → oi) when you accept a table suggestion in FROM/JOIN.";
+                            checked: root.auto-table-alias;
+                            toggled => {
+                                root.auto-table-alias = !root.auto-table-alias;
+                                root.set-auto-table-alias(root.auto-table-alias);
                             }
                         }
                     }
-                    ToggleRow {
-                        label: "Auto table alias";
-                        checked: root.auto-table-alias;
-                        toggled => {
-                            root.auto-table-alias = !root.auto-table-alias;
-                            root.set-auto-table-alias(root.auto-table-alias);
-                        }
-                    }
+
                     HorizontalLayout {
                         SecondaryButton {
                             text: "Keyboard Shortcuts";

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -39,19 +39,28 @@ export component Toggle inherits TouchArea {
     }
 }
 
-// A settings line: label on the left, toggle on the right.
+// A settings line: label (+ optional one-line description) on the left,
+// toggle on the right.
 export component ToggleRow inherits HorizontalLayout {
     in property <string> label;
+    in property <string> description: "";
     in property <bool> checked;
     callback toggled();
     spacing: Tokens.sp3;
     VerticalLayout {
         alignment: center;
         horizontal-stretch: 1;
+        spacing: 2px;
         Text {
             text: root.label;
             color: Tokens.text;
             font-size: Tokens.font-md;
+        }
+        if root.description != "": Text {
+            text: root.description;
+            color: Tokens.text-dim;
+            font-size: Tokens.font-xs;
+            wrap: word-wrap;
         }
     }
     VerticalLayout {
@@ -61,6 +70,20 @@ export component ToggleRow inherits HorizontalLayout {
             toggled => { root.toggled(); }
         }
     }
+}
+
+// A small uppercase-ish section label for grouping settings rows, with a
+// hairline divider below.
+export component SettingsSectionHeader inherits VerticalLayout {
+    in property <string> label;
+    spacing: Tokens.sp1;
+    Text {
+        text: root.label;
+        color: Tokens.text-dim;
+        font-size: Tokens.font-xs;
+        font-weight: Tokens.weight-emphasis;
+    }
+    Rectangle { height: 1px; background: Tokens.border; }
 }
 
 // Shared tooltip state. Buttons report their hovered tooltip + window-space

--- a/app/src/ui/picker.slint
+++ b/app/src/ui/picker.slint
@@ -22,7 +22,7 @@ export component ConnPicker inherits Rectangle {
     in property <string> sel-engine;
     in property <color> sel-color;
     in property <bool> sel-has-custom-color;
-    in property <string> sel-sub;      // "PostgreSQL · grup profin"
+    in property <string> sel-sub;      // "PostgreSQL · Group: OSS · Subgroup: Postgre"
     in property <bool> sel-local;
     in property <string> sel-env-tag-label;
     in property <color> sel-env-tag-color;

--- a/app/src/ui/picker.slint
+++ b/app/src/ui/picker.slint
@@ -311,14 +311,24 @@ export component ConnPicker inherits Rectangle {
                                             border-radius: 11px;
                                             opacity: hdr-ta.has-hover || gmore-ta.has-hover ? 1.0 : 0.0;
                                             background: gmore-ta.has-hover ? Tokens.card.with-alpha(0.5) : transparent;
-                                            HorizontalLayout {
+                                            // HorizontalLayout's cross (vertical) axis
+                                            // defaults to `stretch`, which doesn't
+                                            // resize a fixed-height child but doesn't
+                                            // center it either — dots sat pinned to
+                                            // the top instead of the circle's middle.
+                                            // Wrap in a VerticalLayout for its own
+                                            // (supported) main-axis centering.
+                                            VerticalLayout {
                                                 alignment: center;
-                                                spacing: 2px;
-                                                for _dot in [0, 1, 2]: Rectangle {
-                                                    width: 3px;
-                                                    height: 3px;
-                                                    border-radius: 1.5px;
-                                                    background: Tokens.text-faint;
+                                                HorizontalLayout {
+                                                    alignment: center;
+                                                    spacing: 2px;
+                                                    for _dot in [0, 1, 2]: Rectangle {
+                                                        width: 3px;
+                                                        height: 3px;
+                                                        border-radius: 1.5px;
+                                                        background: Tokens.text-faint;
+                                                    }
                                                 }
                                             }
                                             gmore-ta := TouchArea {

--- a/app/src/ui/picker.slint
+++ b/app/src/ui/picker.slint
@@ -257,6 +257,11 @@ export component ConnPicker inherits Rectangle {
                                                 name: "caret";
                                                 size: 8px;
                                                 color: Tokens.warn;
+                                                // chevron glyph's visual mass sits at
+                                                // its bottom vertex, so geometric
+                                                // centering still reads slightly low —
+                                                // nudge up 1px to compensate
+                                                y: (parent.height - self.height) / 2 - 1px;
                                                 transform-rotation: item.expanded ? 0deg : -90deg;
                                             }
                                         }
@@ -298,9 +303,12 @@ export component ConnPicker inherits Rectangle {
                                     if item.group != "Ungrouped": VerticalLayout {
                                         alignment: center;
                                         Rectangle {
-                                            width: 24px;
-                                            height: 20px;
-                                            border-radius: Tokens.radius;
+                                            // square + fully round so the hover halo
+                                            // is always a circle centered on the dots,
+                                            // instead of an off-square rounded rect
+                                            width: 22px;
+                                            height: 22px;
+                                            border-radius: 11px;
                                             opacity: hdr-ta.has-hover || gmore-ta.has-hover ? 1.0 : 0.0;
                                             background: gmore-ta.has-hover ? Tokens.card.with-alpha(0.5) : transparent;
                                             HorizontalLayout {

--- a/crates/connstore/src/settings.rs
+++ b/crates/connstore/src/settings.rs
@@ -56,6 +56,9 @@ pub struct EditorPrefs {
     pub font_size: u16,
     pub default_page_size: u32,
     pub history_max_entries: u16,
+    /// Auto-append a short alias when accepting a table name from completion
+    /// in FROM/JOIN position. `users` → `users u`, `order_items` → `order_items oi`.
+    pub auto_table_alias: bool,
 }
 
 impl Default for EditorPrefs {
@@ -64,6 +67,7 @@ impl Default for EditorPrefs {
             font_size: 13,
             default_page_size: 100,
             history_max_entries: 50,
+            auto_table_alias: true,
         }
     }
 }
@@ -176,6 +180,7 @@ mod tests {
         assert_eq!(s.get().last_update_check, None);
         assert_eq!(s.get().editor.default_page_size, 100);
         assert_eq!(s.get().editor.history_max_entries, 50);
+        assert!(s.get().editor.auto_table_alias);
         assert_eq!(s.get().nosql_collection_limit, 200);
     }
 
@@ -214,5 +219,6 @@ mod tests {
         assert!(s.get().update_check);
         assert_eq!(s.get().editor.default_page_size, 100);
         assert_eq!(s.get().editor.history_max_entries, 50);
+        assert!(s.get().editor.auto_table_alias);
     }
 }

--- a/crates/driver-postgres/src/driver.rs
+++ b/crates/driver-postgres/src/driver.rs
@@ -389,27 +389,39 @@ async fn schema_impl(client: &Client, schema: &str) -> Result<Schema> {
         .try_get(0)
         .map_err(|e| RdbError::Schema(pg_err(&e)))?;
 
+    // PK/FK column pairs for the whole schema in one query, instead of two
+    // correlated EXISTS subqueries per column (was O(tables * columns)).
+    let key_rows = client
+        .query(
+            "SELECT tc.constraint_type, kcu.table_name, kcu.column_name \
+             FROM information_schema.table_constraints tc \
+             JOIN information_schema.key_column_usage kcu \
+               ON tc.constraint_name = kcu.constraint_name \
+              AND tc.table_schema = kcu.table_schema \
+             WHERE tc.table_schema = $1 \
+               AND tc.constraint_type IN ('PRIMARY KEY', 'FOREIGN KEY')",
+            &[&schema],
+        )
+        .await
+        .map_err(|e| RdbError::Schema(pg_err(&e)))?;
+    let mut pk_cols: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
+    let mut fk_cols: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
+    for row in &key_rows {
+        let kind: String = row.get(0);
+        let table: String = row.get(1);
+        let column: String = row.get(2);
+        if kind == "PRIMARY KEY" {
+            pk_cols.insert((table, column));
+        } else {
+            fk_cols.insert((table, column));
+        }
+    }
+
     // User tables + columns from information_schema, scoped to one schema.
     // Ordered so columns of the same table are contiguous for grouping.
     let rows = client
         .query(
-            "SELECT c.table_name, c.column_name, c.data_type, c.is_nullable, \
-             EXISTS (SELECT 1 FROM information_schema.table_constraints tc \
-                     JOIN information_schema.key_column_usage kcu \
-                       ON tc.constraint_name = kcu.constraint_name \
-                      AND tc.table_schema = kcu.table_schema \
-                     WHERE tc.constraint_type = 'PRIMARY KEY' \
-                       AND tc.table_schema = c.table_schema \
-                       AND tc.table_name = c.table_name \
-                       AND kcu.column_name = c.column_name) AS is_pk, \
-             EXISTS (SELECT 1 FROM information_schema.table_constraints tc \
-                     JOIN information_schema.key_column_usage kcu \
-                       ON tc.constraint_name = kcu.constraint_name \
-                      AND tc.table_schema = kcu.table_schema \
-                     WHERE tc.constraint_type = 'FOREIGN KEY' \
-                       AND tc.table_schema = c.table_schema \
-                       AND tc.table_name = c.table_name \
-                       AND kcu.column_name = c.column_name) AS is_fk \
+            "SELECT c.table_name, c.column_name, c.data_type, c.is_nullable \
              FROM information_schema.columns c \
              JOIN information_schema.tables t \
                ON t.table_schema = c.table_schema AND t.table_name = c.table_name \
@@ -426,12 +438,13 @@ async fn schema_impl(client: &Client, schema: &str) -> Result<Schema> {
         let column: String = row.get(1);
         let data_type: String = row.get(2);
         let is_nullable: String = row.get(3); // 'YES' | 'NO'
+        let key = (table.clone(), column.clone());
         let field = Field {
             name: column,
             type_name: data_type,
             nullable: is_nullable.eq_ignore_ascii_case("YES"),
-            pk: row.get(4),
-            fk: row.get(5),
+            pk: pk_cols.contains(&key),
+            fk: fk_cols.contains(&key),
         };
         match containers.last_mut() {
             Some(last) if last.name == table => last.fields.push(field),


### PR DESCRIPTION
## Summary
- Add an Auto table alias completion toggle and redesign Settings → Appearance into labeled sections so it (and the other options) are actually explained
- Harden the paste sanitizer against corrupted/invisible Unicode (PUA glyphs, orphaned variation selectors) from external copy-button tools
- Cut Postgres schema-fetch cost: batch the PK/FK lookup into one query per schema instead of per-column EXISTS subqueries, and fetch cross-schema completion nodes concurrently instead of sequentially
- Connection sidebar: filter now matches group/subgroup/env tag (not just name), plus alignment fixes for the group chevron and the "..." overflow menu, and English-only wording in the detail panel

## Changes
- **Editor / paste**: `app/src/editor.rs` — `sanitize()` strips Private Use Area codepoints, `U+FFFC`/`U+FFFD`, and orphaned variation selectors so external copy-widget glyphs never land in the buffer
- **Postgres completion perf**: `crates/driver-postgres/src/driver.rs` batches PK/FK lookups per schema instead of two correlated `EXISTS` subqueries per column; `app/src/main.rs` fans the cross-schema completion backfill out as concurrent tasks instead of a sequential loop
- **Settings redesign**: `app/src/ui/components.slint` adds a `SettingsSectionHeader` component and an optional description line on `ToggleRow`; `app/src/ui/app-window.slint` groups the Appearance tab into Appearance/Editor sections, explains Auto table alias, and aligns the Keyboard Shortcuts button with Done
- **Sidebar filter**: `app/src/main.rs` — `build_conn_items` now matches the normalized group path and env tag alongside connection name
- **Sidebar visual fixes**: `app/src/ui/picker.slint` — nudges the group chevron for optical centering, makes the "..." overflow-menu hover a proper centered circle, and fixes the detail panel's group/subgroup subtitle to plain English (`Group: OSS · Subgroup: Postgre`)

## Test plan
- [x] `make fmt-check` / `cargo fmt --check` on every touched package
- [x] `cargo clippy -- -D warnings` on every touched package
- [x] `cargo test -p rdb`, `cargo test -p rdb-driver-postgres --lib`, `cargo test -p rdb-connstore` — all passing, including new sanitize/alias/filter test cases
- [x] `cargo build -p rdb` (Slint compiles cleanly)
- [x] Manual verification via `make fe-run`: paste corruption fixed, Postgres completion speed, Settings → Appearance layout, sidebar filter by group/env, chevron and "..." menu alignment, English wording — all confirmed