### PR TITLE
feat(website): add Google Analytics 4 tracking

### DIFF
--- a/website/src/layouts/Base.astro
+++ b/website/src/layouts/Base.astro
@@ -45,6 +45,16 @@ const ogImageUrl = new URL(ogImage ?? url("/og.png"), Astro.site);
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImageUrl} />
 
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-9YDEWDFM5X"></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-9YDEWDFM5X');
+    </script>
+
     <slot name="head" />
   </head>
   <body class="bg-ink text-fg antialiased">


### PR DESCRIPTION
## Summary

- The marketing site had no analytics, so traffic and install-path interest were invisible.
- Tag lives in the shared `Base` layout, so every page is covered without per-page wiring.

## Changes

- `website/src/layouts/Base.astro` — GA4 gtag snippet (`G-9YDEWDFM5X`) in `<head>`, marked `is:inline` so Astro leaves the snippet untouched.

## Test plan

- [x] Snippet renders in `<head>` on every page (single shared layout)
- [ ] `npm run build` in `website/` passes
- [ ] After deploy, GA4 Realtime shows a hit