### PR TITLE
ci: label pull requests with CLA signing status

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -16,7 +16,20 @@ jobs:
   cla:
     runs-on: ubuntu-latest
     steps:
+      # Labels below are applied with these credentials rather than
+      # GITHUB_TOKEN, so every label on a pull request arrives from
+      # suiflex-bot — the same identity used by suiflex.yml — instead of
+      # splitting the row between two bots. The CLA step itself keeps
+      # GITHUB_TOKEN: it pushes to the cla-signatures branch of this
+      # repository, which is this workflow's own token's job.
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.SUIFLEX_BOT_APP_ID }}
+          private-key: ${{ secrets.SUIFLEX_BOT_PRIVATE_KEY }}
+
       - name: CLA Assistant Lite
+        id: cla
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@v2.6.1
         env:
@@ -45,3 +58,37 @@ jobs:
           custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
           custom-allsigned-prcomment: All contributors have signed the CLA ✅
           lock-pullrequest-aftermerge: false
+
+      # A commit status cannot be filtered from the pull request list, so the
+      # signing state is mirrored onto a label as well:
+      #
+      #   gh label create 'cla: signed' --repo suiflex/rdb --force \
+      #     --color 4ade80 --description 'Contributor has signed the CLA · suiflex-bot'
+      #   gh label create 'cla: not signed' --repo suiflex/rdb --force \
+      #     --color bf8700 --description 'Contributor has not signed the CLA · suiflex-bot'
+      #
+      # Deliberately not in suiflex/.github's sync-labels.sh: that script runs
+      # across every repository in the organization, and only the repositories
+      # with a CLA — this one and suitest — have any use for these two.
+      #
+      # Gate on steps.cla.outcome, NOT on success()/failure(). A comment that is
+      # neither `recheck` nor the sign phrase skips the CLA step entirely, and
+      # success() is true for a skipped step — which would stamp an unsigned
+      # pull request as signed on any passing comment. `skipped` matches
+      # neither branch below, which is the point.
+      - name: Label the signing state
+        if: (steps.cla.outcome == 'success' || steps.cla.outcome == 'failure') && github.event.action != 'closed'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # pull_request_target populates pull_request, issue_comment populates
+          # issue; a pull request is an issue, so the number is the same one.
+          PR: ${{ github.event.pull_request.number || github.event.issue.number }}
+          SIGNED: ${{ steps.cla.outcome == 'success' }}
+        run: |
+          if [ "$SIGNED" = "true" ]; then
+            add='cla: signed'; remove='cla: not signed'
+          else
+            add='cla: not signed'; remove='cla: signed'
+          fi
+          gh pr edit "$PR" --repo "$GITHUB_REPOSITORY" \
+            --add-label "$add" --remove-label "$remove"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,8 @@ Before your first pull request can be merged, you must sign our
 [Contributor License Agreement](CLA.md). It is a one-time step: when you open
 your first PR, the CLA bot comments with instructions and you sign by replying
 with a single comment on the PR. Your signature is recorded on the
-`cla-signatures` branch and covers all future contributions.
+`cla-signatures` branch and covers all future contributions. The PR carries a
+`cla: signed` or `cla: not signed` label showing where it stands.
 
 The CLA keeps the project's licensing flexible (see [CLA.md](CLA.md) § 4)
 while guaranteeing your contributions always remain available under the


### PR DESCRIPTION
## Summary

- The CLA gate is a commit status, and a commit status cannot be filtered from
  the pull request list — there was no way to ask which open pull requests are
  blocked on an unsigned CLA.
- Every other signal on a pull request in this repository is already a label
  (`area: *`, `commit: *`, `needs: conventional commit`), so the signing state
  becomes one too.
- Mirrors suiflex/suitest#142, which does the same thing there. The two
  `cla.yml` files stay structurally identical.

## Changes

**`.github/workflows/cla.yml`** — purely additive; no existing line changed, and
none of the CLA action's inputs are touched (the `develop` document URL, the
`cla-signatures` branch and the maintainers-only allowlist all stay as they are,
along with the comments explaining each).

- Adds an `actions/create-github-app-token@v2` step, so labels arrive from
  `suiflex-bot` rather than `github-actions` and a pull request's labels all
  come from one identity, matching `suiflex.yml`. The CLA step keeps
  `GITHUB_TOKEN`: pushing to `cla-signatures` is that token's job.
- Gives the CLA step `id: cla`.
- Adds one label step that keys off `steps.cla.outcome`, not `success()`. A
  comment that is neither `recheck` nor the sign phrase skips the CLA step
  entirely, and `success()` is true for a skipped step, which would have stamped
  an unsigned pull request as signed on any passing comment. `skipped` matches
  neither branch. Also skipped on `closed`, which would only churn labels on a
  merged pull request.

**`CONTRIBUTING.md`** — one sentence in the CLA section, so a contributor who
sees the new label finds it explained where the flow is described.

**Labels** — created on `suiflex/rdb`, and recorded as a comment in `cla.yml`
next to the step that uses them.

| label | color | rationale |
|---|---|---|
| `cla: signed` | `4ade80` | brand green, the good state |
| `cla: not signed` | `bf8700` | amber, matching `needs: conventional commit` — the family for a label that asks someone to do something |

Deliberately not added to `suiflex/.github`'s `sync-labels.sh`: that script runs
across every repository in the organization, and only the two repositories with
a CLA have any use for these. Worth revisiting if a third gains one.

## Test plan

- [x] `.github/workflows/cla.yml` parses; all three steps resolve
- [x] `shellcheck` clean on the `run` block
- [x] both labels exist on `suiflex/rdb` with the colors above
- [ ] **Unsigned path** — a pull request from an account not in
      `signatures/version1/cla.json` and not in the allowlist: job red, CLA
      comment posted, `cla: not signed` applied by `suiflex-bot`
- [ ] **Signing transition** — the sign comment on that pull request:
      `cla: not signed` removed, `cla: signed` added, job green
- [ ] **Skip path** — an unrelated comment on the same pull request: CLA step
      skipped, labels unchanged
- [ ] **Already-signed path** — a pull request from an existing signer:
      `cla: signed` on the first run, no comment
- [ ] `gh pr list --label 'cla: not signed'` returns the blocked pull requests
