### PR TITLE
ci: apply area labels as suiflex-bot

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -16,9 +16,10 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize]
 
+# The app token below carries the write, so the job's own token only ever
+# reads.
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   label:
@@ -26,8 +27,18 @@ jobs:
     if: github.repository_owner == 'suiflex'
     runs-on: ubuntu-latest
     steps:
+      # Label as suiflex-bot rather than github-actions, so every label on a
+      # pull request comes from the same identity as the ones pr-triage.yml
+      # applies. Same app credentials that workflow passes to the shared
+      # organization job.
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.SUIFLEX_BOT_APP_ID }}
+          private-key: ${{ secrets.SUIFLEX_BOT_PRIVATE_KEY }}
       - uses: actions/labeler@v5
         with:
+          repo-token: ${{ steps.app-token.outputs.token }}
           configuration-path: .github/labeler.yml
           # Drop a label again once a force-push stops touching that area,
           # so the row keeps describing the diff as it stands.


### PR DESCRIPTION
## Summary

- Area labels arrived from `github-actions[bot]` while the triage workflow's labels arrived from `suiflex-bot[bot]`, so one pull request showed two identities doing the same job.
- The labeler itself works: #265 correctly picked up `area: website` and `area: docs`. Only the identity was wrong.

## Changes

- `.github/workflows/pr-labeler.yml` mints the suiflex-bot app token (the same `SUIFLEX_BOT_APP_ID` / `SUIFLEX_BOT_PRIVATE_KEY` credentials `pr-triage.yml` passes to the shared organization workflow) and hands it to the labeler as `repo-token`.
- The job's own `permissions` drop to `contents: read`, since the app token now carries the write.
- Still `pull_request_target` with no checkout — unchanged, and still deliberate.
- The 17 `area: *` label descriptions gained the `· suiflex-bot` suffix the other bot-applied labels use. That suffix was deliberately left off when they were created, because it would have been a false attribution while the default token was applying them.

## Test plan

- [x] YAML parses
- [x] Verified the mismatch on the merged PRs: `gh api repos/suiflex/rdb/issues/265/events` shows `github-actions[bot]` for the two `area:` labels and `suiflex-bot[bot]` for `commit: docs` and `maintainer`
- [x] Label descriptions updated and read back via `gh label list`
- [ ] Confirm on the next pull request after this merges that `area:` labels come from `suiflex-bot[bot]`. This PR itself is still labelled by the old workflow, so it cannot show the fix.