### PR TITLE
ci: stop the area labeler racing and removing labels

### DIFF
--- a/.github/workflows/suiflex.yml
+++ b/.github/workflows/suiflex.yml
@@ -40,6 +40,12 @@ jobs:
   label:
     # Forks of this repository have their own labels, if any.
     if: github.repository_owner == 'suiflex'
+    # Not for ordering's sake — actions/labeler writes with issues.setLabels,
+    # a PUT of the whole label set built from a snapshot read when the job
+    # starts. Run in parallel and that snapshot predates the labels triage
+    # just applied, so the PUT drops them until the next push puts them back.
+    # Waiting costs half a minute and makes the two jobs stop racing.
+    needs: triage
     runs-on: ubuntu-latest
     # The app token below carries the write, so this job's own token only reads.
     permissions:
@@ -56,6 +62,9 @@ jobs:
         with:
           repo-token: ${{ steps.app-token.outputs.token }}
           configuration-path: .github/labeler.yml
-          # Drop a label again once a force-push stops touching that area,
-          # so the row keeps describing the diff as it stands.
-          sync-labels: true
+          # This job only ever adds. Removing is the one thing a PUT-based
+          # writer cannot be trusted with here: a label it decides to drop is
+          # indistinguishable from one someone applied by hand a second ago.
+          # An 'area:' label left over from a reverted change is cheaper than
+          # silently losing a real one.
+          sync-labels: false


### PR DESCRIPTION
## Summary

- The `label` job can silently wipe the labels the `triage` job just applied. `actions/labeler` writes with `issues.setLabels` — a PUT of the whole label set, built from a snapshot read when the job starts. Running the two jobs in parallel means that snapshot predates triage's labels, so whichever finishes last wins and `commit: *` / `maintainer` disappear until the next push restores them.
- `sync-labels: true` makes the same PUT responsible for removals, which is the one thing a writer working from a stale snapshot should not be trusted with.
- Found while porting this workflow to `suiflex/suitest` (suiflex/suitest#139); the same fix is applied there.

## Changes

- **`.github/workflows/suiflex.yml`** — the `label` job now declares `needs: triage`, so its snapshot is read after triage has finished writing. Costs about half a minute of latency.
- **`.github/workflows/suiflex.yml`** — `sync-labels: false`. The labeler only adds now. An `area:` label left behind by a reverted change is cheaper than losing a label someone applied by hand a second earlier.

## Test plan

- [x] `yaml.safe_load` parses the workflow; `jobs.label.needs == "triage"` and `sync-labels == false`
- [x] Behaviour traced to `actions/labeler` v5 `src/labeler.ts:43-61` (`allLabels` seeded from `preexistingLabels`, written back via `api.setLabels`)
- [ ] On this pull request, the `area: ci` label and the `commit: ci` / `maintainer` labels are all present together once both jobs have finished
- [ ] A later push that stops touching an area leaves its label in place (expected, and the reason for the trade-off above)
