### PR TITLE
chore: trim debug info from dev builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6418,7 +6418,7 @@ dependencies = [
 
 [[package]]
 name = "rdb"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,11 @@ lto = true
 codegen-units = 1
 panic = "abort"
 strip = true
+
+# Dev builds: keep target/ small. Backtraces still show file:line.
+[profile.dev]
+debug = "line-tables-only"
+
+# Dependencies rarely need stepping through — no debug info at all.
+[profile.dev.package."*"]
+debug = false


### PR DESCRIPTION
## Summary

- `target/` grows mostly from dependency debug info that is never stepped through during development.
- Dev builds now keep line tables for workspace crates and drop debug info for dependencies entirely.

## Changes

- `Cargo.toml`: add `[profile.dev]` with `debug = "line-tables-only"` and `[profile.dev.package."*"]` with `debug = false`. Release profile untouched.
- `Cargo.lock`: sync the `rdb` version entry with the 0.40.0 release bump (separate commit).

## Test plan

- [x] `cargo build -p rdb-core` succeeds on the dev profile
- [ ] `make be-build` / `make fe-build` on a clean `target/`
- [ ] Backtrace from a panic still shows `file:line` for workspace code