### PR TITLE
docs: correct CI claims and close the sqlite/cassandra coverage gap

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,8 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Question or setup help
+    url: https://github.com/suiflex/rdb/discussions
+    about: Ask in Discussions — installing RDB, connecting to an engine, or checking whether something is a bug before filing one.
+  - name: Report a security vulnerability
+    url: https://github.com/suiflex/rdb/security/policy
+    about: Do not open a public issue for security problems. Follow the security policy instead.

--- a/.github/workflows/rdb-driver-cassandra.yml
+++ b/.github/workflows/rdb-driver-cassandra.yml
@@ -1,0 +1,39 @@
+name: rdb-driver-cassandra
+
+on:
+  push:
+    branches: [develop, main]
+    paths:
+      - crates/driver-cassandra/**
+      - crates/core/**
+      - Cargo.toml
+      - Cargo.lock
+      - rust-toolchain.toml
+      - .github/workflows/rdb-driver-cassandra.yml
+  pull_request:
+    paths:
+      - crates/driver-cassandra/**
+      - crates/core/**
+      - Cargo.toml
+      - Cargo.lock
+      - rust-toolchain.toml
+      - .github/workflows/rdb-driver-cassandra.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: rdb-driver-cassandra
+      - run: cargo fmt -p rdb-driver-cassandra --check
+      - run: cargo clippy -p rdb-driver-cassandra --all-targets -- -D warnings
+      - run: cargo test -p rdb-driver-cassandra --lib

--- a/.github/workflows/rdb-driver-sqlite.yml
+++ b/.github/workflows/rdb-driver-sqlite.yml
@@ -1,0 +1,39 @@
+name: rdb-driver-sqlite
+
+on:
+  push:
+    branches: [develop, main]
+    paths:
+      - crates/driver-sqlite/**
+      - crates/core/**
+      - Cargo.toml
+      - Cargo.lock
+      - rust-toolchain.toml
+      - .github/workflows/rdb-driver-sqlite.yml
+  pull_request:
+    paths:
+      - crates/driver-sqlite/**
+      - crates/core/**
+      - Cargo.toml
+      - Cargo.lock
+      - rust-toolchain.toml
+      - .github/workflows/rdb-driver-sqlite.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: rdb-driver-sqlite
+      - run: cargo fmt -p rdb-driver-sqlite --check
+      - run: cargo clippy -p rdb-driver-sqlite --all-targets -- -D warnings
+      - run: cargo test -p rdb-driver-sqlite --lib

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,16 +33,15 @@ cargo build --release -p rdb   # release binary
 
 One GitHub Actions workflow per component in `.github/workflows/` — `rdb-app`
 plus one per crate: `rdb-core`, `rdb-connstore`, `rdb-driver-postgres`,
-`rdb-driver-mysql`, `rdb-driver-redis`, `rdb-driver-mongo`, `rdb-driver-mssql`,
+`rdb-driver-mysql`, `rdb-driver-redis`, `rdb-driver-mongo`,
+`rdb-driver-sqlite`, `rdb-driver-cassandra`, `rdb-driver-mssql`,
 `rdb-driver-clickhouse`.
 Each has a `paths:` filter, so editing one component only runs that
 component's CI (lean).
 
-- **Known gap**: `rdb-driver-sqlite` and `rdb-driver-cassandra` have no
-  dedicated workflow yet, and the root `Makefile`'s `BE_PKGS` (used by
-  `be-build`/`be-test`/`be-check`) doesn't include them either — use
-  `cargo build/test -p rdb-driver-sqlite` (or `-cassandra`) directly until
-  that's wired up.
+- All ten backend crates are in the root `Makefile`'s `BE_PKGS` (used by
+  `be-build`/`be-test`/`be-check`), so the make targets and CI agree on scope.
+  Adding a crate means adding it to both.
 - Dependents also watch `crates/core/**`, so a `core` change fans out to retest
   core + all dependents (connstore, drivers, app). Other crates stay independent.
 - Backend jobs run `cargo {fmt,clippy} -p <pkg>` and `cargo test -p <pkg> --lib`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,20 +98,16 @@ Run `make all` before opening a pull request. Each driver crate also carries
 `tests/integration.rs`, which needs Docker and runs locally via `make test-it`;
 those are intentionally kept out of CI.
 
-### Two crates CI does not cover yet
+### What CI covers
 
-`rdb-driver-sqlite` and `rdb-driver-cassandra` have **no dedicated CI workflow**
-and are **not** in the `Makefile`'s `BE_PKGS` list. That means neither
-`make be-test` nor CI touches them — a green run tells you nothing about those
-two crates.
+Every backend crate has its own workflow in `.github/workflows/`, and all ten
+are in the `Makefile`'s `BE_PKGS`, so `make be-test` and CI agree on scope.
+Each workflow also watches `crates/core/**`, so a change to `core` fans out and
+retests its dependents.
 
-If your change touches either, test them explicitly and say so in your PR's
-test plan:
-
-```bash
-cargo test -p rdb-driver-sqlite
-cargo test -p rdb-driver-cassandra
-```
+Backend jobs run `cargo fmt -p <pkg> --check`, `cargo clippy -p <pkg>
+--all-targets -- -D warnings`, and `cargo test -p <pkg> --lib`. The `--lib`
+matters: the Docker-backed integration tests are not part of that run.
 
 ## Running and testing the app
 
@@ -249,10 +245,8 @@ Example release notes from commit headers:
 - Fill the test plan honestly: tick what you actually ran, leave the rest
   unchecked. An unchecked box is information; a wrongly ticked one wastes a
   review cycle.
-- CI runs a scoped workflow per component, with two exceptions noted in
-  [Two crates CI does not cover yet](#two-crates-ci-does-not-cover-yet). A
-  `core` change also retests its dependents. Make sure `make all` passes
-  locally first.
+- CI runs a scoped workflow per component — see [What CI covers](#what-ci-covers).
+  Make sure `make all` passes locally first.
 
 ### AI-assisted pull requests
 
@@ -260,9 +254,9 @@ AI-assisted PRs are welcome — plenty of good contributions start that way. We
 don't ask you to label them. We do ask for two things:
 
 - **Evidence.** Say which commands you ran and what they produced. "`make all`
-  passes" plus the driver-specific tests for anything CI skips is enough. The
-  code and CI get reviewed either way; the PR body is where you make that easy
-  to follow.
+  passes", plus `make test-it` if you touched a driver's wire protocol, is
+  enough. The code and CI get reviewed either way; the PR body is where you
+  make that easy to follow.
 - **Understand what you're submitting.** If a reviewer asks why a line is
   there, you should be able to answer. PRs whose author can't are the ones that
   stall.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,39 @@
 # Contributing to RDB
 
 Thanks for your interest in RDB — a native, cross-platform database manager
-(PostgreSQL, MySQL, Redis, MongoDB, and more) built with Rust and Slint.
+(PostgreSQL, MySQL, Redis, MongoDB, SQLite, Cassandra, SQL Server and
+ClickHouse) built with Rust and Slint.
 
 This guide covers how to build, test, and submit changes. By participating you
 agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Quick links
+
+- **Website** — https://rdb.suiflex.dev
+- **Where RDB is headed** — [VISION.md](VISION.md)
+- **Security policy** — [SECURITY.md](SECURITY.md)
+- **Code of Conduct** — [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+- **Bugs & feature requests** — [Issues](https://github.com/suiflex/rdb/issues/new/choose)
+- **Questions & setup help** — [Discussions](https://github.com/suiflex/rdb/discussions)
+
+Reading [VISION.md](VISION.md) first is worth the two minutes — it explains
+what RDB is deliberately *not* trying to be, which is the fastest way to tell
+whether an idea fits before you spend time on it.
+
+## How to contribute
+
+Start here, before opening anything:
+
+1. **Bug or small fix** → open a pull request directly.
+2. **New database engine, or an architectural change** → open an
+   [issue](https://github.com/suiflex/rdb/issues/new/choose) first. Adding an
+   engine touches more places than it looks (see
+   [Adding a database engine](#adding-a-database-engine)); agreeing on the
+   approach up front saves a rewrite.
+3. **Question, setup trouble, or "is this a bug?"** →
+   [Discussions](https://github.com/suiflex/rdb/discussions), not an issue.
+4. **Security vulnerability** → **do not** open a public issue. Follow
+   [SECURITY.md](SECURITY.md).
 
 ## Getting started
 
@@ -14,16 +43,36 @@ RDB is a Cargo workspace:
   driver (in `app/src/dispatch.rs`).
 - `crates/core/` — the `Driver` trait, `Query`, `ResultSet`, `Schema`, errors.
 - `crates/connstore/` — saved connections + OS keychain / AES-GCM.
-- `crates/driver-*/` — one crate per engine, each implementing `Driver`.
+- `crates/driver-*/` — one crate per engine, each implementing `Driver`:
+  `postgres`, `mysql`, `redis`, `mongo`, `sqlite`, `cassandra`, `mssql`,
+  `clickhouse`.
 
-You need a stable Rust toolchain with `rustfmt` and `clippy`:
+The repo also holds a few things that are not part of the Rust build:
+`website/` (the Astro marketing site), `scripts/` (the `install.sh` /
+`install.ps1` entry points), and `npm/` + `packaging/` (the npm wrapper and
+Homebrew/Scoop distribution files).
 
-```bash
-rustup component add rustfmt clippy
-```
+### From zero to a running app
 
-UI builds need the Slint system libraries for your platform — see the
-[Slint prerequisites](https://releases.slint.dev/latest/docs/rust/slint/#prerequisites).
+1. Install a stable Rust toolchain, then the components CI checks against:
+
+   ```bash
+   rustup component add rustfmt clippy
+   ```
+
+2. Install the Slint system libraries for your platform — see the
+   [Slint prerequisites](https://releases.slint.dev/latest/docs/rust/slint/#prerequisites).
+   Backend-only work (`crates/*`) does not need these; the UI build does.
+
+3. Build and launch the UI:
+
+   ```bash
+   make fe-run
+   ```
+
+If you only want to poke at the UI, `make fe-run-mock` starts it with seeded
+in-memory data and no database at all — see
+[Running and testing the app](#running-and-testing-the-app).
 
 ## Build, lint, test
 
@@ -34,7 +83,10 @@ A root `Makefile` wraps the common Cargo invocations and splits the frontend
 ```bash
 make fe-build     # build the rdb UI
 make fe-run       # run the UI
+make fe-run-mock  # run the UI with seeded mock data, no database needed
+make fe-run-mcp   # run the UI with Slint's MCP server (for driving it in tests)
 make be-build     # build backend crates only
+make be-check     # type-check backend crates only
 make be-test      # test backend crates only
 make fmt-check    # format check (make fmt to apply)
 make lint         # clippy, warnings treated as errors
@@ -42,16 +94,103 @@ make test         # test the whole workspace
 make all          # fmt-check + lint + test + build (the CI gate)
 ```
 
-Run `make all` before opening a pull request. Integration tests
-(`tests/integration.rs`) need Docker and run locally via `make test-it`; they
-are intentionally kept out of CI.
+Run `make all` before opening a pull request. Each driver crate also carries
+`tests/integration.rs`, which needs Docker and runs locally via `make test-it`;
+those are intentionally kept out of CI.
+
+### Two crates CI does not cover yet
+
+`rdb-driver-sqlite` and `rdb-driver-cassandra` have **no dedicated CI workflow**
+and are **not** in the `Makefile`'s `BE_PKGS` list. That means neither
+`make be-test` nor CI touches them — a green run tells you nothing about those
+two crates.
+
+If your change touches either, test them explicitly and say so in your PR's
+test plan:
+
+```bash
+cargo test -p rdb-driver-sqlite
+cargo test -p rdb-driver-cassandra
+```
+
+## Running and testing the app
+
+Everything that drives the app is environment-variable driven; there are no
+CLI flags.
+
+| Variable | Effect |
+| --- | --- |
+| `RDB_STORE_DIR=<dir>` | Moves the connection store, settings **and** query tabs to `<dir>`. Without it, a test run reads and overwrites your real saved connections. |
+| `RDB_MOCK=1` | Seeded in-memory data and an in-process driver, no network. Needs `--features mock`. |
+| `RDB_WIN=WxH` | Fixed logical window size, for deterministic screenshots. |
+| `RDB_SCREEN=<name>` | Drives the UI to a named screen (mock mode only). |
+| `RDB_SHOT=<path.bmp>` | Screenshot after `RDB_SHOT_DELAY_MS` (default 1200), then quit. Needs `--features mock`. |
+
+Three things that will cost you an afternoon if you hit them cold:
+
+- **`RDB_MOCK` disables persistence.** Saving query tabs and restoring them on
+  startup both no-op under it, deliberately, so the screenshot harness never
+  touches your real tabs. A persistence test written in mock mode passes
+  without testing anything — use `RDB_STORE_DIR` with a real connection
+  (SQLite is easiest).
+- **A plain `cargo build -p rdb` silently replaces the MCP-enabled binary.**
+  The port stops opening and it looks like the app is broken. Rebuild through
+  `make fe-run-mcp`, which passes `--features slint/mcp`.
+- **A failing test aborts instead of reporting.** The release profile uses
+  `panic=abort`, so a failed assertion becomes `SIGABRT` with no message and no
+  test name. Re-run with
+  `cargo test -p rdb --bin rdb -- --test-threads=1` — the last test printed is
+  the one that failed.
+
+For end-to-end scenarios the workspace tests do not cover, our sibling project
+[`suiflex/suitest`](https://github.com/suiflex/suitest) can drive the app: it
+ships a desktop target that bundles `slint-mcp` in-process, the same mechanism
+`make fe-run-mcp` exposes. Entirely optional — it is not required to
+contribute, and no PR is held up for lacking it.
 
 ## Adding a database engine
 
-1. Create a new `crates/driver-<engine>/` crate that implements the `Driver`
-   trait from `rdb-core`.
-2. Add a variant to the `AnyDriver` enum in `app/src/dispatch.rs` and forward
-   the trait methods.
+New engines are welcome. **Open an issue before you start writing one.** It's
+not a gate to keep contributions out — it's that an engine touches more of the
+codebase than the two obvious steps below suggest, and a short conversation up
+front settles the scope (which engine, which auth modes, whether TLS is in the
+first pass) while it's still cheap to change.
+
+The two structural pieces are:
+
+1. A new `crates/driver-<engine>/` crate implementing the `Driver` trait from
+   `rdb-core`.
+2. A variant in the `AnyDriver` enum in `app/src/dispatch.rs`, forwarding the
+   trait methods.
+
+Once `AnyDriver` has the variant, run `cargo build -p rdb` and fix every error
+it reports. The compiler enumerates the exhaustive `Engine` / `Query` match
+sites for you — do not hand-audit them.
+
+The compiler will **not** catch these, and they are what previous engine
+additions actually missed:
+
+- The `ENGINES` row in `crates/connstore/src/model.rs` — display label, badge
+  key, URL scheme, default port, query language all come from that one row.
+- `scheme_to_engine` in `crates/connstore/src/conn_url.rs`.
+- Slint UI: the engine picker and field visibility in
+  `app/src/ui/conn-form.slint`, plus the engine list in Settings → About.
+- Icons, two separate tracks: a monochrome `app/src/ui/icons/db-<engine>.svg`
+  and a full-color `app/src/ui/icons/brand/<engine>.svg`. If no official mark
+  exists, **don't hand-draw one** — use the text fallback other engines use.
+- The "Database engine" dropdown in `.github/ISSUE_TEMPLATE/bug_report.yml`.
+- Engine lists in `README.md`, `VISION.md` and `website/`.
+
+[CLAUDE.md](CLAUDE.md) carries the full step-by-step checklist and stays the
+source of truth — follow it rather than this summary when you actually do the
+work.
+
+**If your driver reads `SslMode`, it must compile a TLS backend in the same
+change.** `mysql_async` and `scylla` **panic** rather than returning an error
+when asked for TLS with no TLS feature built in, and `panic=abort` turns that
+into a process abort on a worker thread — it never reaches `RdbError` and
+surfaces as a crash with no app symbols. New connection forms default to
+`Disable` so an unconfigured server cannot take the app down.
 
 Keep engine-specific logic (SQL strings, protocol quirks) inside the driver
 crate. The app layer must stay engine-agnostic — the only place it names a
@@ -107,8 +246,26 @@ Example release notes from commit headers:
   `feat/…`, `fix/…`, `refactor/…`, `chore/…`, `docs/…`.
 - Fill out the pull request template (Summary / Changes / Test plan).
 - Keep PRs focused on one logical change — smaller PRs are easier to review.
-- CI runs a scoped workflow per component (a `core` change also retests its
-  dependents). Make sure `make all` passes locally first.
+- Fill the test plan honestly: tick what you actually ran, leave the rest
+  unchecked. An unchecked box is information; a wrongly ticked one wastes a
+  review cycle.
+- CI runs a scoped workflow per component, with two exceptions noted in
+  [Two crates CI does not cover yet](#two-crates-ci-does-not-cover-yet). A
+  `core` change also retests its dependents. Make sure `make all` passes
+  locally first.
+
+### AI-assisted pull requests
+
+AI-assisted PRs are welcome — plenty of good contributions start that way. We
+don't ask you to label them. We do ask for two things:
+
+- **Evidence.** Say which commands you ran and what they produced. "`make all`
+  passes" plus the driver-specific tests for anything CI skips is enough. The
+  code and CI get reviewed either way; the PR body is where you make that easy
+  to follow.
+- **Understand what you're submitting.** If a reviewer asks why a line is
+  there, you should be able to answer. PRs whose author can't are the ones that
+  stall.
 
 ## Reporting bugs & requesting features
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Split FE/BE build entry points. BE = crates/* libs, FE = rdb (app/).
 # Run `make` or `make help` for the target list.
 
-BE_PKGS = rdb-core rdb-connstore rdb-driver-postgres rdb-driver-mysql rdb-driver-redis rdb-driver-mongo rdb-driver-mssql rdb-driver-clickhouse
+BE_PKGS = rdb-core rdb-connstore rdb-driver-postgres rdb-driver-mysql rdb-driver-redis rdb-driver-mongo rdb-driver-sqlite rdb-driver-cassandra rdb-driver-mssql rdb-driver-clickhouse
 FE_PKG  = rdb
 BE_FLAGS = $(addprefix -p ,$(BE_PKGS))
 


### PR DESCRIPTION
## Summary

- `CONTRIBUTING.md` claimed CI ran a scoped workflow per component. It did not — `rdb-driver-sqlite` and `rdb-driver-cassandra` had no workflow and were missing from the `Makefile`'s `BE_PKGS`, so a green run said nothing about either. Rather than document the gap, this closes it.
- The engine-addition section listed two steps where the real work spans the `ENGINES` row, URL scheme mapping, Slint forms, two icon tracks, the issue template and the docs surfaces. Following it as written produced incomplete pull requests.
- The env vars that drive the app for tests and screenshots were documented only in `CLAUDE.md`, so outside contributors had no way to run the UI without a live database.

## Changes

**CI / build**
- Add `.github/workflows/rdb-driver-sqlite.yml` and `rdb-driver-cassandra.yml`, mirroring the existing driver template including the `crates/core/**` path filter. All ten backend crates now have a workflow.
- Add both crates to `BE_PKGS` so `be-build`, `be-check` and `be-test` agree with CI on scope.

**Issue routing**
- Add `contact_links` to `.github/ISSUE_TEMPLATE/config.yml` pointing at Discussions and the security policy. Discussions was enabled but nothing linked to it, and blank issues are disabled, so a setup question had no route other than filing a bug report.

**CONTRIBUTING.md**
- Add Quick links (website, `VISION.md`, `SECURITY.md`, Code of Conduct, issues, discussions) and a "How to contribute" routing list — new engines get an issue before the code.
- Add "From zero to a running app" and "Running and testing the app", covering `RDB_STORE_DIR`, `RDB_MOCK`, `RDB_WIN`, `RDB_SCREEN`, `RDB_SHOT`, plus three traps: mock mode disabling persistence, a plain `cargo build -p rdb` replacing the MCP-enabled binary, and `panic=abort` turning a failed assertion into a bare `SIGABRT`.
- Rewrite the engine section around `cargo build -p rdb` enumerating the exhaustive match sites, and list what the compiler will *not* catch. Add the TLS warning: a driver reading `SslMode` must compile a TLS backend in the same change, since `mysql_async` and `scylla` panic rather than returning an error.
- Correct the integration-test path — those live per-crate at `crates/driver-*/tests/integration.rs`, not at the repo root.
- Fix the crate list (8 drivers by name) and mention `website/`, `scripts/`, `npm/`, `packaging/`.
- Add an AI-assisted PR section: welcome, no AI label asked for, but state the evidence and understand what you're submitting.

**CLAUDE.md**
- Drop the now-closed "Known gap" note and list both new workflows. `AGENTS.md` and `GEMINI.md` are symlinks to this file, so they track automatically.

## Test plan

- [x] `make fmt-check` — exit 0
- [x] `make be-test` — 10 crates, 10 passing, 0 failed (was 8 before `BE_PKGS` grew)
- [x] `make be-check` — clean
- [x] `cargo fmt -p rdb-driver-sqlite --check` and `-p rdb-driver-cassandra` — both clean
- [x] `cargo clippy -p rdb-driver-{sqlite,cassandra} --all-targets -- -D warnings` — both exit 0
- [x] `cargo test -p rdb-driver-sqlite --lib` (4 passed), `-p rdb-driver-cassandra --lib` (3 passed)
- [x] Both new workflows parse as YAML and differ from `rdb-driver-postgres.yml` only in the crate name
- [x] All ten backend crates have a workflow; the list in `CLAUDE.md` matches `.github/workflows/` exactly, checked programmatically in both directions
- [x] Every `Makefile` target named in the guide exists; every relative link and inline path resolves; anchors resolve
- [x] External links return 200: rdb.suiflex.dev, suiflex/suitest, Slint prerequisites, discussions, security policy
- [ ] **The two new workflows have never run on Actions.** Verification above was on macOS; the runners are `ubuntu-latest`, so the bundled `rusqlite` and `scylla` builds are unproven on Linux until this PR's first CI run.

## Note

`Cargo.lock` has unrelated drift on `develop` (`rdb` still pinned at `0.38.0` while `bf93179` bumped the package to `0.39.0`). Deliberately left out of this PR — it predates this branch and deserves its own commit.