### PR TITLE
fix(driver-postgres): render enum, time, timetz and interval values

### DIFF
--- a/crates/driver-postgres/src/driver.rs
+++ b/crates/driver-postgres/src/driver.rs
@@ -458,9 +458,14 @@ async fn schema_impl(client: &Client, schema: &str) -> Result<Schema> {
 
     // User tables + columns from information_schema, scoped to one schema.
     // Ordered so columns of the same table are contiguous for grouping.
+    // data_type reports the literal 'USER-DEFINED' for enum and composite
+    // columns, so fall back to udt_name there to show the real type name.
     let rows = client
         .query(
-            "SELECT c.table_name, c.column_name, c.data_type, c.is_nullable \
+            "SELECT c.table_name, c.column_name, \
+             CASE WHEN c.data_type = 'USER-DEFINED' THEN c.udt_name \
+                  ELSE c.data_type END, \
+             c.is_nullable \
              FROM information_schema.columns c \
              JOIN information_schema.tables t \
                ON t.table_schema = c.table_schema AND t.table_name = c.table_name \

--- a/crates/driver-postgres/src/type_map.rs
+++ b/crates/driver-postgres/src/type_map.rs
@@ -18,6 +18,9 @@ pub enum CellKind {
     Numeric,
     Money,
     Json,
+    Time,
+    TimeTz,
+    Interval,
 }
 
 /// Classify a pg `Type` into a `CellKind`. Unknown types -> `Text` (string
@@ -31,6 +34,9 @@ pub fn classify(ty: &Type) -> CellKind {
         Type::UUID => CellKind::Uuid,
         Type::TIMESTAMPTZ | Type::TIMESTAMP => CellKind::Timestamp,
         Type::DATE => CellKind::Date,
+        Type::TIME => CellKind::Time,
+        Type::TIMETZ => CellKind::TimeTz,
+        Type::INTERVAL => CellKind::Interval,
         Type::NUMERIC => CellKind::Numeric,
         Type::MONEY => CellKind::Money,
         Type::TEXT | Type::VARCHAR | Type::BPCHAR | Type::NAME => CellKind::Text,
@@ -68,6 +74,113 @@ impl std::fmt::Display for PgMoney {
         } else {
             write!(f, "{whole}.{cents:02}")
         }
+    }
+}
+
+/// Render a microsecond count as `HH:MM:SS[.ffffff]`, trailing zeros of the
+/// fractional part trimmed the way Postgres itself prints them.
+fn fmt_hms(micros: u64) -> String {
+    let secs = micros / 1_000_000;
+    let frac = micros % 1_000_000;
+    let (h, m, s) = (secs / 3600, (secs % 3600) / 60, secs % 60);
+    if frac == 0 {
+        format!("{h:02}:{m:02}:{s:02}")
+    } else {
+        let frac = format!("{frac:06}");
+        format!("{h:02}:{m:02}:{s:02}.{}", frac.trim_end_matches('0'))
+    }
+}
+
+/// `timetz`, like `money`, has no `FromSql` anywhere in the crate ecosystem
+/// (`chrono`'s integration covers `time` but not `timetz`), so the column
+/// silently decoded to `Cell::Null`. The binary wire format is a big-endian
+/// `i64` of microseconds since midnight followed by a big-endian `i32` zone
+/// offset in seconds *west* of UTC — the displayed offset is its negation.
+struct PgTimeTz {
+    micros: i64,
+    zone_secs_west: i32,
+}
+
+impl<'a> FromSql<'a> for PgTimeTz {
+    fn from_sql(_ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
+        let bytes: [u8; 12] = raw.try_into()?;
+        Ok(PgTimeTz {
+            micros: i64::from_be_bytes(bytes[..8].try_into()?),
+            zone_secs_west: i32::from_be_bytes(bytes[8..].try_into()?),
+        })
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        *ty == Type::TIMETZ
+    }
+}
+
+impl std::fmt::Display for PgTimeTz {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let utc_offset = -self.zone_secs_west;
+        let sign = if utc_offset < 0 { '-' } else { '+' };
+        let off = utc_offset.unsigned_abs();
+        let (oh, om) = (off / 3600, (off % 3600) / 60);
+        write!(
+            f,
+            "{}{sign}{oh:02}:{om:02}",
+            fmt_hms(self.micros.unsigned_abs())
+        )
+    }
+}
+
+/// `interval` has the same gap. Wire format is a big-endian `i64` of
+/// microseconds, then `i32` days, then `i32` months. Rendered in Postgres's
+/// own default `postgres` interval style.
+struct PgInterval {
+    micros: i64,
+    days: i32,
+    months: i32,
+}
+
+impl<'a> FromSql<'a> for PgInterval {
+    fn from_sql(_ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
+        let bytes: [u8; 16] = raw.try_into()?;
+        Ok(PgInterval {
+            micros: i64::from_be_bytes(bytes[..8].try_into()?),
+            days: i32::from_be_bytes(bytes[8..12].try_into()?),
+            months: i32::from_be_bytes(bytes[12..].try_into()?),
+        })
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        *ty == Type::INTERVAL
+    }
+}
+
+impl std::fmt::Display for PgInterval {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut parts: Vec<String> = Vec::new();
+        let (years, mons) = (self.months / 12, self.months % 12);
+        if years != 0 {
+            parts.push(format!(
+                "{years} year{}",
+                if years.abs() == 1 { "" } else { "s" }
+            ));
+        }
+        if mons != 0 {
+            parts.push(format!(
+                "{mons} mon{}",
+                if mons.abs() == 1 { "" } else { "s" }
+            ));
+        }
+        if self.days != 0 {
+            parts.push(format!(
+                "{} day{}",
+                self.days,
+                if self.days.abs() == 1 { "" } else { "s" }
+            ));
+        }
+        if self.micros != 0 || parts.is_empty() {
+            let sign = if self.micros < 0 { "-" } else { "" };
+            parts.push(format!("{sign}{}", fmt_hms(self.micros.unsigned_abs())));
+        }
+        write!(f, "{}", parts.join(" "))
     }
 }
 
@@ -154,6 +267,25 @@ pub fn extract_cell(row: &Row, idx: usize) -> Cell {
             Ok(Some(v)) => Cell::Text(v.to_string()),
             Ok(None) => Cell::Null,
             Err(_) => string_fallback(row, idx),
+        },
+        // A decode failure here must not fall through to string_fallback:
+        // String's FromSql rejects these OIDs, so that path would produce a
+        // phantom Cell::Null indistinguishable from a real NULL. Same
+        // reasoning as Numeric and Money above.
+        CellKind::Time => match row.try_get::<_, Option<chrono::NaiveTime>>(idx) {
+            Ok(Some(v)) => Cell::Text(v.format("%H:%M:%S%.f").to_string()),
+            Ok(None) => Cell::Null,
+            Err(_) => Cell::Text("<unreadable time value>".to_string()),
+        },
+        CellKind::TimeTz => match row.try_get::<_, Option<PgTimeTz>>(idx) {
+            Ok(Some(v)) => Cell::Text(v.to_string()),
+            Ok(None) => Cell::Null,
+            Err(_) => Cell::Text("<unreadable time value>".to_string()),
+        },
+        CellKind::Interval => match row.try_get::<_, Option<PgInterval>>(idx) {
+            Ok(Some(v)) => Cell::Text(v.to_string()),
+            Ok(None) => Cell::Null,
+            Err(_) => Cell::Text("<unreadable interval value>".to_string()),
         },
         CellKind::Text => string_fallback(row, idx),
     }
@@ -266,6 +398,91 @@ mod tests {
 
     #[test]
     fn unknown_type_falls_back_to_text() {
-        assert_eq!(classify(&Type::INTERVAL), CellKind::Text);
+        assert_eq!(classify(&Type::XML), CellKind::Text);
+    }
+
+    #[test]
+    fn time_types_classify_to_their_own_kinds() {
+        // Same regression as MONEY: these used to land on the default Text
+        // arm, and String's FromSql rejects their OIDs, so every value became
+        // a phantom Cell::Null. They must not classify as Text.
+        assert_eq!(classify(&Type::TIME), CellKind::Time);
+        assert_eq!(classify(&Type::TIMETZ), CellKind::TimeTz);
+        assert_eq!(classify(&Type::INTERVAL), CellKind::Interval);
+    }
+
+    #[test]
+    fn hms_formats_and_trims_fraction() {
+        assert_eq!(fmt_hms(0), "00:00:00");
+        assert_eq!(fmt_hms(52_200_000_000), "14:30:00");
+        assert_eq!(fmt_hms(52_200_500_000), "14:30:00.5");
+        assert_eq!(fmt_hms(52_200_000_001), "14:30:00.000001");
+    }
+
+    fn timetz_payload(micros: i64, zone_secs_west: i32) -> [u8; 12] {
+        let mut raw = [0u8; 12];
+        raw[..8].copy_from_slice(&micros.to_be_bytes());
+        raw[8..].copy_from_slice(&zone_secs_west.to_be_bytes());
+        raw
+    }
+
+    #[test]
+    fn pg_timetz_decodes_documented_binary_format() {
+        // 14:30:00+07 — pg stores the zone as seconds *west* of UTC, so +07:00
+        // arrives as -25200.
+        let raw = timetz_payload(52_200_000_000, -25_200);
+        let v = <PgTimeTz as FromSql>::from_sql(&Type::TIMETZ, &raw).unwrap();
+        assert_eq!(v.to_string(), "14:30:00+07:00");
+
+        let utc = timetz_payload(0, 0);
+        let v = <PgTimeTz as FromSql>::from_sql(&Type::TIMETZ, &utc).unwrap();
+        assert_eq!(v.to_string(), "00:00:00+00:00");
+
+        // 09:15:00-05:30 (a half-hour offset, east of UTC in pg's sign).
+        let west = timetz_payload(33_300_000_000, 19_800);
+        let v = <PgTimeTz as FromSql>::from_sql(&Type::TIMETZ, &west).unwrap();
+        assert_eq!(v.to_string(), "09:15:00-05:30");
+    }
+
+    #[test]
+    fn pg_timetz_rejects_malformed_payload_and_wrong_oid() {
+        assert!(<PgTimeTz as FromSql>::from_sql(&Type::TIMETZ, &[0u8; 8]).is_err());
+        assert!(<PgTimeTz as FromSql>::accepts(&Type::TIMETZ));
+        assert!(!<PgTimeTz as FromSql>::accepts(&Type::TIME));
+    }
+
+    fn interval_payload(micros: i64, days: i32, months: i32) -> [u8; 16] {
+        let mut raw = [0u8; 16];
+        raw[..8].copy_from_slice(&micros.to_be_bytes());
+        raw[8..12].copy_from_slice(&days.to_be_bytes());
+        raw[12..].copy_from_slice(&months.to_be_bytes());
+        raw
+    }
+
+    #[test]
+    fn pg_interval_decodes_documented_binary_format() {
+        let raw = interval_payload(14_706_000_000, 3, 14); // 1 yr 2 mons 3 days 04:05:06
+        let v = <PgInterval as FromSql>::from_sql(&Type::INTERVAL, &raw).unwrap();
+        assert_eq!(v.to_string(), "1 year 2 mons 3 days 04:05:06");
+
+        let day_only = interval_payload(0, 1, 0);
+        let v = <PgInterval as FromSql>::from_sql(&Type::INTERVAL, &day_only).unwrap();
+        assert_eq!(v.to_string(), "1 day");
+
+        // An all-zero interval still has to render as something visible.
+        let zero = interval_payload(0, 0, 0);
+        let v = <PgInterval as FromSql>::from_sql(&Type::INTERVAL, &zero).unwrap();
+        assert_eq!(v.to_string(), "00:00:00");
+
+        let negative = interval_payload(-1_000_000, 0, 0);
+        let v = <PgInterval as FromSql>::from_sql(&Type::INTERVAL, &negative).unwrap();
+        assert_eq!(v.to_string(), "-00:00:01");
+    }
+
+    #[test]
+    fn pg_interval_rejects_malformed_payload_and_wrong_oid() {
+        assert!(<PgInterval as FromSql>::from_sql(&Type::INTERVAL, &[0u8; 12]).is_err());
+        assert!(<PgInterval as FromSql>::accepts(&Type::INTERVAL));
+        assert!(!<PgInterval as FromSql>::accepts(&Type::TIME));
     }
 }

--- a/crates/driver-postgres/src/type_map.rs
+++ b/crates/driver-postgres/src/type_map.rs
@@ -1,6 +1,6 @@
 use rdb_core::result::Cell;
 use std::error::Error;
-use tokio_postgres::types::{FromSql, Type};
+use tokio_postgres::types::{FromSql, Kind, Type};
 use tokio_postgres::Row;
 
 /// Which `Cell` variant a pg column type maps to. Pragmatic, not exhaustive:
@@ -21,6 +21,7 @@ pub enum CellKind {
     Time,
     TimeTz,
     Interval,
+    Enum,
 }
 
 /// Classify a pg `Type` into a `CellKind`. Unknown types -> `Text` (string
@@ -41,6 +42,9 @@ pub fn classify(ty: &Type) -> CellKind {
         Type::MONEY => CellKind::Money,
         Type::TEXT | Type::VARCHAR | Type::BPCHAR | Type::NAME => CellKind::Text,
         Type::JSON | Type::JSONB => CellKind::Json,
+        // Enums are user-defined, so their OID is assigned per database and
+        // can't be matched as a constant - they're identified by kind.
+        _ if matches!(ty.kind(), Kind::Enum(_)) => CellKind::Enum,
         _ => CellKind::Text,
     }
 }
@@ -74,6 +78,22 @@ impl std::fmt::Display for PgMoney {
         } else {
             write!(f, "{whole}.{cents:02}")
         }
+    }
+}
+
+/// `String`'s `FromSql` matches on OID and so rejects every enum, whose OID is
+/// assigned per database - an enum column silently decoded to `Cell::Null`.
+/// Postgres sends an enum value on the wire as its plain label text, so the
+/// decode itself is trivial; only the `accepts` check has to be kind-based.
+struct PgEnum(String);
+
+impl<'a> FromSql<'a> for PgEnum {
+    fn from_sql(_ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
+        Ok(PgEnum(std::str::from_utf8(raw)?.to_string()))
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        matches!(*ty.kind(), Kind::Enum(_))
     }
 }
 
@@ -287,6 +307,11 @@ pub fn extract_cell(row: &Row, idx: usize) -> Cell {
             Ok(None) => Cell::Null,
             Err(_) => Cell::Text("<unreadable interval value>".to_string()),
         },
+        CellKind::Enum => match row.try_get::<_, Option<PgEnum>>(idx) {
+            Ok(Some(v)) => Cell::Text(v.0),
+            Ok(None) => Cell::Null,
+            Err(_) => Cell::Text("<unreadable enum value>".to_string()),
+        },
         CellKind::Text => string_fallback(row, idx),
     }
 }
@@ -394,6 +419,35 @@ mod tests {
     fn json_types_classify_as_json() {
         assert_eq!(classify(&Type::JSON), CellKind::Json);
         assert_eq!(classify(&Type::JSONB), CellKind::Json);
+    }
+
+    /// Build a `Type` standing in for a user-defined enum. Real ones get their
+    /// OID at CREATE TYPE time; only the kind matters to `classify`/`accepts`.
+    fn enum_type() -> Type {
+        Type::new(
+            "status".to_string(),
+            16_384,
+            Kind::Enum(vec!["active".to_string(), "inactive".to_string()]),
+            "public".to_string(),
+        )
+    }
+
+    #[test]
+    fn enum_classifies_by_kind_not_oid() {
+        // Enum OIDs are per-database, so the OID-constant match can never see
+        // them; without a kind check they fell to Text and string_fallback
+        // turned every label into a phantom NULL.
+        assert_eq!(classify(&enum_type()), CellKind::Enum);
+        assert_ne!(classify(&enum_type()), CellKind::Text);
+    }
+
+    #[test]
+    fn pg_enum_reads_wire_label_and_accepts_only_enums() {
+        let v = <PgEnum as FromSql>::from_sql(&enum_type(), b"active").unwrap();
+        assert_eq!(v.0, "active");
+        assert!(<PgEnum as FromSql>::accepts(&enum_type()));
+        assert!(!<PgEnum as FromSql>::accepts(&Type::TEXT));
+        assert!(<PgEnum as FromSql>::from_sql(&enum_type(), &[0xff, 0xfe]).is_err());
     }
 
     #[test]

--- a/crates/driver-postgres/tests/integration.rs
+++ b/crates/driver-postgres/tests/integration.rs
@@ -92,6 +92,81 @@ async fn select_returns_tabular_rows() {
 
 #[tokio::test]
 #[ignore = "requires docker"]
+async fn enum_and_time_columns_render_their_values() {
+    use rdb_core::query::Query;
+    use rdb_core::result::{Cell, ResultSet};
+
+    let (_container, cfg) = start_pg().await;
+    let driver = PostgresDriver::connect(&cfg).await.expect("connect");
+
+    // These four used to decode to Cell::Null, indistinguishable from a real
+    // NULL, because String's FromSql rejects their OIDs (#253).
+    driver
+        .query(&Query::Sql(
+            "CREATE TYPE status AS ENUM ('active', 'inactive')".into(),
+        ))
+        .await
+        .expect("create enum type");
+    driver
+        .query(&Query::Sql(
+            "CREATE TABLE t253 (id INT4 PRIMARY KEY, s status, start_time TIME, \
+             tz_time TIMETZ, span INTERVAL)"
+                .into(),
+        ))
+        .await
+        .expect("create table");
+    driver
+        .query(&Query::Sql(
+            "INSERT INTO t253 VALUES (1, 'active', '14:30:00', '14:30:00+07', \
+             '1 day 02:03:04'), (2, NULL, NULL, NULL, NULL)"
+                .into(),
+        ))
+        .await
+        .expect("insert");
+
+    let rs = driver
+        .query(&Query::Sql(
+            "SELECT s, start_time, tz_time, span FROM t253 ORDER BY id".into(),
+        ))
+        .await
+        .expect("select");
+
+    match rs {
+        ResultSet::Tabular { cols, rows } => {
+            assert_eq!(cols[0].type_name, "status");
+            assert!(matches!(&rows[0][0], Cell::Text(v) if v == "active"));
+            assert!(matches!(&rows[0][1], Cell::Text(v) if v == "14:30:00"));
+            assert!(matches!(&rows[0][2], Cell::Text(v) if v == "14:30:00+07:00"));
+            assert!(matches!(&rows[0][3], Cell::Text(v) if v == "1 day 02:03:04"));
+            // A real NULL must still read as NULL, not as a decoded value.
+            for cell in &rows[1] {
+                assert!(matches!(cell, Cell::Null));
+            }
+        }
+        other => panic!("expected Tabular, got {other:?}"),
+    }
+
+    // The sidebar names the enum type itself, not the literal 'USER-DEFINED'
+    // that information_schema.data_type reports for it.
+    let schema = driver.schema_for("public").await.expect("schema");
+    let table = schema
+        .databases
+        .iter()
+        .flat_map(|d| &d.containers)
+        .find(|c| c.name == "t253")
+        .expect("t253 in schema");
+    let s_field = table
+        .fields
+        .iter()
+        .find(|f| f.name == "s")
+        .expect("s column");
+    assert_eq!(s_field.type_name, "status");
+
+    driver.close().await.expect("close");
+}
+
+#[tokio::test]
+#[ignore = "requires docker"]
 async fn non_sql_queries_are_unsupported() {
     use rdb_core::error::RdbError;
     use rdb_core::query::{MongoKind, MongoOp, Query};


### PR DESCRIPTION
## Summary

- Postgres `ENUM` and `TIME` columns rendered as `NULL` in the grid (#253) — not a display bug, a silent decode failure that made real data indistinguishable from a real NULL.
- `timetz` and `interval` were broken identically and are fixed in the same pass; the existing `unknown_type_falls_back_to_text` test actually asserted the lossy behavior for `INTERVAL`, so it encoded the bug as intent.
- The schema sidebar named enum columns `USER-DEFINED` while the grid header already showed the real type name.

Root cause is in `crates/driver-postgres/src/type_map.rs`: `classify()` matched only concrete OID constants and sent everything else to `_ => CellKind::Text`, whose `string_fallback` maps any decode failure to `Cell::Null`. `String`'s `FromSql` accepts only text-family OIDs, and matches on OID — so it rejects `time`/`timetz`/`interval` and can never see an enum, whose OID is assigned per database. Same defect `MONEY` had, already documented in that file.

## Changes

**`crates/driver-postgres/src/type_map.rs`**
- New `CellKind` variants `Time`, `TimeTz`, `Interval`, `Enum`.
- `time` decodes through `chrono::NaiveTime` (`with-chrono-0_4` was already enabled).
- `PgTimeTz` and `PgInterval` decoders over their documented binary layouts — neither type has a `FromSql` anywhere in the ecosystem. Modelled on the existing `PgMoney`.
- `PgEnum` classified by `Kind::Enum` rather than OID; the wire value is already the plain label, so decoding is a UTF-8 read.
- Decode failures return a visible `<unreadable …>` placeholder instead of falling through to `string_fallback` — a phantom NULL is the bug being fixed.
- Unit tests for the new `classify` arms and hand-built binary payloads for each decoder, including malformed-payload and wrong-OID rejection. `unknown_type_falls_back_to_text` retargeted to `Type::XML`.

**`crates/driver-postgres/src/driver.rs`**
- Schema introspection falls back to `udt_name` when `information_schema.columns.data_type` reports the literal `USER-DEFINED`.

**`crates/driver-postgres/tests/integration.rs`**
- Docker-gated test covering enum/time/timetz/interval values, the enum's type name in both the grid header and the schema tree, and that real NULLs still read as `Cell::Null`. The enum path can't be unit-tested — its OID only exists once a database has run `CREATE TYPE`.

MySQL is unaffected: `driver-mysql/src/convert.rs` switches on the value rather than the column type, so enum arrives as `Value::Bytes` and time goes through the `as_sql` catch-all.

## Test plan

- [x] `make fmt-check`
- [x] `make lint` (clippy, warnings as errors) — clean
- [x] `make be-test` — full backend suite green
- [x] `cargo test -p rdb-driver-postgres --lib` — 26 passed
- [x] `cargo test -p rdb-driver-postgres --test integration -- --ignored` against a real Postgres container — 5 passed, including the new test asserting `active`, `14:30:00`, `14:30:00+07:00`, `1 day 02:03:04` and the `status` type name
- [x] Regression check: `money`, `numeric`, `jsonb`, `uuid`, `timestamptz` still render as before

Fixes #253
