### PR TITLE
docs: update website release data for v0.39.0

### DIFF
--- a/website/src/data/release.json
+++ b/website/src/data/release.json
@@ -1,78 +1,78 @@
 {
-  "tag": "v0.38.0",
-  "published": "2026-08-14",
+  "tag": "v0.39.0",
+  "published": "2026-08-15",
   "assets": [
     {
       "name": "rdb-aarch64-apple-darwin.dmg",
-      "size": 9321202,
-      "sha256": "3553d5b628111c40064222576c8f8c8ba1e93ca40ee39e9a239a2f1428676784",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.38.0/rdb-aarch64-apple-darwin.dmg"
+      "size": 11869206,
+      "sha256": "da13d8af7c1e636f123b5a85a18ae8da7c5155a0da7de3fd9796b7e099f978d6",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.39.0/rdb-aarch64-apple-darwin.dmg"
     },
     {
       "name": "rdb-aarch64-apple-darwin.tar.gz",
-      "size": 8766661,
-      "sha256": "5458a176f73012796128f737317ca60c71156685af847ed6e160780f9b0f3b50",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.38.0/rdb-aarch64-apple-darwin.tar.gz"
+      "size": 11223994,
+      "sha256": "bb798508f76372e20347eec8c3b88e525c4301affb6cb38347533e962c6b5749",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.39.0/rdb-aarch64-apple-darwin.tar.gz"
     },
     {
       "name": "rdb-aarch64-pc-windows-msvc.exe",
-      "size": 19700736,
-      "sha256": "bba4a06564346d41d33c8c06296fcdae973acdec843580cd8a14a383b0506cb5",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.38.0/rdb-aarch64-pc-windows-msvc.exe"
+      "size": 23107072,
+      "sha256": "291de9630aee8e295c3e8ff0d10fb56c231b92281af26dc9aab84459adba225d",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.39.0/rdb-aarch64-pc-windows-msvc.exe"
     },
     {
       "name": "rdb-aarch64-pc-windows-msvc.zip",
-      "size": 9067789,
-      "sha256": "5e00e8415ab896fedca038bfdb5421ca56a6d57a2c07540429ab7406a8029902",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.38.0/rdb-aarch64-pc-windows-msvc.zip"
+      "size": 11536123,
+      "sha256": "ff51f03bd489ba6157aba90046905f0034eb7f6872e8fa1e226222d9efdaa1b3",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.39.0/rdb-aarch64-pc-windows-msvc.zip"
     },
     {
       "name": "rdb-aarch64-unknown-linux-gnu",
-      "size": 23104056,
-      "sha256": "cb2b6296e7bd13888d10bbcbefb922220af80cb63d5a1fbf0c9c3a51e90b64c1",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.38.0/rdb-aarch64-unknown-linux-gnu"
+      "size": 26577464,
+      "sha256": "c50eccec0b78f8b2459e47017129409c1835d784a82c117f1a95d48a7b5c051f",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.39.0/rdb-aarch64-unknown-linux-gnu"
     },
     {
       "name": "rdb-aarch64-unknown-linux-gnu.tar.gz",
-      "size": 11078490,
-      "sha256": "e0511664c207e4aa7cb6c34a13ca9a97a92d706a892f80e66fd31dfa114a3d4f",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.38.0/rdb-aarch64-unknown-linux-gnu.tar.gz"
+      "size": 13488506,
+      "sha256": "1a220d7e064d3264e4251f4f328123190410502f4321da32fd9d5f4c570a221f",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.39.0/rdb-aarch64-unknown-linux-gnu.tar.gz"
     },
     {
       "name": "rdb-x86_64-apple-darwin.dmg",
-      "size": 11104920,
-      "sha256": "cba015e9dc6924de7e131a69e671ab07fb8d686f5d02f1887fa6212dfa5dcdd6",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.38.0/rdb-x86_64-apple-darwin.dmg"
+      "size": 13667233,
+      "sha256": "467c5e20ba0db9866b62b5c55100c56e4a56cd686da0d065a77bb34a030a3599",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.39.0/rdb-x86_64-apple-darwin.dmg"
     },
     {
       "name": "rdb-x86_64-apple-darwin.tar.gz",
-      "size": 9925416,
-      "sha256": "3c84f4125f0152968409bc67a237e8d69e8feb3afeb3ad3b6441679f9e230a40",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.38.0/rdb-x86_64-apple-darwin.tar.gz"
+      "size": 12369579,
+      "sha256": "057fa445396e148a56759f80ef426dd86dbd2088643d3f69ff2af51999c54133",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.39.0/rdb-x86_64-apple-darwin.tar.gz"
     },
     {
       "name": "rdb-x86_64-pc-windows-msvc.exe",
-      "size": 21362176,
-      "sha256": "114d21f7586e679b8311b34041948feb5f0280735f02c1a23f9063926ba14354",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.38.0/rdb-x86_64-pc-windows-msvc.exe"
+      "size": 24881664,
+      "sha256": "671920e5ee7fe9b5131b871c8b9a436b9e6221672907dbc5d801c77cb24ab83b",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.39.0/rdb-x86_64-pc-windows-msvc.exe"
     },
     {
       "name": "rdb-x86_64-pc-windows-msvc.zip",
-      "size": 9609195,
-      "sha256": "6f0fe9f27496c2adc5c7871337c59effbc91e9902d0e87b540f3e2a85872225b",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.38.0/rdb-x86_64-pc-windows-msvc.zip"
+      "size": 12071864,
+      "sha256": "317875c3d5dc3c6e894bb25706d30549abdb1cc09c2500491ed3cabd7e375aec",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.39.0/rdb-x86_64-pc-windows-msvc.zip"
     },
     {
       "name": "rdb-x86_64-unknown-linux-gnu",
-      "size": 28739992,
-      "sha256": "09dacab43d9416130c81192afe2f44e7faff77240760156f2c3c9ce083ee7ca4",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.38.0/rdb-x86_64-unknown-linux-gnu"
+      "size": 32080376,
+      "sha256": "09f6cea853f38f1848e206aa7914959a5c1726e083eab167f23c84c4efe67cb6",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.39.0/rdb-x86_64-unknown-linux-gnu"
     },
     {
       "name": "rdb-x86_64-unknown-linux-gnu.tar.gz",
-      "size": 11608570,
-      "sha256": "ec8bbe3a6c3f8f19ac75e8bba97c5da13bc1988c19472774b246453ce699ae25",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.38.0/rdb-x86_64-unknown-linux-gnu.tar.gz"
+      "size": 14021214,
+      "sha256": "f063229260f7378c268324becdfd079d152ae96179cf0217322f6821382bdfcb",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.39.0/rdb-x86_64-unknown-linux-gnu.tar.gz"
     }
   ]
 }


### PR DESCRIPTION
Automated release-data refresh for v0.39.0.