### PR TITLE
ci: label pull requests with suiflex-bot

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,0 +1,25 @@
+# Thin caller. The logic lives in suiflex/.github so that every repository in
+# the organization labels pull requests the same way and changes land in one
+# place.
+name: PR Triage
+
+on:
+  # pull_request_target, not pull_request: a fork's pull request runs with a
+  # read-only token, which cannot apply labels — the one case that matters most
+  # here. This is safe because the workflow never checks out or executes the
+  # pull request's code; it only passes GitHub-provided event metadata to
+  # pinned actions. The same pattern is used by cla.yml in this repository and
+  # by pr_issue_labeler.yml in zed-industries/zed.
+  #
+  # Do not "tidy" this to pull_request.
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  triage:
+    # Forks of this repository should not try to run the organization's bot.
+    if: github.repository_owner == 'suiflex'
+    uses: suiflex/.github/.github/workflows/pr-triage.yml@main
+    secrets:
+      app_id: ${{ secrets.SUIFLEX_BOT_APP_ID }}
+      private_key: ${{ secrets.SUIFLEX_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- Pull requests here carry no automatic signal about who opened them or what they contain, so triage starts by reading the author list and the commits by hand.
- Adopts the organization-wide labeler defined in [`suiflex/.github`](https://github.com/suiflex/.github/pull/9). All logic lives there; this repository only calls it.

## Changes

- Adds `.github/workflows/pr-triage.yml`, a caller stub. Pull requests get `maintainer`, `first contribution`, or `bot` for the author, plus one `commit: <type>` label per conventional-commit type on the branch, and `needs: conventional commit` when a message is one `release-please` cannot parse.

The trigger is `pull_request_target` rather than `pull_request`, and the file carries a comment saying so. A fork's pull request runs with a read-only token that cannot apply labels — which is the case this is most needed for. It is safe because the workflow never checks out or executes the pull request's code; it only passes GitHub-provided event metadata to pinned actions. The same pattern is already used by `cla.yml` in this repository.

## Test plan

- [x] Workflow parses as valid YAML
- [x] Upstream logic covered by `scripts/test-pr-triage.mjs` in `suiflex/.github` — 8 checks pass
- [ ] Merge `suiflex/.github#9` first; this stub references it at `@main` and fails until then
- [ ] Create the `suiflex-bot` App and set `SUIFLEX_BOT_APP_ID` / `SUIFLEX_BOT_PRIVATE_KEY` as org secrets
- [ ] Run `sync-labels.sh` against this repository so the labels exist
- [ ] Confirm on a live PR that labels appear and the actor reads `suiflex-bot`