### PR TITLE
feat(app): copy pending grid edits as SQL

### DIFF
--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -440,6 +440,8 @@ callback create-table-commit();
     callback mark-delete();
     callback commit-edits();
     callback discard-edits();
+    // Pending edits as SQL text, to the clipboard, without writing anything.
+    callback copy-edit-sql();
     // Tab / Shift+Tab while editing: store the cell, edit the neighbour.
     callback cell-advance(int, int, string, bool);
 
@@ -1959,6 +1961,9 @@ callback create-table-commit();
                         }
                         commit-edits() => {
                             root.commit-edits();
+                        }
+                        copy-edit-sql() => {
+                            root.copy-edit-sql();
                         }
                         p1-commit-edits() => {
                             root.p1-commit-edits();

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -312,6 +312,7 @@ export component WorkArea inherits Rectangle {
     callback mark-delete();
     callback commit-edits();
     callback discard-edits();
+    callback copy-edit-sql();
 
     background: Tokens.canvas;
 
@@ -673,6 +674,17 @@ export component WorkArea inherits Rectangle {
                         height: 22px;
                         clicked => {
                             if (root.split && root.active-pane == 1) { root.p1-discard-edits(); } else { root.discard-edits(); }
+                        }
+                    }
+                }
+                VerticalLayout {
+                    alignment: center;
+                    SecondaryButton {
+                        text: "Copy SQL";
+                        tooltip: "Copy the statements a commit would run, without writing anything";
+                        height: 22px;
+                        clicked => {
+                            root.copy-edit-sql();
                         }
                     }
                 }

--- a/app/src/wire/edit.rs
+++ b/app/src/wire/edit.rs
@@ -505,6 +505,70 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) {
         });
     }
 
+    // ----- "Copy SQL": the statements a commit would run, without running them -----
+    // Serves both panes; the pending-edits strip already reports whichever pane
+    // is active, so the button follows the same rule.
+    {
+        let weak = window.as_weak();
+        let panes = panes.clone();
+        let cur_engine = cur_engine.clone();
+        let query_console = query_console.clone();
+        window.on_copy_edit_sql(move || {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let pane = if w.get_split() {
+                w.get_active_pane().clamp(0, 1) as usize
+            } else {
+                0
+            };
+            let ops = {
+                let buf = panes[pane].edit_buf.lock().unwrap();
+                if buf.is_empty() {
+                    return;
+                }
+                let dg = panes[pane].displayed_grid.lock().unwrap();
+                let Some(g) = dg.as_ref() else {
+                    return;
+                };
+                buf.to_ops(g)
+            };
+            let ops = match ops {
+                Ok(ops) if !ops.is_empty() => ops,
+                Ok(_) => return,
+                Err(msg) => {
+                    set_p_status_error(&w, pane, true);
+                    set_p_result_status(&w, pane, SharedString::from(format!("error: {msg}")));
+                    return;
+                }
+            };
+            let Some(engine) = *cur_engine.borrow() else {
+                return;
+            };
+            let statements = dispatch::write_statements(engine, &ops);
+            if statements.is_empty() {
+                return;
+            }
+            for statement in &statements {
+                append_query_console(&query_console, statement.clone());
+            }
+            sync_query_console(&w, &query_console);
+            let sql = statements.join(";\n") + ";";
+            let n = statements.len();
+            let copied = clip_set(&sql);
+            set_p_status_error(&w, pane, !copied);
+            set_p_result_status(
+                &w,
+                pane,
+                SharedString::from(if copied {
+                    format!("{n} statement{} copied", if n == 1 { "" } else { "s" })
+                } else {
+                    "error: no clipboard available".to_string()
+                }),
+            );
+        });
+    }
+
     // ----- right (split) pane: discard/commit, mirrors the left pane above -----
     {
         let weak = window.as_weak();


### PR DESCRIPTION
## Summary

- Changing a cell value only offered **Commit**, so the generated statements could not be seen before they ran.
- The pending-edits strip now has a **Copy SQL** button that produces the same statements a commit would issue, without touching the database.

## Changes

- `app/src/wire/edit.rs`: `on_copy_edit_sql` builds the `WriteOp`s from the active pane's edit buffer, renders them via the existing `dispatch::write_statements`, appends them to the query console, and copies them to the clipboard. Reports `N statements copied`, or a clipboard error.
- `app/src/ui/workarea.slint`: `Copy SQL` secondary button between Discard and Commit.
- `app/src/ui/app-window.slint`: `copy-edit-sql()` callback forwarded to root.

## Test plan

- [ ] `cargo build -p rdb` (CI)
- [ ] `make lint` / `make fmt-check` (CI)
- [ ] Manual: edit a cell, press Copy SQL, confirm the clipboard holds the UPDATE and no write reaches the database
- [ ] Manual: same in a split with the right pane active