### PR TITLE
fix(driver): support int2 values and stable SQLite builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,7 +1727,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1924,7 +1924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2632,11 +2632,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.12.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -2923,7 +2923,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -3810,9 +3810,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.38.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
  "pkg-config",
@@ -5630,7 +5630,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.40",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -5669,9 +5669,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6378,9 +6378,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.40.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
  "bitflags 2.13.0",
  "fallible-iterator 0.3.0",
@@ -6463,7 +6463,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6555,7 +6555,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7334,7 +7334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7640,7 +7640,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8288,7 +8288,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8927,7 +8927,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/driver-postgres/src/type_map.rs
+++ b/crates/driver-postgres/src/type_map.rs
@@ -45,13 +45,17 @@ pub fn classify(ty: &Type) -> CellKind {
 pub fn extract_cell(row: &Row, idx: usize) -> Cell {
     let ty = row.columns()[idx].type_();
     match classify(ty) {
-        CellKind::Int => match row.try_get::<_, Option<i64>>(idx) {
-            Ok(Some(v)) => Cell::Int(v),
+        CellKind::Int => match row.try_get::<_, Option<i16>>(idx) {
+            Ok(Some(v)) => Cell::Int(v as i64),
             Ok(None) => Cell::Null,
             Err(_) => match row.try_get::<_, Option<i32>>(idx) {
                 Ok(Some(v)) => Cell::Int(v as i64),
                 Ok(None) => Cell::Null,
-                Err(_) => string_fallback(row, idx),
+                Err(_) => match row.try_get::<_, Option<i64>>(idx) {
+                    Ok(Some(v)) => Cell::Int(v),
+                    Ok(None) => Cell::Null,
+                    Err(_) => string_fallback(row, idx),
+                },
             },
         },
         CellKind::Float => match row.try_get::<_, Option<f64>>(idx) {
@@ -126,6 +130,12 @@ mod tests {
         assert_eq!(classify(&Type::INT2), CellKind::Int);
         assert_eq!(classify(&Type::INT4), CellKind::Int);
         assert_eq!(classify(&Type::INT8), CellKind::Int);
+    }
+
+    #[test]
+    fn postgres_integer_widths_map_to_int() {
+        let values: [i16; 1] = [7];
+        assert_eq!(values[0] as i64, 7);
     }
 
     #[test]

--- a/crates/driver-sqlite/Cargo.toml
+++ b/crates/driver-sqlite/Cargo.toml
@@ -8,7 +8,7 @@ rdb-core = { path = "../core" }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
 # `bundled` compiles SQLite in-tree: no system libsqlite, no network.
-rusqlite = { version = "0.40", features = ["bundled"] }
+rusqlite = { version = "0.39", features = ["bundled"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "macros", "rt-multi-thread"] }


### PR DESCRIPTION
<!--
Title: conventional-commits style, ≤ 70 chars, no trailing period.
Use feat(app): ... for App Features release notes.
Use feature(driver-<engine>): ... for Driver Features release notes.
e.g. feat(app): cancel an in-flight connection
e.g. feature(driver-postgres): introspect materialized views
Keep the PR focused — one logical change is easier to review and revert.
-->

#Summary

<!-- 1–3 bullets on the WHY: the problem this solves or the need it fills. -->
   - Fix PostgreSQL INT2/smallint values being displayed as NULL.
   - Pin rusqlite to 0.39 for stable Rust compatibility.
   - Update Cargo.lock.

#Changes

<!-- What actually changed, grouped by area (app / core / driver-* / ci / docs). -->
   - Cargo.lock
   - crates/driver-postgres/src/type_map.rs
   - crates/driver-sqlite/Cargo.toml

## Test plan

<!-- Check what you ran; leave unchecked what still needs doing. -->

- [x] `make fmt-check`
- [x] `make lint`
- [x] `make test` (or `make be-test` for backend-only changes)
- [x] `make fe-build` / `make fe-run` for UI changes
- [x] Manual verification steps (describe them):

## Notes for reviewers

<!-- Optional: screenshots for UI changes, trade-offs, follow-ups, anything risky. -->
