### PR TITLE
docs: add a Contributor License Agreement and enforce it on PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,6 +29,11 @@ Keep the PR focused — one logical change is easier to review and revert.
 - [ ] `make fe-build` / `make fe-run` for UI changes
 - [ ] Manual verification steps (describe them):
 
+## First pull request?
+
+- [ ] I have signed the [Contributor License Agreement](../CLA.md) — the bot
+      will comment below with the one-line reply that signs it.
+
 ## Notes for reviewers
 
 <!-- Optional: screenshots for UI changes, trade-offs, follow-ups, anything risky. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,8 +31,9 @@ Keep the PR focused — one logical change is easier to review and revert.
 
 ## First pull request?
 
-- [ ] I have signed the [Contributor License Agreement](../CLA.md) — the bot
-      will comment below with the one-line reply that signs it.
+- [ ] I have signed the
+      [Contributor License Agreement](https://github.com/suiflex/rdb/blob/develop/CLA.md)
+      — the bot will comment below with the one-line reply that signs it.
 
 ## Notes for reviewers
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,44 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant Lite
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: signatures/version1/cla.json
+          # This repo's default branch is `develop`; there is no `main`.
+          path-to-document: https://github.com/suiflex/rdb/blob/develop/CLA.md
+          # Signatures MUST live on their own branch, not on `develop`. The
+          # `protect-develop` ruleset requires a pull request for the default
+          # branch, so the action's direct commit of signature data would be
+          # rejected as a rule violation. `cla-signatures` is outside that
+          # ruleset and stays writable.
+          branch: cla-signatures
+          # Maintainers and bots only. Contributors are deliberately absent:
+          # the allowlist silences the bot, it does not record a signature, so
+          # allowlisting them would hide exactly what needs collecting.
+          allowlist: mulhamna,badrus123,*[bot]
+          custom-notsigned-comment: >
+            Thanks for your contribution! Before we can merge, please read our
+            [Contributor License Agreement](https://github.com/suiflex/rdb/blob/develop/CLA.md)
+            and sign it by posting the comment below.
+          custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
+          custom-allsigned-prcomment: All contributors have signed the CLA ✅
+          lock-pullrequest-aftermerge: false

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,94 @@
+# RDB Individual Contributor License Agreement
+
+**Version 1.0 — 2026-08-20**
+
+Thank you for your interest in contributing to RDB (the "Project"), maintained
+by the owner of the [`suiflex/rdb`](https://github.com/suiflex/rdb)
+repository and its successors and assigns (the "Maintainer").
+
+This Contributor License Agreement ("Agreement") clarifies the intellectual
+property rights granted with Contributions from any person or entity. This
+protects you as a contributor as well as the Maintainer and users of the
+Project; it does not change your rights to use your own Contributions for any
+other purpose.
+
+By commenting `I have read the CLA Document and I hereby sign the CLA` on a
+pull request in the Project repository, you accept and agree to the following
+terms for your present and future Contributions submitted to the Project.
+
+## 1. Definitions
+
+**"You"** (or **"Your"**) means the copyright owner or legal entity authorized
+by the copyright owner that is making this Agreement.
+
+**"Contribution"** means any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally submitted
+by You to the Project for inclusion in, or documentation of, the Project. For
+the purposes of this definition, "submitted" means any form of electronic,
+verbal, or written communication sent to the Project or its representatives,
+including but not limited to communication on pull requests, issues, and
+mailing lists, but excluding communication that is conspicuously marked or
+otherwise designated in writing by You as "Not a Contribution."
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the
+Maintainer and to recipients of software distributed by the Maintainer a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare derivative works of, publicly display,
+publicly perform, sublicense, and distribute Your Contributions and such
+derivative works.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the
+Maintainer and to recipients of software distributed by the Maintainer a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made, use,
+offer to sell, sell, import, and otherwise transfer Your Contributions, where
+such license applies only to those patent claims licensable by You that are
+necessarily infringed by Your Contributions alone or by combination of Your
+Contributions with the Project. If any entity institutes patent litigation
+against You or any other entity alleging that Your Contribution, or the Project
+to which You have contributed, constitutes direct or contributory patent
+infringement, then any patent licenses granted to that entity under this
+Agreement for that Contribution or the Project shall terminate as of the date
+such litigation is filed.
+
+## 4. Relicensing
+
+You acknowledge that the Maintainer may license the Project, including Your
+Contributions, under different license terms in the future, including both open
+source licenses approved by the Open Source Initiative and proprietary or
+commercial license terms (for example, an enterprise edition). The Maintainer
+agrees that Your Contributions will always additionally remain available under
+the terms of the open source license under which they were originally accepted
+(currently the Apache License, Version 2.0).
+
+## 5. Representations
+
+You represent that:
+
+1. You are legally entitled to grant the above licenses.
+2. Each of Your Contributions is Your original creation, or You have identified
+   in the Contribution any third-party material and its license.
+3. If Your employer has rights to intellectual property that You create that
+   includes Your Contributions, You have received permission to make
+   Contributions on behalf of that employer, or Your employer has waived such
+   rights for Your Contributions to the Project.
+4. You will notify the Project if You become aware of any facts or
+   circumstances that would make these representations inaccurate.
+
+## 6. No Warranty / No Support Obligation
+
+You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. Unless required by applicable law or
+agreed to in writing, You provide Your Contributions on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+---
+
+*This Agreement is adapted from the Apache Software Foundation Individual
+Contributor License Agreement v2.2.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,12 +13,25 @@ agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
 - **Where RDB is headed** — [VISION.md](VISION.md)
 - **Security policy** — [SECURITY.md](SECURITY.md)
 - **Code of Conduct** — [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+- **Contributor License Agreement** — [CLA.md](CLA.md)
 - **Bugs & feature requests** — [Issues](https://github.com/suiflex/rdb/issues/new/choose)
 - **Questions & setup help** — [Discussions](https://github.com/suiflex/rdb/discussions)
 
 Reading [VISION.md](VISION.md) first is worth the two minutes — it explains
 what RDB is deliberately *not* trying to be, which is the fastest way to tell
 whether an idea fits before you spend time on it.
+
+## Contributor License Agreement (CLA)
+
+Before your first pull request can be merged, you must sign our
+[Contributor License Agreement](CLA.md). It is a one-time step: when you open
+your first PR, the CLA bot comments with instructions and you sign by replying
+with a single comment on the PR. Your signature is recorded on the
+`cla-signatures` branch and covers all future contributions.
+
+The CLA keeps the project's licensing flexible (see [CLA.md](CLA.md) § 4)
+while guaranteeing your contributions always remain available under the
+[Apache License 2.0](LICENSE).
 
 ## How to contribute
 
@@ -268,5 +281,7 @@ Use the issue forms under **Issues → New issue**. Security vulnerabilities mus
 
 ## License
 
-By contributing, you agree that your contributions are licensed under the
-[Apache License 2.0](LICENSE) that covers this project.
+The project is licensed under the [Apache License 2.0](LICENSE). By
+contributing, you agree to the terms of the
+[Contributor License Agreement](CLA.md), which licenses your contributions
+under Apache 2.0 and grants the maintainer the rights described there.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,22 @@
+# Contributors
+
+People who have contributed to RDB and added themselves here.
+
+This is a self-registration list, not the record of who wrote what — that is
+the [contributors graph](https://github.com/suiflex/rdb/graphs/contributors)
+and `git log`, and nobody is missing from those. Add yourself in your own pull
+request whenever you like; leaving your name off changes nothing about the
+credit you already have.
+
+Doing it in a pull request is also the simplest way to sign the
+[CLA](CLA.md) if you contributed before it existed: the bot comments on your
+PR, you reply once, and your signature is on file.
+
+## Maintainers
+
+- [@mulhamna](https://github.com/mulhamna)
+- [@badrus123](https://github.com/badrus123)
+
+## Contributors
+
+<!-- Add yourself here, alphabetically by handle, in your own PR. -->


### PR DESCRIPTION
## Summary

- RDB has had no CLA. Contribution terms were one sentence in `CONTRIBUTING.md` restating inbound=outbound, which Apache-2.0 §5 already implies and which grants the project nothing beyond it.
- Adopts the agreement `suiflex/suitest` already runs, so both repos ask contributors for the same thing: the Apache ICLA v2.2 plus a relicensing section, with the reciprocal half intact — contributions always remain additionally available under the licence they were accepted under.
- Adds the bot so the agreement is actually asked for rather than merely published.

## Changes

**Document**
- `CLA.md` — Individual CLA. Employer-owned IP is covered by the §5.3 representation rather than a separate corporate agreement.

**Automation**
- `.github/workflows/cla.yml` — `contributor-assistant/github-action@v2.6.1`.
- `cla-signatures` — orphan branch seeded with `{"signedContributors":[]}`, already pushed.

**Docs**
- `CONTRIBUTING.md` — signing step added where a first-time contributor hits it, and the closing licence paragraph now hands off to the CLA.
- `CONTRIBUTORS.md` — self-registration list. It gives anyone who contributed before the CLA a natural reason to open a PR, which is what puts them in front of the bot.
- `.github/PULL_REQUEST_TEMPLATE.md` — one-time CLA line, kept out of the per-PR test-plan list.

## Three settings differ from suitest's copy, deliberately

1. **`branch: cla-signatures`** — not a preference. The `protect-develop` ruleset is active on the default branch with a `pull_request` rule, so the action's direct commit would be rejected. suitest hit exactly this; its signature store sat broken for roughly six weeks.
2. **`path-to-document: .../blob/develop/CLA.md`** — this repo has no `main` branch, so suitest's path would 404 for every contributor the bot talks to.
3. **`allowlist: mulhamna,badrus123,*[bot]`** — maintainer admins and bots only. Allowlisting suppresses the prompt without recording anything, so listing contributors there would hide the signatures this exists to collect.

## Test plan

- [x] `CLA.md` diffed against suitest's — byte-identical apart from project name, repo link and version date
- [x] `cla.yml` parses (`yaml.safe_load`); `path-to-signatures`, `path-to-document`, `branch` and `allowlist` asserted
- [x] `cla-signatures` confirmed orphan (`parents=[]`, one commit); blob hash identical to suitest's seed
- [x] `gh api .../branches/cla-signatures` returns `protected=false` — the storage branch is writable by the action
- [x] Every relative markdown link resolves to a real file
- [x] No `blob/main`, `suitest` or `Suitest` strings leaked into the new files
- [x] Live bot run — only possible once this is on `develop`, since `pull_request_target` loads the workflow from the base branch. This PR will therefore **not** trigger the bot.

## Notes for reviewers

The bot cannot be exercised until this merges. First real test is the first PR opened afterwards.

Retroactive signatures are a follow-up, not part of this PR. Four prior contributors hold copyright in surviving code; the critical one is the SSH tunnelling crate's author, who is not a repo collaborator and so needs a fork or temporary write access. Until that is settled, §4 should not be exercised.