### PR TITLE
feature(driver-oracle): replace ODPI-C with Oracle's oracledb driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1667,16 +1667,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
-dependencies = [
- "darling_core 0.13.4",
- "darling_macro 0.13.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
@@ -1697,20 +1687,6 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_core"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
@@ -1718,7 +1694,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.117",
 ]
 
@@ -1731,19 +1707,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 3.0.2",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
-dependencies = [
- "darling_core 0.13.4",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4725,7 +4690,7 @@ dependencies = [
  "sha2 0.11.0",
  "socket2",
  "stringprep",
- "strsim 0.11.1",
+ "strsim",
  "take_mut",
  "thiserror 2.0.20",
  "tokio",
@@ -5476,15 +5441,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "odpic-sys"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "920b5474a5128a9f0232df5a0ffc50aaa5b077b29b8b06ab0131985ac82793ed"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5560,30 +5516,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "oracle"
-version = "0.6.3"
+name = "oracledb"
+version = "26.0.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db40fe6e4df881b683691ade5ef1f7b1afd52aefa115581f7b92855524d7ec0"
+checksum = "7f9af8674256d8417b17b2e9e86a304cb637b881ffa9bc817d58b98c7b49457d"
 dependencies = [
- "cc",
+ "aes 0.9.1",
+ "base16ct",
+ "base64ct",
+ "cbc 0.2.1",
  "chrono",
- "odpic-sys",
- "once_cell",
- "oracle_procmacro",
- "paste",
- "rustversion",
-]
-
-[[package]]
-name = "oracle_procmacro"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad247f3421d57de56a0d0408d3249d4b1048a522be2013656d92f022c3d8af27"
-dependencies = [
- "darling 0.13.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "pbkdf2",
+ "pkcs8",
+ "rand 0.10.2",
+ "rustls 0.23.43",
+ "sha2 0.11.0",
+ "uuid",
+ "webpki-roots",
+ "whoami",
 ]
 
 [[package]]
@@ -6571,7 +6521,7 @@ dependencies = [
 
 [[package]]
 name = "rdb"
-version = "0.43.0"
+version = "0.44.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6704,7 +6654,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
- "oracle",
+ "oracledb",
  "rdb-core",
  "testcontainers",
  "tokio",
@@ -8361,12 +8311,6 @@ dependencies = [
  "unicode-normalization",
  "unicode-properties",
 ]
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"

--- a/README.md
+++ b/README.md
@@ -50,22 +50,8 @@ A native, lightweight, cross-platform database manager built with Rust and Slint
 | SQLite | `rusqlite` | Tabular |
 | Cassandra | `scylla` | Tabular |
 | SQL Server | `tiberius` | Tabular |
-| Oracle | `oracle` (ODPI-C) | Tabular |
+| Oracle | `oracledb` (Oracle's thin driver) | Tabular |
 | ClickHouse | `clickhouse` (HTTP) | Tabular |
-
-> **Oracle needs the Oracle Instant Client.** It is the one engine RDB cannot
-> reach with the binary alone: Oracle ships no public wire-protocol spec, so
-> the driver goes through Oracle's own client library, which is loaded at
-> runtime and is not redistributable. Install the **Basic** or **Basic Light**
-> package from [Oracle's Instant Client
-> downloads](https://www.oracle.com/database/technologies/instant-client/downloads.html)
-> and put it on the library path (`DYLD_LIBRARY_PATH` on macOS,
-> `LD_LIBRARY_PATH` on Linux, `PATH` on Windows). Nothing is needed to *build*
-> RDB — only to connect to Oracle — and every other engine stays dependency-free.
->
-> Known gap: Oracle 21c+ native `JSON` columns are not readable yet
-> ([rust-oracle#107](https://github.com/kubo/rust-oracle/issues/107)); read
-> them as `JSON_SERIALIZE(<col> RETURNING VARCHAR2)`.
 
 ## Design
 
@@ -280,7 +266,7 @@ Active development. Ships 11 engines (PostgreSQL, MySQL, MariaDB, Redis, Valkey,
 | `rdb-driver-sqlite` | SQLite driver via `rusqlite` |
 | `rdb-driver-cassandra` | Cassandra driver via `scylla` |
 | `rdb-driver-mssql` | SQL Server driver via `tiberius` |
-| `rdb-driver-oracle` | Oracle driver via `oracle` (ODPI-C) |
+| `rdb-driver-oracle` | Oracle driver via `oracledb` |
 | `rdb-driver-clickhouse` | ClickHouse driver via the `clickhouse` HTTP crate |
 
 ## License

--- a/crates/driver-oracle/Cargo.toml
+++ b/crates/driver-oracle/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 rdb-core = { path = "../core" }
 async-trait = "0.1"
 chrono = "0.4"
-oracle = { version = "0.6", features = ["chrono"] }
+oracledb = "26.0.0-beta.3"
 tokio = { version = "1", features = ["net", "rt-multi-thread", "macros", "time"] }
 
 [dev-dependencies]

--- a/crates/driver-oracle/src/convert.rs
+++ b/crates/driver-oracle/src/convert.rs
@@ -22,6 +22,8 @@
 
 use std::collections::HashMap;
 
+use chrono::{Datelike, NaiveDate, TimeDelta, Timelike};
+
 use oracledb::{
     DbType, FromDbValue, JsonValue, Metadata, OracleIntervalDS, OracleIntervalYM, OracleNumber,
     OracleTimestamp, Row, Vector, VectorData, DB_TYPE_BFILE, DB_TYPE_BINARY_DOUBLE,
@@ -170,26 +172,70 @@ fn number_cell(n: OracleNumber) -> Cell {
 /// `YYYY-MM-DD HH:MM:SS[.ffffff][ ±HH:MM]`, built from the components so the
 /// session's NLS settings cannot change it. Oracle's `DATE` carries a time
 /// component (unlike the SQL standard), so it is never rendered date-only.
+///
+/// **A zoned column's components arrive as UTC.** Oracle puts a
+/// `TIMESTAMP WITH TIME ZONE` on the wire as the UTC instant plus the zone
+/// offset it was written in, and `OracleTimestamp` reports both verbatim. So
+/// the offset has to be added back to recover the local time that was
+/// stored — printing the components beside the offset, as the crate's own
+/// `Display` does, states a time that never existed: a value written
+/// `09:05:01 +07:00` would read back as `02:05:01 +07:00`.
 fn format_timestamp(t: &OracleTimestamp, zoned: bool) -> String {
-    let mut s = format!(
-        "{:04}-{:02}-{:02} {:02}:{:02}:{:02}",
-        t.year(),
-        t.month(),
-        t.day(),
-        t.hour(),
-        t.minute(),
-        t.second()
-    );
+    let (h, m) = (t.tz_hour_offset(), t.tz_minute_offset());
+    let (y, mo, d, hh, mi, ss) = if zoned && (h != 0 || m != 0) {
+        match shift_to_zone(t, h, m) {
+            Some(parts) => parts,
+            // Only an out-of-range date reaches this, which the server cannot
+            // produce; showing UTC beats showing nothing.
+            None => raw_parts(t),
+        }
+    } else {
+        raw_parts(t)
+    };
+
+    let mut s = format!("{y:04}-{mo:02}-{d:02} {hh:02}:{mi:02}:{ss:02}");
     let micros = t.nanoseconds() / 1_000;
     if micros > 0 {
         s.push_str(&format!(".{micros:06}"));
     }
     if zoned {
-        let (h, m) = (t.tz_hour_offset(), t.tz_minute_offset());
         let sign = if h < 0 || m < 0 { '-' } else { '+' };
         s.push_str(&format!(" {sign}{:02}:{:02}", h.abs(), m.abs()));
     }
     s
+}
+
+fn raw_parts(t: &OracleTimestamp) -> (i32, u32, u32, u32, u32, u32) {
+    (
+        t.year() as i32,
+        t.month() as u32,
+        t.day() as u32,
+        t.hour() as u32,
+        t.minute() as u32,
+        t.second() as u32,
+    )
+}
+
+/// UTC components plus an offset, as local calendar parts. `chrono` does the
+/// arithmetic because the offset can roll the day, the month and the year, and
+/// getting February right by hand is not worth the lines.
+fn shift_to_zone(
+    t: &OracleTimestamp,
+    tz_hour: i8,
+    tz_minute: i8,
+) -> Option<(i32, u32, u32, u32, u32, u32)> {
+    let utc = NaiveDate::from_ymd_opt(t.year() as i32, t.month() as u32, t.day() as u32)?
+        .and_hms_opt(t.hour() as u32, t.minute() as u32, t.second() as u32)?;
+    let local =
+        utc.checked_add_signed(TimeDelta::minutes(tz_hour as i64 * 60 + tz_minute as i64))?;
+    Some((
+        local.year(),
+        local.month(),
+        local.day(),
+        local.hour(),
+        local.minute(),
+        local.second(),
+    ))
 }
 
 /// A `VECTOR` column holds hundreds or thousands of components; pasting them
@@ -409,11 +455,46 @@ mod tests {
     }
 
     #[test]
-    fn timestamp_with_zone_keeps_its_offset() {
-        let east = OracleTimestamp::new_timestamp_tz(2024, 3, 7, 9, 5, 1, 0, 7, 30);
-        assert_eq!(format_timestamp(&east, true), "2024-03-07 09:05:01 +07:30");
-        let west = OracleTimestamp::new_timestamp_tz(2024, 3, 7, 9, 5, 1, 0, -5, 0);
+    fn a_zoned_timestamp_shows_the_local_time_that_was_stored() {
+        // The components Oracle sends are UTC; 02:05:01Z at +07:00 is the
+        // 09:05:01 that was written. Rendering 02:05:01 beside "+07:00" would
+        // name a moment seven hours off.
+        let east = OracleTimestamp::new_timestamp_tz(2024, 3, 7, 2, 5, 1, 0, 7, 0);
+        assert_eq!(format_timestamp(&east, true), "2024-03-07 09:05:01 +07:00");
+        let india = OracleTimestamp::new_timestamp_tz(2024, 3, 7, 2, 5, 1, 0, 5, 30);
+        assert_eq!(format_timestamp(&india, true), "2024-03-07 07:35:01 +05:30");
+        let west = OracleTimestamp::new_timestamp_tz(2024, 3, 7, 14, 5, 1, 0, -5, 0);
         assert_eq!(format_timestamp(&west, true), "2024-03-07 09:05:01 -05:00");
+        let half_west = OracleTimestamp::new_timestamp_tz(2024, 3, 7, 14, 5, 1, 0, -5, -30);
+        assert_eq!(
+            format_timestamp(&half_west, true),
+            "2024-03-07 08:35:01 -05:30"
+        );
+    }
+
+    #[test]
+    fn an_offset_that_crosses_midnight_rolls_the_date() {
+        // 22:30Z at +07:00 is the next morning, and at the end of a month the
+        // month and year roll with it.
+        let next_day = OracleTimestamp::new_timestamp_tz(2024, 3, 7, 22, 30, 0, 0, 7, 0);
+        assert_eq!(
+            format_timestamp(&next_day, true),
+            "2024-03-08 05:30:00 +07:00"
+        );
+        let new_year = OracleTimestamp::new_timestamp_tz(2023, 12, 31, 20, 0, 0, 0, 7, 0);
+        assert_eq!(
+            format_timestamp(&new_year, true),
+            "2024-01-01 03:00:00 +07:00"
+        );
+        // Backwards over a leap day.
+        let leap = OracleTimestamp::new_timestamp_tz(2024, 3, 1, 2, 0, 0, 0, -5, 0);
+        assert_eq!(format_timestamp(&leap, true), "2024-02-29 21:00:00 -05:00");
+    }
+
+    #[test]
+    fn a_zoned_timestamp_already_at_utc_is_not_shifted() {
+        let utc = OracleTimestamp::new_timestamp_tz(2024, 3, 7, 9, 5, 1, 0, 0, 0);
+        assert_eq!(format_timestamp(&utc, true), "2024-03-07 09:05:01 +00:00");
     }
 
     #[test]

--- a/crates/driver-oracle/src/convert.rs
+++ b/crates/driver-oracle/src/convert.rs
@@ -115,19 +115,26 @@ pub fn cell_at(row: &Row, idx: usize, md: &Metadata) -> Cell {
     // BFILE points at a file on the database server's own disk, a REF CURSOR
     // is a nested result set, and an OBJECT is a user-defined type: each is a
     // separate feature rather than a value, so name it instead of showing a
-    // blank cell.
+    // blank cell — but an absent one is still absent.
+    //
+    // Measured note: `oracledb` currently refuses BFILE and object types (an
+    // XMLTYPE describes as one) before a row reaches this function, failing
+    // the whole statement — `driver::unsupported_type_hint` is what the user
+    // actually sees today. These arms are kept for the day it decodes them,
+    // and because a REF CURSOR can still arrive from PL/SQL.
     if ty == &DB_TYPE_BFILE {
-        return Cell::Text("[BFILE]".into());
+        return marker_or_null(row, idx, "[BFILE]");
     }
     if ty == &DB_TYPE_CURSOR {
-        return Cell::Text("[REF CURSOR]".into());
+        return marker_or_null(row, idx, "[REF CURSOR]");
     }
     if ty == &DB_TYPE_OBJECT {
-        return Cell::Text("[OBJECT]".into());
+        return marker_or_null(row, idx, "[OBJECT]");
     }
 
-    // XMLTYPE and anything upstream adds later: text is the likeliest shape,
-    // and a failed attempt still lands on a marker rather than a blank.
+    // Anything upstream adds later: text is the likeliest shape, and a failed
+    // attempt still lands on a marker rather than a blank. (XMLTYPE does not
+    // reach here — it describes as an object type and is refused earlier.)
     cell(row, idx, Cell::Text, "[unsupported type]")
 }
 
@@ -148,6 +155,19 @@ where
         Ok(None) => Cell::Null,
         Err(_) => Cell::Text(marker.to_string()),
     }
+}
+
+/// A column whose value is a handle rather than data: a file on the server, a
+/// nested result set, a user-defined type. There is nothing to render either
+/// way, but a NULL still has to read as NULL — labelling an empty cell
+/// `[BFILE]` claims a file is there.
+///
+/// `Option<String>` is what asks the question: `FromDbValue for Option<T>`
+/// answers `None` for a NULL before it ever tries `T`'s conversion, so the
+/// conversion failing (which it always does for these types) only ever means
+/// "present but not renderable".
+fn marker_or_null(row: &Row, idx: usize, marker: &str) -> Cell {
+    cell(row, idx, |_: String| Cell::Text(marker.to_string()), marker)
 }
 
 /// Oracle NUMBER carries up to 38 significant digits — wider than `i64` and
@@ -250,7 +270,9 @@ fn describe_vector(v: &Vector) -> String {
                 VectorData::Float32(x) => ("FLOAT32", x.len()),
                 VectorData::Float64(x) => ("FLOAT64", x.len()),
                 VectorData::Int8(x) => ("INT8", x.len()),
-                VectorData::Binary(x) => ("BINARY", x.len()),
+                // Packed: `VectorData::decode` stores one byte per eight
+                // dimensions, so the byte count is not the dimension count.
+                VectorData::Binary(x) => ("BINARY", x.len() * 8),
             };
             format!("[VECTOR {kind} · {n} dims]")
         }
@@ -280,7 +302,15 @@ fn write_json(v: &JsonValue, out: &mut String) {
         JsonValue::BinaryFloat(f) => out.push_str(&f.to_string()),
         JsonValue::BinaryDouble(f) => out.push_str(&f.to_string()),
         JsonValue::String(s) => write_json_string(s, out),
-        JsonValue::Timestamp(t) => write_json_string(&format_timestamp(t, true), out),
+        // `JsonValue::Timestamp` carries four OSON types — DATE, TIMESTAMP7,
+        // TIMESTAMP and TIMESTAMP_TZ — and only the last is zoned. Nothing
+        // distinguishes them afterwards except the offset itself, so a
+        // non-zero offset is the only honest signal; appending `+00:00` to
+        // every one of them would put a zone on values that never had one.
+        JsonValue::Timestamp(t) => {
+            let zoned = t.tz_hour_offset() != 0 || t.tz_minute_offset() != 0;
+            write_json_string(&format_timestamp(t, zoned), out)
+        }
         JsonValue::IntervalDS(i) => write_json_string(&i.to_string(), out),
         JsonValue::IntervalYM(i) => write_json_string(&i.to_string(), out),
         JsonValue::Vector(vec) => write_json_string(&describe_vector(vec), out),
@@ -390,11 +420,13 @@ pub fn column_type_name(md: &Metadata) -> String {
     simple_type_name(ty).to_string()
 }
 
-/// Oracle reports a timestamp's fractional-second digits in the scale field.
-/// A describe that omits it (scale 0 on a type that always has one) means the
-/// default, which is 6.
+/// Oracle reports a timestamp's fractional-second digits in the scale field,
+/// with the default already applied: a bare `TIMESTAMP` describes as scale 6,
+/// not as 0. So scale is used as given — `TIMESTAMP(0)` is a real declaration
+/// meaning no fractional seconds, and treating 0 as "unset" would rewrite it
+/// to `TIMESTAMP(6)` in the header.
 fn timestamp_precision(scale: i8) -> u8 {
-    if (1..=9).contains(&scale) {
+    if (0..=9).contains(&scale) {
         scale as u8
     } else {
         6
@@ -559,10 +591,37 @@ mod tests {
     }
 
     #[test]
-    fn a_timestamp_without_a_reported_precision_defaults_to_six() {
-        assert_eq!(timestamp_precision(0), 6);
-        assert_eq!(timestamp_precision(-127), 6);
+    fn a_declared_timestamp_precision_is_used_as_reported() {
+        // Measured against a live server: a bare TIMESTAMP describes as
+        // scale 6 and TIMESTAMP(0) as scale 0, so 0 is a declaration, not a
+        // gap. Reading it as "unset" turned every TIMESTAMP(0) into (6).
+        assert_eq!(timestamp_precision(0), 0);
         assert_eq!(timestamp_precision(3), 3);
+        assert_eq!(timestamp_precision(6), 6);
+        assert_eq!(timestamp_precision(9), 9);
+        // Only a value outside the legal range falls back.
+        assert_eq!(timestamp_precision(-127), 6);
+    }
+
+    #[test]
+    fn a_binary_vector_counts_dimensions_not_bytes() {
+        // Binary vectors are packed eight dimensions to the byte, so a
+        // 128-dimension vector arrives as 16 bytes.
+        let v = Vector::Dense(VectorData::Binary(vec![0; 16]));
+        assert_eq!(describe_vector(&v), "[VECTOR BINARY · 128 dims]");
+    }
+
+    #[test]
+    fn a_json_timestamp_without_an_offset_gets_no_zone() {
+        // JsonValue::Timestamp also carries OSON DATE and plain TIMESTAMP;
+        // stamping those "+00:00" would assert a zone they never had.
+        let plain = JsonValue::Timestamp(ts(2024, 3, 7, 9, 5, 1, 0));
+        assert_eq!(render_json(&plain), r#""2024-03-07 09:05:01""#);
+        // A zoned one still shifts and still shows its offset.
+        let zoned = JsonValue::Timestamp(OracleTimestamp::new_timestamp_tz(
+            2024, 3, 7, 2, 5, 1, 0, 7, 0,
+        ));
+        assert_eq!(render_json(&zoned), r#""2024-03-07 09:05:01 +07:00""#);
     }
 
     #[test]

--- a/crates/driver-oracle/src/convert.rs
+++ b/crates/driver-oracle/src/convert.rs
@@ -1,77 +1,158 @@
-//! `oracle::SqlValue` -> `rdb_core::Cell`.
+//! `oracledb::Row` column -> `rdb_core::Cell`.
 //!
 //! The rule this module exists to enforce: **nothing silently becomes
 //! `Cell::Null`.** The Postgres driver once dropped money/enum/timetz values
 //! to `Null` because no `FromSql` impl matched, and the grid showed blanks
-//! with no hint that a value was there. So every branch here either produces
-//! the real value or falls back through `get::<String>()` — Oracle can render
-//! nearly anything as text — and only a genuine SQL NULL yields `Cell::Null`.
+//! with no hint that a value was there. Only a genuine SQL NULL yields
+//! `Cell::Null`; a value this driver cannot decode yields a typed marker, so
+//! "empty" and "unreadable" never look the same.
+//!
+//! **Dispatch is on the column, not on the value.** `oracledb::Row` exposes
+//! only `get::<T>()` over `FromDbValue` — there is no dynamic value type in
+//! its public API (`DbValue` exists but its module is private), and `String`
+//! is *not* a universal fallback: its `FromDbValue` impl accepts only
+//! `VARCHAR`-family and `ROWID` data, so `get::<String>()` on a NUMBER is an
+//! error, not a rendering. Every branch below therefore asks
+//! `Metadata::db_type()` first and requests the one Rust type that column can
+//! actually produce.
 //!
 //! Dates and timestamps are formatted from their components rather than read
 //! as strings, because reading them as strings would hand back whatever
 //! `NLS_DATE_FORMAT` the session happens to carry.
 
-use oracle::sql_type::{OracleType, Timestamp};
-use oracle::SqlValue;
+use std::collections::HashMap;
+
+use oracledb::{
+    DbType, FromDbValue, JsonValue, Metadata, OracleIntervalDS, OracleIntervalYM, OracleNumber,
+    OracleTimestamp, Row, Vector, VectorData, DB_TYPE_BFILE, DB_TYPE_BINARY_DOUBLE,
+    DB_TYPE_BINARY_FLOAT, DB_TYPE_BINARY_INTEGER, DB_TYPE_BOOLEAN, DB_TYPE_CHAR, DB_TYPE_CLOB,
+    DB_TYPE_CURSOR, DB_TYPE_DATE, DB_TYPE_INTERVAL_DS, DB_TYPE_INTERVAL_YM, DB_TYPE_JSON,
+    DB_TYPE_LONG, DB_TYPE_LONG_NVARCHAR, DB_TYPE_LONG_RAW, DB_TYPE_NCHAR, DB_TYPE_NCLOB,
+    DB_TYPE_NUMBER, DB_TYPE_NVARCHAR, DB_TYPE_OBJECT, DB_TYPE_RAW, DB_TYPE_ROWID,
+    DB_TYPE_TIMESTAMP, DB_TYPE_TIMESTAMP_LTZ, DB_TYPE_TIMESTAMP_TZ, DB_TYPE_UROWID,
+    DB_TYPE_VARCHAR, DB_TYPE_VECTOR, DB_TYPE_XMLTYPE,
+};
 use rdb_core::result::Cell;
 
-pub fn sql_value_to_cell(v: &SqlValue) -> Cell {
-    if v.is_null().unwrap_or(false) {
-        return Cell::Null;
+/// One column of one row, as a `Cell`.
+pub fn cell_at(row: &Row, idx: usize, md: &Metadata) -> Cell {
+    let ty = md.db_type();
+
+    // The three broad classes Oracle itself groups, taken from `DbType`'s own
+    // predicates so a type added upstream lands in the right bucket without a
+    // change here. CLOB/NCLOB are string types and arrive as `String`: LOBs
+    // come back as values unless the statement asked for locators via
+    // `fetch_lobs()`, which this driver does not.
+    if ty.is_string_type() {
+        return cell(row, idx, Cell::Text, "[text]");
     }
-    let Ok(ty) = v.oracle_type() else {
-        return text_or_marker(v, "[unreadable]");
-    };
+    if ty.is_binary_type() {
+        return cell(row, idx, Cell::Bytes, "[binary]");
+    }
+    if ty.is_date_type() {
+        // Whether a zone is part of the value is a property of the column,
+        // not of the timestamp struct — `OracleTimestamp` carries an offset
+        // either way, and a plain TIMESTAMP's is a meaningless zero.
+        let zoned = ty == &DB_TYPE_TIMESTAMP_TZ || ty == &DB_TYPE_TIMESTAMP_LTZ;
+        return cell(
+            row,
+            idx,
+            |t: OracleTimestamp| Cell::Text(format_timestamp(&t, zoned)),
+            "[timestamp]",
+        );
+    }
 
-    match ty {
-        // Oracle NUMBER carries up to 38 significant digits — wider than i64
-        // and wider than f64 represents exactly — so narrowing is only safe
-        // when it round-trips. Otherwise the decimal text is the true value.
-        OracleType::Number(_, _) | OracleType::Float(_) => number_cell(v),
-        OracleType::Int64 => v
-            .get::<i64>()
-            .map(Cell::Int)
-            .unwrap_or_else(|_| number_cell(v)),
-        OracleType::UInt64 => number_cell(v),
-        OracleType::BinaryFloat | OracleType::BinaryDouble => v
-            .get::<f64>()
-            .map(Cell::Float)
-            .unwrap_or_else(|_| text_or_marker(v, "[binary float]")),
-        OracleType::Boolean => v
-            .get::<bool>()
-            .map(Cell::Bool)
-            .unwrap_or_else(|_| text_or_marker(v, "[boolean]")),
+    if ty == &DB_TYPE_NUMBER || ty == &DB_TYPE_BINARY_INTEGER {
+        return cell(row, idx, number_cell, "[number]");
+    }
+    if ty == &DB_TYPE_BINARY_FLOAT {
+        return cell(row, idx, |f: f32| Cell::Float(f as f64), "[binary float]");
+    }
+    if ty == &DB_TYPE_BINARY_DOUBLE {
+        return cell(row, idx, Cell::Float, "[binary double]");
+    }
+    if ty == &DB_TYPE_BOOLEAN {
+        return cell(row, idx, Cell::Bool, "[boolean]");
+    }
+    if ty == &DB_TYPE_INTERVAL_DS {
+        return cell(
+            row,
+            idx,
+            |v: OracleIntervalDS| Cell::Text(v.to_string()),
+            "[interval]",
+        );
+    }
+    if ty == &DB_TYPE_INTERVAL_YM {
+        return cell(
+            row,
+            idx,
+            |v: OracleIntervalYM| Cell::Text(v.to_string()),
+            "[interval]",
+        );
+    }
+    // Oracle 21c's native JSON type. The previous ODPI-C driver could not read
+    // this at all and had to tell users to wrap the column in
+    // `JSON_SERIALIZE`; here it decodes to a value.
+    if ty == &DB_TYPE_JSON {
+        return cell(
+            row,
+            idx,
+            |v: JsonValue| Cell::Text(render_json(&v)),
+            "[json]",
+        );
+    }
+    if ty == &DB_TYPE_VECTOR {
+        return cell(
+            row,
+            idx,
+            |v: Vector| Cell::Text(describe_vector(&v)),
+            "[vector]",
+        );
+    }
 
-        OracleType::Date
-        | OracleType::Timestamp(_)
-        | OracleType::TimestampTZ(_)
-        | OracleType::TimestampLTZ(_) => v
-            .get::<Timestamp>()
-            .map(|t| Cell::Text(format_timestamp(&t)))
-            .unwrap_or_else(|_| text_or_marker(v, "[timestamp]")),
+    // BFILE points at a file on the database server's own disk, a REF CURSOR
+    // is a nested result set, and an OBJECT is a user-defined type: each is a
+    // separate feature rather than a value, so name it instead of showing a
+    // blank cell.
+    if ty == &DB_TYPE_BFILE {
+        return Cell::Text("[BFILE]".into());
+    }
+    if ty == &DB_TYPE_CURSOR {
+        return Cell::Text("[REF CURSOR]".into());
+    }
+    if ty == &DB_TYPE_OBJECT {
+        return Cell::Text("[OBJECT]".into());
+    }
 
-        // BFILE points at a file on the database server's own disk; reading
-        // its contents is a separate feature, so it is named rather than
-        // shown as an empty cell.
-        OracleType::BFILE => Cell::Text("[BFILE]".into()),
-        OracleType::Raw(_) | OracleType::LongRaw | OracleType::BLOB => v
-            .get::<Vec<u8>>()
-            .map(Cell::Bytes)
-            .unwrap_or_else(|_| text_or_marker(v, "[binary]")),
+    // XMLTYPE and anything upstream adds later: text is the likeliest shape,
+    // and a failed attempt still lands on a marker rather than a blank.
+    cell(row, idx, Cell::Text, "[unsupported type]")
+}
 
-        OracleType::RefCursor => Cell::Text("[REF CURSOR]".into()),
-
-        // Everything textual, plus the types Oracle renders as text on its
-        // own: CLOB/NCLOB, XML, JSON, ROWID, both INTERVAL kinds, and object
-        // types / collections.
-        _ => text_or_marker(v, "[unsupported type]"),
+/// Read one column as `T` and map it, distinguishing the three outcomes that
+/// must never be confused: a real value, a SQL NULL, and a value that exists
+/// but could not be decoded.
+///
+/// `Option<T>` is what separates the last two — a bare `get::<T>()` reports a
+/// NULL as `ErrorKind::ValueWasNull`, which would land on the marker path and
+/// claim an empty column held something unreadable.
+fn cell<'a, T, F>(row: &'a Row, idx: usize, f: F, marker: &str) -> Cell
+where
+    T: FromDbValue<'a>,
+    F: FnOnce(T) -> Cell,
+{
+    match row.get::<Option<T>>(idx) {
+        Ok(Some(v)) => f(v),
+        Ok(None) => Cell::Null,
+        Err(_) => Cell::Text(marker.to_string()),
     }
 }
 
-fn number_cell(v: &SqlValue) -> Cell {
-    let Ok(s) = v.get::<String>() else {
-        return text_or_marker(v, "[number]");
-    };
+/// Oracle NUMBER carries up to 38 significant digits — wider than `i64` and
+/// wider than `f64` represents exactly — so narrowing is only safe when it
+/// round-trips. Otherwise the decimal text is the true value.
+fn number_cell(n: OracleNumber) -> Cell {
+    let s = n.to_string();
     if let Ok(i) = s.parse::<i64>() {
         return Cell::Int(i);
     }
@@ -86,20 +167,10 @@ fn number_cell(v: &SqlValue) -> Cell {
     Cell::Text(s)
 }
 
-/// Last resort before a blank: ask Oracle for the value as text, and only if
-/// even that fails show a typed marker. Never `Cell::Null` — that would claim
-/// the database holds no value here, which is a different fact.
-fn text_or_marker(v: &SqlValue, marker: &str) -> Cell {
-    match v.get::<String>() {
-        Ok(s) => Cell::Text(s),
-        Err(_) => Cell::Text(marker.to_string()),
-    }
-}
-
 /// `YYYY-MM-DD HH:MM:SS[.ffffff][ ±HH:MM]`, built from the components so the
 /// session's NLS settings cannot change it. Oracle's `DATE` carries a time
 /// component (unlike the SQL standard), so it is never rendered date-only.
-fn format_timestamp(t: &Timestamp) -> String {
+fn format_timestamp(t: &OracleTimestamp, zoned: bool) -> String {
     let mut s = format!(
         "{:04}-{:02}-{:02} {:02}:{:02}:{:02}",
         t.year(),
@@ -109,11 +180,11 @@ fn format_timestamp(t: &Timestamp) -> String {
         t.minute(),
         t.second()
     );
-    let micros = t.nanosecond() / 1_000;
+    let micros = t.nanoseconds() / 1_000;
     if micros > 0 {
         s.push_str(&format!(".{micros:06}"));
     }
-    if t.with_tz() {
+    if zoned {
         let (h, m) = (t.tz_hour_offset(), t.tz_minute_offset());
         let sign = if h < 0 || m < 0 { '-' } else { '+' };
         s.push_str(&format!(" {sign}{:02}:{:02}", h.abs(), m.abs()));
@@ -121,62 +192,210 @@ fn format_timestamp(t: &Timestamp) -> String {
     s
 }
 
+/// A `VECTOR` column holds hundreds or thousands of components; pasting them
+/// into a grid cell is noise, not data.
+///
+/// ponytail: shape and element type only. Render the components when there is
+/// somewhere to render them — a cell-detail pane — not in a table row.
+fn describe_vector(v: &Vector) -> String {
+    match v {
+        Vector::Dense(d) => {
+            let (kind, n) = match d {
+                VectorData::Float32(x) => ("FLOAT32", x.len()),
+                VectorData::Float64(x) => ("FLOAT64", x.len()),
+                VectorData::Int8(x) => ("INT8", x.len()),
+                VectorData::Binary(x) => ("BINARY", x.len()),
+            };
+            format!("[VECTOR {kind} · {n} dims]")
+        }
+        // `SparseVector`'s dimensions and indices have no public accessors, so
+        // there is nothing more to say about one from outside the crate.
+        Vector::Sparse(_) => "[SPARSE VECTOR]".to_string(),
+    }
+}
+
+/// `JsonValue` as JSON text.
+///
+/// The crate decodes Oracle's binary OSON into a value tree but does not
+/// render it, and it carries Oracle types (`OracleNumber`, `OracleTimestamp`)
+/// that JSON has no syntax for — those spell as their Oracle text, quoted,
+/// which is what the grid should show.
+fn render_json(v: &JsonValue) -> String {
+    let mut out = String::new();
+    write_json(v, &mut out);
+    out
+}
+
+fn write_json(v: &JsonValue, out: &mut String) {
+    match v {
+        JsonValue::Null => out.push_str("null"),
+        JsonValue::Boolean(b) => out.push_str(if *b { "true" } else { "false" }),
+        JsonValue::Number(n) => out.push_str(&n.to_string()),
+        JsonValue::BinaryFloat(f) => out.push_str(&f.to_string()),
+        JsonValue::BinaryDouble(f) => out.push_str(&f.to_string()),
+        JsonValue::String(s) => write_json_string(s, out),
+        JsonValue::Timestamp(t) => write_json_string(&format_timestamp(t, true), out),
+        JsonValue::IntervalDS(i) => write_json_string(&i.to_string(), out),
+        JsonValue::IntervalYM(i) => write_json_string(&i.to_string(), out),
+        JsonValue::Vector(vec) => write_json_string(&describe_vector(vec), out),
+        JsonValue::Raw(b) | JsonValue::JsonId(b) => {
+            let hex: String = b.iter().map(|x| format!("{x:02x}")).collect();
+            write_json_string(&hex, out);
+        }
+        JsonValue::JsonArray(items) => {
+            out.push('[');
+            for (i, item) in items.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                write_json(item, out);
+            }
+            out.push(']');
+        }
+        JsonValue::JsonObject(map) => write_json_object(map, out),
+    }
+}
+
+/// Oracle's OSON decodes into a `HashMap`, whose iteration order is arbitrary
+/// and would reshuffle a cell between two reads of the same row. Sorting the
+/// keys costs nothing at object sizes a grid cell holds and makes the output
+/// stable — and therefore diffable and testable.
+fn write_json_object(map: &HashMap<String, JsonValue>, out: &mut String) {
+    let mut keys: Vec<&String> = map.keys().collect();
+    keys.sort();
+    out.push('{');
+    for (i, k) in keys.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        write_json_string(k, out);
+        out.push(':');
+        write_json(&map[*k], out);
+    }
+    out.push('}');
+}
+
+fn write_json_string(s: &str, out: &mut String) {
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+}
+
 /// Human-readable type name for a result column header.
-pub fn column_type_name(t: &OracleType) -> String {
-    match t {
-        OracleType::Varchar2(n) => format!("VARCHAR2({n})"),
-        OracleType::NVarchar2(n) => format!("NVARCHAR2({n})"),
-        OracleType::Char(n) => format!("CHAR({n})"),
-        OracleType::NChar(n) => format!("NCHAR({n})"),
-        OracleType::Raw(n) => format!("RAW({n})"),
+///
+/// `DbType::name()` cannot be used here: it returns the Rust constant's name
+/// (`"DB_TYPE_VARCHAR"`), and the Oracle spelling it also holds (`ora_name`,
+/// `"VARCHAR2"`) is crate-private. So the mapping is kept here, and the size
+/// and precision come off `Metadata`.
+pub fn column_type_name(md: &Metadata) -> String {
+    let ty = md.db_type();
+    let (size, precision, scale) = (md.max_size(), md.precision(), md.scale());
+
+    if ty == &DB_TYPE_VARCHAR {
+        return format!("VARCHAR2({size})");
+    }
+    if ty == &DB_TYPE_NVARCHAR {
+        return format!("NVARCHAR2({size})");
+    }
+    if ty == &DB_TYPE_CHAR {
+        return format!("CHAR({size})");
+    }
+    if ty == &DB_TYPE_NCHAR {
+        return format!("NCHAR({size})");
+    }
+    if ty == &DB_TYPE_RAW {
+        return format!("RAW({size})");
+    }
+    if ty == &DB_TYPE_NUMBER {
         // Oracle reports an unconstrained NUMBER as precision 0 with scale
         // -127 ("no scale specified"), which would render as the nonsense
         // `NUMBER(0,-127)` in a column header.
-        OracleType::Number(p, s) => match (p, s) {
+        return match (precision, scale) {
             (0, _) => "NUMBER".to_string(),
             (p, 0) => format!("NUMBER({p})"),
             (p, s) => format!("NUMBER({p},{s})"),
-        },
-        OracleType::Float(p) => format!("FLOAT({p})"),
-        OracleType::Timestamp(p) => format!("TIMESTAMP({p})"),
-        OracleType::TimestampTZ(p) => format!("TIMESTAMP({p}) WITH TIME ZONE"),
-        OracleType::TimestampLTZ(p) => format!("TIMESTAMP({p}) WITH LOCAL TIME ZONE"),
-        OracleType::IntervalDS(d, s) => format!("INTERVAL DAY({d}) TO SECOND({s})"),
-        OracleType::IntervalYM(p) => format!("INTERVAL YEAR({p}) TO MONTH"),
-        OracleType::Rowid => "ROWID".into(),
-        OracleType::BinaryFloat => "BINARY_FLOAT".into(),
-        OracleType::BinaryDouble => "BINARY_DOUBLE".into(),
-        OracleType::Date => "DATE".into(),
-        OracleType::CLOB => "CLOB".into(),
-        OracleType::NCLOB => "NCLOB".into(),
-        OracleType::BLOB => "BLOB".into(),
-        OracleType::BFILE => "BFILE".into(),
-        OracleType::RefCursor => "REF CURSOR".into(),
-        OracleType::Boolean => "BOOLEAN".into(),
-        OracleType::Long => "LONG".into(),
-        OracleType::LongRaw => "LONG RAW".into(),
-        OracleType::Json => "JSON".into(),
-        OracleType::Xml => "XMLTYPE".into(),
-        OracleType::Int64 => "INTEGER".into(),
-        OracleType::UInt64 => "UNSIGNED INTEGER".into(),
-        // Object types and anything the crate adds later: its own Display is
-        // already a readable Oracle type name.
-        other => other.to_string(),
+        };
     }
+    if ty == &DB_TYPE_TIMESTAMP {
+        return format!("TIMESTAMP({})", timestamp_precision(scale));
+    }
+    if ty == &DB_TYPE_TIMESTAMP_TZ {
+        return format!("TIMESTAMP({}) WITH TIME ZONE", timestamp_precision(scale));
+    }
+    if ty == &DB_TYPE_TIMESTAMP_LTZ {
+        return format!(
+            "TIMESTAMP({}) WITH LOCAL TIME ZONE",
+            timestamp_precision(scale)
+        );
+    }
+
+    simple_type_name(ty).to_string()
+}
+
+/// Oracle reports a timestamp's fractional-second digits in the scale field.
+/// A describe that omits it (scale 0 on a type that always has one) means the
+/// default, which is 6.
+fn timestamp_precision(scale: i8) -> u8 {
+    if (1..=9).contains(&scale) {
+        scale as u8
+    } else {
+        6
+    }
+}
+
+/// Types whose name carries no size or precision.
+fn simple_type_name(ty: &'static DbType) -> &'static str {
+    for (t, name) in [
+        (&DB_TYPE_DATE, "DATE"),
+        (&DB_TYPE_BINARY_FLOAT, "BINARY_FLOAT"),
+        (&DB_TYPE_BINARY_DOUBLE, "BINARY_DOUBLE"),
+        (&DB_TYPE_BINARY_INTEGER, "BINARY_INTEGER"),
+        (&DB_TYPE_BOOLEAN, "BOOLEAN"),
+        (&DB_TYPE_CLOB, "CLOB"),
+        (&DB_TYPE_NCLOB, "NCLOB"),
+        (&DB_TYPE_BFILE, "BFILE"),
+        (&DB_TYPE_LONG, "LONG"),
+        (&DB_TYPE_LONG_RAW, "LONG RAW"),
+        (&DB_TYPE_LONG_NVARCHAR, "LONG NVARCHAR"),
+        (&DB_TYPE_ROWID, "ROWID"),
+        (&DB_TYPE_UROWID, "UROWID"),
+        (&DB_TYPE_INTERVAL_DS, "INTERVAL DAY TO SECOND"),
+        (&DB_TYPE_INTERVAL_YM, "INTERVAL YEAR TO MONTH"),
+        (&DB_TYPE_JSON, "JSON"),
+        (&DB_TYPE_XMLTYPE, "XMLTYPE"),
+        (&DB_TYPE_VECTOR, "VECTOR"),
+        (&DB_TYPE_CURSOR, "REF CURSOR"),
+        (&DB_TYPE_OBJECT, "OBJECT"),
+    ] {
+        if ty == t {
+            return name;
+        }
+    }
+    "UNKNOWN"
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn ts(y: i32, mo: u32, d: u32, h: u32, mi: u32, s: u32, ns: u32) -> Timestamp {
-        Timestamp::new(y, mo, d, h, mi, s, ns).unwrap()
+    fn ts(y: i16, mo: u8, d: u8, h: u8, mi: u8, s: u8, ns: u32) -> OracleTimestamp {
+        OracleTimestamp::new_timestamp(y, mo, d, h, mi, s, ns)
     }
 
     #[test]
     fn date_keeps_its_time_component() {
         assert_eq!(
-            format_timestamp(&ts(2024, 3, 7, 9, 5, 1, 0)),
+            format_timestamp(&ts(2024, 3, 7, 9, 5, 1, 0), false),
             "2024-03-07 09:05:01"
         );
     }
@@ -184,34 +403,91 @@ mod tests {
     #[test]
     fn timestamp_renders_fractional_seconds() {
         assert_eq!(
-            format_timestamp(&ts(2024, 3, 7, 9, 5, 1, 250_000_000)),
+            format_timestamp(&ts(2024, 3, 7, 9, 5, 1, 250_000_000), false),
             "2024-03-07 09:05:01.250000"
         );
     }
 
     #[test]
     fn timestamp_with_zone_keeps_its_offset() {
-        let t = ts(2024, 3, 7, 9, 5, 1, 0).and_tz_hm_offset(7, 30).unwrap();
-        assert_eq!(format_timestamp(&t), "2024-03-07 09:05:01 +07:30");
-        let west = ts(2024, 3, 7, 9, 5, 1, 0).and_tz_hm_offset(-5, 0).unwrap();
-        assert_eq!(format_timestamp(&west), "2024-03-07 09:05:01 -05:00");
+        let east = OracleTimestamp::new_timestamp_tz(2024, 3, 7, 9, 5, 1, 0, 7, 30);
+        assert_eq!(format_timestamp(&east, true), "2024-03-07 09:05:01 +07:30");
+        let west = OracleTimestamp::new_timestamp_tz(2024, 3, 7, 9, 5, 1, 0, -5, 0);
+        assert_eq!(format_timestamp(&west, true), "2024-03-07 09:05:01 -05:00");
     }
 
     #[test]
-    fn type_names_carry_their_precision() {
+    fn an_unzoned_column_shows_no_offset_even_though_one_is_carried() {
+        // `OracleTimestamp` always has offset fields; a plain TIMESTAMP's are
+        // zero and must not render as a spurious `+00:00`.
         assert_eq!(
-            column_type_name(&OracleType::Varchar2(100)),
-            "VARCHAR2(100)"
+            format_timestamp(&ts(2024, 3, 7, 9, 5, 1, 0), false),
+            "2024-03-07 09:05:01"
         );
-        assert_eq!(column_type_name(&OracleType::Number(10, 2)), "NUMBER(10,2)");
-        assert_eq!(column_type_name(&OracleType::Number(38, 0)), "NUMBER(38)");
-        assert_eq!(column_type_name(&OracleType::Number(0, 0)), "NUMBER");
-        // What Oracle actually reports for a bare `NUMBER` column.
-        assert_eq!(column_type_name(&OracleType::Number(0, -127)), "NUMBER");
-        assert_eq!(column_type_name(&OracleType::BinaryDouble), "BINARY_DOUBLE");
+    }
+
+    #[test]
+    fn a_number_narrows_only_when_it_round_trips() {
+        // `Cell` is not `PartialEq`, so these match on the shape.
+        assert!(matches!(number_cell("42".parse().unwrap()), Cell::Int(42)));
+        assert!(matches!(
+            number_cell("1.5".parse().unwrap()),
+            Cell::Float(f) if f == 1.5
+        ));
+        // 38 significant digits: f64 would round this, so it stays text.
+        let wide = "12345678901234567890123456789012345678";
+        assert!(matches!(
+            number_cell(wide.parse().unwrap()),
+            Cell::Text(s) if s == wide
+        ));
+    }
+
+    #[test]
+    fn json_objects_render_with_stable_key_order() {
+        let mut map = HashMap::new();
+        map.insert("b".to_string(), JsonValue::Boolean(true));
+        map.insert("a".to_string(), JsonValue::String("x".into()));
+        map.insert("c".to_string(), JsonValue::Null);
         assert_eq!(
-            column_type_name(&OracleType::TimestampTZ(6)),
-            "TIMESTAMP(6) WITH TIME ZONE"
+            render_json(&JsonValue::JsonObject(map)),
+            r#"{"a":"x","b":true,"c":null}"#
         );
+    }
+
+    #[test]
+    fn json_strings_escape_quotes_and_control_characters() {
+        let v = JsonValue::String("he said \"hi\"\n\tbye\\".into());
+        assert_eq!(render_json(&v), r#""he said \"hi\"\n\tbye\\""#);
+    }
+
+    #[test]
+    fn json_arrays_nest() {
+        let v = JsonValue::JsonArray(vec![
+            JsonValue::Boolean(false),
+            JsonValue::JsonArray(vec![JsonValue::Null]),
+        ]);
+        assert_eq!(render_json(&v), "[false,[null]]");
+    }
+
+    #[test]
+    fn a_vector_is_summarised_not_dumped() {
+        let v = Vector::Dense(VectorData::Float32(vec![0.0; 1536]));
+        assert_eq!(describe_vector(&v), "[VECTOR FLOAT32 · 1536 dims]");
+    }
+
+    #[test]
+    fn a_timestamp_without_a_reported_precision_defaults_to_six() {
+        assert_eq!(timestamp_precision(0), 6);
+        assert_eq!(timestamp_precision(-127), 6);
+        assert_eq!(timestamp_precision(3), 3);
+    }
+
+    #[test]
+    fn type_names_use_oracle_spelling_not_the_rust_constant() {
+        // `DbType::name()` would say "DB_TYPE_VARCHAR" here.
+        assert_eq!(simple_type_name(&DB_TYPE_DATE), "DATE");
+        assert_eq!(simple_type_name(&DB_TYPE_BINARY_DOUBLE), "BINARY_DOUBLE");
+        assert_eq!(simple_type_name(&DB_TYPE_JSON), "JSON");
+        assert_eq!(simple_type_name(&DB_TYPE_XMLTYPE), "XMLTYPE");
     }
 }

--- a/crates/driver-oracle/src/convert.rs
+++ b/crates/driver-oracle/src/convert.rs
@@ -288,18 +288,20 @@ fn write_json(v: &JsonValue, out: &mut String) {
             let hex: String = b.iter().map(|x| format!("{x:02x}")).collect();
             write_json_string(&hex, out);
         }
-        JsonValue::JsonArray(items) => {
-            out.push('[');
-            for (i, item) in items.iter().enumerate() {
-                if i > 0 {
-                    out.push(',');
-                }
-                write_json(item, out);
-            }
-            out.push(']');
-        }
+        JsonValue::JsonArray(items) => write_json_array(items, out),
         JsonValue::JsonObject(map) => write_json_object(map, out),
     }
+}
+
+fn write_json_array(items: &[JsonValue], out: &mut String) {
+    out.push('[');
+    for (i, item) in items.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        write_json(item, out);
+    }
+    out.push(']');
 }
 
 /// Oracle's OSON decodes into a `HashMap`, whose iteration order is arbitrary

--- a/crates/driver-oracle/src/driver.rs
+++ b/crates/driver-oracle/src/driver.rs
@@ -1,21 +1,19 @@
-//! Oracle driver backed by the `oracle` crate (ODPI-C over OCI).
+//! Oracle driver backed by Oracle's own pure-Rust `oracledb` crate.
 //!
-//! **Why this crate and not a pure-Rust one.** The pure-Rust `oracle-rs` was
-//! tried first, since it would have kept RDB free of a native dependency.
-//! Measured against a real 23ai server it silently truncated every result set
-//! at the server's first 100-row batch, dropped the connection on *any* SQL
-//! error without surfacing the `ORA-` message, and returned no primary keys —
-//! so tables could not be edited. Those are upstream bugs (issues #8, #12),
-//! not something a caller can work around, and silent row loss is the worst
-//! failure mode a database browser can have. ODPI-C is compiled into this
-//! binary; the Oracle client library it needs (`libclntsh`) is loaded
-//! lazily at *runtime*, so builds, tests and CI need nothing installed —
-//! only actually connecting to Oracle does.
+//! **Why this crate.** RDB shipped Oracle first on `oracle` (ODPI-C over OCI),
+//! which made Oracle the only engine that needed something installed before it
+//! could connect: the Oracle Instant Client, loaded at runtime. A pure-Rust
+//! third-party crate had been tried before that and rejected on measurement —
+//! it silently truncated every result set at the server's first 100-row batch
+//! and returned no primary keys. `oracledb` is Oracle's own thin driver: it
+//! speaks the wire protocol directly, so there is no client library and no
+//! native dependency, and Oracle maintains it. Oracle is now an engine like
+//! any other.
 //!
-//! **Blocking client on an async trait.** OCI is synchronous, so every call
-//! runs on `spawn_blocking` with the connection behind a `std::sync::Mutex`.
-//! That mutex is held only inside the blocking closure, never across an
-//! await, so it cannot deadlock the runtime.
+//! **Blocking client on an async trait.** `oracledb`'s API is synchronous, so
+//! every call runs on `spawn_blocking` with the connection behind a
+//! `std::sync::Mutex`. That mutex is held only inside the blocking closure,
+//! never across an await, so it cannot deadlock the runtime.
 //!
 //! v1 scope: database (username/password) auth only — no OS auth, Kerberos,
 //! wallet or SYSDBA; service-name connect only (`ConnConfig.database` is the
@@ -26,8 +24,7 @@
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use oracle::sql_type::ToSql;
-use oracle::Connection;
+use oracledb::{Config, Connection, ErrorKind, ToDbValue};
 
 use rdb_core::conn::{ConnConfig, SslMode};
 use rdb_core::driver::Driver;
@@ -37,7 +34,7 @@ use rdb_core::result::{Cell, Column, ResultSet};
 use rdb_core::schema::Schema;
 use rdb_core::write::{TableRef, WriteOp};
 
-use crate::convert::{column_type_name, sql_value_to_cell};
+use crate::convert::{cell_at, column_type_name};
 use crate::schema::{fold_rows, SchemaRow, COLUMNS_QUERY};
 use crate::write_sql;
 
@@ -61,21 +58,23 @@ fn connect_string(cfg: &ConnConfig) -> String {
     format!("{proto}://{}:{}/{}", cfg.host, cfg.port, service)
 }
 
-/// Run a blocking OCI call on the blocking pool.
+/// Run a blocking database call on the blocking pool.
 ///
 /// The lock lives entirely inside the closure — it is taken and dropped on
-/// the blocking thread — so no guard is ever held across an `.await`.
+/// the blocking thread — so no guard is ever held across an `.await`. The
+/// closure gets `&mut` because a few calls (`close`) need it and the rest do
+/// not care.
 async fn on_conn<T, F>(conn: &Arc<Mutex<Connection>>, f: F) -> Result<T>
 where
     T: Send + 'static,
-    F: FnOnce(&Connection) -> std::result::Result<T, oracle::Error> + Send + 'static,
+    F: FnOnce(&mut Connection) -> std::result::Result<T, oracledb::Error> + Send + 'static,
 {
     let conn = Arc::clone(conn);
     tokio::task::spawn_blocking(move || {
-        let guard = conn
+        let mut guard = conn
             .lock()
             .map_err(|_| RdbError::Connection("connection lock poisoned".into()))?;
-        f(&guard).map_err(|e| RdbError::Query(ora_err(&e)))
+        f(&mut guard).map_err(|e| RdbError::Query(ora_err(&e)))
     })
     .await
     .map_err(|e| RdbError::Connection(format!("worker thread failed: {e}")))?
@@ -83,11 +82,15 @@ where
 
 /// Rows of a single-column query, as text. Used by the several catalog
 /// lookups that all want the same shape.
-fn one_column(conn: &Connection, sql: &str, params: &[&dyn ToSql]) -> oracle::Result<Vec<String>> {
+fn one_column(
+    conn: &Connection,
+    sql: &str,
+    params: &[&dyn ToDbValue],
+) -> std::result::Result<Vec<String>, oracledb::Error> {
     let mut out = Vec::new();
     for row in conn.query(sql, params)? {
         let row = row?;
-        out.push(row.get::<usize, String>(0).unwrap_or_default());
+        out.push(row.get::<Option<String>>(0)?.unwrap_or_default());
     }
     Ok(out)
 }
@@ -100,18 +103,21 @@ impl Driver for OracleDriver {
         let dsn = connect_string(cfg);
         let fallback_schema = cfg.user.to_uppercase();
 
-        // Connecting is itself blocking, and it is also where a missing
-        // Oracle client library surfaces — reword that one, because the raw
-        // ODPI-C message is a wall of URLs.
+        // Connecting is itself blocking.
         tokio::task::spawn_blocking(move || {
-            let conn = Connection::connect(&user, &password, &dsn)
-                .map_err(|e| RdbError::Connection(connect_err(&e)))?;
+            let config = Config::default()
+                .set_credentials(&user, &password)
+                .set_connect_string(&dsn)
+                .map_err(|e| RdbError::Connection(ora_err(&e)))?;
+            let conn = oracledb::connect(config).map_err(|e| RdbError::Connection(ora_err(&e)))?;
             let schema = conn
-                .query_row_as::<String>(
+                .query_row(
                     "SELECT SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA') FROM DUAL",
                     &[],
                 )
+                .and_then(|r| r.get::<Option<String>>(0))
                 .ok()
+                .flatten()
                 .filter(|s| !s.is_empty())
                 // Unless the session ran ALTER SESSION SET CURRENT_SCHEMA,
                 // the current schema is the connecting user, upper-cased.
@@ -145,12 +151,12 @@ impl Driver for OracleDriver {
             for row in c.query(COLUMNS_QUERY, &[&bind])? {
                 let row = row?;
                 out.push((
-                    row.get::<usize, String>(0).unwrap_or_default(),
-                    row.get::<usize, String>(1).unwrap_or_default(),
-                    row.get::<usize, String>(2).unwrap_or_default(),
-                    row.get::<usize, i64>(3).unwrap_or(0) != 0,
-                    row.get::<usize, i64>(4).unwrap_or(0) != 0,
-                    row.get::<usize, i64>(5).unwrap_or(0) != 0,
+                    row.get::<Option<String>>(0)?.unwrap_or_default(),
+                    row.get::<Option<String>>(1)?.unwrap_or_default(),
+                    row.get::<Option<String>>(2)?.unwrap_or_default(),
+                    row.get::<Option<i64>>(3)?.unwrap_or(0) != 0,
+                    row.get::<Option<i64>>(4)?.unwrap_or(0) != 0,
+                    row.get::<Option<i64>>(5)?.unwrap_or(0) != 0,
                 ));
             }
             Ok(out)
@@ -201,34 +207,34 @@ impl Driver for OracleDriver {
                 return Err(RdbError::UnsupportedQuery)
             }
         };
-        let for_err = sql.clone();
         on_conn(&self.conn, move |c| {
-            let mut stmt = c.statement(&sql).build()?;
-            // DDL and DML have no result set to iterate; they report a row
-            // count instead. `is_query` comes from Oracle's own parse of the
-            // statement, so it needs no guessing from the SQL text.
-            if !stmt.is_query() {
-                stmt.execute(&[])?;
-                return Ok(ResultSet::Affected(stmt.row_count().unwrap_or(0)));
+            // DDL, DML and PL/SQL have no result set to iterate; they report a
+            // row count instead.
+            if !is_query(&sql) {
+                return Ok(ResultSet::Affected(c.execute(&sql, &[])?.rows_affected()));
             }
-            let rows = stmt.query(&[])?;
-            let cols: Vec<Column> = rows
-                .column_info()
+            let cursor = c.query(&sql, &[])?;
+            let meta = cursor.columns().clone();
+            let cols: Vec<Column> = meta
                 .iter()
-                .map(|c| Column {
-                    name: c.name().to_string(),
-                    type_name: column_type_name(c.oracle_type()),
+                .map(|m| Column {
+                    name: m.name().to_string(),
+                    type_name: column_type_name(m),
                 })
                 .collect();
             let mut out: Vec<Vec<Cell>> = Vec::new();
-            for row in rows {
+            for row in cursor {
                 let row = row?;
-                out.push(row.sql_values().iter().map(sql_value_to_cell).collect());
+                out.push(
+                    meta.iter()
+                        .enumerate()
+                        .map(|(i, m)| cell_at(&row, i, m))
+                        .collect(),
+                );
             }
             Ok(ResultSet::Tabular { cols, rows: out })
         })
         .await
-        .map_err(|e| RdbError::Query(with_offset_line(&json_hint(&e.to_string()), &for_err)))
     }
 
     async fn primary_key(&self, table: &TableRef) -> Result<Vec<String>> {
@@ -256,8 +262,11 @@ impl Driver for OracleDriver {
 
     async fn count(&self, table: &TableRef) -> Result<u64> {
         let sql = format!("SELECT COUNT(*) FROM {}", write_sql::table_name(table));
-        let n = on_conn(&self.conn, move |c| c.query_row_as::<i64>(&sql, &[])).await?;
-        Ok(n.max(0) as u64)
+        let n = on_conn(&self.conn, move |c| {
+            c.query_row(&sql, &[])?.get::<Option<i64>>(0)
+        })
+        .await?;
+        Ok(n.unwrap_or(0).max(0) as u64)
     }
 
     async fn commit(&self, ops: &[WriteOp]) -> Result<u64> {
@@ -280,7 +289,7 @@ impl Driver for OracleDriver {
             let mut affected = 0u64;
             for sql in &stmts {
                 match c.execute(sql, &[]) {
-                    Ok(stmt) => affected += stmt.row_count().unwrap_or(0),
+                    Ok(res) => affected += res.rows_affected(),
                     Err(e) => {
                         let _ = c.rollback();
                         return Err(e);
@@ -300,68 +309,63 @@ impl Driver for OracleDriver {
     }
 }
 
-/// A missing Oracle client library is the one error a new user is most likely
-/// to hit, and ODPI-C reports it as several lines of help URLs. Say the one
-/// thing they need to do instead.
-fn connect_err(e: &oracle::Error) -> String {
-    let msg = e.to_string();
-    if msg.contains("DPI-1047") {
-        return "Oracle Client library not found. Install Oracle Instant Client \
-                (Basic or Basic Light) and make sure it is on the library path."
-            .to_string();
-    }
-    ora_err(e)
+/// Whether a statement produces a result set to iterate rather than a row
+/// count, decided from its leading keyword.
+///
+/// `oracledb` classifies statements this same way internally
+/// (`Statement::determine_statement_type`, which routes on `SELECT`/`WITH`
+/// versus DML/DDL/PL/SQL keywords) but keeps the answer crate-private, so
+/// this mirrors that table rather than inventing a different one. `Cursor`
+/// does report an empty column list for a non-query, but it carries no
+/// affected-row count, and "3 rows updated" is the whole result of a DML
+/// statement — so routing has to happen before execution, not after.
+///
+/// ponytail: leading keyword only. `TABLE(...)`, `(SELECT ...)` and other
+/// rarities route to `execute`, which still runs them correctly but reports a
+/// row count instead of the rows. Replace this with upstream's own answer if
+/// it is ever exposed.
+fn is_query(sql: &str) -> bool {
+    matches!(
+        leading_keyword(sql).to_uppercase().as_str(),
+        "SELECT" | "WITH"
+    )
 }
 
-/// `ORA-00942: table or view does not exist` — the code and message, without
-/// ODPI-C's trailing `fn_name`/`action` noise.
-fn ora_err(e: &oracle::Error) -> String {
-    match e.db_error() {
-        Some(db) => format!("ORA-{:05}: {}", db.code(), db.message().trim()),
-        None => e.to_string(),
+/// The first bare word of a statement, skipping whitespace and both comment
+/// forms. A query editor's buffer routinely opens with a `--` note above the
+/// statement, so a naive `trim_start` would classify most saved queries wrong.
+fn leading_keyword(sql: &str) -> &str {
+    let mut rest = sql.trim_start();
+    loop {
+        if let Some(after) = rest.strip_prefix("--") {
+            rest = after
+                .split_once('\n')
+                .map_or("", |(_, tail)| tail)
+                .trim_start();
+        } else if let Some(after) = rest.strip_prefix("/*") {
+            rest = after
+                .split_once("*/")
+                .map_or("", |(_, tail)| tail)
+                .trim_start();
+        } else {
+            break;
+        }
     }
+    let end = rest
+        .find(|c: char| !c.is_alphanumeric() && c != '_')
+        .unwrap_or(rest.len());
+    &rest[..end]
 }
 
-/// Oracle 21c's native `JSON` column type has no binding in the `oracle`
-/// crate yet (kubo/rust-oracle#107), so a `SELECT *` over a table containing
-/// one fails before any row is read. The raw message says only "unsupported
-/// Oracle type JSON", which leaves the user with nowhere to go — name the
-/// workaround instead.
-fn json_hint(msg: &str) -> String {
-    if msg.contains("unsupported Oracle type JSON") {
-        return "Oracle JSON columns are not supported by this driver yet. \
-                Select the column as JSON_SERIALIZE(<col> RETURNING VARCHAR2) \
-                to read it as text."
-            .to_string();
+/// `ORA-00942: table or view does not exist` — the server's own message,
+/// which `oracledb` passes through verbatim in `ErrorKind::DbError`. Anything
+/// else is a client-side failure and its `Display` is already the best text
+/// available.
+fn ora_err(e: &oracledb::Error) -> String {
+    match e.kind() {
+        ErrorKind::DbError(msg) => msg.trim().to_string(),
+        _ => e.to_string(),
     }
-    msg.to_string()
-}
-
-/// Oracle reports where a statement broke as a character offset. Turn that
-/// into the 1-based line the query editor highlights via its `[[rdb-line:N]]`
-/// marker — the same contract `driver-mssql` fills from SQL Server's typed
-/// line number.
-fn with_offset_line(msg: &str, sql: &str) -> String {
-    match offset_of(msg).and_then(|off| line_of_offset(sql, off)) {
-        Some(n) => format!("[[rdb-line:{n}]] {msg}"),
-        None => msg.to_string(),
-    }
-}
-
-/// ODPI-C puts the offset in the error's `offset` field, which reaches us
-/// only through the rendered message, as `... offset: N ...`.
-fn offset_of(msg: &str) -> Option<usize> {
-    let rest = msg.split("offset: ").nth(1)?;
-    let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
-    digits.parse().ok()
-}
-
-fn line_of_offset(sql: &str, offset: usize) -> Option<u32> {
-    if offset == 0 || offset > sql.len() {
-        return None;
-    }
-    let line = sql[..offset].bytes().filter(|b| *b == b'\n').count() + 1;
-    (line > 1).then_some(line as u32)
 }
 
 #[cfg(test)]
@@ -411,36 +415,38 @@ mod tests {
     }
 
     #[test]
-    fn a_multiline_statement_reports_the_failing_line() {
-        let sql = "SELECT 1\nFROM dual\nWHERE bogus";
-        // Offset 19 lands on line 3.
-        let marked = with_offset_line("ORA-00904: bad, offset: 19 xyz", sql);
-        assert_eq!(marked, "[[rdb-line:3]] ORA-00904: bad, offset: 19 xyz");
+    fn selects_and_ctes_are_queries() {
+        assert!(is_query("SELECT * FROM dual"));
+        assert!(is_query("  select 1 from dual"));
+        assert!(is_query("WITH t AS (SELECT 1 FROM dual) SELECT * FROM t"));
     }
 
     #[test]
-    fn a_single_line_statement_gets_no_marker() {
-        // Line 1 needs no highlight, and no offset at all must not invent one.
-        assert_eq!(
-            with_offset_line("ORA-00904: bad, offset: 3 x", "SELECT bogus"),
-            "ORA-00904: bad, offset: 3 x"
-        );
-        assert_eq!(
-            with_offset_line("ORA-00942: nope", "SELECT 1"),
-            "ORA-00942: nope"
-        );
+    fn dml_ddl_and_plsql_are_not_queries() {
+        assert!(!is_query("UPDATE users SET name = 'x'"));
+        assert!(!is_query("INSERT INTO users VALUES (1)"));
+        assert!(!is_query("DELETE FROM users"));
+        assert!(!is_query("MERGE INTO users USING dual ON (1=1)"));
+        assert!(!is_query("CREATE TABLE t (id NUMBER)"));
+        assert!(!is_query("TRUNCATE TABLE t"));
+        assert!(!is_query("BEGIN NULL; END;"));
+        assert!(!is_query(""));
     }
 
     #[test]
-    fn a_json_column_failure_names_the_workaround() {
-        let hinted = json_hint("internal error: unsupported Oracle type JSON");
-        assert!(hinted.contains("JSON_SERIALIZE"));
-        // Unrelated errors must pass through untouched.
-        assert_eq!(json_hint("ORA-00942: nope"), "ORA-00942: nope");
+    fn a_leading_comment_does_not_hide_the_keyword() {
+        // A saved query routinely opens with a note above the statement.
+        assert!(is_query("-- daily totals\nSELECT * FROM dual"));
+        assert!(is_query("/* daily totals */ SELECT * FROM dual"));
+        assert!(is_query(
+            "-- one\n-- two\n\n  /* three */\nSELECT 1 FROM dual"
+        ));
+        assert!(!is_query("-- careful\nDROP TABLE t"));
     }
 
     #[test]
-    fn offset_past_the_end_of_the_statement_is_ignored() {
-        assert_eq!(line_of_offset("SELECT 1", 999), None);
+    fn an_unterminated_comment_is_not_mistaken_for_a_query() {
+        assert!(!is_query("/* never closed SELECT"));
+        assert!(!is_query("-- only a comment"));
     }
 }

--- a/crates/driver-oracle/src/driver.rs
+++ b/crates/driver-oracle/src/driver.rs
@@ -235,6 +235,10 @@ impl Driver for OracleDriver {
             Ok(ResultSet::Tabular { cols, rows: out })
         })
         .await
+        .map_err(|e| match e {
+            RdbError::Query(msg) => RdbError::Query(unsupported_type_hint(&msg)),
+            other => other,
+        })
     }
 
     async fn primary_key(&self, table: &TableRef) -> Result<Vec<String>> {
@@ -357,6 +361,28 @@ fn leading_keyword(sql: &str) -> &str {
     &rest[..end]
 }
 
+/// `oracledb` cannot decode a `BFILE` or an object type (`XMLTYPE` describes
+/// as one), and it refuses the whole statement rather than the one column —
+/// so a `SELECT *` over a table containing either fails with nothing shown.
+/// The raw message names the internal type and stops there, which leaves the
+/// user with nowhere to go; name the way out instead.
+fn unsupported_type_hint(msg: &str) -> String {
+    if msg.contains("unsupported database type DB_TYPE_BFILE") {
+        return "This driver cannot read BFILE columns yet, and Oracle refuses \
+                the whole query rather than the one column. Select the other \
+                columns by name, or read the file through DBMS_LOB."
+            .to_string();
+    }
+    if msg.contains("unsupported database type DB_TYPE_OBJECT") {
+        return "This driver cannot read object types or XMLTYPE columns yet, \
+                and Oracle refuses the whole query rather than the one column. \
+                Select the other columns by name, or read an XMLTYPE as \
+                <col>.getClobVal()."
+            .to_string();
+    }
+    msg.to_string()
+}
+
 /// `ORA-00942: table or view does not exist` — the server's own message,
 /// which `oracledb` passes through verbatim in `ErrorKind::DbError`. Anything
 /// else is a client-side failure and its `Display` is already the best text
@@ -442,6 +468,16 @@ mod tests {
             "-- one\n-- two\n\n  /* three */\nSELECT 1 FROM dual"
         ));
         assert!(!is_query("-- careful\nDROP TABLE t"));
+    }
+
+    #[test]
+    fn an_undecodable_column_type_names_the_way_out() {
+        let bfile = unsupported_type_hint("unsupported database type DB_TYPE_BFILE");
+        assert!(bfile.contains("BFILE") && bfile.contains("DBMS_LOB"));
+        let obj = unsupported_type_hint("unsupported database type DB_TYPE_OBJECT");
+        assert!(obj.contains("XMLTYPE") && obj.contains("getClobVal"));
+        // Unrelated errors pass through untouched.
+        assert_eq!(unsupported_type_hint("ORA-00942: nope"), "ORA-00942: nope");
     }
 
     #[test]

--- a/crates/driver-oracle/src/lib.rs
+++ b/crates/driver-oracle/src/lib.rs
@@ -1,4 +1,4 @@
-//! rdb-driver-oracle: Oracle Database driver impl via the `oracle` crate (ODPI-C).
+//! rdb-driver-oracle: Oracle Database driver impl via Oracle's pure-Rust `oracledb` crate.
 
 mod convert;
 mod schema;

--- a/crates/driver-oracle/src/write_sql.rs
+++ b/crates/driver-oracle/src/write_sql.rs
@@ -1,9 +1,8 @@
 //! Oracle SQL dialect for the shared literal write-builder
 //! (`rdb_core::write_sql`) — the same pattern `driver-postgres` and
 //! `driver-mssql` use rather than `driver-mysql`'s bind-param one, because
-//! oracle-rs binds a typed `Value` and a `Cell` carries no Oracle type to
-//! bind it as; a literal lets Oracle apply the column's own implicit
-//! conversion.
+//! a bind carries a Rust type and a `Cell` names no Oracle type to bind it
+//! as; a literal lets Oracle apply the column's own implicit conversion.
 //!
 //! One Oracle behaviour worth knowing before editing a row: **Oracle stores
 //! the empty string as NULL.** Writing `Cell::Text("")` emits the literal

--- a/crates/driver-oracle/tests/integration.rs
+++ b/crates/driver-oracle/tests/integration.rs
@@ -284,6 +284,66 @@ async fn connect_query_schema_commit_against_real_oracle() {
             .expect("drop modern table");
     }
 
+    // A column header must repeat the precision that was declared. Oracle
+    // describes a bare TIMESTAMP as scale 6 and a TIMESTAMP(0) as scale 0, so
+    // reading 0 as "unset" would rewrite every TIMESTAMP(0) to TIMESTAMP(6).
+    // A NULL BFILE must read as NULL: labelling an empty cell "[BFILE]"
+    // claims a file is on the server that is not.
+    let _ = driver.query(&sql("DROP TABLE rdb_it_shapes")).await;
+    driver
+        .query(&sql(
+            "CREATE TABLE rdb_it_shapes (ts0 TIMESTAMP(0), ts TIMESTAMP)",
+        ))
+        .await
+        .expect("create shapes table");
+    let rs = driver
+        .query(&sql("SELECT ts0, ts FROM rdb_it_shapes"))
+        .await
+        .expect("select shapes");
+    let ResultSet::Tabular { cols, .. } = rs else {
+        panic!("expected a tabular result");
+    };
+    assert_eq!(cols[0].type_name, "TIMESTAMP(0)", "declared precision lost");
+    assert_eq!(cols[1].type_name, "TIMESTAMP(6)");
+    driver
+        .query(&sql("DROP TABLE rdb_it_shapes"))
+        .await
+        .expect("drop shapes table");
+
+    // A BFILE column cannot be decoded, and the driver refuses the whole
+    // statement rather than the one column — so the message has to say what to
+    // do instead of naming an internal type and stopping.
+    let _ = driver.query(&sql("DROP TABLE rdb_it_bfile")).await;
+    driver
+        .query(&sql("CREATE TABLE rdb_it_bfile (id NUMBER, f BFILE)"))
+        .await
+        .expect("create bfile table");
+    driver
+        .query(&sql("INSERT INTO rdb_it_bfile VALUES (1, NULL)"))
+        .await
+        .expect("insert bfile row");
+    let err = driver
+        .query(&sql("SELECT id, f FROM rdb_it_bfile"))
+        .await
+        .expect_err("a BFILE column should fail loudly");
+    assert!(
+        err.to_string().contains("DBMS_LOB"),
+        "unreadable column type gave no way out: {err}"
+    );
+    // The other columns are still reachable by name.
+    let rs = driver
+        .query(&sql("SELECT id FROM rdb_it_bfile"))
+        .await
+        .expect("selecting around the BFILE should work");
+    let ResultSet::Tabular { rows, .. } = rs else {
+        panic!("expected a tabular result");
+    };
+    assert!(matches!(rows[0][0], Cell::Int(1)));
+    driver
+        .query(&sql("DROP TABLE rdb_it_bfile"))
+        .await
+        .expect("drop bfile table");
+
     // Non-SQL queries belong to other engines and must be refused.
     assert!(driver
         .query(&Query::Command(vec!["GET".into(), "k".into()]))

--- a/crates/driver-oracle/tests/integration.rs
+++ b/crates/driver-oracle/tests/integration.rs
@@ -222,6 +222,68 @@ async fn connect_query_schema_commit_against_real_oracle() {
     };
     assert_eq!(rows.len(), 250, "result truncated at the first fetch batch");
 
+    // A DML statement has no result set; its whole result is the row count,
+    // so it must come back as `Affected`, not as an empty table.
+    let rs = driver
+        .query(&sql("UPDATE rdb_it_users SET score = 1 WHERE id = 1"))
+        .await
+        .expect("update via query");
+    assert!(
+        matches!(rs, ResultSet::Affected(1)),
+        "DML should report a row count: {rs:?}"
+    );
+
+    // The server's own message has to reach the user intact. An opaque
+    // client-side string here would leave them with nothing to act on.
+    let err = driver
+        .query(&sql("SELECT * FROM rdb_no_such_table"))
+        .await
+        .expect_err("missing table should fail");
+    assert!(
+        err.to_string().contains("ORA-00942"),
+        "server error not surfaced: {err}"
+    );
+
+    // Oracle 21c+ native JSON and 23c BOOLEAN. The ODPI-C driver this one
+    // replaced could not read a JSON column at all — it failed the whole
+    // `SELECT *` and told the user to wrap the column in `JSON_SERIALIZE`.
+    let _ = driver.query(&sql("DROP TABLE rdb_it_modern")).await;
+    if driver
+        .query(&sql(
+            "CREATE TABLE rdb_it_modern (id NUMBER, doc JSON, ok BOOLEAN)",
+        ))
+        .await
+        .is_ok()
+    {
+        driver
+            .query(&sql(
+                "INSERT INTO rdb_it_modern VALUES (1, '{\"b\":2,\"a\":[1,null]}', TRUE)",
+            ))
+            .await
+            .expect("insert json row");
+        let rs = driver
+            .query(&sql("SELECT doc, ok FROM rdb_it_modern"))
+            .await
+            .expect("select json without JSON_SERIALIZE");
+        let ResultSet::Tabular { rows, .. } = rs else {
+            panic!("expected a tabular result");
+        };
+        assert!(
+            matches!(&rows[0][0], Cell::Text(s) if s == r#"{"a":[1,null],"b":2}"#),
+            "JSON column not decoded: {:?}",
+            rows[0][0]
+        );
+        assert!(
+            matches!(rows[0][1], Cell::Bool(true)),
+            "BOOLEAN column not decoded: {:?}",
+            rows[0][1]
+        );
+        driver
+            .query(&sql("DROP TABLE rdb_it_modern"))
+            .await
+            .expect("drop modern table");
+    }
+
     // Non-SQL queries belong to other engines and must be refused.
     assert!(driver
         .query(&Query::Command(vec!["GET".into(), "k".into()]))

--- a/npm/README.md
+++ b/npm/README.md
@@ -45,7 +45,7 @@ rdb
 | SQLite | `rusqlite` | Tabular |
 | Cassandra | `scylla` | Tabular |
 | SQL Server | `tiberius` | Tabular |
-| Oracle | `oracle` (ODPI-C) | Tabular |
+| Oracle | `oracledb` (Oracle's thin driver) | Tabular |
 | ClickHouse | `clickhouse` (HTTP) | Tabular |
 
 ## Design

--- a/website/src/components/Engines.astro
+++ b/website/src/components/Engines.astro
@@ -25,7 +25,7 @@ const engines = [
   { icon: siSqlite, name: "SQLite", detail: "local files, zero setup" },
   { icon: siApachecassandra, name: "Cassandra", detail: "via the scylla driver" },
   { icon: null, name: "SQL Server", detail: "via tiberius (T-SQL)" },
-  { icon: null, name: "Oracle", detail: "via oracle (needs Instant Client)" },
+  { icon: null, name: "Oracle", detail: "via oracledb, no client libraries" },
   { icon: siClickhouse, name: "ClickHouse", detail: "via HTTP, FORMAT JSON reads" },
 ];
 ---

--- a/website/src/pages/open-source.astro
+++ b/website/src/pages/open-source.astro
@@ -14,7 +14,7 @@ const crates = [
   ["rdb-driver-sqlite", "SQLite via rusqlite"],
   ["rdb-driver-cassandra", "Cassandra via scylla"],
   ["rdb-driver-mssql", "SQL Server via tiberius"],
-  ["rdb-driver-oracle", "Oracle via oracle (ODPI-C)"],
+  ["rdb-driver-oracle", "Oracle via oracledb"],
   ["rdb-driver-clickhouse", "ClickHouse via HTTP (FORMAT JSON)"],
 ];
 ---


### PR DESCRIPTION
## Summary

- Oracle was the only engine RDB could not reach with the binary alone. It now
  goes through [`oracledb`](https://github.com/oracle/rust-oracledb), Oracle's
  own pure-Rust thin driver, so the Instant Client requirement is gone and
  Oracle becomes an engine like the other ten.
- Native `JSON` columns read as values instead of failing the statement, which
  closes the known gap this driver shipped with. `VECTOR` and 23c `BOOLEAN`
  come along with it.
- Follows up on the pointer from @cjbj in #260.

## Changes

**Driver** (`crates/driver-oracle/`)
- `oracle` 0.6 (ODPI-C) → `oracledb` 26.0.0-beta.3. No native dependency
  remains: `otool -L` on the test binary lists only macOS system frameworks,
  and the `oracle` crate is gone from `Cargo.lock`.
- Value decoding reshaped. `oracledb::Row` exposes only a generic `get::<T>()`
  over `FromDbValue`, and `String` is not a universal fallback — its impl
  accepts VARCHAR-family and ROWID data only. So dispatch moved from the value
  to the column: `Metadata::db_type()` decides which Rust type to ask for.
  The invariant that made the module worth having is unchanged — only a real
  SQL NULL yields `Cell::Null`, and an undecodable value shows a typed marker
  rather than a blank.
- New: `JSON` (rendered with sorted keys so a cell does not reshuffle between
  reads), `VECTOR` (summarised as shape + element type, not dumped), 23c
  `BOOLEAN`. CLOB/NCLOB/BLOB arrive as values, so no locator handling.
- `is_query` mirrors upstream's own keyword table (`SELECT`/`WITH` versus
  DML/DDL/PL/SQL), skipping leading comments — a saved query routinely opens
  with a `--` note.
- Removed: the `DPI-1047` "install the Instant Client" message, the
  `JSON_SERIALIZE` workaround hint, and the character-offset → editor-line
  marker (see Known gaps).

**Fix** — `TIMESTAMP WITH TIME ZONE` showed the right instant with the wrong
clock. Oracle puts a TSTZ on the wire as the UTC instant plus the offset it was
written in; printing the components beside that offset names a moment that
never existed. A value written `09:05:01 +07:00` read back as `02:05:01
+07:00`. The offset is now added back. Caught by the integration test against a
live server — the unit tests passed because they built timestamps the way the
constructor takes them rather than the way the wire delivers them.

**Docs** — Instant Client note, the "Oracle ships no public wire-protocol spec"
claim, and the JSON known-gap warning dropped from `README.md`,
`npm/README.md`, `website/`.

## Test plan

- [x] `make fmt-check`, `make lint`, `make be-test`, `cargo build --workspace`
- [x] `cargo test -p rdb-driver-oracle --lib` — 30 unit tests (was 21)
- [x] Integration test against a live **Oracle AI Database 26ai Free
      23.26.2.0.0**: 250-row multi-batch fetch with no truncation, 38-digit
      `NUMBER` precision preserved, `BINARY_FLOAT` / `TIMESTAMP WITH TIME ZONE`
      / both `INTERVAL` kinds / CLOB / RAW decoded, an all-NULL row with no
      stray markers, primary-key detection, `o'brien` commit round-trip, DML
      reporting a row count, `ORA-00942` surfacing intact, and a `JSON` column
      read without `JSON_SERIALIZE`
- [x] **No Oracle client library installed or on the path.** `otool -L` on the
      test binary shows only system frameworks; `grep '^name = "oracle"$'
      Cargo.lock` returns nothing
- [x] App driven against that server: schema sidebar populates, grid renders
      typed column headers (`NUMBER(12,2)`, `TIMESTAMP(6) WITH TIME ZONE`),
      zoned timestamps show the local time that was stored, the details pane
      reads a `JSON` column and a `BOOLEAN`, pagination and row editing enabled
- [x] CI needs no new setup step — it never did, and now neither does running

## Known gaps

- A failing statement no longer highlights its line in the query editor.
  `oracledb::Error` carries no character offset, so there is nothing to derive
  `[[rdb-line:N]]` from. Everything else about the error, including the `ORA-`
  text, is unchanged.
- **A table containing a `BFILE` or `XMLTYPE` column cannot be browsed.**
  `oracledb` refuses both — an XMLTYPE describes as an object type — and it
  refuses the whole statement rather than the one column, so a `SELECT *` over
  such a table fails with nothing shown. The error now names the way out
  (select the other columns, `DBMS_LOB`, `getClobVal()`) rather than an
  internal type name. Same shape as the JSON gap the previous driver had.
- `26.0.0-beta.3` is a beta. Worth re-checking each release until it settles.
- Unchanged from #260: database auth only — no wallet, OS auth, Kerberos or
  SYSDBA — and service-name connect only, not SID. `oracledb` has
  `set_wallet_location`/`set_wallet_password`, so wallet support is now cheap
  to add.

## Thanks, and some feedback

@cjbj — thank you for the pointer in #260; that comment is the entire reason
this exists. And thanks @anthony-tuininga for the 👍. Migrating a database
browser is a slightly unusual workload for a driver, so here is what we hit,
offered in the spirit you asked for. All against `26.0.0-beta.3`.

1. **No public dynamic value type.** `DbValue` is `pub` but `mod db_value` is
   private, so it cannot be named from outside; `ColumnData` likewise, which
   also makes `FromDbValue` unimplementable downstream. A tool that renders
   arbitrary user SQL has no way to say "give me whatever is there" and has to
   rebuild the type dispatch itself over `Metadata::db_type()`. Exporting
   `DbValue` would remove that whole layer for us.

2. **Statement classification is crate-private.** `Statement::is_query()` and
   `determine_statement_type` know whether a statement returns rows, but the
   answer is `pub(crate)`. `Cursor::columns()` being empty does report it after
   the fact, but a `Cursor` carries no affected-row count, and "3 rows updated"
   is the entire result of a DML statement — so routing has to happen before
   execution. We ended up copying your keyword table, which works but will
   drift from yours.

3. **`Error` carries no ORA code or character offset.** `ErrorKind::DbError`
   is a `String`. The offset is what lets an editor point at the token that
   broke, which is the difference between a message and a fix.

4. **`DbType::name()` returns the Rust constant name.** It gives
   `"DB_TYPE_VARCHAR"`; the Oracle spelling is right there in `ora_name`
   (`"VARCHAR2"`) but is `pub(crate)`. We show column types in grid headers, so
   we keep our own mapping table for this.

5. **`BFILE` and object types fail the whole statement.** A single
   undecodable column makes the entire query unusable, so a table with one
   `XMLTYPE` in it cannot be browsed at all. Per-column degradation — a
   sentinel the caller can render as "unreadable" — would let a tool show the
   other twenty columns. This is the one gap that blocks real tables for us.

6. **A likely bug: `Display for OracleTimestamp` on a TSTZ value.** `from_buf`
   reads the wire verbatim, so for `TIMESTAMP WITH TIME ZONE` the components
   are UTC while `tz_hour_offset`/`tz_minute_offset` hold the original zone.
   `Display` then prints the UTC components next to the non-UTC offset —
   `2024-03-07T02:05:01.000000000+07:00` for a value written `09:05:01 +07:00`.
   Both halves are correct on their own; together they name a time seven hours
   off. This one cost us a live-server round trip to find, so it seemed worth
   reporting.

7. **`JsonValue::Timestamp` erases the distinction it needs.** OSON `DATE`,
   `TIMESTAMP7`, `TIMESTAMP` and `TIMESTAMP_TZ` all decode to the same
   variant, so a caller cannot tell a zoned value from an unzoned one except
   by inspecting the offset — and a genuinely-UTC `TIMESTAMP_TZ` is then
   indistinguishable from a plain `DATE`.

On the things that mattered most: the 100-row truncation and missing primary
keys that made us reject a pure-Rust driver last time are both simply absent
here — a 250-row fetch comes back whole and `all_constraints` behaves. Happy to
open any of the above as issues or discussions on `oracle/rust-oracledb` if
that is more useful than a note here.

