### PR TITLE
ci: move the Guardener gate onto its two workflows

### DIFF
--- a/.github/workflows/guardener-report.yml
+++ b/.github/workflows/guardener-report.yml
@@ -1,0 +1,35 @@
+# Reports what guardener.yml found. The second half of the organization's
+# ForgeGuard gate; the workflow it calls lives in suiflex/Guardener.
+#
+# A separate file rather than another trigger on guardener.yml, and that is
+# forced rather than chosen: Guardener's `--fix` may only add files, never edit
+# them, so a second trigger bolted onto the gate's own workflow could not reach
+# the repositories that already have one.
+#
+# `workflow_run` because this half holds the credentials, and a pull request
+# from a fork runs with a read-only token that cannot create a check run. Waking
+# on the scan's completion instead puts it in this repository's context. It
+# never checks the pull request out.
+name: Guardener report
+
+on:
+  workflow_run:
+    # The name of the workflow above, which is what the run is called even
+    # though the work happens in a reusable workflow it calls.
+    workflows: ["Guardener"]
+    types: [completed]
+
+permissions:
+  contents: read
+  # The workflow this calls reads the scan's artifact, which belongs to another
+  # workflow run. A called workflow cannot hold a permission its caller does not,
+  # so granting it there and not here is a startup failure, not a smaller grant.
+  actions: read
+
+jobs:
+  report:
+    if: github.repository_owner == 'suiflex'
+    uses: suiflex/Guardener/.github/workflows/report.yml@main
+    secrets:
+      app_id: ${{ secrets.GUARDENER_BOT_APP_ID }}
+      private_key: ${{ secrets.GUARDENER_BOT_PRIVATE_KEY }}

--- a/.github/workflows/guardener.yml
+++ b/.github/workflows/guardener.yml
@@ -1,21 +1,22 @@
 # Runs the organization's ForgeGuard gate over this pull request's changed
 # lines. The policy and the workflow both live in suiflex/Guardener; this file
 # only says that the repository takes part.
+#
+# The gate is in two halves and this is the first: it reads the branch and holds
+# nothing. `pull_request`, not `pull_request_target`, and no secrets — on a fork
+# this job runs with code its author controls, so there must be nothing here
+# worth reaching. The findings are reported by guardener-report.yml, which holds
+# the credentials and never checks the branch out.
 name: Guardener
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
 
 jobs:
   forgeguard:
     if: github.repository_owner == 'suiflex'
     uses: suiflex/Guardener/.github/workflows/check.yml@main
-    secrets:
-      app_id: ${{ secrets.GUARDENER_BOT_APP_ID }}
-      private_key: ${{ secrets.GUARDENER_BOT_PRIVATE_KEY }}
-      # Omit these three and the gate still runs; only the model's second
-      # opinion is left out.
-      model_url: ${{ secrets.GUARDENER_MODEL_URL }}
-      model_key: ${{ secrets.GUARDENER_MODEL_KEY }}
-      model: ${{ secrets.GUARDENER_MODEL }}


### PR DESCRIPTION
## Summary

- Pull requests from forks are not gated in this repository. The job dies at the checkout in about four seconds, so an outside contributor gets a red mark carrying no findings — `actions/checkout` v7 refuses to check out a fork under `pull_request_target`.
- suiflex/Guardener#3 split the gate so a fork's code and the app's private key never meet in one job. Each watched repository moves its own stub; this is that move.
- Proven end to end in suitest first: suiflex/suitest#179, a pull request from a fork, now reports `guardener / forgeguard | success` with a summary naming the quality commands it skipped.

## Changes

- `.github/workflows/guardener.yml` — triggers on `pull_request` instead of `pull_request_target`, and passes no secrets. On a fork this job runs code its author controls, so there is now nothing in it worth reaching.
- `.github/workflows/guardener-report.yml` — new. Wakes on the scan's completion via `workflow_run`, in this repository's context, and posts the check run and comment. It never checks the branch out.

Both files are copied byte for byte from `suiflex/Guardener/templates/workflows/`.

## What to expect

The reporting half only starts working once it is on the default branch: GitHub never runs a pull request's copy of a `workflow_run` workflow. So this pull request cannot demonstrate it — scans will run and nothing will post them until this merges.

Open pull requests need one new event to pick up the changed workflow: a push, a rebase, or a close and reopen. Re-running an older run does not work — it replays the trigger it was created with.

Nothing breaks in the meantime. Until this merges, the gate keeps reporting from the single-workflow path exactly as it does today.

## Test plan

- [x] Both files taken from the Guardener templates unchanged
- [x] Templates validated before rollout: the scan stub triggers on `pull_request` and declares no secrets; the report stub grants `actions: read`, which its called workflow needs to read the scan's artifact
- [ ] **Only observable after merge:** a fork's pull request reporting findings, for the `workflow_run` reason above
