### PR TITLE
docs: align the MongoDB query docs with the mongosh browse form

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,9 @@
 
 ## Project
 
-Native cross-platform database manager (PostgreSQL, MySQL, Redis, MongoDB, SQLite, Cassandra) built with Rust + Slint UI. Monorepo workspace.
+Native cross-platform database manager (PostgreSQL, MySQL, MariaDB, Redis,
+Valkey, MongoDB, SQLite, Cassandra, SQL Server, Oracle, ClickHouse) built with
+Rust + Slint UI. Monorepo workspace.
 
 Alongside the Rust workspace (`app/`, `crates/*`) the repo also holds: `website/`
 (Astro marketing site, deployed by Cloudflare Pages' Git integration on every
@@ -262,6 +264,15 @@ Everything here is env-var driven; there are no CLI flags.
 both no-op under it, deliberately, so the screenshot harness never touches the
 developer's tabs. A persistence test written in mock mode passes without testing
 anything — use `RDB_STORE_DIR` with a real (SQLite is easiest) connection.
+
+**Mock mode ignores `saved_queries.json` entirely.** `main.rs` takes
+`default_saved()` whenever `mock_mode()` is true, so the sidebar's Queries tab
+always shows the same four seeded queries. Seeding that file (even via a
+redirected `HOME`) to drive the harness towards a particular editor buffer does
+nothing; `RDB_SCREEN=sql` likewise always opens `emiten-per-sektor`. Reaching a
+buffer the seed doesn't contain — an indented one, say, which is what the gutter
+needs before it shows any fold arrows — means adding an `RDB_SCREEN` branch that
+calls `load_editor_text`, the way `sql-empty` and `sql-multi` already do.
 
 **Driving the UI from outside** — Slint 1.17 embeds an MCP server in the app:
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ The release binary lands at `target/release/rdb`.
 | PostgreSQL, MySQL, MariaDB, SQLite, SQL Server, Oracle, ClickHouse | SQL | `SELECT * FROM users` |
 | Cassandra | CQL (no JOIN/subquery/HAVING) | `SELECT * FROM keyspace.table` |
 | Redis, Valkey | command tokens | `GET user:1`, `SET user:1 value` |
-| MongoDB | mongosh chain, or a JSON envelope | `db.users.find({ age: { $gt: 20 } }).limit(5)`<br>`{"collection":"users","op":"find","body":{}}` |
+| MongoDB | mongosh chain | `db.users.find({ age: { $gt: 20 } }).limit(5)`<br>`use('shop')`<br>`db.getCollection('fs.files').find({}).sort({ _id: -1 })` |
 
 More detail (including MongoDB's supported methods/modifiers) is on the
 [docs page](https://rdb.suiflex.dev/docs).

--- a/website/src/pages/docs.astro
+++ b/website/src/pages/docs.astro
@@ -24,7 +24,7 @@ const guides = [
 
 const querySyntax = [
   {
-    engines: "PostgreSQL, MySQL, SQLite, SQL Server, ClickHouse",
+    engines: "PostgreSQL, MySQL, MariaDB, SQLite, SQL Server, Oracle, ClickHouse",
     language: "SQL",
     examples: ["SELECT * FROM users WHERE active = true"],
   },
@@ -35,16 +35,46 @@ const querySyntax = [
     note: "No JOIN, subquery, or HAVING: CQL is a narrower dialect than SQL.",
   },
   {
-    engines: "Redis",
+    engines: "Redis, Valkey",
     language: "command tokens",
     examples: ["GET user:1", "SET user:1 value", "HGETALL user:1"],
   },
   {
     engines: "MongoDB",
-    language: "mongosh chain, or a JSON envelope",
+    language: "mongosh chain",
     examples: [
       "db.users.find({ age: { $gt: 20 } }).limit(5)",
-      '{"collection":"users","op":"find","body":{}}',
+      "use('shop')\ndb.orders.find({ status: 'open' }).sort({ _id: -1 })",
+    ],
+    note: "Opening a collection writes this same form into the editor, so what you browse is a query you can edit.",
+  },
+];
+
+// What the Mongo query tab actually accepts. Kept next to the syntax table
+// because the README points here for it.
+const mongoSupport = [
+  {
+    title: "Methods",
+    items: [
+      "find({ ... })",
+      "aggregate([ ... ])",
+      "insertOne({ ... })",
+    ],
+  },
+  {
+    title: "Chain modifiers",
+    items: [
+      ".limit(n)",
+      ".skip(n)",
+      ".sort({ field: 1 | -1 })",
+    ],
+  },
+  {
+    title: "Addressing",
+    items: [
+      "use('database')",
+      "db.collection",
+      "db.getCollection('fs.files')",
     ],
   },
 ];
@@ -108,6 +138,43 @@ const querySyntax = [
           ))
         }
       </div>
+    </div>
+  </section>
+
+  <section class="border-t border-line bg-panel" aria-label="MongoDB support">
+    <div class="mx-auto max-w-4xl px-4 py-14 sm:px-6">
+      <h2 class="font-display text-2xl font-semibold tracking-tight">What the MongoDB tab accepts</h2>
+      <p class="mt-3 max-w-xl text-sm leading-relaxed text-fg-2">
+        Query bodies are read as JSON5, so unquoted keys and single-quoted
+        strings work exactly as they do in mongosh. Modifiers may appear in any
+        order and apply to <code class="font-mono text-[13px]">find</code>;
+        an aggregation carries its own paging as pipeline stages.
+      </p>
+      <div class="mt-6 grid gap-4 sm:grid-cols-3">
+        {
+          mongoSupport.map((group) => (
+            <div class="rounded-xl border border-line bg-bg px-4 py-4">
+              <span class="block text-sm font-medium">{group.title}</span>
+              <ul class="mt-3 space-y-2">
+                {group.items.map((item) => (
+                  <li class="rounded-lg border border-line bg-code px-3 py-2 font-mono text-[13px] text-fg-2">
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))
+        }
+      </div>
+      <p class="mt-5 max-w-xl text-xs leading-relaxed text-fg-3">
+        Not yet parsed: <code class="font-mono">ObjectId(...)</code> and the
+        write and read helpers beyond the three above
+        (<code class="font-mono">findOne</code>,
+        <code class="font-mono">updateMany</code>,
+        <code class="font-mono">deleteOne</code> and friends). Autocomplete
+        offers some of these ahead of the parser, so they will complete and then
+        fail to run.
+      </p>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary

- Follow-up to #264. Opening a collection now prefills mongosh syntax, so the docs that still advertised the JSON envelope pointed readers at a form the app no longer produces.
- Fills in the MongoDB methods and modifiers the README already promised were on the docs page.

## Changes

- `README.md` / `website/src/pages/docs.astro` — the MongoDB row drops the JSON envelope and shows the form the app writes, including `use('db')` and `getCollection(...)`. Nothing generates an envelope any more; it survives only as a parser fallback for tabs saved in the old shape.
- `website/src/pages/docs.astro` — new "What the MongoDB tab accepts" section: supported methods, chain modifiers, collection addressing, the JSON5 body rules, and the helpers that autocomplete offers but the parser rejects.
- `website/src/pages/docs.astro` — two stale engine lists corrected: the SQL row was missing MariaDB and Oracle, the command-token row was missing Valkey.
- `CLAUDE.md` — mock mode always takes the seeded query list, so seeding `saved_queries.json` to drive the screenshot harness does nothing; reaching another buffer needs an `RDB_SCREEN` branch. Project engine list raised from six to the eleven that ship.

## Test plan

- [x] `npm run build` in `website/` completes clean
- [x] Rendered `dist/docs/index.html` checked: new section present, engine rows correct, no envelope example left anywhere on the page
- [x] `npm/README.md` reviewed — it carries no query-syntax table, so it needed no change
- [ ] Read the deployed docs page once Cloudflare Pages picks up the merge