### PR TITLE
chore: point CODEOWNERS at @suiflex/maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Default owner for everything in this repo.
 # See https://docs.github.com/articles/about-code-owners
-* @suiflex/maintener
+* @suiflex/maintainers


### PR DESCRIPTION
## Summary

- The `maintener` team was renamed to `maintainers`, leaving this repository's CODEOWNERS pointing at a team that no longer exists.
- GitHub does not surface an unresolvable owner — it silently requests no review — so this repo currently has no code owner review at all. Confirmed with `gh api repos/suiflex/rdb/codeowners/errors` returning `Unknown owner`.

## Changes

- `.github/CODEOWNERS`: default owner `@suiflex/maintener` → `@suiflex/maintainers`.

## Test plan

- [x] `gh api repos/suiflex/rdb/codeowners/errors` on the default branch reports `Unknown owner` (the bug)
- [x] `gh api "repos/suiflex/rdb/codeowners/errors?ref=chore/codeowners-maintainers-team"` returns an empty error list
- [x] This PR requests review from `@suiflex/maintainers`