### PR TITLE
ci: credit contributors in release notes and changelog

### DIFF
--- a/.github/scripts/attribute_changelog.py
+++ b/.github/scripts/attribute_changelog.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Add contributor attribution to the newest release block of CHANGELOG.md.
+
+Runs right after fold_changelog.py in the release-please workflow, on the
+pending release branch. It rewrites only the topmost
+`## <product>: [x.y.z]` block:
+
+  * each bullet gains ` (@handle)` after the subject (before the commit
+    link), resolved from the commit's GitHub author. Commits authored by a
+    maintainer are left untouched so that work reads as plain maintainer
+    work.
+  * a `### Thanks` section lists every non-maintainer contributor in the
+    block (returning contributors included).
+  * a `### New Contributors` section welcomes anyone whose commit email is
+    not present in git history before the previous release tag.
+
+Re-runnable: a block that already carries a `### Thanks` section is returned
+unchanged. fold_changelog.py rebuilds the block from scratch on every run, so
+in the workflow this always re-derives the attribution from a clean block.
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+MAINTAINERS = {"mulhamna", "badrus123"}
+
+HEADING = "# Changelog"
+_HEAD_RE = re.compile(r"^## (?:.+?: )?\[([^\]]+)\]\(([^)]*)\)")
+_PREVTAG_RE = re.compile(r"/compare/(.+?)\.\.\.")
+_BULLET_RE = re.compile(
+    r"^(\* (?:\*\*[^:*]+:\*\* )?)(.*?)( \(\[[0-9a-f]+\]\([^)]*\)\))\s*$"
+)
+_SHA_RE = re.compile(r"\[([0-9a-f]+)\]")
+
+
+def _split_top_block(text):
+    """Return (before, top_block, after) splitting on `## ` release headings.
+
+    `before` keeps the `# Changelog` title and any preamble; `top_block` is
+    the newest release section; `after` is every older section.
+    """
+    parts = re.split(r"^(?=## )", text, flags=re.MULTILINE)
+    head = parts[0] if parts and not parts[0].startswith("## ") else ""
+    sections = parts[1:] if head else parts
+    if not sections:
+        return text, "", ""
+    return head, sections[0], "".join(sections[1:])
+
+
+def gh_author(sha):
+    """(login, name, email) for a commit sha, via `gh api`. All may be None.
+
+    ponytail: one gh api call per bullet, cached by sha. A release is a
+    handful of commits; batch via the GraphQL API if that ever stops being
+    true.
+    """
+    repo = os.environ.get("GITHUB_REPOSITORY", "suiflex/rdb")
+    proc = subprocess.run(
+        [
+            "gh", "api", f"repos/{repo}/commits/{sha}",
+            "--jq", "[.author.login, .commit.author.name, .commit.author.email]"
+            " | @tsv",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        return (None, None, None)
+    cols = (proc.stdout.rstrip("\n").split("\t") + ["", "", ""])[:3]
+    return tuple(c or None for c in cols)
+
+
+def prev_emails(prevtag):
+    """Author emails in git history up to and including `prevtag`."""
+    if not prevtag:
+        return set()
+    proc = subprocess.run(
+        ["git", "log", prevtag, "--format=%ae"],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        return set()
+    return {line.strip() for line in proc.stdout.splitlines() if line.strip()}
+
+
+def _token(login, name):
+    """Display token for a contributor: `@login` when known, else the name."""
+    if login:
+        return f"@{login}"
+    return name or "an unknown contributor"
+
+
+def attribute(text, resolve=gh_author, history=prev_emails, product="RDB"):
+    before, block, after = _split_top_block(text)
+    if not block:
+        return text
+    if "### Thanks" in block or "### New Contributors" in block:
+        return text  # already attributed this run
+
+    lines = block.splitlines()
+    head_match = _HEAD_RE.match(lines[0])
+    if not head_match:
+        return text
+    prevtag_match = _PREVTAG_RE.search(head_match.group(2))
+    prevtag = prevtag_match.group(1) if prevtag_match else None
+
+    cache = {}
+    contributors = []  # ordered, de-duped display tokens (non-maintainers)
+    seen_tokens = set()
+    release_emails = {}  # email -> display token, non-maintainers only
+
+    out_lines = []
+    for line in lines:
+        m = _BULLET_RE.match(line)
+        if not m:
+            out_lines.append(line)
+            continue
+        prefix, subject, link = m.group(1), m.group(2), m.group(3)
+        sha = _SHA_RE.search(link).group(1)
+        if sha not in cache:
+            cache[sha] = resolve(sha)
+        login, name, email = cache[sha]
+
+        is_maintainer = bool(login) and login.lower() in MAINTAINERS
+        if is_maintainer:
+            out_lines.append(line)
+            continue
+
+        token = _token(login, name)
+        out_lines.append(f"{prefix}{subject} ({token}){link}")
+        if token not in seen_tokens:
+            seen_tokens.add(token)
+            contributors.append(token)
+        if email:
+            release_emails.setdefault(email, token)
+
+    if not contributors:
+        return text  # nothing to credit (maintainer-only release)
+
+    known = history(prevtag)
+    newcomers = [
+        token
+        for email, token in release_emails.items()
+        if email not in known
+    ]
+
+    block = "\n".join(out_lines).rstrip("\n")
+    block += "\n\n\n### Thanks\n\n"
+    block += "Thanks to everyone who contributed to this release:\n\n"
+    block += "\n".join(f"* {t}" for t in contributors) + "\n"
+    if prevtag and newcomers:
+        block += "\n\n### New Contributors\n\n"
+        block += "\n".join(
+            f"* {t} made their first contribution" for t in newcomers
+        ) + "\n"
+
+    rebuilt = before + block.rstrip("\n")
+    if after:
+        rebuilt += "\n\n" + after
+    return rebuilt.rstrip("\n") + "\n"
+
+
+def main():
+    dst = sys.argv[1] if len(sys.argv) > 1 else "CHANGELOG.md"
+    product = os.environ.get("PRODUCT_NAME", "RDB")
+    if not os.path.exists(dst):
+        print(f"{dst} not present; nothing to attribute")
+        return
+    with open(dst, encoding="utf-8") as fh:
+        text = fh.read()
+    out = attribute(text, product=product)
+    if out == text:
+        print("no attribution changes")
+        return
+    with open(dst, "w", encoding="utf-8") as fh:
+        fh.write(out)
+    print(f"attributed contributors in {dst}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/attribute_changelog.py
+++ b/.github/scripts/attribute_changelog.py
@@ -60,11 +60,11 @@ def gh_author(sha):
     proc = subprocess.run(
         [
             "gh", "api", f"repos/{repo}/commits/{sha}",
-            "--jq", "[.author.login, .commit.author.name, .commit.author.email]"
-            " | @tsv",
+            "--jq", "[.author.login, .commit.author.name, .commit.author.email] | @tsv",
         ],
         capture_output=True,
         text=True,
+        check=False,
     )
     if proc.returncode != 0:
         return (None, None, None)
@@ -80,6 +80,7 @@ def prev_emails(prevtag):
         ["git", "log", prevtag, "--format=%ae"],
         capture_output=True,
         text=True,
+        check=False,
     )
     if proc.returncode != 0:
         return set()

--- a/.github/scripts/attribute_changelog.py
+++ b/.github/scripts/attribute_changelog.py
@@ -26,8 +26,6 @@ import sys
 
 MAINTAINERS = {"mulhamna", "badrus123"}
 
-HEADING = "# Changelog"
-_HEAD_RE = re.compile(r"^## (?:.+?: )?\[([^\]]+)\]\(([^)]*)\)")
 _PREVTAG_RE = re.compile(r"/compare/(.+?)\.\.\.")
 _BULLET_RE = re.compile(
     r"^(\* (?:\*\*[^:*]+:\*\* )?)(.*?)( \(\[[0-9a-f]+\]\([^)]*\)\))\s*$"
@@ -102,7 +100,10 @@ def attribute(text, resolve=gh_author, history=prev_emails, product="RDB"):
         return text  # already attributed this run
 
     lines = block.splitlines()
-    head_match = _HEAD_RE.match(lines[0])
+    head_re = re.compile(
+        r"^## " + re.escape(product) + r": \[([^\]]+)\]\(([^)]*)\)"
+    )
+    head_match = head_re.match(lines[0])
     if not head_match:
         return text
     prevtag_match = _PREVTAG_RE.search(head_match.group(2))

--- a/.github/scripts/test_attribute_changelog.py
+++ b/.github/scripts/test_attribute_changelog.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Self-check for attribute_changelog.py. Run: python3 test_attribute_changelog.py"""
+
+from attribute_changelog import attribute
+
+# sha -> (login, name, email)
+AUTHORS = {
+    "aaa": ("ekacahya21", "Eka Cahya", "eka@example.com"),
+    "bbb": ("wahyuakbarwibowo", "Wahyu Akbar", "wahyu@example.com"),
+    "ccc": ("mulhamna", "Mulham", "mulham@example.com"),
+    "ddd": (None, "Anon Person", "anon@example.com"),
+    "eee": ("ekacahya21", "Eka Cahya", "eka@example.com"),
+}
+
+ROOT = """# Changelog
+
+## RDB: [0.31.0](https://example.com/compare/v0.30.0...v0.31.0) (2026-08-03)
+
+
+### App Features
+
+* **app:** shiny new thing ([aaa](https://example.com/commit/aaaaaa))
+* **app:** another new thing ([eee](https://example.com/commit/eeeeee))
+
+
+### Bug Fixes
+
+* **app:** fix a thing ([bbb](https://example.com/commit/bbbbbb))
+* **ci:** a maintainer chore ([ccc](https://example.com/commit/cccccc))
+
+## RDB: [0.30.0](https://example.com/compare/v0.29.0...v0.30.0) (2026-08-01)
+
+
+### Bug Fixes
+
+* **app:** something old ([999](https://example.com/commit/999999))
+"""
+
+
+def _resolve(sha):
+    return AUTHORS[sha]
+
+
+def test_appends_handle_before_the_commit_link():
+    out = attribute(ROOT, resolve=_resolve, history=lambda t: {"eka@example.com", "wahyu@example.com"})
+    assert "* **app:** shiny new thing (@ekacahya21) ([aaa]" in out, out
+    assert "* **app:** fix a thing (@wahyuakbarwibowo) ([bbb]" in out, out
+
+
+def test_maintainer_commits_are_left_untouched():
+    out = attribute(ROOT, resolve=_resolve, history=lambda t: {"eka@example.com", "wahyu@example.com"})
+    assert "* **ci:** a maintainer chore ([ccc](https://example.com/commit/cccccc))" in out
+    assert "@mulhamna" not in out
+
+
+def test_thanks_section_lists_non_maintainers_deduped():
+    out = attribute(ROOT, resolve=_resolve, history=lambda t: {"eka@example.com", "wahyu@example.com"})
+    top = out.split("## RDB: [0.30.0]")[0]
+    assert "### Thanks" in top
+    assert top.count("* @ekacahya21\n") == 1, top
+    assert "* @wahyuakbarwibowo\n" in top
+
+
+def test_new_contributors_are_those_absent_from_history():
+    # only Eka is in prior history -> Wahyu and the login-less Anon are new
+    root = ROOT.replace(
+        "* **ci:** a maintainer chore ([ccc](https://example.com/commit/cccccc))",
+        "* **app:** anon fix ([ddd](https://example.com/commit/dddddd))",
+    )
+    out = attribute(root, resolve=_resolve, history=lambda t: {"eka@example.com"})
+    top = out.split("## RDB: [0.30.0]")[0]
+    assert "### New Contributors" in top
+    assert "* @wahyuakbarwibowo made their first contribution" in top
+    assert "* Anon Person made their first contribution" in top
+    assert "@ekacahya21 made their first contribution" not in top
+
+
+def test_older_blocks_are_untouched():
+    out = attribute(ROOT, resolve=_resolve, history=lambda t: set())
+    tail = out.split("## RDB: [0.30.0]")[1]
+    assert tail.strip() == (
+        "(https://example.com/compare/v0.29.0...v0.30.0) (2026-08-01)\n\n\n"
+        "### Bug Fixes\n\n"
+        "* **app:** something old ([999](https://example.com/commit/999999))"
+    )
+
+
+def test_is_idempotent():
+    once = attribute(ROOT, resolve=_resolve, history=lambda t: {"eka@example.com"})
+    twice = attribute(once, resolve=_resolve, history=lambda t: {"eka@example.com"})
+    assert once == twice
+
+
+def test_maintainer_only_release_gets_no_sections():
+    root = """# Changelog
+
+## RDB: [0.31.0](https://example.com/compare/v0.30.0...v0.31.0) (2026-08-03)
+
+
+### Bug Fixes
+
+* **ci:** a maintainer chore ([ccc](https://example.com/commit/cccccc))
+"""
+    out = attribute(root, resolve=_resolve, history=lambda t: set())
+    assert out == root
+    assert "### Thanks" not in out
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_"):
+            fn()
+            print(f"ok {name}")
+    print("all checks passed")

--- a/.github/scripts/test_attribute_changelog.py
+++ b/.github/scripts/test_attribute_changelog.py
@@ -107,8 +107,10 @@ def test_maintainer_only_release_gets_no_sections():
 
 
 if __name__ == "__main__":
-    for name, fn in sorted(globals().items()):
-        if name.startswith("test_"):
-            fn()
-            print(f"ok {name}")
+    cases = sorted(
+        (name, fn) for name, fn in globals().items() if name.startswith("test_")
+    )
+    for name, fn in cases:
+        fn()
+        print(f"ok {name}")
     print("all checks passed")

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -53,6 +53,32 @@ jobs:
           gh release edit "${{ steps.release.outputs.tag_name }}" \
             --title "RDB ${{ steps.release.outputs.tag_name }}"
 
+      # release-please builds the Release body from its own plain changelog
+      # notes. By the time a release is created the enriched block (per-line
+      # @handles + Thanks + New Contributors, added by the fold step below on
+      # each feature-PR merge) is already on develop, which this job has
+      # checked out. Replace the body with that block so the credited notes
+      # are what people see on the Release page. Skip if the block is missing
+      # or has no section yet, so a race can't wipe the notes.
+      - name: Use the credited changelog block as the Release body
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag_name }}
+        run: |
+          version="${TAG#v}"
+          awk -v h="## RDB: [$version](" '
+            index($0, h) == 1 { grab = 1; next }
+            grab && /^## / { exit }
+            grab { print }
+          ' CHANGELOG.md | sed '/./,$!d' > release-notes.md
+          if [ -s release-notes.md ] && grep -q '^### ' release-notes.md; then
+            gh release edit "$TAG" --notes-file release-notes.md
+          else
+            echo "no credited block for $version yet; leaving the body as-is"
+          fi
+          rm -f release-notes.md
+
       # We keep CHANGELOG.md at the repo root, but release-please resolves
       # `changelog-path` relative to its package dir and rejects `..`. The
       # package is rooted at the repo, so the config points it at
@@ -82,14 +108,19 @@ jobs:
             echo "no open release PR; nothing to fold"
             exit 0
           fi
-          # Copy the script out before switching branches: the release branch
+          # Copy the scripts out before switching branches: the release branch
           # is only rebuilt when release-please rewrites it, so it can carry an
-          # older copy of this script than the commit that triggered this run.
-          script=$(mktemp)
-          cp .github/scripts/fold_changelog.py "$script"
+          # older copy of these scripts than the commit that triggered this run.
+          # fold_changelog.py splices release-please's section into the root
+          # file; attribute_changelog.py then credits contributors in that
+          # newest block (per-line @handles, a Thanks list, New Contributors).
+          scripts=$(mktemp -d)
+          cp .github/scripts/fold_changelog.py \
+             .github/scripts/attribute_changelog.py "$scripts"/
           git fetch origin "$branch"
           git checkout "$branch"
-          python3 "$script"
+          python3 "$scripts/fold_changelog.py"
+          python3 "$scripts/attribute_changelog.py"
           rm -f app/CHANGELOG.md
           if git diff --quiet -- CHANGELOG.md app/CHANGELOG.md; then
             echo "CHANGELOG already folded into the root"
@@ -98,5 +129,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A CHANGELOG.md app/CHANGELOG.md
-          git commit -m "docs: fold changelog into the repo root"
+          git commit -m "docs: fold and attribute changelog"
           git push origin "$branch"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,6 +227,9 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/); the
 - One logical change per commit. Each commit should leave the tree in a
   buildable, testable state so `git revert` stays safe.
 - Do **not** hand-edit the `release-please`-managed sections of any changelog.
+  Each release also gets **Thanks** and **New Contributors** sections added
+  automatically from the commits it contains — those are generated too, so
+  don't edit them by hand either.
 
 Example release notes from commit headers:
 


### PR DESCRIPTION
## Summary

- Release notes and the changelog only ever named a commit's scope, subject and short SHA, so contributors were invisible in every release.
- Each release now credits the people in it: a `(@handle)` on every non-maintainer commit line, a **Thanks** list, and a **New Contributors** welcome for first-timers.
- Commits authored by a maintainer (`@mulhamna`, `@badrus123`) are left untouched and never listed, so maintainer work still reads as maintainer work.

## Changes

- **`.github/scripts/attribute_changelog.py`** (new) — post-processes the newest `## RDB: [x.y.z]` block of `CHANGELOG.md`:
  - resolves each bullet's GitHub author via `gh api repos/<repo>/commits/<sha>` (falls back to the commit author name when the email isn't linked to an account), and inserts the handle before the commit link.
  - appends `### Thanks` listing every non-maintainer contributor in the block (returning contributors included).
  - appends `### New Contributors` for anyone whose commit email is absent from git history before the previous release tag.
  - re-runnable: a block that already has the sections, or a maintainer-only release, is returned unchanged.
- **`.github/scripts/test_attribute_changelog.py`** (new) — 7 checks: handle insertion, maintainer exclusion, dedup, first-timer detection, older blocks untouched, idempotence, maintainer-only release.
- **`.github/workflows/release-please.yml`**
  - the "Fold CHANGELOG" step now runs `attribute_changelog.py` right after `fold_changelog.py` (both copied to a tmpdir first, as before); bot commit message is now `docs: fold and attribute changelog`.
  - new step: once a release is cut, replace the GitHub Release body with the credited changelog block (guarded — skips if the block or its sections aren't present yet, so a race can't blank the notes).
- **`CONTRIBUTING.md`** — one note that the Thanks / New Contributors sections are generated and must not be hand-edited.

No change needed on the website — `website/src/pages/changelog.astro` already parses the new format (handle sits before the SHA link; the two sections render as plain bullet lists).

## Test plan

- [x] `cd .github/scripts && python3 test_attribute_changelog.py` — 7/7
- [x] `cd .github/scripts && python3 test_fold_changelog.py` — 6/6 (unchanged, still green)
- [x] Dry-run `attribute_changelog.py` on a copy of `CHANGELOG.md` — older release blocks byte-identical (`diff` clean); current releases are maintainer-only so correctly produce no change
- [x] Synthetic end-to-end: maintainer line untouched and absent from both sections; returning contributor in Thanks only; login-less contributor rendered by name in both
- [x] `cd website && npm run build` — 9 pages, changelog page parses the enriched block
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-please.yml'))"`
- [ ] Real pipeline: verify on the next release PR merge that the folded commit carries the sections and the Release body picks them up
