### PR TITLE
feat: optional query error highlight, relicense to Apache-2.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,4 +118,4 @@ Use the issue forms under **Issues → New issue**. Security vulnerabilities mus
 ## License
 
 By contributing, you agree that your contributions are licensed under the
-[MIT License](LICENSE) that covers this project.
+[Apache License 2.0](LICENSE) that covers this project.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ members = [
     "app",
 ]
 
+[workspace.package]
+license = "Apache-2.0"
+
 # Size-optimized release profile (target: binary < 15 MB).
 [profile.release]
 opt-level = "z"

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,202 @@
-MIT License
 
-Copyright (c) 2026 suiflex
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+   1. Definitions.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 suiflex
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+RDB
+Copyright 2026 suiflex
+
+This product includes software developed by the RDB contributors
+(https://github.com/suiflex/rdb).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <p align="center">
   <a href="https://github.com/suiflex/rdb/actions/workflows/rdb-app.yml"><img src="https://img.shields.io/github/actions/workflow/status/suiflex/rdb/rdb-app.yml?branch=develop&style=for-the-badge" alt="Build status"></a>
   <a href="https://github.com/suiflex/rdb/releases"><img src="https://img.shields.io/github/v/tag/suiflex/rdb?include_prereleases&style=for-the-badge&label=release" alt="Release"></a>
-  <a href="./LICENSE"><img src="https://img.shields.io/badge/License-MIT-4ade80.svg?style=for-the-badge" alt="MIT License"></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-4ade80.svg?style=for-the-badge" alt="Apache 2.0 License"></a>
   <img src="https://img.shields.io/badge/platform-macOS_·_Linux_·_Windows-4ade80?style=for-the-badge" alt="Platforms">
   <img src="https://img.shields.io/badge/built_with-Rust-4ade80?style=for-the-badge" alt="Built with Rust">
 </p>
@@ -267,4 +267,4 @@ Active development. Ships 8 engines (PostgreSQL, MySQL, Redis, MongoDB, SQLite, 
 
 ## License
 
-MIT
+Apache-2.0

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rdb"
 version = "0.37.0"
 edition = "2021"
+license.workspace = true
 
 [[bin]]
 name = "rdb"

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2967,6 +2967,9 @@ fn mark_from(spot: &editor::ErrorSpot, origin: (i32, i32)) -> ErrorMark {
 
 /// Arm (or clear) the editor's error highlight for `pane`. `None` clears it.
 fn set_p_error_mark(w: &MainWindow, pane: usize, mark: Option<ErrorMark>) {
+    // One gate for every caller: the mark stays in pane state either way, so
+    // turning the preference back on can re-arm it without a re-run.
+    let mark = mark.filter(|_| w.get_error_highlight());
     let m = mark.unwrap_or(ErrorMark {
         line: -1,
         from: -1,
@@ -4314,6 +4317,7 @@ fn main() -> Result<(), slint::PlatformError> {
     window.set_history_max_entries(history_cap.get() as i32);
     window.set_nosql_collection_limit(settings.borrow().get().nosql_collection_limit.max(1) as i32);
     window.set_auto_table_alias(settings.borrow().get().editor.auto_table_alias);
+    window.set_error_highlight(settings.borrow().get().editor.error_highlight);
     window.set_app_version(env!("CARGO_PKG_VERSION").into());
 
     // Fixed window size for the screenshot loop: RDB_WIN=WxH (logical px).
@@ -12494,6 +12498,25 @@ fn main() -> Result<(), slint::PlatformError> {
             let _ = settings
                 .borrow_mut()
                 .update(|s| s.editor.auto_table_alias = v);
+        });
+    }
+
+    // ----- settings: query-error-highlight toggle -----
+    {
+        let settings = settings.clone();
+        let panes = panes.clone();
+        let w = window.as_weak();
+        window.on_set_error_highlight(move |v| {
+            let _ = settings
+                .borrow_mut()
+                .update(|s| s.editor.error_highlight = v);
+            let Some(w) = w.upgrade() else { return };
+            // Repaint both panes from the marks already held in pane state so
+            // the change shows without waiting for the next failed run.
+            for pane in 0..2 {
+                let mark = *panes[pane].error_mark.lock().unwrap();
+                set_p_error_mark(&w, pane, mark);
+            }
         });
     }
 

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -619,6 +619,8 @@ callback create-table-commit();
     // Auto-append alias when accepting a table name from completion in FROM/JOIN position.
     in-out property <bool> auto-table-alias: true;
     callback set-auto-table-alias(bool);
+    in-out property <bool> error-highlight: true;
+    callback set-error-highlight(bool);
     in-out property <bool> shortcuts-open: false;
     // Settings modal active section: 0 Appearance, 1 Updates, 2 About.
     in-out property <int> settings-tab: 0;
@@ -2769,6 +2771,15 @@ callback create-table-commit();
                             toggled => {
                                 root.auto-table-alias = !root.auto-table-alias;
                                 root.set-auto-table-alias(root.auto-table-alias);
+                            }
+                        }
+                        ToggleRow {
+                            label: "Highlight query errors";
+                            description: "Marks the failing line and token in the editor.";
+                            checked: root.error-highlight;
+                            toggled => {
+                                root.error-highlight = !root.error-highlight;
+                                root.set-error-highlight(root.error-highlight);
                             }
                         }
                     }

--- a/crates/connstore/Cargo.toml
+++ b/crates/connstore/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rdb-connstore"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 rdb-core = { path = "../core" }

--- a/crates/connstore/src/settings.rs
+++ b/crates/connstore/src/settings.rs
@@ -59,6 +59,8 @@ pub struct EditorPrefs {
     /// Auto-append a short alias when accepting a table name from completion
     /// in FROM/JOIN position. `users` → `users u`, `order_items` → `order_items oi`.
     pub auto_table_alias: bool,
+    /// Mark the failing line and token in the editor when a query errors.
+    pub error_highlight: bool,
 }
 
 impl Default for EditorPrefs {
@@ -68,6 +70,7 @@ impl Default for EditorPrefs {
             default_page_size: 100,
             history_max_entries: 50,
             auto_table_alias: true,
+            error_highlight: true,
         }
     }
 }
@@ -181,6 +184,7 @@ mod tests {
         assert_eq!(s.get().editor.default_page_size, 100);
         assert_eq!(s.get().editor.history_max_entries, 50);
         assert!(s.get().editor.auto_table_alias);
+        assert!(s.get().editor.error_highlight);
         assert_eq!(s.get().nosql_collection_limit, 200);
     }
 
@@ -220,5 +224,6 @@ mod tests {
         assert_eq!(s.get().editor.default_page_size, 100);
         assert_eq!(s.get().editor.history_max_entries, 50);
         assert!(s.get().editor.auto_table_alias);
+        assert!(s.get().editor.error_highlight);
     }
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rdb-core"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 async-trait = "0.1"

--- a/crates/driver-cassandra/Cargo.toml
+++ b/crates/driver-cassandra/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rdb-driver-cassandra"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 rdb-core = { path = "../core" }

--- a/crates/driver-clickhouse/Cargo.toml
+++ b/crates/driver-clickhouse/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rdb-driver-clickhouse"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 rdb-core = { path = "../core" }

--- a/crates/driver-mongo/Cargo.toml
+++ b/crates/driver-mongo/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rdb-driver-mongo"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 rdb-core = { path = "../core" }

--- a/crates/driver-mssql/Cargo.toml
+++ b/crates/driver-mssql/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rdb-driver-mssql"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 rdb-core = { path = "../core" }

--- a/crates/driver-mysql/Cargo.toml
+++ b/crates/driver-mysql/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rdb-driver-mysql"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 rdb-core = { path = "../core" }

--- a/crates/driver-postgres/Cargo.toml
+++ b/crates/driver-postgres/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rdb-driver-postgres"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 rdb-core = { path = "../core" }

--- a/crates/driver-redis/Cargo.toml
+++ b/crates/driver-redis/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rdb-driver-redis"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 rdb-core = { path = "../core" }

--- a/crates/driver-sqlite/Cargo.toml
+++ b/crates/driver-sqlite/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rdb-driver-sqlite"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 rdb-core = { path = "../core" }

--- a/npm/README.md
+++ b/npm/README.md
@@ -91,4 +91,4 @@ pub enum ResultSet {
 
 ## License
 
-MIT
+Apache-2.0

--- a/npm/package.json
+++ b/npm/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git+https://github.com/suiflex/rdb.git"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "bin": {
     "rdb": "bin/rdb.js"
   },

--- a/packaging/rdb.json.tmpl
+++ b/packaging/rdb.json.tmpl
@@ -2,7 +2,7 @@
   "version": "@VERSION@",
   "description": "Native cross-platform database manager (PostgreSQL, MySQL, Redis, MongoDB)",
   "homepage": "https://github.com/suiflex/rdb",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "architecture": {
     "64bit": {
       "url": "@BASE@/rdb-x86_64-pc-windows-msvc.zip",

--- a/packaging/rdb.rb.tmpl
+++ b/packaging/rdb.rb.tmpl
@@ -5,7 +5,7 @@ class Rdb < Formula
   desc "Native cross-platform database manager (PostgreSQL, MySQL, Redis, MongoDB)"
   homepage "https://github.com/suiflex/rdb"
   version "@VERSION@"
-  license "MIT"
+  license "Apache-2.0"
 
   on_macos do
     on_arm do

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -48,7 +48,7 @@ const year = new Date().getFullYear();
       }
     </div>
     <div class="mt-12 flex flex-col justify-between gap-3 border-t border-line pt-6 text-sm text-fg-3 sm:flex-row">
-      <p>MIT licensed. Copyright {year} the RDB contributors.</p>
+      <p>Apache-2.0 licensed. Copyright {year} the RDB contributors.</p>
       <p>
         Built in the open at
         <a href={GITHUB} rel="noopener" class="text-fg-2 underline decoration-line underline-offset-4 hover:text-fg">

--- a/website/src/pages/download.astro
+++ b/website/src/pages/download.astro
@@ -76,7 +76,7 @@ const platforms: Platform[] = [
     <p class="mt-4 text-lg text-fg-2">
       Latest stable release
       <span class="font-mono text-fg">{release.tag}</span>, published {release.published}.
-      Free under the MIT license.
+      Free under the Apache-2.0 license.
     </p>
     <p class="mt-2 text-sm text-fg-3">
       Release notes and older versions live on

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -19,7 +19,7 @@ const structuredData = {
   applicationCategory: "DeveloperApplication",
   operatingSystem: "macOS, Windows, Linux",
   offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
-  license: "https://opensource.org/license/mit",
+  license: "https://opensource.org/license/apache-2-0",
   softwareVersion: release.tag.replace(/^v/, ""),
   downloadUrl: REPO_LINKS.releases,
 };
@@ -59,7 +59,7 @@ const structuredData = {
         </a>
       </div>
       <p class="mt-6 font-mono text-xs text-fg-3">
-        {release.tag} for macOS, Windows, and Linux. MIT licensed.
+        {release.tag} for macOS, Windows, and Linux. Apache-2.0 licensed.
       </p>
       <a
         href="https://www.producthunt.com/products/rdb?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-rdb"
@@ -233,7 +233,7 @@ const structuredData = {
           Built in the open.
         </h2>
         <p class="mt-4 leading-relaxed text-fg-2">
-          RDB is MIT licensed and developed entirely on GitHub. Read the
+          RDB is Apache-2.0 licensed and developed entirely on GitHub. Read the
           code, report a bug, or help shape what comes next: every engine is
           a self-contained Rust crate behind one
           <code class="rounded bg-code px-1.5 py-0.5 font-mono text-sm">Driver</code>
@@ -249,7 +249,7 @@ const structuredData = {
       <ul class="grid content-start gap-3 sm:grid-cols-2">
         {
           [
-            { label: "Source code", note: "the whole app, MIT licensed", href: GITHUB },
+            { label: "Source code", note: "the whole app, Apache-2.0 licensed", href: GITHUB },
             { label: "Good first issues", note: "a gentle place to start", href: REPO_LINKS.goodFirstIssues },
             { label: "Contributing guide", note: "setup, style, PR flow", href: REPO_LINKS.contributing },
             { label: "Discussions", note: "questions and ideas", href: REPO_LINKS.discussions },
@@ -318,7 +318,7 @@ const structuredData = {
         </a>
       </div>
       <p class="mt-6 font-mono text-xs text-fg-3">
-        Free forever under the MIT license.
+        Free forever under the Apache-2.0 license.
       </p>
     </div>
   </section>

--- a/website/src/pages/license.astro
+++ b/website/src/pages/license.astro
@@ -12,15 +12,17 @@ const licenseText = readFileSync(resolve(process.cwd(), "../LICENSE"), "utf-8").
 
 <Base
   title="RDB license"
-  description="RDB is released under the MIT license: free to use, modify, and redistribute, commercially or otherwise."
+  description="RDB is released under the Apache License 2.0: free to use, modify, and redistribute, commercially or otherwise."
   path="/license"
 >
   <section class="mx-auto max-w-3xl px-4 pt-16 pb-20 sm:px-6">
     <h1 class="font-display text-4xl font-semibold tracking-tight sm:text-5xl">License</h1>
     <p class="mt-4 text-lg leading-relaxed text-fg-2">
-      RDB is released under the MIT license. In practice that means you can
-      use it at work, modify it, and redistribute it, free of charge. The
-      only condition is keeping the copyright notice.
+      RDB is released under the Apache License 2.0. In practice that means
+      you can use it at work, modify it, and redistribute it, free of charge,
+      and every contributor grants you a patent licence for their work. In
+      return, keep the licence and NOTICE files with any copy you pass on, and
+      say which files you changed.
     </p>
     <pre
       class="mt-10 overflow-x-auto rounded-xl border border-line bg-code p-6 font-mono text-xs leading-relaxed whitespace-pre-wrap text-fg-2">{licenseText}</pre>

--- a/website/src/pages/open-source.astro
+++ b/website/src/pages/open-source.astro
@@ -20,7 +20,7 @@ const crates = [
 
 <Base
   title="Contribute to RDB"
-  description="RDB is MIT-licensed and built in the open. Read the code, report a bug, pick up a good first issue, or add a driver for your favorite database."
+  description="RDB is Apache-2.0 licensed and built in the open. Read the code, report a bug, pick up a good first issue, or add a driver for your favorite database."
   path="/open-source"
 >
   <section class="mx-auto max-w-4xl px-4 pt-16 pb-12 sm:px-6">
@@ -28,7 +28,7 @@ const crates = [
       Built in the open. Yours to shape.
     </h1>
     <p class="mt-4 max-w-xl text-lg leading-relaxed text-fg-2">
-      Every line of RDB is public and MIT licensed. Read the code, report a
+      Every line of RDB is public and Apache-2.0 licensed. Read the code, report a
       bug, or help decide what comes next.
     </p>
     <div class="mt-8 flex flex-wrap gap-3">


### PR DESCRIPTION
## Summary

- The query editor repaints on every failed query — tinted statement, red gutter line, squiggled token — with no way to opt out. Some people read the error text and would rather the editor stay as they typed it. This adds a preference for it.
- The project moves from MIT to Apache-2.0. MIT grants no patent rights and says nothing about trademarks, which makes the project harder to clear through corporate legal review than it needs to be. The MIT text is removed rather than kept alongside — this is a switch, not a dual license.

## Changes

### Settings

- `crates/connstore`: `EditorPrefs.error_highlight`, default `true`. The container-level `#[serde(default)]` means an existing `settings.json` keeps the current behavior.
- `app/src/main.rs`: the gate lives in `set_p_error_mark` alone, which every caller already goes through — both run paths and the re-lex re-apply. The `ErrorMark` stays in pane state either way, so flipping the setting repaints both panes without needing the query to fail again.
- `app/src/ui/app-window.slint`: **Highlight query errors** toggle in Settings → Appearance, wired the same way as the existing `auto-table-alias`.

### License

- `LICENSE`: the full Apache License 2.0 text, appendix boilerplate filled in. New `NOTICE` alongside it.
- Docs: `README.md` (badge + License section), `CONTRIBUTING.md`, `npm/README.md`.
- Package metadata: `npm/package.json`, `packaging/rdb.rb.tmpl` (Homebrew), `packaging/rdb.json.tmpl` (Scoop). Also `license = "Apache-2.0"` in `[workspace.package]` with `license.workspace = true` across all eleven crates — no manifest declared a license at all before, so publishing any of them would have shipped none.
- Website: ten user-visible mentions plus the schema.org `license` URL, across `Footer.astro`, `download.astro`, `index.astro`, `open-source.astro`, and `license.astro`. The licence page needed more than a rename — its summary described MIT's single condition, so it now names the patent grant, keeping the LICENSE and NOTICE files, and marking changed files.
- Untouched: `website/package-lock.json`, whose `"license": "MIT"` entries are third-party dependencies. GitHub's own repo license badge is auto-detected from `LICENSE` and flips on merge.

## Test plan

- [x] `cargo build -p rdb` — clean
- [x] `cargo fmt --check -p rdb` — clean
- [x] `cargo clippy -p rdb --bins -- -D warnings` — clean
- [x] `cargo test -p rdb-connstore --lib` — 47 passed, 1 ignored
- [x] `cargo metadata --no-deps` — all eleven crates resolve to `Apache-2.0`
- [x] `npm run build` in `website/` — 9 pages, exit 0; the rendered `dist/license/index.html` reads "Apache License 2.0" and `dist/index.html` carries the new wording
- [x] `grep -rnw MIT` across the repo returns nothing outside `package-lock.json`
- [x] Manual: toggle **Highlight query errors** off with a failed query on screen — the highlight clears without a re-run, returns when toggled back on, and the choice survives a restart

## Note on the relicense

`git log` lists four human contributors besides the maintainer. MIT permits sublicensing, so redistributing the existing code under Apache-2.0 is the accepted path, but a clean relicense usually collects an acknowledgement from each contributor first. Flagging it here so the decision is on the record rather than implied by the diff.
