### PR TITLE
docs: correct two stale comments in the Mongo path

### DIFF
--- a/app/src/editor/mongo.rs
+++ b/app/src/editor/mongo.rs
@@ -1,4 +1,4 @@
-//! mongosh method words for the editor lexer. `lex_line` uppercases every
+//! mongosh method words and chain modifiers for the editor lexer. `lex_line` uppercases every
 //! identifier before matching (shared across all four dialects), so these
 //! stay uppercase even though real mongosh calls are lowercase/camelCase.
 

--- a/crates/driver-mongo/src/driver.rs
+++ b/crates/driver-mongo/src/driver.rs
@@ -401,6 +401,8 @@ impl Driver for MongoDriver {
         Ok(vec!["_id".to_string()])
     }
 
+    /// Whole-collection count: the browse footer's total and its page bounds
+    /// therefore describe the collection, not the filter the grid is showing.
     async fn count(&self, table: &TableRef) -> Result<u64> {
         let db = table.database.as_deref().unwrap_or(&self.default_db);
         self.client


### PR DESCRIPTION
## Summary

- Doubles as the smoke test for #266: this pull request touches `app/` and `crates/driver-mongo/`, so it should pick up `area: app` and `area: driver-mongo` — and those labels should now come from `suiflex-bot`, not `github-actions`.
- The two comment changes are real but minor; close this without merging if the label check is all you wanted.

## Changes

- `app/src/editor/mongo.rs` — the lexer word list holds chain modifiers now, not only methods.
- `crates/driver-mongo/src/driver.rs` — mark `count` as whole-collection where it is defined, since that is why a filtered browse still reports the collection's total in the footer.

## Test plan

- [x] `make fmt-check`
- [ ] `area: app` and `area: driver-mongo` appear on this pull request
- [ ] `gh api repos/suiflex/rdb/issues/<n>/events` shows `suiflex-bot[bot]` as the actor for both