### PR TITLE
fix(app): repair Mongo browsing, the fold arrow and Run New

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,98 @@
+# Path -> label map for the PR area labeler (.github/workflows/pr-labeler.yml).
+#
+# One entry per component, mirroring the per-crate CI workflows: a reviewer can
+# tell from the label row which parts of the workspace a pull request touches
+# without opening the diff.
+#
+# Adding a crate means adding it here as well as to the Makefile's BE_PKGS and
+# its own workflow — nothing checks that this file stayed in sync.
+
+
+"area: app":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app/**"
+
+"area: core":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/core/**"
+
+"area: connstore":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/connstore/**"
+
+"area: tunnel":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/tunnel/**"
+
+"area: driver-postgres":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/driver-postgres/**"
+
+"area: driver-mysql":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/driver-mysql/**"
+
+"area: driver-redis":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/driver-redis/**"
+
+"area: driver-mongo":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/driver-mongo/**"
+
+"area: driver-sqlite":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/driver-sqlite/**"
+
+"area: driver-cassandra":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/driver-cassandra/**"
+
+"area: driver-mssql":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/driver-mssql/**"
+
+"area: driver-clickhouse":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/driver-clickhouse/**"
+
+"area: driver-oracle":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/driver-oracle/**"
+
+"area: website":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "website/**"
+
+"area: ci":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "Makefile"
+
+"area: packaging":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "npm/**"
+          - "packaging/**"
+          - "scripts/install.*"
+
+"area: docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "*.md"
+          - "docs/**"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,34 @@
+name: PR Area Labels
+
+# Marks each pull request with the parts of the workspace it touches, from the
+# path map in .github/labeler.yml. This lives here rather than in the shared
+# suiflex/.github triage workflow because the map is specific to this
+# repository's layout; pr-triage.yml still owns the author and commit-type
+# labels that every repository in the organization gets.
+#
+# pull_request_target, not pull_request: a fork's pull request runs with a
+# read-only token, so `pull-requests: write` is ignored and the labels never
+# appear — exactly the case that matters. That is only safe because the job
+# NEVER checks out the pull request. actions/labeler reads the configuration
+# through the API from the base branch, so a fork cannot supply its own map.
+# Do not add a checkout step, and do not "tidy" this to pull_request.
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    # Forks of this repository have their own labels, if any.
+    if: github.repository_owner == 'suiflex'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml
+          # Drop a label again once a force-push stops touching that area,
+          # so the row keeps describing the diff as it stands.
+          sync-labels: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6571,7 +6571,7 @@ dependencies = [
 
 [[package]]
 name = "rdb"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/app/src/editor/mongo.rs
+++ b/app/src/editor/mongo.rs
@@ -2,7 +2,17 @@
 //! identifier before matching (shared across all four dialects), so these
 //! stay uppercase even though real mongosh calls are lowercase/camelCase.
 
-pub const KEYWORDS: &[&str] = &["FIND", "AGGREGATE"];
+pub const KEYWORDS: &[&str] = &[
+    "FIND",
+    "AGGREGATE",
+    "INSERTONE",
+    // Chain modifiers and the database switch, which a browse query leads with.
+    "USE",
+    "GETCOLLECTION",
+    "SKIP",
+    "LIMIT",
+    "SORT",
+];
 
 /// True when `word` (already uppercased) is a highlighted Mongo keyword.
 pub fn is_keyword(word: &str) -> bool {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2657,17 +2657,21 @@ fn browse_text(
             }
         }
         rdb_connstore::Engine::Mongo => {
+            // mongosh shape, not the JSON envelope: it is what a Mongo user
+            // already knows how to edit, and it can carry a `.sort(...)` the
+            // envelope has no field for. `parse_mongo_line` reads it back.
             let db = table
                 .database
                 .as_deref()
-                .map(|d| format!("\"database\":\"{d}\","))
+                .filter(|d| !d.is_empty())
+                .map(|d| format!("use('{d}')\n"))
                 .unwrap_or_default();
             let body = match filter.trim() {
                 "" => "{}",
                 f => f,
             };
             format!(
-                "{{\"collection\":\"{}\",{db}\"op\":\"find\",\"body\":{body},\"limit\":{limit},\"skip\":{offset}}}",
+                "{db}db.{}.find({body}).skip({offset}).limit({limit})",
                 table.name
             )
         }
@@ -5702,13 +5706,45 @@ mod tests {
         };
         assert_eq!(
             browse_text(rdb_connstore::Engine::Mongo, &m, 1, 50, "", &[]),
-            "{\"collection\":\"orders\",\"database\":\"shop\",\"op\":\"find\",\"body\":{},\"limit\":50,\"skip\":50}"
+            "use('shop')\ndb.orders.find({}).skip(50).limit(50)"
         );
         // A filter document lands in the find body.
         assert_eq!(
-            browse_text(rdb_connstore::Engine::Mongo, &m, 0, 20, r#"{"status":"A"}"#, &[]),
-            "{\"collection\":\"orders\",\"database\":\"shop\",\"op\":\"find\",\"body\":{\"status\":\"A\"},\"limit\":20,\"skip\":0}"
+            browse_text(
+                rdb_connstore::Engine::Mongo,
+                &m,
+                0,
+                20,
+                r#"{"status":"A"}"#,
+                &[]
+            ),
+            "use('shop')\ndb.orders.find({\"status\":\"A\"}).skip(0).limit(20)"
         );
+    }
+
+    // What the browse toolbar emits has to survive the parser it is handed to.
+    #[test]
+    fn mongo_browse_text_round_trips_through_parse_query() {
+        let m = rdb_core::write::TableRef {
+            database: Some("shop".into()),
+            schema: None,
+            name: "orders".into(),
+        };
+        // A bare key is what the filter box lets through now, so parse it too.
+        let text = browse_text(rdb_connstore::Engine::Mongo, &m, 2, 20, "{status:'A'}", &[]);
+        let q = crate::query_parse::parse_query(rdb_connstore::Engine::Mongo, &text)
+            .expect("browse text must parse");
+        let rdb_core::query::Query::Mongo(op) = q else {
+            panic!("expected a Mongo op");
+        };
+        assert_eq!(op.collection, "orders");
+        assert_eq!(op.database.as_deref(), Some("shop"));
+        assert_eq!(op.limit, Some(20));
+        assert_eq!(op.skip, Some(40));
+        let rdb_core::query::MongoKind::Find(f) = op.kind else {
+            panic!("expected a find");
+        };
+        assert_eq!(f, serde_json::json!({"status": "A"}));
     }
 
     #[test]

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -5035,6 +5035,16 @@ fn main() -> Result<(), slint::PlatformError> {
                     ..Default::default()
                 };
             }
+            // The Mongo filter box is a plain window property, so it keeps
+            // whatever the previous tab left in it unless the restored state is
+            // pushed back out: the box read empty while the query it came back
+            // to was still filtered.
+            let filter = SharedString::from(browse.lock().unwrap().mongo_filter.clone());
+            if pane == 1 {
+                w.set_p1_mongo_filter(filter);
+            } else {
+                w.set_mongo_filter(filter);
+            }
 
             // Function source is still a left-group view; table chrome is fully
             // group-local so moving a table keeps its toolbar and footer.

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2670,10 +2670,26 @@ fn browse_text(
                 "" => "{}",
                 f => f,
             };
-            format!(
-                "{db}db.{}.find({body}).skip({offset}).limit({limit})",
-                table.name
-            )
+            // A plain identifier reads best as `db.orders`; anything else (a
+            // dot, a dash, a space — GridFS's `fs.files`, the `system.*`
+            // collections) has to go through getCollection or the parser would
+            // split the name at its first dot.
+            let ident = !table.name.is_empty()
+                && !table.name.starts_with(|c: char| c.is_ascii_digit())
+                && table
+                    .name
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_');
+            let coll = if ident {
+                format!("db.{}", table.name)
+            } else if table.name.contains('\'') {
+                // ponytail: the parser unquotes by trimming, not unescaping, so
+                // pick the quote the name does not use rather than escaping it.
+                format!("db.getCollection(\"{}\")", table.name)
+            } else {
+                format!("db.getCollection('{}')", table.name)
+            };
+            format!("{db}{coll}.find({body}).skip({offset}).limit({limit})")
         }
         rdb_connstore::Engine::Redis | rdb_connstore::Engine::Valkey => {
             format!("BROWSE {} {offset} {limit}", table.name)
@@ -5745,6 +5761,29 @@ mod tests {
             panic!("expected a find");
         };
         assert_eq!(f, serde_json::json!({"status": "A"}));
+    }
+
+    // GridFS and the system collections carry a dot, which the short
+    // `db.<name>.` form cannot express: the parser would split the name there.
+    #[test]
+    fn mongo_browse_text_quotes_a_dotted_collection() {
+        let m = rdb_core::write::TableRef {
+            database: Some("shop".into()),
+            schema: None,
+            name: "fs.files".into(),
+        };
+        let text = browse_text(rdb_connstore::Engine::Mongo, &m, 0, 20, "", &[]);
+        assert_eq!(
+            text,
+            "use('shop')\ndb.getCollection('fs.files').find({}).skip(0).limit(20)"
+        );
+        let q = crate::query_parse::parse_query(rdb_connstore::Engine::Mongo, &text)
+            .expect("dotted collection must parse");
+        let rdb_core::query::Query::Mongo(op) = q else {
+            panic!("expected a Mongo op");
+        };
+        assert_eq!(op.collection, "fs.files");
+        assert_eq!(op.limit, Some(20));
     }
 
     #[test]

--- a/app/src/query_parse.rs
+++ b/app/src/query_parse.rs
@@ -109,7 +109,7 @@ pub fn editor_hint(engine: Engine) -> &'static str {
         | Engine::Clickhouse => "SELECT * FROM table",
         Engine::Cassandra => "SELECT * FROM keyspace.table",
         Engine::Redis | Engine::Valkey => "SET key value",
-        Engine::Mongo => r#"db.coll.find({ })  ·  or JSON envelope"#,
+        Engine::Mongo => r#"db.coll.find({ }).sort({ _id: -1 })  ·  use('db') to switch"#,
     }
 }
 
@@ -209,15 +209,25 @@ fn strip_use(s: &str) -> (Option<String>, &str) {
 /// preceded the query.
 fn parse_mongo_line(s: &str, database: Option<String>) -> Result<Query, String> {
     let rest = &s[3..]; // drop "db."
-    let dot = rest
-        .find('.')
-        .ok_or_else(|| "expected db.<collection>.<op>(...)".to_string())?;
-    let collection = rest[..dot].trim().to_string();
+                        // `db.getCollection('fs.files')` is mongosh's escape hatch for names that
+                        // are not plain identifiers. Splitting on the first dot cannot reach those:
+                        // GridFS and the `system.*` collections all carry one.
+    let (collection, after_collection) = if rest.trim_start().starts_with("getCollection") {
+        // Keep the leading '.' so `next_call` sees `.getCollection(...)`.
+        let (_, arg, tail) = next_call(&s[2..])?;
+        let name = arg.trim().trim_matches(|c| c == '\'' || c == '"');
+        (name.to_string(), tail)
+    } else {
+        let dot = rest
+            .find('.')
+            .ok_or_else(|| "expected db.<collection>.<op>(...)".to_string())?;
+        (rest[..dot].trim().to_string(), &rest[dot..])
+    };
     if collection.is_empty() {
         return Err("missing collection in db.<collection>.<op>(...)".into());
     }
 
-    let (method, arg, mut cursor) = next_call(&rest[dot..])?;
+    let (method, arg, mut cursor) = next_call(after_collection)?;
     let kind = match method {
         "find" => MongoKind::Find(parse_json_arg(arg, "find")?),
         "insertOne" | "insert" => MongoKind::Insert(parse_json_arg(arg, method)?),

--- a/app/src/query_parse.rs
+++ b/app/src/query_parse.rs
@@ -278,25 +278,30 @@ fn next_call(s: &str) -> Result<(&str, &str, &str), String> {
 }
 
 /// Extract the balanced `(...)` whose opening paren is at byte index `open`,
-/// respecting JSON string literals so parens inside strings don't unbalance the
+/// respecting string literals so parens inside strings don't unbalance the
 /// scan. Returns the inner text and the byte index just past the closing `)`.
 /// Parens/quotes are ASCII, so all slice boundaries fall on char boundaries.
+///
+/// Both quote styles count: bodies are parsed as json5, where `'a)b'` is as
+/// ordinary as `"a)b"`. Tracking the opening quote rather than a flag is what
+/// keeps `"it's"` from reading as the start of a single-quoted string.
 fn extract_parens(s: &str, open: usize) -> Result<(&str, usize), String> {
     let b = s.as_bytes();
-    let (mut depth, mut in_str, mut esc, mut i) = (0i32, false, false, open);
+    let (mut depth, mut esc, mut i) = (0i32, false, open);
+    let mut quote: Option<u8> = None;
     while i < b.len() {
         let c = b[i];
-        if in_str {
+        if let Some(q) = quote {
             if esc {
                 esc = false;
             } else if c == b'\\' {
                 esc = true;
-            } else if c == b'"' {
-                in_str = false;
+            } else if c == q {
+                quote = None;
             }
         } else {
             match c {
-                b'"' => in_str = true,
+                b'"' | b'\'' => quote = Some(c),
                 b'(' => depth += 1,
                 b')' => {
                     depth -= 1;
@@ -573,6 +578,24 @@ mod tests {
                 _ => panic!("expected Find"),
             },
             _ => panic!("expected Mongo"),
+        }
+    }
+
+    #[test]
+    fn mongo_line_paren_inside_single_quoted_string_stays_balanced() {
+        // json5 bodies use single quotes as readily as double, so the paren
+        // scan has to respect both.
+        for text in [
+            r#"db.c.find({ note: 'a)b' })"#,
+            r#"db.c.find({ note: "it's )" })"#,
+        ] {
+            match parse_query(Engine::Mongo, text).expect(text) {
+                Query::Mongo(op) => match op.kind {
+                    MongoKind::Find(f) => assert!(f.get("note").is_some(), "{text}"),
+                    _ => panic!("expected Find"),
+                },
+                _ => panic!("expected Mongo"),
+            }
         }
     }
 

--- a/app/src/ui/code-editor.slint
+++ b/app/src/ui/code-editor.slint
@@ -10,8 +10,8 @@ import { CompletionList } from "components.slint";
 export component CodeEditor inherits Rectangle {
     in property <[[Span]]> lines;
     // Per-line fold metadata, parallel to `lines`. `fold-state`: 0 plain,
-    // 1 open statement head (▾), 2 closed head (▸). `line-hidden`: body line
-    // of a closed statement, collapsed to zero height.
+    // 1 open statement head (triangle down), 2 closed head (triangle right).
+    // `line-hidden`: body line of a closed statement, collapsed to zero height.
     in property <[int]> fold-state;
     in property <[bool]> line-hidden;
     callback toggle-fold(int);
@@ -174,17 +174,17 @@ export component CodeEditor inherits Rectangle {
                                         clicked => {
                                             root.toggle-fold(li);
                                         }
-                                        // TouchArea is not a layout, so the icon
-                                        // would pin to (0,0) of the row and read
-                                        // as a stray tick instead of a chevron.
-                                        VerticalLayout {
-                                            alignment: center;
-                                            AppIcon {
-                                                name: "caret";
-                                                size: 12px;
-                                                color: fold-ta.has-hover ? Tokens.accent : Tokens.text-dim;
-                                                transform-rotation: root.fold-state[li] == 2 ? -90deg : 0deg;
-                                            }
+                                        // "fold", not the shared "caret": that
+                                        // one draws a 12x6 stroke inside a 24x24
+                                        // box, so at this size only ~6x3px of
+                                        // hairline chevron survives and reads as
+                                        // a stray tick. This glyph is a solid
+                                        // triangle in a box its own size.
+                                        AppIcon {
+                                            name: "fold";
+                                            size: 10px;
+                                            color: fold-ta.has-hover ? Tokens.accent : Tokens.text-dim;
+                                            transform-rotation: root.fold-state[li] == 2 ? -90deg : 0deg;
                                         }
                                     }
                                 }

--- a/app/src/ui/code-editor.slint
+++ b/app/src/ui/code-editor.slint
@@ -174,11 +174,17 @@ export component CodeEditor inherits Rectangle {
                                         clicked => {
                                             root.toggle-fold(li);
                                         }
-                                        AppIcon {
-                                            name: "caret";
-                                            size: 12px;
-                                            color: fold-ta.has-hover ? Tokens.accent : Tokens.text-dim;
-                                            transform-rotation: root.fold-state[li] == 2 ? -90deg : 0deg;
+                                        // TouchArea is not a layout, so the icon
+                                        // would pin to (0,0) of the row and read
+                                        // as a stray tick instead of a chevron.
+                                        VerticalLayout {
+                                            alignment: center;
+                                            AppIcon {
+                                                name: "caret";
+                                                size: 12px;
+                                                color: fold-ta.has-hover ? Tokens.accent : Tokens.text-dim;
+                                                transform-rotation: root.fold-state[li] == 2 ? -90deg : 0deg;
+                                            }
                                         }
                                     }
                                 }

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -858,6 +858,8 @@ export component FilterField inherits Rectangle {
     in property <string> placeholder;
     in-out property <string> text <=> input.text;
     in property <string> trailing-cap: "";
+    // Show an inline × that empties the field and re-submits it.
+    in property <bool> clearable;
     callback edited(string);
     callback submitted;
     // Autocomplete. The candidate list is supplied by the owner (Rust fills it
@@ -926,6 +928,33 @@ export component FilterField inherits Rectangle {
                     } else if cursor-position.x + self.x > parent.width - 4px - self.text-cursor-width {
                         self.x = parent.width - cursor-position.x - 4px - self.text-cursor-width;
                     }
+                }
+            }
+        }
+        // Clearing an applied filter has no other route: ⌘Z only ever covered
+        // the code editor's own buffer, never a toolbar input, and by the time
+        // the box holds text the query behind it has already re-run.
+        if root.clearable && input.text != "": VerticalLayout {
+            alignment: center;
+            Rectangle {
+                width: 18px;
+                height: 18px;
+                border-radius: Tokens.radius;
+                background: clear-ta.has-hover ? Tokens.chrome : transparent;
+                animate background { duration: Tokens.fade; }
+                clear-ta := TouchArea {
+                    mouse-cursor: pointer;
+                    clicked => {
+                        input.text = "";
+                        // `submitted` is the existing apply path and already
+                        // drops the suggestion popup, so no `edited` is needed.
+                        root.submitted();
+                    }
+                }
+                AppIcon {
+                    name: "close";
+                    size: 10px;
+                    color: clear-ta.has-hover ? Tokens.text : Tokens.text-faint;
                 }
             }
         }

--- a/app/src/ui/components.slint
+++ b/app/src/ui/components.slint
@@ -934,7 +934,9 @@ export component FilterField inherits Rectangle {
             KeyCap { text: root.trailing-cap; }
         }
     }
-    if input.text == "": Text {
+    // Also gated on focus: the caret sits at the same x as the first glyph, so
+    // a focused-but-empty field draws the caret on top of the placeholder.
+    if input.text == "" && !input.has-focus: Text {
         x: Tokens.sp2 + 6px + 14px;
         text: root.placeholder;
         color: Tokens.text-faint;

--- a/app/src/ui/icons.slint
+++ b/app/src/ui/icons.slint
@@ -43,6 +43,7 @@ export component AppIcon inherits Image {
         name == "play"      ? @image-url("icons/play.svg")     :
         name == "copy"      ? @image-url("icons/copy.svg")     :
         name == "caret"     ? @image-url("icons/caret.svg")    :
+        name == "fold"      ? @image-url("icons/fold.svg")     :
         name == "star"      ? @image-url("icons/star.svg")     :
         name == "pencil"    ? @image-url("icons/pencil.svg")   :
         name == "db-postgres"  ? @image-url("icons/db-postgres.svg")  :

--- a/app/src/ui/icons/fold.svg
+++ b/app/src/ui/icons/fold.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" fill="#000"><path d="M1.5 4h9L6 9.5z"/></svg>

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -222,6 +222,7 @@ export component QueryPane inherits Rectangle {
                         width: 260px;
                         height: 28px;
                         placeholder: "Filter — { \"field\": value }";
+                        clearable: true;
                         text <=> root.mongo-filter;
                         submitted => { root.apply-mongo-filter(); }
                         completion-items: root.filter-completion-items;

--- a/app/src/wire/browse.rs
+++ b/app/src/wire/browse.rs
@@ -509,19 +509,9 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
             w.set_filter_completion_items(ModelRc::from(Rc::new(
                 VecModel::<PaletteItem>::default(),
             )));
+            // Same as the left pane: validation is left to the query path.
             let raw = w.get_p1_mongo_filter().to_string();
             let trimmed = raw.trim();
-            if !trimmed.is_empty() {
-                if let Err(e) = serde_json::from_str::<serde_json::Value>(trimmed) {
-                    set_p_status_error(&w, 1, true);
-                    set_p_result_status(
-                        &w,
-                        1,
-                        SharedString::from(format!("invalid filter JSON: {e}")),
-                    );
-                    return;
-                }
-            }
             {
                 let mut st = panes[1].browse.lock().unwrap();
                 st.mongo_filter = trimmed.to_string();
@@ -711,14 +701,12 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
             )));
             let raw = w.get_mongo_filter().to_string();
             let trimmed = raw.trim();
-            // Empty clears the filter; otherwise it must be a JSON document.
-            if !trimmed.is_empty() {
-                if let Err(e) = serde_json::from_str::<serde_json::Value>(trimmed) {
-                    w.set_status_error(true);
-                    w.set_result_status(SharedString::from(format!("invalid filter JSON: {e}")));
-                    return;
-                }
-            }
+            // Deliberately unvalidated here. The filter is spliced into the
+            // browse query and parsed by `query_parse` (json5, so bare keys and
+            // single quotes work like they do in the editor); a bad document
+            // comes back through the normal query error path, which browse mode
+            // actually renders. Rejecting it here instead set a status string
+            // that nothing painted, so Enter looked like a no-op.
             {
                 let mut st = browse.lock().unwrap();
                 st.mongo_filter = trimmed.to_string();

--- a/app/src/wire/runner.rs
+++ b/app/src/wire/runner.rs
@@ -420,41 +420,30 @@ pub(crate) fn build(window: &MainWindow, state: &AppState) -> (PaneSqlFn, PaneSq
                                 tab.loading = false;
                                 tab.view = Some(sr.clone());
                                 let is_browse = tab.kind == "table";
-                                if is_browse {
-                                    tab.results.clear();
-                                    tab.active_result = 0;
-                                } else {
-                                    // ⌘\ opens a new result tab; snapshot the
-                                    // outgoing result's live grid (sort/filters/
-                                    // search) so returning to it keeps its state.
-                                    if new_tab && is_active {
-                                        if let Some(r) = tab.results.get_mut(tab.active_result) {
-                                            let mut hidden: Vec<usize> = hidden_cols
-                                                .lock()
-                                                .unwrap()
-                                                .iter()
-                                                .copied()
-                                                .collect();
-                                            hidden.sort_unstable();
-                                            r.grid = GridState {
-                                                col_filters: col_filters.lock().unwrap().clone(),
-                                                sort: *sort_state.lock().unwrap(),
-                                                hidden,
-                                                col_order: col_order.lock().unwrap().clone(),
-                                                col_widths: get_p_col_widths(&w, pane),
-                                                grid_filter: w.get_grid_filter().to_string(),
-                                                filter_col: w.get_filter_col().to_string(),
-                                                filter_op: w.get_filter_op().to_string(),
-                                            };
-                                        }
+                                // ⌘\ opens a new result tab; snapshot the
+                                // outgoing result's live grid (sort/filters/
+                                // search) so returning to it keeps its state.
+                                // A browse tab takes the same path: it used to
+                                // drop every result, which made ⌘\ and the Run
+                                // New button silently do nothing there.
+                                if new_tab && is_active {
+                                    if let Some(r) = tab.results.get_mut(tab.active_result) {
+                                        let mut hidden: Vec<usize> =
+                                            hidden_cols.lock().unwrap().iter().copied().collect();
+                                        hidden.sort_unstable();
+                                        r.grid = GridState {
+                                            col_filters: col_filters.lock().unwrap().clone(),
+                                            sort: *sort_state.lock().unwrap(),
+                                            hidden,
+                                            col_order: col_order.lock().unwrap().clone(),
+                                            col_widths: get_p_col_widths(&w, pane),
+                                            grid_filter: w.get_grid_filter().to_string(),
+                                            filter_col: w.get_filter_col().to_string(),
+                                            filter_op: w.get_filter_op().to_string(),
+                                        };
                                     }
-                                    store_result(
-                                        &mut tab.results,
-                                        &mut tab.active_result,
-                                        sr,
-                                        new_tab,
-                                    );
                                 }
+                                store_result(&mut tab.results, &mut tab.active_result, sr, new_tab);
                                 let tab_results = tab.results.clone();
                                 let tab_active = tab.active_result;
                                 if !is_active {
@@ -462,11 +451,7 @@ pub(crate) fn build(window: &MainWindow, state: &AppState) -> (PaneSqlFn, PaneSq
                                 }
                                 *results.lock().unwrap() = tab_results;
                                 *active_result.lock().unwrap() = tab_active;
-                                if is_browse {
-                                    set_result_tabs(&w, pane, &[], 0);
-                                } else {
-                                    set_result_tabs(&w, pane, &results.lock().unwrap(), tab_active);
-                                }
+                                set_result_tabs(&w, pane, &results.lock().unwrap(), tab_active);
                                 present_view(
                                     &w,
                                     pane,


### PR DESCRIPTION
## Summary

- The Mongo browse toolbar was effectively dead: pressing Enter on a filter did nothing visible, and the editor showed an internal JSON envelope instead of a query anyone could hand-edit.
- Two smaller papercuts in the same screens: the gutter fold arrow drew as a stray tick, and Run New (⌘\) ran its query and then discarded the result.
- Adds an area labeler so a pull request says which parts of the workspace it touches.

## Changes

**Mongo browsing**
- Browse tabs now prefill mongosh syntax (`use('db')` + `db.coll.find({}).skip(0).limit(20)`) instead of the JSON envelope, which had no `sort` field at all. The envelope parser stays for tabs already persisted in that shape.
- Dropped the strict-JSON gate on the filter box. It rejected `{name:"Garuda"}` while the editor accepted the same document via json5, then reported the failure into a status line that browse mode never paints — so Enter read as a no-op. Validation now happens on the query path, which reports through the results pane.
- Collection names that are not plain identifiers go through `db.getCollection('fs.files')`; the short form splits the name at its first dot, which broke GridFS and the `system.*` collections.
- The paren scanner tracks single-quoted strings, so `find({note:'a)b'})` no longer closes the call early.
- The filter box is repainted on tab switch; browse state was restored but the box was not.
- An inline × clears an applied filter. Undo only ever covered the code editor's buffer, so there was no way back from a filter once it ran.
- Highlights the rest of the mongosh vocabulary (`use`, `getCollection`, `skip`, `limit`, `sort`, `insertOne`).

**Editor and result tabs**
- The fold arrow uses a glyph sized for the gutter. The shared caret strokes a 12x6 chevron inside a 24x24 box, so roughly 6x3 pixels of hairline actually reached the screen.
- Browse tabs keep their result list, so Run New appends a second result instead of running the query and clearing it. Paging still replaces the active result. The streaming path already behaved this way.
- The filter placeholder hides on focus; the caret was drawn on top of its first letter.

**CI**
- `.github/labeler.yml` + `pr-labeler.yml` apply `area: *` labels from changed paths. The map is repo-specific, so it lives here rather than in the shared org triage workflow. The 17 labels exist in the repository already.

## Test plan

- [x] `make fmt-check`
- [x] `make lint`
- [x] `cargo test -p rdb --bin rdb -- --test-threads=1` — 266 passed
- [x] `make be-test` — all crates green
- [x] New tests cover the two parser bugs: a `)` inside a single-quoted string, and `browse_text` → `parse_query` round-tripping a dotted collection name
- [x] Manual: filter with single quotes, × clears it, tab switch keeps the box in sync
- [x] Manual: fold arrow reads as a triangle in an indented query (the mock screenshot harness always loads the unindented seed, so this could not be captured)
- [x] Manual: open a GridFS `fs.files` collection
- [ ] The labeler only takes effect once it is on `develop`, so this PR will not label itself