### PR TITLE
fix(app): correct the query editor caret grid, auto-pair and copy

### DIFF
--- a/app/src/editor.rs
+++ b/app/src/editor.rs
@@ -194,6 +194,10 @@ pub struct EditorState {
     redo_stack: Vec<Snap>,
     /// Last undo push came from plain typing — coalesce the next one.
     typing: bool,
+    /// Cursor position parked between a pair this editor auto-closed itself.
+    /// Backspace only unwraps both halves at that exact spot, so a quote the
+    /// user typed next to another one loses a single character like any other.
+    auto_pair: Option<(usize, usize)>,
 }
 
 const UNDO_CAP: usize = 200;
@@ -427,6 +431,32 @@ impl EditorState {
         self.push_undo(one_char && self.sel.is_none());
         self.remove_selection();
         self.insert_raw(&s);
+    }
+
+    /// Insert `open` with its closer and park the cursor between them, arming
+    /// the one-keystroke unwrap in `backspace_pair`.
+    pub fn insert_pair(&mut self, open: char, closer: char) {
+        self.insert(&format!("{open}{closer}"));
+        self.move_cursor(0, -1);
+        self.auto_pair = Some((self.line, self.col));
+    }
+
+    /// Read and clear the armed auto-close position. The caller takes it once
+    /// per keystroke, so any key other than `insert_pair` disarms the unwrap.
+    pub fn take_pair(&mut self) -> Option<(usize, usize)> {
+        self.auto_pair.take()
+    }
+
+    /// Backspace that removes both halves of a pair, but only the one this
+    /// editor auto-closed and that the cursor has not left since. `armed` is
+    /// the value `take_pair` returned at the start of this keystroke.
+    pub fn backspace_pair(&mut self, armed: Option<(usize, usize)>) -> bool {
+        let unwrap = armed == Some((self.line, self.col)) && self.sel.is_none();
+        self.backspace();
+        if unwrap {
+            self.delete();
+        }
+        unwrap
     }
 
     fn insert_raw(&mut self, s: &str) {
@@ -1154,6 +1184,39 @@ mod tests {
     fn regions(text: &str) -> Vec<(usize, usize)> {
         let lines: Vec<String> = text.lines().map(str::to_string).collect();
         fold_regions(&lines)
+    }
+
+    #[test]
+    fn backspace_unwraps_only_the_pair_the_editor_closed() {
+        // Auto-closed and never left: one keystroke takes both halves.
+        let mut ed = EditorState::from_text("select ");
+        ed.insert_pair('(', ')');
+        assert_eq!(ed.text(), "select ()");
+        let armed = ed.take_pair();
+        assert!(ed.backspace_pair(armed));
+        assert_eq!(ed.text(), "select ");
+
+        // A quote the user typed next to an existing one is not a pair the
+        // editor owns, so backspace takes a single character.
+        let mut ed = EditorState::from_text("select ''");
+        assert!(!ed.backspace_pair(None));
+        assert_eq!(ed.text(), "select '");
+
+        // Armed, but the cursor moved away: still a plain backspace.
+        let mut ed = EditorState::from_text("select ");
+        ed.insert_pair('"', '"');
+        let armed = ed.take_pair();
+        ed.move_cursor(0, 1);
+        assert!(!ed.backspace_pair(armed));
+        assert_eq!(ed.text(), "select \"");
+
+        // Typing inside the pair disarms it: the closer survives.
+        let mut ed = EditorState::from_text("");
+        ed.insert_pair('(', ')');
+        let armed = ed.take_pair();
+        ed.insert("a");
+        assert!(!ed.backspace_pair(armed));
+        assert_eq!(ed.text(), "()");
     }
 
     #[test]

--- a/app/src/editor.rs
+++ b/app/src/editor.rs
@@ -451,7 +451,23 @@ impl EditorState {
     /// editor auto-closed and that the cursor has not left since. `armed` is
     /// the value `take_pair` returned at the start of this keystroke.
     pub fn backspace_pair(&mut self, armed: Option<(usize, usize)>) -> bool {
-        let unwrap = armed == Some((self.line, self.col)) && self.sel.is_none();
+        // The arm alone is not enough: the ⌘ combos return before the caller
+        // gets to take it, so it can still be set after an undo or a paste.
+        // Require the pair to actually be there too.
+        let l = &self.lines[self.line];
+        let around = (
+            self.col.checked_sub(1).and_then(|c| l.chars().nth(c)),
+            l.chars().nth(self.col),
+        );
+        let is_pair = matches!(
+            around,
+            (Some('('), Some(')'))
+                | (Some('['), Some(']'))
+                | (Some('{'), Some('}'))
+                | (Some('"'), Some('"'))
+                | (Some('\''), Some('\''))
+        );
+        let unwrap = is_pair && armed == Some((self.line, self.col)) && self.sel.is_none();
         self.backspace();
         if unwrap {
             self.delete();
@@ -1209,6 +1225,12 @@ mod tests {
         ed.move_cursor(0, 1);
         assert!(!ed.backspace_pair(armed));
         assert_eq!(ed.text(), "select \"");
+
+        // A stale arm from a ⌘ combo that skipped `take_pair` cannot unwrap
+        // text that is no longer a pair.
+        let mut ed = EditorState::from_text("ab");
+        assert!(!ed.backspace_pair(Some((0, 2))));
+        assert_eq!(ed.text(), "a");
 
         // Typing inside the pair disarms it: the closer survives.
         let mut ed = EditorState::from_text("");

--- a/app/src/export.rs
+++ b/app/src/export.rs
@@ -149,6 +149,17 @@ fn tsv(g: &GridModel, header_row: bool) -> String {
     out
 }
 
+/// Clipboard flavour of a TSV: the same text without the trailing newline a
+/// text file wants. Copying a single cell out of the result grid otherwise
+/// put the value plus an Enter on the clipboard, so pasting it into the query
+/// editor opened a new line.
+pub fn for_clipboard(mut s: String) -> String {
+    if s.ends_with('\n') {
+        s.pop();
+    }
+    s
+}
+
 /// JSON array of row objects (`[{ "col": "val", "nullcol": null }]`). Built
 /// through `serde_json` so escaping is correct.
 pub fn to_json(g: &GridModel) -> String {
@@ -260,6 +271,14 @@ mod tests {
     #[test]
     fn tsv_body_drops_the_header() {
         assert_eq!(to_tsv_body(&grid()), "1\ta,\"b\" \n");
+    }
+
+    #[test]
+    fn clipboard_tsv_drops_only_the_final_newline() {
+        assert_eq!(for_clipboard(to_tsv_body(&grid())), "1\ta,\"b\" ");
+        // An empty trailing row is still a row: only one newline comes off.
+        assert_eq!(for_clipboard("a\n\n".to_string()), "a\n");
+        assert_eq!(for_clipboard(String::new()), "");
     }
 
     #[test]

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -393,7 +393,7 @@ callback create-table-commit();
     in-out property <bool> results-collapsed: false;
     callback editor-key(string, bool, bool, bool) -> bool;
     callback editor-press(int, int, bool);
-    callback editor-drag(int, int);
+    callback editor-drag(int, int, int);
     callback editor-select-word(int, int);
     // find-in-editor (⌘F)
     in property <bool> find-open;
@@ -580,7 +580,7 @@ callback create-table-commit();
     callback p1-toggle-fold(int);
     callback p1-editor-key(string, bool, bool, bool) -> bool;
     callback p1-editor-press(int, int, bool);
-    callback p1-editor-drag(int, int);
+    callback p1-editor-drag(int, int, int);
     callback p1-editor-select-word(int, int);
     in property <int> p1-pending-count;
     callback p1-commit-edits();
@@ -1817,7 +1817,7 @@ callback create-table-commit();
                         p1-toggle-fold(l) => { root.p1-toggle-fold(l); }
                         p1-editor-key(t, cmd, alt, shift) => { root.p1-editor-key(t, cmd, alt, shift) }
                         p1-editor-press(l, c, sh) => { root.p1-editor-press(l, c, sh); }
-                        p1-editor-drag(l, c) => { root.p1-editor-drag(l, c); }
+                        p1-editor-drag(l, r, c) => { root.p1-editor-drag(l, r, c); }
                         p1-editor-select-word(l, c) => { root.p1-editor-select-word(l, c); }
                         p1-completion-choose(i) => { root.p1-completion-choose(i); }
                         p1-select-result-tab(i) => { root.p1-select-result-tab(i); }
@@ -1913,7 +1913,7 @@ callback create-table-commit();
                         index-rows: root.index-rows;
                         editor-key(t, cmd, alt, shift) => { root.editor-key(t, cmd, alt, shift) }
                         editor-press(l, c, sh) => { root.editor-press(l, c, sh); }
-                        editor-drag(l, c) => { root.editor-drag(l, c); }
+                        editor-drag(l, r, c) => { root.editor-drag(l, r, c); }
                         editor-select-word(l, c) => { root.editor-select-word(l, c); }
                         find-open: root.find-open;
                         find-text <=> root.find-text;

--- a/app/src/ui/code-editor.slint
+++ b/app/src/ui/code-editor.slint
@@ -51,8 +51,14 @@ export component CodeEditor inherits Rectangle {
 
     property <length> line-h: 21px;
     property <length> gutter-w: 40px;
-    // IBM Plex Mono advance width, measured from a hidden probe.
-    property <length> charw: probe.preferred-width / 10;
+    // IBM Plex Mono advance width: 600/1000 em, read straight from the hmtx
+    // table of the font vendored in assets/fonts. Taken from the font metric
+    // rather than measured off a hidden Text probe because `preferred-width`
+    // is not a reliable multiple of the advance at every size -- at
+    // font-base 14px it reports 85.05px for ten characters that render in
+    // 84.0px, and that 0.1px per character piles up until the caret sits
+    // whole characters away from the glyph it belongs to on a long line.
+    property <length> charw: Tokens.font-md * 0.6;
 
     background: Tokens.canvas;
 
@@ -84,13 +90,6 @@ export component CodeEditor inherits Rectangle {
             edit-scroll.visible-width - Tokens.sp2
                 - (root.gutter-w + Tokens.sp3 + root.cursor-col * root.charw)
                 - 2 * root.charw);
-    }
-
-    probe := Text {
-        text: "0000000000";
-        font-family: Tokens.mono;
-        font-size: Tokens.font-md;
-        visible: false;
     }
 
     focus-scope := FocusScope {

--- a/app/src/ui/code-editor.slint
+++ b/app/src/ui/code-editor.slint
@@ -36,7 +36,10 @@ export component CodeEditor inherits Rectangle {
     // Mouse: press places the caret, drag extends the selection, double-click
     // selects the word. All carry (line, col) hit-tested from the pointer.
     callback press-pos(int, int, bool);
-    callback drag-pos(int, int);
+    // (pressed line, rows travelled on screen, column) — the row delta stays
+    // separate because folded lines draw at zero height, so the host has to
+    // skip them to turn it back into a buffer line.
+    callback drag-pos(int, int, int);
     callback select-word(int, int);
     // SQL autocomplete popup, anchored under the caret
     in property <[PaletteItem]> completion-items;
@@ -127,8 +130,10 @@ export component CodeEditor inherits Rectangle {
                     // delta so a drag can cross lines while still grabbed here.
                     property <int> hit-col:
                         max(0, round((line-ta.mouse-x - root.gutter-w - Tokens.sp3) / root.charw));
-                    property <int> hit-line:
-                        clamp(li + floor(line-ta.mouse-y / root.line-h), 0, root.lines.length - 1);
+                    // Rows the pointer has travelled from this one, signed. A
+                    // press is always inside its own row, so only a drag ever
+                    // sees anything but 0.
+                    property <int> hit-rows: floor(line-ta.mouse-y / root.line-h);
 
                     line-ta := TouchArea {
                         // Sub-pixel jitter between the two taps of a double-click
@@ -143,18 +148,18 @@ export component CodeEditor inherits Rectangle {
                                 focus-scope.focus();
                                 self.press-x = self.mouse-x;
                                 self.press-y = self.mouse-y;
-                                root.press-pos(parent.hit-line, parent.hit-col, e.modifiers.shift);
+                                root.press-pos(li, parent.hit-col, e.modifiers.shift);
                             }
                         }
                         moved => {
                             if (self.pressed
                                 && (abs(self.mouse-x - self.press-x) > 3px
                                     || abs(self.mouse-y - self.press-y) > 3px)) {
-                                root.drag-pos(parent.hit-line, parent.hit-col);
+                                root.drag-pos(li, parent.hit-rows, parent.hit-col);
                             }
                         }
                         double-clicked => {
-                            root.select-word(parent.hit-line, parent.hit-col);
+                            root.select-word(li, parent.hit-col);
                         }
                     }
 

--- a/app/src/ui/query-pane.slint
+++ b/app/src/ui/query-pane.slint
@@ -75,7 +75,7 @@ export component QueryPane inherits Rectangle {
     callback toggle-fold(int);
     callback editor-key(string, bool, bool, bool) -> bool;
     callback editor-press(int, int, bool);
-    callback editor-drag(int, int);
+    callback editor-drag(int, int, int);
     callback editor-select-word(int, int);
 
     // ----- autocomplete -----
@@ -605,7 +605,7 @@ export component QueryPane inherits Rectangle {
                     completion-choose(i) => { root.completion-choose(i); }
                     edit-key(t, cmd, alt, shift) => { root.editor-key(t, cmd, alt, shift) }
                     press-pos(l, c, sh) => { root.editor-press(l, c, sh); }
-                    drag-pos(l, c) => { root.editor-drag(l, c); }
+                    drag-pos(l, r, c) => { root.editor-drag(l, r, c); }
                     select-word(l, c) => { root.editor-select-word(l, c); }
                 }
                 Rectangle { height: 1px; background: Tokens.border; }

--- a/app/src/ui/workarea.slint
+++ b/app/src/ui/workarea.slint
@@ -110,7 +110,7 @@ export component WorkArea inherits Rectangle {
     callback close-result-tab(int);
     callback editor-key(string, bool, bool, bool) -> bool;
     callback editor-press(int, int, bool);
-    callback editor-drag(int, int);
+    callback editor-drag(int, int, int);
     callback editor-select-word(int, int);
     in property <bool> find-open;
     in-out property <string> find-text;
@@ -255,7 +255,7 @@ export component WorkArea inherits Rectangle {
     callback p1-toggle-fold(int);
     callback p1-editor-key(string, bool, bool, bool) -> bool;
     callback p1-editor-press(int, int, bool);
-    callback p1-editor-drag(int, int);
+    callback p1-editor-drag(int, int, int);
     callback p1-editor-select-word(int, int);
     callback p1-completion-choose(int);
     callback p1-select-result-tab(int);
@@ -470,7 +470,7 @@ export component WorkArea inherits Rectangle {
             toggle-fold(l) => { root.toggle-fold(l); }
             editor-key(t, cmd, alt, shift) => { root.editor-key(t, cmd, alt, shift) }
             editor-press(l, c, sh) => { root.editor-press(l, c, sh); }
-            editor-drag(l, c) => { root.editor-drag(l, c); }
+            editor-drag(l, r, c) => { root.editor-drag(l, r, c); }
             editor-select-word(l, c) => { root.editor-select-word(l, c); }
             completion-items: root.completion-items;
             completion-visible: root.completion-visible;
@@ -624,7 +624,7 @@ export component WorkArea inherits Rectangle {
                 toggle-fold(l) => { root.p1-toggle-fold(l); }
                 editor-key(t, cmd, alt, shift) => { root.p1-editor-key(t, cmd, alt, shift) }
                 editor-press(l, c, sh) => { root.p1-editor-press(l, c, sh); }
-                editor-drag(l, c) => { root.p1-editor-drag(l, c); }
+                editor-drag(l, r, c) => { root.p1-editor-drag(l, r, c); }
                 editor-select-word(l, c) => { root.p1-editor-select-word(l, c); }
                 completion-items: root.p1-completion-items;
                 completion-visible: root.p1-completion-visible;

--- a/app/src/wire/editor.rs
+++ b/app/src/wire/editor.rs
@@ -87,10 +87,20 @@ pub(crate) fn ui_spans(spans: Vec<editor::Span>, error_line: bool) -> Vec<Span> 
             let cols = sp.text.chars().count() as i32;
             let start = col;
             col += cols;
+            // A tab has no glyph in IBM Plex Mono and draws as a tofu box. It
+            // already sits in exactly one grid cell, so swapping it for a
+            // space on the way to the renderer keeps every column where it is
+            // and only changes what is painted — the buffer, and the text
+            // handed to the driver, keep the tab the user pasted.
+            let text = if sp.text.contains('\t') {
+                sp.text.replace('\t', " ")
+            } else {
+                sp.text
+            };
             Span {
                 col: start,
                 cols,
-                text: sp.text.into(),
+                text: text.into(),
                 kind: sp.kind,
                 sel: sp.sel,
             }
@@ -815,4 +825,19 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) -> (PaneFn, PaneTextFn
     }
 
     (sync_editor, load_editor_text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tabs_are_painted_as_spaces_without_moving_columns() {
+        let spans = editor::lex_line(rdb_connstore::QueryLanguage::Sql, "select\ta");
+        let ui = ui_spans(spans, false);
+        let joined: String = ui.iter().map(|s| s.text.as_str()).collect();
+        assert_eq!(joined, "select a");
+        // Each span still starts where it did: a tab is one cell, not eight.
+        assert_eq!(ui.last().map(|s| s.col + s.cols), Some(8));
+    }
 }

--- a/app/src/wire/editor.rs
+++ b/app/src/wire/editor.rs
@@ -108,6 +108,40 @@ pub(crate) fn ui_spans(spans: Vec<editor::Span>, error_line: bool) -> Vec<Span> 
         .collect()
 }
 
+/// Body lines collapsed under a closed fold head — the rows the editor draws
+/// at zero height.
+fn hidden_lines(lines: &[String], folded: &HashSet<usize>) -> Vec<bool> {
+    let mut hidden = vec![false; lines.len()];
+    for (head, end) in editor::fold_regions(lines) {
+        if folded.contains(&head) {
+            for h in hidden.iter_mut().take(end + 1).skip(head + 1) {
+                *h = true;
+            }
+        }
+    }
+    hidden
+}
+
+/// Buffer line `rows` *visible* rows away from `from`. A drag is hit-tested in
+/// screen rows, but a selection is addressed in buffer lines, and a line
+/// collapsed under a closed fold occupies no row — counting buffer lines
+/// instead landed the drag inside the folded block.
+fn line_after_rows(hidden: &[bool], from: usize, rows: i32) -> usize {
+    let step: isize = if rows < 0 { -1 } else { 1 };
+    let mut at = from as isize;
+    for _ in 0..rows.unsigned_abs() {
+        let mut next = at + step;
+        while next >= 0 && (next as usize) < hidden.len() && hidden[next as usize] {
+            next += step;
+        }
+        if next < 0 || next as usize >= hidden.len() {
+            break;
+        }
+        at = next;
+    }
+    at as usize
+}
+
 pub(crate) fn wire(window: &MainWindow, state: &AppState) -> (PaneFn, PaneTextFn) {
     let AppState {
         panes,
@@ -168,18 +202,12 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) -> (PaneFn, PaneTextFn
             // `hidden` blanks out the body lines of a closed region; nested
             // closed regions just union their ranges.
             let n = ed.lines.len();
-            let mut hidden = vec![false; n];
             let mut fold_state = vec![0i32; n];
             let folded = folded_heads.borrow();
-            for (h, e) in editor::fold_regions(&ed.lines) {
-                let closed = folded.contains(&h);
-                fold_state[h] = if closed { 2 } else { 1 };
-                if closed {
-                    for hl in hidden.iter_mut().take(e + 1).skip(h + 1) {
-                        *hl = true;
-                    }
-                }
+            for (h, _) in editor::fold_regions(&ed.lines) {
+                fold_state[h] = if folded.contains(&h) { 2 } else { 1 };
             }
+            let hidden = hidden_lines(&ed.lines, &folded);
             let cursor_visual_row = hidden
                 .iter()
                 .take(ed.line)
@@ -794,17 +822,27 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) -> (PaneFn, PaneTextFn
     {
         let panes = panes.clone();
         let sync_editor = sync_editor.clone();
-        let drag: Rc<dyn Fn(usize, i32, i32)> = Rc::new(move |pane, line, col| {
-            panes[pane].ed_state.borrow_mut().move_to(line, col, true);
+        // `rows` is how many rows *on screen* the pointer has travelled from
+        // the line it was pressed on, so folded lines have to be skipped to
+        // turn it back into a buffer line.
+        let drag: Rc<dyn Fn(usize, i32, i32, i32)> = Rc::new(move |pane, line, rows, col| {
+            let ed_state = panes[pane].ed_state.clone();
+            let line = {
+                let ed = ed_state.borrow();
+                let hidden = hidden_lines(&ed.lines, &panes[pane].folded_heads.borrow());
+                let from = (line.max(0) as usize).min(hidden.len().saturating_sub(1));
+                line_after_rows(&hidden, from, rows) as i32
+            };
+            ed_state.borrow_mut().move_to(line, col, true);
             sync_editor(pane);
         });
         window.on_editor_drag({
             let drag = drag.clone();
-            move |line, col| drag(0, line, col)
+            move |line, rows, col| drag(0, line, rows, col)
         });
         window.on_p1_editor_drag({
             let drag = drag.clone();
-            move |line, col| drag(1, line, col)
+            move |line, rows, col| drag(1, line, rows, col)
         });
     }
     {
@@ -830,6 +868,32 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) -> (PaneFn, PaneTextFn
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn drag_rows_skip_the_lines_a_closed_fold_collapsed() {
+        // select / a, / b are one region: folding line 0 hides lines 1 and 2,
+        // so the rows on screen read select, from, t.
+        let lines: Vec<String> = "select\n  a,\n  b\nfrom\n  t"
+            .split('\n')
+            .map(str::to_string)
+            .collect();
+        let folded: HashSet<usize> = [0].into_iter().collect();
+        let hidden = hidden_lines(&lines, &folded);
+        assert_eq!(hidden, vec![false, true, true, false, false]);
+
+        // One row down from `select` is `from` (line 3), not `  a,` (line 1).
+        assert_eq!(line_after_rows(&hidden, 0, 1), 3);
+        assert_eq!(line_after_rows(&hidden, 0, 2), 4);
+        // Past the end clamps to the last visible line.
+        assert_eq!(line_after_rows(&hidden, 0, 9), 4);
+        // Upwards, and standing still.
+        assert_eq!(line_after_rows(&hidden, 4, -2), 0);
+        assert_eq!(line_after_rows(&hidden, 3, 0), 3);
+
+        // Nothing folded: rows and buffer lines agree again.
+        let hidden = hidden_lines(&lines, &HashSet::new());
+        assert_eq!(line_after_rows(&hidden, 0, 2), 2);
+    }
 
     #[test]
     fn tabs_are_painted_as_spaces_without_moving_columns() {

--- a/app/src/wire/editor.rs
+++ b/app/src/wire/editor.rs
@@ -616,6 +616,9 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) -> (PaneFn, PaneTextFn
                     ) {
                         ed.set_selecting(shift);
                     }
+                    // Taken once per keystroke: anything that is not another
+                    // auto-close disarms the pair unwrap below.
+                    let armed_pair = ed.take_pair();
                     let mut it = text.chars();
                     let handled = match (it.next(), it.next()) {
                         (Some(c), None) => match c {
@@ -627,26 +630,13 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) -> (PaneFn, PaneTextFn
                                 true
                             }
                             '\u{8}' => {
-                                // Delete both sides of an empty pair in one
-                                // keystroke, mirroring the auto-close below.
-                                let before = ed
-                                    .col
-                                    .checked_sub(1)
-                                    .and_then(|c| ed.lines[ed.line].chars().nth(c));
-                                let after = ed.lines[ed.line].chars().nth(ed.col);
-                                let is_empty_pair = ed.selection().is_none()
-                                    && matches!(
-                                        (before, after),
-                                        (Some('('), Some(')'))
-                                            | (Some('['), Some(']'))
-                                            | (Some('{'), Some('}'))
-                                            | (Some('"'), Some('"'))
-                                            | (Some('\''), Some('\''))
-                                    );
-                                ed.backspace();
-                                if is_empty_pair {
-                                    ed.delete();
-                                }
+                                // Unwrap an empty pair in one keystroke, but
+                                // only the one auto-closed below and only
+                                // while the cursor still sits inside it.
+                                // Matching on the surrounding characters alone
+                                // ate both quotes of an `''` the user typed
+                                // themselves.
+                                ed.backspace_pair(armed_pair);
                                 true
                             }
                             '\u{7f}' => {
@@ -707,8 +697,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) -> (PaneFn, PaneTextFn
                                     '{' => '}',
                                     other => other, // quotes close themselves
                                 };
-                                ed.insert(&format!("{c}{closer}"));
-                                ed.move_cursor(0, -1);
+                                ed.insert_pair(c, closer);
                                 true
                             }
                             c if !c.is_control() => {

--- a/app/src/wire/split_pane.rs
+++ b/app/src/wire/split_pane.rs
@@ -73,10 +73,10 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) {
             // belongs to a whole-grid copy, not to a couple of cells pasted
             // into a spreadsheet.
             let block = selected_block(&w, 0, &grid, all);
-            let text = match block {
+            let text = export::for_clipboard(match block {
                 Some(r) => export::to_tsv_body(&sliced_grid(&grid, r)),
                 None => export::to_tsv(&grid),
-            };
+            });
             use copypasta::ClipboardProvider;
             let msg =
                 match copypasta::ClipboardContext::new().and_then(|mut cb| cb.set_contents(text)) {
@@ -576,10 +576,10 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) {
                 return;
             };
             let block = selected_block(&w, 1, &grid, all);
-            let text = match block {
+            let text = export::for_clipboard(match block {
                 Some(r) => export::to_tsv_body(&sliced_grid(&grid, r)),
                 None => export::to_tsv(&grid),
-            };
+            });
             use copypasta::ClipboardProvider;
             let msg =
                 match copypasta::ClipboardContext::new().and_then(|mut cb| cb.set_contents(text)) {


### PR DESCRIPTION
## Summary

- The query editor's character grid took its cell width from a hidden `Text` probe, and `preferred-width` is not a reliable multiple of the glyph advance at every font size. At font-base 14px it reports 85.05px for ten characters the renderer draws in 84.0px, so the 0.1px error accumulated until the caret sat whole characters away from the glyph it belonged to — typing and deleting landed mid-word on a long statement.
- Backspace decided to unwrap a pair from the two characters around the cursor, so a `''` the user typed themselves lost both quotes.
- Copying a cell out of the result grid put the value plus a newline on the clipboard, so pasting it into the editor opened a new line.

## Changes

**Caret grid** (`app/src/ui/code-editor.slint`)
- Read the advance from the vendored font's own metric (IBM Plex Mono, 600/1000 em) instead of measuring a probe; the probe element is gone.

**Auto-pair** (`app/src/editor.rs`, `app/src/wire/editor.rs`)
- `EditorState` tracks where it parked the cursor when it auto-closed a pair; `backspace_pair` unwraps only at that spot, and only while the pair is still there. The arm is taken once per keystroke, so anything else disarms it.
- Tabs are painted as spaces on the way to the renderer — the font has no tab glyph and drew a tofu box. The buffer and the text handed to the driver keep the pasted tab.

**Drag across a fold** (`app/src/wire/editor.rs`, four `.slint` files)
- A drag was hit-tested as the pressed line plus `mouse-y / line-h`, treating a screen row as a buffer line; a line collapsed under a closed fold draws at zero height, so a drag crossing one landed inside the hidden lines. The row delta now travels to the host separately and is walked over the visible lines there. Press and double-click pass their own row directly.

**Clipboard** (`app/src/export.rs`, `app/src/wire/split_pane.rs`)
- Strip the final newline on the two clipboard paths; the `.tsv` file export keeps it.

## Test plan

- [x] Caret drift measured off screenshots of a 400-character ruler line at every font size in the 10–18 clamp. Worst case went from **4.8 characters** off at column 400 (font-base 14) to **0.11**.
- [x] Reported symptom reproduced and resolved: an identical 119-character statement renders a two-cell gap before `::json` before the change and flush after it.
- [x] `make test` — 19 suites, 475 passed, 0 failed.
- [x] `make lint` (`clippy --all-targets -D warnings`) and `make fmt-check` clean.
- [x] Runtime smoke: editor spans, gutter and fold triangles render correctly after the `sync_editor` refactor.
- [x] Manual pass in `make fe-run`.