### PR TITLE
feat(app): support multiple simultaneous connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6521,7 +6521,7 @@ dependencies = [
 
 [[package]]
 name = "rdb"
-version = "0.44.1"
+version = "0.45.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -4471,6 +4471,29 @@ fn driver_for<'a, V>(
     }
 }
 
+/// Locks `driver_pool` and `current` just long enough to clone the `Arc`
+/// `driver_for` picks. Replaces the same lock-then-lookup copied across
+/// every wiring module.
+async fn resolve_driver(
+    driver_pool: &DriverPool,
+    current: &DriverSlot,
+    connection_id: Option<&str>,
+) -> Option<(rdb_connstore::Engine, Arc<AnyDriver>)> {
+    let pool = driver_pool.read().await;
+    let guard = current.lock().await;
+    driver_for(&pool, guard.as_ref(), connection_id).map(|(e, d)| (*e, d.clone()))
+}
+
+/// True only if `pool[id]` is still exactly `driver` (identity, not value) —
+/// guards against a disconnect racing a fast reconnect on the same id.
+fn still_the_disconnected_driver<V>(
+    pool: &HashMap<String, (rdb_connstore::Engine, Arc<V>)>,
+    id: &str,
+    driver: &Arc<V>,
+) -> bool {
+    pool.get(id).is_some_and(|(_, d)| Arc::ptr_eq(d, driver))
+}
+
 #[cfg(test)]
 mod driver_pool_tests {
     use super::driver_for;
@@ -4508,6 +4531,44 @@ mod driver_pool_tests {
     fn none_when_nothing_matches() {
         let pool: HashMap<String, &str> = HashMap::new();
         assert_eq!(driver_for(&pool, None, Some("conn-a")), None);
+    }
+
+    #[test]
+    fn evicts_when_pool_still_holds_the_disconnected_driver() {
+        use super::still_the_disconnected_driver;
+        use std::sync::Arc;
+        let driver = Arc::new(1);
+        let mut pool = HashMap::new();
+        pool.insert(
+            "conn-a".to_string(),
+            (rdb_connstore::Engine::Postgres, driver.clone()),
+        );
+        assert!(still_the_disconnected_driver(&pool, "conn-a", &driver));
+    }
+
+    #[test]
+    fn refuses_to_evict_a_driver_a_fast_reconnect_already_replaced() {
+        // Regression: a disconnect-then-reconnect race on the same id must
+        // never let the disconnect's async cleanup remove the *new* driver.
+        use super::still_the_disconnected_driver;
+        use std::sync::Arc;
+        let old_driver = Arc::new(1);
+        let new_driver = Arc::new(1); // equal value, distinct connection
+        let mut pool = HashMap::new();
+        pool.insert(
+            "conn-a".to_string(),
+            (rdb_connstore::Engine::Postgres, new_driver.clone()),
+        );
+        assert!(!still_the_disconnected_driver(&pool, "conn-a", &old_driver));
+    }
+
+    #[test]
+    fn refuses_to_evict_when_entry_already_gone() {
+        use super::still_the_disconnected_driver;
+        use std::sync::Arc;
+        let driver = Arc::new(1);
+        let pool: HashMap<String, (rdb_connstore::Engine, Arc<i32>)> = HashMap::new();
+        assert!(!still_the_disconnected_driver(&pool, "conn-a", &driver));
     }
 }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -388,7 +388,7 @@ mod build_conn_items_tests {
     #[test]
     fn implied_ancestor_header_renders_with_zero_direct_members() {
         let (_dir, store) = store_with_groups(&[Some("Work/Production")]);
-        let rows = build_conn_items(&store, &HashSet::new(), "");
+        let rows = build_conn_items(&store, &HashSet::new(), "", &HashSet::new());
         // Work (0 direct, 1 nested) -> Work/Production (1 direct) -> the connection.
         assert_eq!(rows.len(), 3);
         assert!(rows[0].is_header);
@@ -408,7 +408,7 @@ mod build_conn_items_tests {
     fn collapsing_a_parent_hides_the_whole_subtree() {
         let (_dir, store) = store_with_groups(&[Some("Work/Production"), Some("Work")]);
         let collapsed = HashSet::from(["Work".to_string()]);
-        let rows = build_conn_items(&store, &collapsed, "");
+        let rows = build_conn_items(&store, &collapsed, "", &HashSet::new());
         // Only the Work header itself remains visible.
         assert_eq!(rows.len(), 1);
         assert!(rows[0].is_header);
@@ -420,7 +420,7 @@ mod build_conn_items_tests {
     #[test]
     fn is_group_end_lands_on_the_deepest_last_row_of_each_top_level_group() {
         let (_dir, store) = store_with_groups(&[Some("Work/Production"), Some("LOCAL")]);
-        let rows = build_conn_items(&store, &HashSet::new(), "");
+        let rows = build_conn_items(&store, &HashSet::new(), "", &HashSet::new());
         // Work, Work/Production, conn0 (deepest last row of the Work card),
         // LOCAL, conn1 (last row of the LOCAL card).
         assert_eq!(rows.len(), 5);
@@ -453,15 +453,28 @@ fn subtree_conn_count(
 /// folders followed by its own direct connection rows. Never touches
 /// `is_group_end` — that is only meaningful at the top-level group's true
 /// last visible row, which the caller marks after the whole subtree returns.
+/// Read-only lookups threaded through `emit_group_subtree`'s recursion —
+/// bundled so the function stays under clippy's argument-count limit.
+struct GroupCtx<'a> {
+    child_folders: &'a std::collections::HashMap<Option<String>, Vec<String>>,
+    direct_conns: &'a std::collections::HashMap<String, Vec<usize>>,
+    collapsed: &'a HashSet<String>,
+    live: &'a HashSet<String>,
+}
+
 fn emit_group_subtree(
     path: &str,
     depth: i32,
     store: &rdb_connstore::ConnStore,
-    child_folders: &std::collections::HashMap<Option<String>, Vec<String>>,
-    direct_conns: &std::collections::HashMap<String, Vec<usize>>,
-    collapsed: &HashSet<String>,
+    ctx: &GroupCtx,
     rows: &mut Vec<ConnItem>,
 ) {
+    let GroupCtx {
+        child_folders,
+        direct_conns,
+        collapsed,
+        live,
+    } = *ctx;
     let expanded = !collapsed.contains(path);
     rows.push(ConnItem {
         id: SharedString::default(),
@@ -482,6 +495,7 @@ fn emit_group_subtree(
         env_tag_color: theme::accent_or_default(""),
         is_group_end: false,
         depth,
+        live: false,
     });
     if !expanded {
         // Collapsing a folder hides its whole subtree, not just its direct rows.
@@ -489,15 +503,7 @@ fn emit_group_subtree(
     }
     if let Some(children) = child_folders.get(&Some(path.to_string())) {
         for child in children {
-            emit_group_subtree(
-                child,
-                depth + 1,
-                store,
-                child_folders,
-                direct_conns,
-                collapsed,
-                rows,
-            );
+            emit_group_subtree(child, depth + 1, store, ctx, rows);
         }
     }
     if let Some(idxs) = direct_conns.get(path) {
@@ -534,6 +540,7 @@ fn emit_group_subtree(
                     .unwrap_or_else(|| theme::accent_or_default("")),
                 is_group_end: false,
                 depth,
+                live: live.contains(&s.id),
             });
         }
     }
@@ -555,6 +562,7 @@ fn build_conn_items(
     store: &rdb_connstore::ConnStore,
     collapsed: &HashSet<String>,
     filter: &str,
+    live: &HashSet<String>,
 ) -> Vec<ConnItem> {
     let needle = filter.trim().to_lowercase();
     // child_folders[None] is the top-level order; child_folders[Some(p)] is
@@ -639,19 +647,18 @@ fn build_conn_items(
                             .unwrap_or_else(|| theme::accent_or_default("")),
                         is_group_end: false,
                         depth: 0,
+                        live: live.contains(&s.id),
                     });
                 }
             }
         } else {
-            emit_group_subtree(
-                path,
-                0,
-                store,
-                &child_folders,
-                &direct_conns,
+            let ctx = GroupCtx {
+                child_folders: &child_folders,
+                direct_conns: &direct_conns,
                 collapsed,
-                &mut rows,
-            );
+                live,
+            };
+            emit_group_subtree(path, 0, store, &ctx, &mut rows);
         }
         // Whatever this top-level group's true last visible row ended up
         // being (its header if collapsed, its deepest descendant otherwise)
@@ -703,9 +710,10 @@ fn build_sidebar_model(
     store: &rdb_connstore::ConnStore,
     collapsed: &HashSet<String>,
     filter: &str,
+    live: &HashSet<String>,
 ) -> ModelRc<TopLevelGroup> {
     ModelRc::from(Rc::new(VecModel::from(group_conn_items(build_conn_items(
-        store, collapsed, filter,
+        store, collapsed, filter, live,
     )))))
 }
 
@@ -719,7 +727,8 @@ fn build_conn_palette_items(
     collapsed: &HashSet<String>,
     filter: &str,
 ) -> (Vec<PaletteItem>, Vec<i32>) {
-    let rows = build_conn_items(store, collapsed, filter);
+    // Palette items don't render liveness, so an empty set is fine here.
+    let rows = build_conn_items(store, collapsed, filter, &HashSet::new());
     let mut items: Vec<PaletteItem> = Vec::new();
     let mut map: Vec<i32> = Vec::new();
     for r in rows {
@@ -853,6 +862,7 @@ mod row_group_at_y_tests {
             env_tag_color: Default::default(),
             is_group_end: false,
             depth: 0,
+            live: false,
         }
     }
 
@@ -1553,6 +1563,33 @@ fn connection_badge_info(store: &rdb_connstore::ConnStore, connection_id: &str) 
             has_custom_color: c.color.is_some(),
         })
         .unwrap_or_default()
+}
+
+/// Point the topbar identity chrome (name, accent, env pill, sidebar
+/// selection) at `connection_id` — called when switching to a tab so the
+/// chrome always names the connection that tab's queries actually run
+/// against, not whichever was last explicitly connected. A no-op when the
+/// tab carries no `connection_id` (tabs predating multi-connection, or a
+/// disconnected scratch tab) — leaves the topbar as-is rather than guessing.
+fn sync_conn_chrome(w: &MainWindow, store: &rdb_connstore::ConnStore, connection_id: Option<&str>) {
+    let Some((idx, sc)) = connection_id.and_then(|id| {
+        store
+            .list()
+            .iter()
+            .position(|c| c.id == id)
+            .map(|idx| (idx, store.list()[idx].clone()))
+    }) else {
+        return;
+    };
+    w.set_selected_conn(idx as i32);
+    w.set_status_conn(SharedString::from(sc.name.clone()));
+    w.set_bc_conn(SharedString::from(sc.name));
+    w.global::<Theme>()
+        .set_accent(theme::accent_or_default(sc.color.as_deref().unwrap_or("")));
+    w.set_active_env_tag_label(theme::env_tag_label(sc.env_tag).into());
+    w.set_active_env_tag_color(
+        theme::env_tag_color(sc.env_tag).unwrap_or_else(|| theme::accent_or_default("")),
+    );
 }
 
 fn workspace_tab_index(tabs: &[WorkspaceTab], active_id: Option<&str>) -> Option<usize> {
@@ -4405,6 +4442,131 @@ fn read_conn_form(w: &MainWindow) -> Result<FormConn, &'static str> {
 /// removes query-vs-ping (and query-vs-query) serialization.
 type DriverSlot = Arc<tokio::sync::Mutex<Option<(rdb_connstore::Engine, Arc<AnyDriver>)>>>;
 
+/// Every connection opened this session, keyed by `connection_id`, so a
+/// query started from a tab reaches *that tab's* connection even after
+/// `current` has since moved on to another one (`current` still tracks only
+/// the actively-focused connection, for the sidebar/browse/schema flows that
+/// have no other notion of "which connection"). Entries persist for the
+/// session — bounded by how many distinct saved connections the user opens,
+/// not a leak.
+// RwLock: reads (per-dispatch lookup) run concurrent; writes (connect,
+// evict) stay exclusive but rare.
+type DriverPool =
+    Arc<tokio::sync::RwLock<HashMap<String, (rdb_connstore::Engine, Arc<AnyDriver>)>>>;
+
+/// Resolve which driver a query should run against: the pool entry for its
+/// own connection id when there is one, else `current` (covers only a tab
+/// with no `connection_id` yet). A tab that *has* a `connection_id` but it's
+/// missing from `pool` means that connection was explicitly disconnected —
+/// falling back to `current` there would silently run the query against
+/// whatever unrelated connection happens to be focused now.
+fn driver_for<'a, V>(
+    pool: &'a HashMap<String, V>,
+    current: Option<&'a V>,
+    connection_id: Option<&str>,
+) -> Option<&'a V> {
+    match connection_id {
+        Some(id) => pool.get(id),
+        None => current,
+    }
+}
+
+#[cfg(test)]
+mod driver_pool_tests {
+    use super::driver_for;
+    use std::collections::HashMap;
+
+    #[test]
+    fn picks_the_tabs_own_connection_over_current() {
+        let mut pool = HashMap::new();
+        pool.insert("conn-a".to_string(), "driver-a");
+        pool.insert("conn-b".to_string(), "driver-b");
+        let current = Some(&"driver-b");
+        // Tab belongs to conn-a even though conn-b is the one focused now.
+        assert_eq!(
+            driver_for(&pool, current, Some("conn-a")),
+            Some(&"driver-a")
+        );
+    }
+
+    #[test]
+    fn falls_back_to_current_when_tab_has_no_connection_id() {
+        let pool: HashMap<String, &str> = HashMap::new();
+        let current = Some(&"driver-b");
+        assert_eq!(driver_for(&pool, current, None), Some(&"driver-b"));
+    }
+
+    #[test]
+    fn none_when_tab_has_a_connection_id_missing_from_pool() {
+        // Explicitly disconnected: must not silently fall back to `current`.
+        let pool: HashMap<String, &str> = HashMap::new();
+        let current = Some(&"driver-b");
+        assert_eq!(driver_for(&pool, current, Some("conn-a")), None);
+    }
+
+    #[test]
+    fn none_when_nothing_matches() {
+        let pool: HashMap<String, &str> = HashMap::new();
+        assert_eq!(driver_for(&pool, None, Some("conn-a")), None);
+    }
+}
+
+/// The focused tab's own connection id — the one a query/browse/edit action
+/// started from that tab must run against, per `driver_for`. Duplicated by
+/// hand across every wiring module before this, which is how the tab-vs-
+/// `current` mismatch bugs (see `driver_for`) kept reappearing.
+fn focused_tab_connection_id(
+    active_tab_id: &std::sync::Mutex<Option<String>>,
+    workspace_tabs: &std::sync::Mutex<Vec<WorkspaceTab>>,
+) -> Option<String> {
+    let id = active_tab_id.lock().unwrap().clone()?;
+    workspace_tabs
+        .lock()
+        .unwrap()
+        .iter()
+        .find(|t| t.id == id)
+        .and_then(|t| t.connection_id.clone())
+}
+
+/// Connection ids any open tab still references, across both split-pane
+/// groups. A pool entry whose id falls out of this set has no tab left that
+/// could query it — safe to close.
+fn live_connection_ids(tabs: &[WorkspaceTab]) -> HashSet<String> {
+    tabs.iter()
+        .filter_map(|t| t.connection_id.clone())
+        .collect()
+}
+
+#[cfg(test)]
+mod live_connection_ids_tests {
+    use super::{live_connection_ids, WorkspaceTab};
+
+    fn tab(id: &str, connection_id: Option<&str>) -> WorkspaceTab {
+        let mut t = WorkspaceTab::sql(id.into(), 0);
+        t.connection_id = connection_id.map(str::to_string);
+        t
+    }
+
+    #[test]
+    fn collects_every_distinct_connection_still_open() {
+        let tabs = vec![
+            tab("q1", Some("conn-a")),
+            tab("q2", Some("conn-b")),
+            tab("q3", Some("conn-a")),
+            tab("q4", None),
+        ];
+        let live = live_connection_ids(&tabs);
+        assert_eq!(live.len(), 2);
+        assert!(live.contains("conn-a"));
+        assert!(live.contains("conn-b"));
+    }
+
+    #[test]
+    fn no_tabs_means_nothing_live() {
+        assert!(live_connection_ids(&[]).is_empty());
+    }
+}
+
 /// Slot holding the "re-run the current browse query" closure. Set once the
 /// browse view knows what it is browsing; `None` before that.
 type BrowseTrigger = Rc<RefCell<Option<Rc<dyn Fn()>>>>;
@@ -4427,6 +4589,7 @@ struct AppState {
     settings: Rc<RefCell<rdb_connstore::SettingsStore>>,
     history_cap: Rc<Cell<usize>>,
     current: DriverSlot,
+    driver_pool: DriverPool,
     raw_nodes: Arc<Mutex<Vec<model::VmTreeNode>>>,
     expanded_tables: Arc<Mutex<HashSet<String>>>,
     loaded_dbs: Arc<Mutex<HashSet<String>>>,
@@ -4437,6 +4600,14 @@ struct AppState {
     active_tab_id: Arc<Mutex<Option<String>>>,
     active_group1_tab_id: Arc<Mutex<Option<String>>>,
     current_connection_id: Arc<Mutex<Option<String>>>,
+    // Ids with a driver actually in `driver_pool` right now — set at connect
+    // success, cleared at disconnect. Distinct from `live_connection_ids`
+    // (which open tabs merely *reference*): a tab keeps its `connection_id`
+    // after that connection is disconnected (so reconnecting can pick it
+    // back up), so the tab-based set can't tell the sidebar dot or the
+    // "another connection is still around" check whether a connection is
+    // actually live right now.
+    connected_ids: Arc<Mutex<HashSet<String>>>,
     query_number: Arc<std::sync::atomic::AtomicUsize>,
     collapsed_categories: Rc<RefCell<HashSet<String>>>,
     sidebar_filter: Arc<Mutex<String>>,
@@ -4594,6 +4765,7 @@ fn main() -> Result<(), slint::PlatformError> {
     // query. Drivers are `&self`, internally pooled and cheap to clone, so this
     // removes query↔ping (and query↔query) serialization.
     let current: DriverSlot = Arc::new(tokio::sync::Mutex::new(None));
+    let driver_pool: DriverPool = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
 
     // Set of group labels the user has collapsed in the sidebar.
     let collapsed: Rc<RefCell<HashSet<String>>> = Rc::new(RefCell::new(HashSet::new()));
@@ -4670,6 +4842,8 @@ fn main() -> Result<(), slint::PlatformError> {
         Arc::new(std::sync::Mutex::new(None));
     let current_connection_id: Arc<std::sync::Mutex<Option<String>>> =
         Arc::new(std::sync::Mutex::new(None));
+    let connected_ids: Arc<std::sync::Mutex<HashSet<String>>> =
+        Arc::new(std::sync::Mutex::new(HashSet::new()));
     // One-shot database override for the next connect: the database switcher sets
     // it, then re-invokes the connect path, which consumes it (take) so a plain
     // reconnect from the picker still uses the connection's saved database.
@@ -4767,6 +4941,7 @@ fn main() -> Result<(), slint::PlatformError> {
         settings: settings.clone(),
         history_cap: history_cap.clone(),
         current: current.clone(),
+        driver_pool: driver_pool.clone(),
         raw_nodes: raw_nodes.clone(),
         expanded_tables: expanded_tables.clone(),
         loaded_dbs: loaded_dbs.clone(),
@@ -4777,6 +4952,7 @@ fn main() -> Result<(), slint::PlatformError> {
         active_tab_id: active_tab_id.clone(),
         active_group1_tab_id: active_group1_tab_id.clone(),
         current_connection_id: current_connection_id.clone(),
+        connected_ids: connected_ids.clone(),
         query_number: query_number.clone(),
         collapsed_categories: collapsed_categories.clone(),
         sidebar_filter: sidebar_filter.clone(),
@@ -4802,6 +4978,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let store = store.clone();
         let collapsed = collapsed.clone();
         let conn_filter = conn_filter.clone();
+        let connected_ids = connected_ids.clone();
         move || {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -4810,10 +4987,12 @@ fn main() -> Result<(), slint::PlatformError> {
                 &store.borrow(),
                 &collapsed.borrow(),
                 &conn_filter.borrow(),
+                &connected_ids.lock().unwrap(),
             ));
         }
     };
     rebuild_sidebar();
+    window.on_refresh_connections(rebuild_sidebar.clone());
     window.set_schema_tree(ModelRc::from(Rc::new(VecModel::<TreeNode>::default())));
 
     let (sync_editor, load_editor_text) = wire::editor::wire(&window, &state);
@@ -4973,6 +5152,8 @@ fn main() -> Result<(), slint::PlatformError> {
         let load_editor_text = load_editor_text.clone();
         let panes = panes.clone();
         let last_view = last_view.clone();
+        let store = store.clone();
+        let current_connection_id = current_connection_id.clone();
         Rc::new(move |w, abs_index| {
             let (tab, pane, group_index) = {
                 let tabs = tabs.lock().unwrap();
@@ -4985,6 +5166,17 @@ fn main() -> Result<(), slint::PlatformError> {
             };
             if pane == 0 {
                 *active_tab_id.lock().unwrap() = Some(tab.id.clone());
+                // Topbar identity follows whichever tab is now on screen, not
+                // the last connection explicitly picked from the connect flow.
+                sync_conn_chrome(w, &store.borrow(), tab.connection_id.as_deref());
+                // `current_connection_id` is the single "what does a NEW action
+                // target" pointer (new tab, browse-from-sidebar) — it must track
+                // the focused tab too, or a plain tab switch leaves it aimed at
+                // whatever connection was last explicitly clicked, and a New
+                // Query fired right after silently lands on the wrong one.
+                if let Some(cid) = tab.connection_id.clone() {
+                    *current_connection_id.lock().unwrap() = Some(cid);
+                }
             } else {
                 *active_group1_tab_id.lock().unwrap() = Some(tab.id.clone());
             }

--- a/app/src/ui/app-window.slint
+++ b/app/src/ui/app-window.slint
@@ -36,7 +36,10 @@ export component MainWindow inherits Window {
     icon: @image-url("../../assets/icon.png");
     preferred-width: 1240px;
     preferred-height: 780px;
-    min-width: 760px;
+    // Toolbar row (breadcrumb + search pill + aux icon cluster) needs ~950px
+    // of fixed-width content when connected; below that the icon cluster on
+    // the right gets pushed past the window edge instead of shrinking.
+    min-width: 980px;
     min-height: 500px;
     background: Tokens.chrome;
     default-font-size: 13px;
@@ -280,6 +283,13 @@ callback create-table-commit();
     in property <string> conn-status: "connecting";
     callback disconnect();
     callback conn-filter(string);
+    // Re-render the connections sidebar (live dots etc.) from Rust state.
+    // Needed as a callback, not a plain fn call, because the connect flow's
+    // success/failure is only known from an async task off the UI thread —
+    // invoke_from_event_loop's closure must be Send, so it can't touch the
+    // Rc-based connection store directly; invoking this callback bounces
+    // back into a plain sync handler that can.
+    callback refresh-connections();
 
     // ----- work area models -----
     in-out property <string> query-text;
@@ -1271,6 +1281,9 @@ callback create-table-commit();
                     sidebar-w: root.sidebar-w;
                     schema-list: root.schema-list;
                     schema-name: root.schema-name;
+                    connections: root.connections;
+                    selected-conn: root.selected-conn;
+                    connect-clicked(i) => { root.connect-clicked(i); }
                     set-rail(v) => { root.sidebar-rail = v; }
                     set-visible(v) => { root.sidebar-visible = v; }
                     set-w(v) => { root.sidebar-w = v; }
@@ -1389,6 +1402,16 @@ callback create-table-commit();
                                     padding-left: Tokens.sp3;
                                     padding-right: Tokens.sp1;
                                     spacing: Tokens.sp2;
+                                    // connection color dot
+                                    if tab.engine != "": VerticalLayout {
+                                        alignment: center;
+                                        Rectangle {
+                                            width: 6px;
+                                            height: 6px;
+                                            border-radius: 3px;
+                                            background: tab.has-custom-color ? tab.color : Tokens.db-color(tab.engine);
+                                        }
+                                    }
                                     if tab.kind == "table": VerticalLayout {
                                         alignment: center;
                                         Rectangle {
@@ -1596,6 +1619,16 @@ callback create-table-commit();
                                 p1-tab-content := HorizontalLayout {
                                     padding-left: Tokens.sp3;
                                     padding-right: Tokens.sp2;
+                                    spacing: Tokens.sp2;
+                                    if tab.engine != "": VerticalLayout {
+                                        alignment: center;
+                                        Rectangle {
+                                            width: 6px;
+                                            height: 6px;
+                                            border-radius: 3px;
+                                            background: tab.has-custom-color ? tab.color : Tokens.db-color(tab.engine);
+                                        }
+                                    }
                                     Text {
                                         vertical-alignment: center;
                                         text: tab.kind == "sql" ? ">_" : tab.kind == "function" ? "ƒ" : "▦";
@@ -2158,6 +2191,9 @@ callback create-table-commit();
                     sidebar-w: root.sidebar-w;
                     schema-list: root.schema-list;
                     schema-name: root.schema-name;
+                    connections: root.connections;
+                    selected-conn: root.selected-conn;
+                    connect-clicked(i) => { root.connect-clicked(i); }
                     set-rail(v) => { root.sidebar-rail = v; }
                     set-visible(v) => { root.sidebar-visible = v; }
                     set-w(v) => { root.sidebar-w = v; }

--- a/app/src/ui/connections-panel.slint
+++ b/app/src/ui/connections-panel.slint
@@ -1,0 +1,112 @@
+// Standalone connections list: own card to the left of the Items/Queries/
+// History sidebar, always visible as its own section, never hidden behind
+// a tab switch.
+import { Tokens } from "tokens.slint";
+import { TopLevelGroup } from "structs.slint";
+import { FloatingCard } from "components.slint";
+import { ScrollView } from "std-widgets.slint";
+
+export component ConnectionsPanel inherits Rectangle {
+    in property <[TopLevelGroup]> connections;
+    // Store index of the active tab's connection — same field the picker
+    // uses (`selected-conn`), so "active" always means the same row
+    // everywhere instead of drifting on a name-string comparison.
+    in property <int> selected-conn: -1;
+    callback connect-clicked(int);
+
+    background: Tokens.canvas;
+
+    card := FloatingCard {
+        x: Tokens.sp1;
+        y: Tokens.sp1;
+        width: parent.width - 2 * Tokens.sp1;
+        height: parent.height - 2 * Tokens.sp1;
+
+        VerticalLayout {
+            Rectangle {
+                height: 26px;
+                Text {
+                    x: Tokens.sp2;
+                    text: "CONNECTIONS";
+                    color: Tokens.text-faint;
+                    font-size: Tokens.font-xs;
+                    font-weight: Tokens.weight-emphasis;
+                    vertical-alignment: center;
+                }
+            }
+            list := ScrollView {
+                vertical-stretch: 1;
+                VerticalLayout {
+                    width: list.visible-width;
+                    padding-left: Tokens.sp2;
+                    padding-right: Tokens.sp2;
+                    padding-bottom: Tokens.sp1;
+                    spacing: 2px;
+                    for group in root.connections: VerticalLayout {
+                        for item in group.rows: Rectangle {
+                            property <bool> active: !item.is-header && item.index == root.selected-conn;
+                            height: 26px;
+                            border-radius: Tokens.radius;
+                            background: item.is-header ? transparent
+                                : active ? Tokens.accent-tint
+                                : (ta.has-hover ? Tokens.border : transparent);
+                            ta := TouchArea {
+                                enabled: !item.is-header;
+                                clicked => { root.connect-clicked(item.index); }
+                            }
+                            HorizontalLayout {
+                                padding-left: Tokens.sp2 + item.depth * Tokens.sp3;
+                                padding-right: Tokens.sp2;
+                                spacing: Tokens.sp2;
+                                if item.is-header: Text {
+                                    text: item.name;
+                                    color: Tokens.text-faint;
+                                    font-size: Tokens.font-xs;
+                                    font-weight: Tokens.weight-emphasis;
+                                    vertical-alignment: center;
+                                }
+                                if !item.is-header: Rectangle {
+                                    width: 8px;
+                                    VerticalLayout {
+                                        alignment: center;
+                                        Rectangle {
+                                            width: 8px;
+                                            height: 8px;
+                                            border-radius: 4px;
+                                            background: item.has-custom-color ? item.color : Tokens.db-color(item.engine);
+                                        }
+                                    }
+                                }
+                                if !item.is-header: Text {
+                                    horizontal-stretch: 1;
+                                    text: item.name;
+                                    color: active ? Tokens.on-tint : Tokens.text;
+                                    font-size: Tokens.font-sm;
+                                    font-weight: active ? Tokens.weight-emphasis : 400;
+                                    vertical-alignment: center;
+                                    overflow: elide;
+                                }
+                                // Live/offline dot, always drawn (not just when
+                                // live) — with two connections open, disconnecting
+                                // one must show which is which, not just silently
+                                // vanish from a shared "connected" state.
+                                if !item.is-header: Rectangle {
+                                    width: 6px;
+                                    VerticalLayout {
+                                        alignment: center;
+                                        Rectangle {
+                                            width: 6px;
+                                            height: 6px;
+                                            border-radius: 3px;
+                                            background: item.live ? Tokens.ok : Tokens.error;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/ui/nav-cluster.slint
+++ b/app/src/ui/nav-cluster.slint
@@ -8,9 +8,10 @@
 // edge) and only one renders — a shared owner keeps them in lock-step, which a
 // duplicated two-way binding would not.
 import { Tokens } from "tokens.slint";
-import { TreeNode } from "structs.slint";
+import { TreeNode, TopLevelGroup } from "structs.slint";
 import { IconButton } from "components.slint";
 import { Sidebar } from "sidebar.slint";
+import { ConnectionsPanel } from "connections-panel.slint";
 
 export component NavCluster inherits HorizontalLayout {
     // Sidebar on the right: splitter on the inner (left) edge, drag sign flipped.
@@ -29,11 +30,14 @@ export component NavCluster inherits HorizontalLayout {
     in property <bool> sidebar-rail: false;
     in property <length> sidebar-w;
     in property <int> focus-tick;
+    in property <[TopLevelGroup]> connections;
+    in property <int> selected-conn: -1;
 
     callback set-rail(bool);
     callback set-visible(bool);
     callback set-w(length);
 
+    callback connect-clicked(int);
     callback disconnect();
     callback open-function(string);
     callback open-query(string, int);
@@ -64,43 +68,58 @@ export component NavCluster inherits HorizontalLayout {
                     if root.sidebar-w - (self.mouse-x - self.pressed-x) < 150px {
                         root.set-rail(true);
                     } else {
-                        root.set-w(clamp(root.sidebar-w - (self.mouse-x - self.pressed-x), 184px, 360px));
+                        root.set-w(clamp(root.sidebar-w - (self.mouse-x - self.pressed-x), 320px, 560px));
                     }
                 }
             }
         }
     }
 
-    if root.sidebar-visible && !root.sidebar-rail: Sidebar {
-        focus-tick: root.focus-tick;
+    // Connections rail sits to the left of, and separate from, the Items/
+    // Queries/History card — its own column, not stacked above it.
+    if root.sidebar-visible && !root.sidebar-rail: HorizontalLayout {
         horizontal-stretch: 0;
         min-width: root.sidebar-w;
         max-width: root.sidebar-w;
-        tree: root.tree;
-        conn-name: root.conn-name;
-        active-table: root.active-table;
-        active-count: root.active-count;
-        query-tree: root.query-tree;
-        mode: root.sidebar-mode;
-        tree-loading: root.tree-loading;
-        schema-list: root.schema-list;
-        schema-name: root.schema-name;
-        disconnect() => { root.disconnect(); }
-        open-function(f) => { root.open-function(f); }
-        open-query(q, i) => { root.open-query(q, i); }
-        insert-query(i) => { root.insert-query(i); }
-        rerun-query(i) => { root.rerun-query(i); }
-        history-action(i, a) => { root.history-action(i, a); }
-        run-saved-query(i) => { root.run-saved-query(i); }
-        query-action(i, a) => { root.query-action(i, a); }
-        mode-changed(m) => { root.mode-changed(m); }
-        open-table(db, t) => { root.open-table(db, t); }
-        pin-table(db, t) => { root.pin-table(db, t); }
-        toggle-fields(db, t) => { root.toggle-fields(db, t); }
-        toggle-node(t) => { root.toggle-node(t); }
-        select-schema(s) => { root.select-schema(s); }
-        filter-tree(t) => { root.filter-tree(t); }
-        add-item() => { root.add-item(); }
+        spacing: 0px;
+
+        ConnectionsPanel {
+            horizontal-stretch: 0;
+            width: 132px;
+            connections: root.connections;
+            selected-conn: root.selected-conn;
+            connect-clicked(i) => { root.connect-clicked(i); }
+        }
+
+        Sidebar {
+            focus-tick: root.focus-tick;
+            horizontal-stretch: 1;
+            tree: root.tree;
+            conn-name: root.conn-name;
+            active-table: root.active-table;
+            active-count: root.active-count;
+            query-tree: root.query-tree;
+            mode: root.sidebar-mode;
+            tree-loading: root.tree-loading;
+            schema-list: root.schema-list;
+            schema-name: root.schema-name;
+            disconnect() => { root.disconnect(); }
+            open-function(f) => { root.open-function(f); }
+            open-query(q, i) => { root.open-query(q, i); }
+            insert-query(i) => { root.insert-query(i); }
+            rerun-query(i) => { root.rerun-query(i); }
+            history-action(i, a) => { root.history-action(i, a); }
+            run-saved-query(i) => { root.run-saved-query(i); }
+            query-action(i, a) => { root.query-action(i, a); }
+            mode-changed(m) => { root.mode-changed(m); }
+            open-table(db, t) => { root.open-table(db, t); }
+            pin-table(db, t) => { root.pin-table(db, t); }
+            toggle-fields(db, t) => { root.toggle-fields(db, t); }
+            toggle-node(t) => { root.toggle-node(t); }
+            select-schema(s) => { root.select-schema(s); }
+            filter-tree(t) => { root.filter-tree(t); }
+            add-item() => { root.add-item(); }
+        }
     }
 
     // icon rail: compact tab icons when collapsed below the min width.
@@ -172,7 +191,7 @@ export component NavCluster inherits HorizontalLayout {
                     if root.sidebar-w + (self.mouse-x - self.pressed-x) < 150px {
                         root.set-rail(true);
                     } else {
-                        root.set-w(clamp(root.sidebar-w + (self.mouse-x - self.pressed-x), 184px, 360px));
+                        root.set-w(clamp(root.sidebar-w + (self.mouse-x - self.pressed-x), 320px, 560px));
                     }
                 }
             }

--- a/app/src/ui/structs.slint
+++ b/app/src/ui/structs.slint
@@ -58,6 +58,9 @@ export struct ConnItem {
     // Nesting depth of this row's group (0 = top-level). Drives left indent;
     // mirrors `TreeNode.depth`.
     depth: int,
+    // Has an open driver right now (a workspace tab is bound to it). False
+    // for headers and for connections never connected this session.
+    live: bool,
 }
 // One top-level card in the sidebar: its own header row plus every row
 // nested under it (subgroup headers, direct connections), so the sidebar

--- a/app/src/ui/tokens.slint
+++ b/app/src/ui/tokens.slint
@@ -108,7 +108,10 @@ export global Tokens {
     out property <length> titlebar-h: 44px + zoom-delta;
     out property <length> doc-tab-row-h: 35px + zoom-delta;
     out property <length> doc-tab-h: 30px + zoom-delta;
-    out property <length> sidebar-w: 218px;
+    // Shared by the connections rail (fixed 132px) + the Items/Queries/
+    // History card beside it — wide enough that neither is squished on
+    // first launch, before the user ever drags the splitter.
+    out property <length> sidebar-w: 400px;
     out property <length> grid-row-h: 24px + zoom-delta;
     out property <length> grid-header-h: 27px + zoom-delta;
     out property <length> status-bar-h: 34px + zoom-delta;

--- a/app/src/wire/browse.rs
+++ b/app/src/wire/browse.rs
@@ -18,6 +18,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
         store,
         panes,
         current,
+        driver_pool,
         cur_engine,
         raw_nodes,
         expanded_tables,
@@ -107,6 +108,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
         let cur_engine = cur_engine.clone();
         let browse = browse.clone();
         let current = current.clone();
+        let driver_pool = driver_pool.clone();
         let rt = rt.clone();
         let run_browse = run_browse.clone();
         let edit_buf = edit_buf.clone();
@@ -229,15 +231,19 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
             // Fetch total + primary key off-thread; footer updates when done.
             let weak2 = weak.clone();
             let current = current.clone();
+            let driver_pool = driver_pool.clone();
             let browse = browse.clone();
             let edit_buf = edit_buf.clone();
             let workspace_tabs = workspace_tabs.clone();
             let active_tab_id = active_tab_id.clone();
             let query_console = query_console.clone();
+            let table_connection_id = (!connection_id.is_empty()).then(|| connection_id.clone());
             rt.spawn(async move {
                 let picked = {
+                    let pool = driver_pool.read().await;
                     let guard = current.lock().await;
-                    guard.as_ref().map(|(e, d)| (*e, d.clone()))
+                    driver_for(&pool, guard.as_ref(), table_connection_id.as_deref())
+                        .map(|(e, d)| (*e, d.clone()))
                 };
                 let Some((engine, driver)) = picked.as_ref() else {
                     return;
@@ -358,9 +364,12 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
         let weak = window.as_weak();
         let browse = browse.clone();
         let current = current.clone();
+        let driver_pool = driver_pool.clone();
         let rt = rt.clone();
         let run_browse = run_browse.clone();
         let guard_pending = guard_pending.clone();
+        let active_tab_id = active_tab_id.clone();
+        let workspace_tabs = workspace_tabs.clone();
         window.on_refresh_page(move || {
             if weak.upgrade().is_some_and(|w| guard_pending(&w)) {
                 return;
@@ -371,11 +380,17 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
             let Some(table) = table else { return };
             let weak2 = weak.clone();
             let current = current.clone();
+            let driver_pool = driver_pool.clone();
             let browse = browse.clone();
+            // The focused tab's own connection, not whatever `current` is —
+            // switching focus between already-open tabs never touches `current`.
+            let tab_connection_id = focused_tab_connection_id(&active_tab_id, &workspace_tabs);
             rt.spawn(async move {
                 let driver = {
+                    let pool = driver_pool.read().await;
                     let guard = current.lock().await;
-                    guard.as_ref().map(|(_, d)| d.clone())
+                    driver_for(&pool, guard.as_ref(), tab_connection_id.as_deref())
+                        .map(|(_, d)| d.clone())
                 };
                 let Some(driver) = driver else {
                     return;

--- a/app/src/wire/browse.rs
+++ b/app/src/wire/browse.rs
@@ -239,12 +239,8 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
             let query_console = query_console.clone();
             let table_connection_id = (!connection_id.is_empty()).then(|| connection_id.clone());
             rt.spawn(async move {
-                let picked = {
-                    let pool = driver_pool.read().await;
-                    let guard = current.lock().await;
-                    driver_for(&pool, guard.as_ref(), table_connection_id.as_deref())
-                        .map(|(e, d)| (*e, d.clone()))
-                };
+                let picked =
+                    resolve_driver(&driver_pool, &current, table_connection_id.as_deref()).await;
                 let Some((engine, driver)) = picked.as_ref() else {
                     return;
                 };
@@ -386,12 +382,9 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
             // switching focus between already-open tabs never touches `current`.
             let tab_connection_id = focused_tab_connection_id(&active_tab_id, &workspace_tabs);
             rt.spawn(async move {
-                let driver = {
-                    let pool = driver_pool.read().await;
-                    let guard = current.lock().await;
-                    driver_for(&pool, guard.as_ref(), tab_connection_id.as_deref())
-                        .map(|(_, d)| d.clone())
-                };
+                let driver = resolve_driver(&driver_pool, &current, tab_connection_id.as_deref())
+                    .await
+                    .map(|(_, d)| d);
                 let Some(driver) = driver else {
                     return;
                 };

--- a/app/src/wire/conn_form.rs
+++ b/app/src/wire/conn_form.rs
@@ -48,6 +48,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) {
         collapsed,
         conn_filter,
         editing_id,
+        connected_ids,
         ..
     } = state.clone();
 
@@ -505,12 +506,14 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) {
             let store = store.clone();
             let collapsed = collapsed.clone();
             let conn_filter = conn_filter.clone();
+            let connected_ids = connected_ids.clone();
             move || {
                 if let Some(w) = weak.upgrade() {
                     w.set_connections(build_sidebar_model(
                         &store.borrow(),
                         &collapsed.borrow(),
                         &conn_filter.borrow(),
+                        &connected_ids.lock().unwrap(),
                     ));
                 }
             }
@@ -632,6 +635,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) {
         let editing_id = editing_id.clone();
         let collapsed = collapsed.clone();
         let conn_filter = conn_filter.clone();
+        let connected_ids = connected_ids.clone();
         window.on_form_delete_confirmed(move || {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -653,6 +657,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) {
                 &store.borrow(),
                 &collapsed.borrow(),
                 &conn_filter.borrow(),
+                &connected_ids.lock().unwrap(),
             ));
         });
     }

--- a/app/src/wire/connect.rs
+++ b/app/src/wire/connect.rs
@@ -12,7 +12,345 @@ use slint::{ComponentHandle, Model, ModelRc, SharedString, VecModel};
 
 use crate::*;
 
-pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
+/// Decides what a connection switch does with the open tabs, before
+/// touching any UI or shared state.
+struct TabRestorePlan {
+    tabs: Vec<WorkspaceTab>,
+    active: Option<String>,
+    active_p1: Option<String>,
+    active_group: usize,
+    /// A surviving SQL tab stays active across the switch, so its last
+    /// result is still meaningful — leave it on screen instead of blanking.
+    /// Only a fresh restore (first connect / DB switch) clears.
+    standby: bool,
+}
+
+fn plan_tab_restore(
+    tabs_restored: &Rc<Cell<bool>>,
+    workspace_tabs: &Arc<Mutex<Vec<WorkspaceTab>>>,
+    active_tab_id: &Arc<Mutex<Option<String>>>,
+    active_group1_tab_id: &Arc<Mutex<Option<String>>>,
+    query_number: &Arc<std::sync::atomic::AtomicUsize>,
+) -> TabRestorePlan {
+    let restore = should_restore_query_tabs(tabs_restored.get());
+    tabs_restored.set(true);
+    let (tabs, active, active_p1, active_group) = if restore {
+        let (tabs, active, active_p1, active_group, max_number) = load_query_tabs();
+        // Never let a freshly-minted tab reuse a number a restored tab
+        // already holds — `fetch_max` only ever raises the counter.
+        query_number.fetch_max(max_number, std::sync::atomic::Ordering::Relaxed);
+        (tabs, active, active_p1, active_group)
+    } else {
+        // Retain every open tab across the switch so the workspace behaves
+        // like a set of persistent documents — the SQL scratch tabs keep
+        // their results ("standby") and the connection-scoped table/
+        // collection tabs stay open too, their last data now a snapshot
+        // until the user hits Refresh against the new connection. Only the
+        // in-flight loading flag is cleared so no tab is left showing a
+        // stuck spinner.
+        let mut kept: Vec<WorkspaceTab> = std::mem::take(&mut *workspace_tabs.lock().unwrap());
+        for t in &mut kept {
+            t.loading = false;
+        }
+        // Picking a connection changes what NEW actions target (new tab,
+        // browse-from-sidebar) — it must never rewrite a tab that's already
+        // open. Each tab is permanently locked to the connection it was
+        // created against (routed by its own `connection_id` through
+        // `driver_pool`); reassigning the focused one here is what made
+        // switching connections look like it dragged the open query tab
+        // along with it.
+        let active = active_tab_id
+            .lock()
+            .unwrap()
+            .clone()
+            .filter(|id| kept.iter().any(|t| t.id == *id))
+            .or_else(|| kept.first().map(|t| t.id.clone()));
+        // Connection switch keeps the in-memory focus + right-group tab.
+        let active_p1 = active_group1_tab_id
+            .lock()
+            .unwrap()
+            .clone()
+            .filter(|id| kept.iter().any(|t| t.id == *id));
+        (kept, active, active_p1, 0usize)
+    };
+    let standby = !restore && active.is_some();
+    TabRestorePlan {
+        tabs,
+        active,
+        active_p1,
+        active_group,
+        standby,
+    }
+}
+
+/// Connect + fetch the initial schema, bounded by `timeout_secs` so an
+/// unreachable host can't spin forever (the Cancel button aborts sooner).
+async fn attempt_connect(
+    engine: rdb_connstore::Engine,
+    cfg: rdb_connstore::Result<rdb_core::conn::ConnConfig>,
+    nosql_limit: usize,
+    timeout_secs: u64,
+) -> Result<(AnyDriver, rdb_core::schema::Schema, Option<String>), rdb_core::error::RdbError> {
+    let attempt = async {
+        let cfg = cfg.map_err(|e| rdb_core::error::RdbError::Connection(e.to_string()))?;
+        let driver = AnyDriver::connect(engine, &cfg).await?;
+        // Apply the NoSQL collection cap before any schema fetch so the
+        // first sidebar load already honors it (Mongo only).
+        driver.set_collection_limit(nosql_limit);
+        // MongoDB: when the connection names a database, scope the sidebar
+        // to it (matching the schema switcher) instead of listing every
+        // database on the server.
+        let scoped_db = if matches!(engine, rdb_connstore::Engine::Mongo) {
+            cfg.database.clone().filter(|d| !d.is_empty())
+        } else {
+            None
+        };
+        let schema = match &scoped_db {
+            Some(db) => driver.schema_for(db).await?,
+            None => driver.schema().await?,
+        };
+        Ok::<_, rdb_core::error::RdbError>((driver, schema, scoped_db))
+    };
+    match tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), attempt).await {
+        Ok(r) => r,
+        Err(_) => Err(rdb_core::error::RdbError::Connection(
+            "connection timed out".into(),
+        )),
+    }
+}
+
+/// Publishes the driver, builds the sidebar tree and autocomplete seed,
+/// pushes it to the UI, then keeps loading every other Postgres schema in
+/// the background so cross-schema completion fills in without blocking the
+/// first paint.
+#[allow(clippy::too_many_arguments)]
+async fn finish_connect_success(
+    weak: slint::Weak<MainWindow>,
+    engine: rdb_connstore::Engine,
+    driver: AnyDriver,
+    schema: rdb_core::schema::Schema,
+    scoped_db: Option<String>,
+    connection_id: String,
+    mut slot: tokio::sync::OwnedMutexGuard<Option<(rdb_connstore::Engine, Arc<AnyDriver>)>>,
+    store_driver: DriverSlot,
+    driver_pool: DriverPool,
+    connected_ids: Arc<Mutex<HashSet<String>>>,
+    expanded_tables: Arc<Mutex<HashSet<String>>>,
+    loaded_dbs: Arc<Mutex<HashSet<String>>>,
+    raw_nodes: Arc<Mutex<Vec<model::VmTreeNode>>>,
+    completion_nodes: Arc<Mutex<Vec<model::VmTreeNode>>>,
+    fn_defs: Arc<Mutex<HashMap<String, String>>>,
+) {
+    // Postgres: list real namespaces so the sidebar schema switcher offers
+    // more than "public". Engine-specific SQL lives in the driver, not here.
+    let pg_schemas: Vec<SharedString> = if matches!(engine, rdb_connstore::Engine::Postgres) {
+        driver
+            .list_schemas()
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .map(SharedString::from)
+            .collect()
+    } else {
+        Vec::new()
+    };
+    // Databases on the server, backing the breadcrumb switcher. Empty for
+    // engines that can't switch database.
+    let db_names: Vec<SharedString> = driver
+        .list_databases()
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .map(SharedString::from)
+        .collect();
+    let driver = Arc::new(driver);
+    *slot = Some((engine, driver.clone()));
+    drop(slot);
+    driver_pool
+        .write()
+        .await
+        .insert(connection_id.clone(), (engine, driver.clone()));
+    // Now genuinely connected — the sidebar dot and "another connection is
+    // still around" checks read this, not tab scoping (see `connected_ids`
+    // on `AppState`).
+    connected_ids.lock().unwrap().insert(connection_id);
+    let nodes = model::to_tree_model(&schema);
+    let fields = model::to_structure_model(&schema);
+    // Scoped Mongo tree holds only the selected database: open it and mark
+    // it loaded so its collections show at once (mirrors the schema
+    // switcher).
+    let (exp, loaded) = match &scoped_db {
+        Some(db) => {
+            let mut e = expanded_tables.lock().unwrap();
+            let mut l = loaded_dbs.lock().unwrap();
+            e.insert(db.clone());
+            l.insert(db.clone());
+            (e.clone(), l.clone())
+        }
+        None => (HashSet::new(), HashSet::new()),
+    };
+    // Stash raw nodes for later expand/collapse rebuilds, and render the
+    // initial view (Functions collapsed, Tables open, fields hidden).
+    // Matches the reseed done on connect above; collapsed_categories itself
+    // is !Send so can't cross here.
+    let rows = schema_display_rows(
+        &nodes,
+        &exp,
+        &default_collapsed_cats(),
+        &loaded,
+        Some(engine),
+        "",
+    );
+    // Postgres browses namespaces, not databases: the selector must say
+    // "public", never the db name (a `"dbname"."table"` query would fail).
+    let mut schema_names: Vec<SharedString> = if matches!(engine, rdb_connstore::Engine::Postgres) {
+        if pg_schemas.is_empty() {
+            vec![SharedString::from("public")]
+        } else {
+            pg_schemas
+        }
+    } else if scoped_db.is_some() && !db_names.is_empty() {
+        // Mongo scoped its tree to one database: still list every database
+        // so the switcher can reach them.
+        db_names.clone()
+    } else {
+        schema
+            .databases
+            .iter()
+            .map(|d| SharedString::from(d.name.clone()))
+            .collect()
+    };
+    if schema_names.is_empty() {
+        schema_names.push(SharedString::from("public"));
+    }
+    // Scoped Mongo starts on its selected database; otherwise default to
+    // "public" when present, else the first name.
+    let schema_current = match &scoped_db {
+        Some(db) => SharedString::from(db.clone()),
+        None => schema_names
+            .iter()
+            .find(|s| s.as_str() == "public")
+            .unwrap_or(&schema_names[0])
+            .clone(),
+    };
+    // Format only makes sense for text query languages.
+    let sql_capable = matches!(
+        rdb_connstore::Engine::language(engine),
+        rdb_connstore::QueryLanguage::Sql | rdb_connstore::QueryLanguage::Cql
+    );
+    *raw_nodes.lock().unwrap() = nodes;
+    // Seed autocomplete with the active schema's tables plus a bare node for
+    // every other schema name, so `schema.` autocompletes immediately. The
+    // remaining schemas' tables and columns fill in from the background
+    // load below.
+    let all_schema_names: Vec<String> = schema_names.iter().map(|s| s.to_string()).collect();
+    {
+        let mut seed =
+            build_completion_seed(&driver, engine, schema_current.as_str(), &schema).await;
+        for name in &all_schema_names {
+            if name != schema_current.as_str() {
+                seed.push(model::VmTreeNode {
+                    label: name.clone(),
+                    kind: "database".into(),
+                });
+            }
+        }
+        *completion_nodes.lock().unwrap() = seed;
+    }
+    {
+        let mut defs = fn_defs.lock().unwrap();
+        defs.clear();
+        for db in &schema.databases {
+            for f in &db.functions {
+                defs.insert(f.name.clone(), f.definition.clone());
+            }
+        }
+    }
+    let _ = slint::invoke_from_event_loop(move || {
+        if let Some(w) = weak.upgrade() {
+            w.set_schema_tree(ModelRc::from(Rc::new(VecModel::from(rows))));
+            w.set_sql_capable(sql_capable);
+            w.set_new_tab_label(crate::query_parse::language_label(engine).into());
+            w.set_schema_name(schema_current);
+            w.set_schema_list(ModelRc::from(Rc::new(VecModel::from(schema_names))));
+            w.set_db_list(ModelRc::from(Rc::new(VecModel::from(db_names))));
+            let sfields: Vec<StructField> = fields
+                .into_iter()
+                .map(|f| StructField {
+                    name: f.name.into(),
+                    type_name: f.type_name.into(),
+                    nullable: f.nullable,
+                })
+                .collect();
+            w.set_structure_columns(ModelRc::from(Rc::new(VecModel::from(sfields))));
+            w.set_status_latency(SharedString::from("connected"));
+            w.set_conn_status(SharedString::from("connected"));
+            w.set_picker_error(SharedString::default());
+            w.set_connecting(false);
+            w.set_tree_loading(false);
+            // Swap the picker for the workspace.
+            w.set_connected(true);
+            // Sidebar dot now shows this connection live, even before any
+            // tab has run a query against it.
+            w.invoke_refresh_connections();
+        }
+    });
+    // Load every other schema's tables so cross-schema `schema.table`
+    // autocompletes. Runs after the sidebar (active schema) already
+    // rendered; the popup just gains more names as this fills. Fetched
+    // concurrently, one task per schema, instead of sequentially.
+    if matches!(engine, rdb_connstore::Engine::Postgres) && all_schema_names.len() > 1 {
+        let driver = {
+            let guard = store_driver.lock().await;
+            guard.as_ref().map(|(_, d)| d.clone())
+        };
+        if let Some(driver) = driver {
+            let handles: Vec<_> = all_schema_names
+                .iter()
+                .cloned()
+                .map(|name| {
+                    let driver = driver.clone();
+                    tokio::spawn(async move {
+                        driver
+                            .schema_for(&name)
+                            .await
+                            .ok()
+                            .map(|s| model::to_completion_nodes(&name, &s))
+                    })
+                })
+                .collect();
+            let mut all = Vec::new();
+            for handle in handles {
+                if let Ok(Some(nodes)) = handle.await {
+                    all.extend(nodes);
+                }
+            }
+            if !all.is_empty() {
+                *completion_nodes.lock().unwrap() = all;
+            }
+        }
+    }
+}
+
+/// A failed connect stays on the picker and surfaces the error there.
+fn finish_connect_failure(weak: slint::Weak<MainWindow>, e: rdb_core::error::RdbError) {
+    eprintln!("connect failed: {e}");
+    let _ = slint::invoke_from_event_loop(move || {
+        if let Some(w) = weak.upgrade() {
+            w.set_connected(false);
+            w.set_connecting(false);
+            w.set_tree_loading(false);
+            // `e`'s own `Display` already reads "connection failed: …" —
+            // don't prefix it again.
+            w.set_picker_error(SharedString::from(format!("{e}")));
+        }
+    });
+}
+
+/// `on_connect_clicked`: flush the active tab, resolve the picked
+/// connection, reset workspace state for it, paint the UI immediately,
+/// then spawn the driver connect on tokio.
+fn handle_connect_clicked(state: &AppState, fns: &AppFns, weak: slint::Weak<MainWindow>, idx: i32) {
     let AppState {
         rt,
         store,
@@ -20,7 +358,6 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
         current,
         driver_pool,
         cur_engine,
-        collapsed,
         raw_nodes,
         completion_nodes,
         expanded_tables,
@@ -37,7 +374,6 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
         last_view,
         connect_handle,
         fn_defs,
-        conn_modal_map,
         tabs_restored,
         ..
     } = state.clone();
@@ -52,6 +388,320 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
     let browse = panes[0].browse.clone();
     let edit_buf = panes[0].edit_buf.clone();
     let results = panes[0].results.clone();
+
+    // Flush the active tab(s) into the workspace model first, or a switch
+    // reads stale/empty text and drops inactive tabs' results.
+    if let Some(w) = weak.upgrade() {
+        save_active_tab(&w);
+        save_p1_tab(&w);
+    }
+    let i = idx as usize;
+    // One-shot: set by the database switcher, empty for a fresh picker
+    // connect (which then uses the connection's saved database).
+    let db_ovr = db_override.lock().unwrap().take();
+    let (sc, cfg) = {
+        let st = store.borrow();
+        let Some(sc) = st.list().get(i).cloned() else {
+            return;
+        };
+        let cfg = st.conn_config_for(&sc.id).map(|mut c| {
+            if let Some(db) = db_ovr.clone() {
+                c.database = Some(db);
+            }
+            c
+        });
+        (sc, cfg)
+    };
+    *current_connection_id.lock().unwrap() = Some(sc.id.clone());
+    // Usually keeps the tabs `main` already restored at startup; falls back
+    // to a disk read only if startup found none. Either way, switching
+    // connections doesn't lose open queries.
+    let TabRestorePlan {
+        tabs: init_tabs,
+        active: init_active,
+        active_p1: init_active_p1,
+        active_group: init_active_group,
+        standby,
+    } = plan_tab_restore(
+        &tabs_restored,
+        &workspace_tabs,
+        &active_tab_id,
+        &active_group1_tab_id,
+        &query_number,
+    );
+    *workspace_tabs.lock().unwrap() = init_tabs;
+    *active_tab_id.lock().unwrap() = init_active.clone();
+    *active_group1_tab_id.lock().unwrap() = init_active_p1.clone();
+    if !standby {
+        results.lock().unwrap().clear();
+        *last_view.lock().unwrap() = None;
+        edit_buf.lock().unwrap().clear();
+    }
+    *browse.lock().unwrap() = BrowseState {
+        limit: default_browse_limit(sc.engine),
+        ..Default::default()
+    };
+    query_console.lock().unwrap().clear();
+    // Reflect selection + accent immediately.
+    if let Some(w) = weak.upgrade() {
+        paint_connect_ui(
+            &w,
+            &sc,
+            db_ovr.as_deref(),
+            idx,
+            init_active.as_deref(),
+            init_active_p1.as_deref(),
+            init_active_group,
+            standby,
+            &store,
+            &workspace_tabs,
+            &query_console,
+            &load_editor_text,
+            &restore_tab,
+        );
+        *current_connection_id.lock().unwrap() = Some(sc.id.clone());
+    }
+    // Fresh connection: nothing browsed, nothing expanded.
+    *cur_engine.borrow_mut() = Some(sc.engine);
+    // Editors were lexed before the engine was known; repaint both panes
+    // so a tab with no engine of its own isn't stuck on the old dialect.
+    sync_editor(0);
+    sync_editor(1);
+    expanded_tables.lock().unwrap().clear();
+    loaded_dbs.lock().unwrap().clear();
+    *collapsed_categories.borrow_mut() = default_collapsed_cats();
+
+    spawn_connect_task(
+        rt,
+        weak,
+        &sc,
+        cfg,
+        current,
+        driver_pool,
+        connected_ids,
+        raw_nodes,
+        completion_nodes,
+        fn_defs,
+        expanded_tables,
+        loaded_dbs,
+        connect_handle,
+    );
+}
+
+/// Paints the topbar/sidebar/editor into their "connecting" state and
+/// restores whichever tab the switch landed on. Split out of
+/// `handle_connect_clicked` since it's pure UI work, no driver/tokio
+/// involved.
+#[allow(clippy::too_many_arguments)]
+fn paint_connect_ui(
+    w: &MainWindow,
+    sc: &rdb_connstore::SavedConnection,
+    db_ovr: Option<&str>,
+    conn_idx: i32,
+    init_active: Option<&str>,
+    init_active_p1: Option<&str>,
+    init_active_group: usize,
+    standby: bool,
+    store: &Rc<RefCell<rdb_connstore::ConnStore>>,
+    workspace_tabs: &Arc<Mutex<Vec<WorkspaceTab>>>,
+    query_console: &Arc<Mutex<Vec<String>>>,
+    load_editor_text: &PaneTextFn,
+    restore_tab: &WindowPaneFn,
+) {
+    {
+        let tabs = workspace_tabs.lock().unwrap();
+        set_workspace_tabs(w, &tabs, init_active);
+    }
+    if !standby {
+        clear_grid(w, 0);
+    }
+    sync_query_console(w, query_console);
+    w.set_selected_conn(conn_idx);
+    // Show progress + clear any prior failure immediately.
+    w.set_connecting(true);
+    // Dim the sidebar tree while the new schema loads so a connection/db
+    // switch isn't a silent, frozen-looking reload.
+    w.set_tree_loading(true);
+    w.set_conn_status(SharedString::from("connecting"));
+    w.set_picker_error(SharedString::default());
+    w.global::<Theme>()
+        .set_accent(theme::accent_or_default(sc.color.as_deref().unwrap_or("")));
+    w.set_status_conn(SharedString::from(sc.name.clone()));
+    w.set_bc_conn(SharedString::from(sc.name.clone()));
+    w.set_active_env_tag_label(theme::env_tag_label(sc.env_tag).into());
+    w.set_active_env_tag_color(
+        theme::env_tag_color(sc.env_tag).unwrap_or_else(|| theme::accent_or_default("")),
+    );
+    w.set_bc_db(SharedString::from(
+        db_ovr
+            .map(str::to_string)
+            .or_else(|| sc.database.clone())
+            .unwrap_or_default(),
+    ));
+    w.set_bc_schema(SharedString::from(
+        if matches!(sc.engine, rdb_connstore::Engine::Postgres) {
+            "public"
+        } else {
+            ""
+        },
+    ));
+    // Load the restored active tab's SQL, else empty (the engine hint shows
+    // as a ghost placeholder rendered by CodeEditor).
+    let init_text = init_active
+        .and_then(|id| {
+            workspace_tabs
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|t| t.id == id)
+                .map(|t| t.query_text.clone())
+        })
+        .unwrap_or_default();
+    load_editor_text(0, &init_text);
+    w.set_editor_placeholder(SharedString::from(if mock::mock_mode() {
+        ""
+    } else {
+        crate::query_parse::editor_hint(sc.engine)
+    }));
+    w.set_active_table(SharedString::default());
+    // Seed the browse page size from the engine default (Mongo = 20).
+    let dft_limit = default_browse_limit(sc.engine);
+    w.set_limit_text(SharedString::from(dft_limit.to_string()));
+    w.set_filter_operators(ModelRc::from(Rc::new(VecModel::from(filter_operators(
+        sc.engine,
+    )))));
+    w.set_filter_op(SharedString::from("="));
+    // Mirror the operator list to the right split pane's filter row.
+    w.set_p1_filter_operators(ModelRc::from(Rc::new(VecModel::from(filter_operators(
+        sc.engine,
+    )))));
+    w.set_p1_filter_op(SharedString::from("="));
+    // Keep the active tab's last result visible instead of blanking the
+    // grid. No-op if the tab has no stored result yet (first connect).
+    let active_idx = init_active.and_then(|id| {
+        workspace_tabs
+            .lock()
+            .unwrap()
+            .iter()
+            .position(|t| t.id == id)
+    });
+    if let Some(idx) = active_idx {
+        restore_tab(w, idx);
+    }
+    // Restore the right group's active tab, then land on the group that was
+    // focused last session.
+    if let Some(p1_id) = init_active_p1 {
+        let p1_idx = workspace_tabs
+            .lock()
+            .unwrap()
+            .iter()
+            .position(|t| t.id == p1_id);
+        if let Some(idx) = p1_idx {
+            restore_tab(w, idx);
+        }
+    }
+    w.set_active_pane(init_active_group as i32);
+    // restore_tab() above re-syncs chrome to the repainted tab's own
+    // connection as a side effect. If that tab belongs to a different
+    // connection, its side effect drags the topbar back; reapply the
+    // picked connection last so it wins.
+    sync_conn_chrome(w, &store.borrow(), Some(&sc.id));
+}
+
+/// Claims the driver slot, connects on tokio, and publishes the result
+/// back to the UI. Aborts any still-running connect from a previous
+/// selection first, so switching mid-connect can't leak the old task.
+#[allow(clippy::too_many_arguments)]
+fn spawn_connect_task(
+    rt: Arc<tokio::runtime::Runtime>,
+    weak: slint::Weak<MainWindow>,
+    sc: &rdb_connstore::SavedConnection,
+    cfg: rdb_connstore::Result<rdb_core::conn::ConnConfig>,
+    current: DriverSlot,
+    driver_pool: DriverPool,
+    connected_ids: Arc<Mutex<HashSet<String>>>,
+    raw_nodes: Arc<Mutex<Vec<model::VmTreeNode>>>,
+    completion_nodes: Arc<Mutex<Vec<model::VmTreeNode>>>,
+    fn_defs: Arc<Mutex<HashMap<String, String>>>,
+    expanded_tables: Arc<Mutex<HashSet<String>>>,
+    loaded_dbs: Arc<Mutex<HashSet<String>>>,
+    connect_handle: Rc<RefCell<Option<tokio::task::JoinHandle<()>>>>,
+) {
+    let weak2 = weak.clone();
+    let store_driver = current.clone();
+    // Claim the driver slot now, so a query/browse task spawned right
+    // after this click can't observe a stale None; it awaits this lock
+    // instead and resolves once connect lands.
+    let claimed = current.clone().try_lock_owned().ok();
+    let engine = sc.engine;
+    let connection_id = sc.id.clone();
+    // NoSQL collection cap to push onto the fresh connection (Mongo only).
+    let nosql_limit = weak
+        .upgrade()
+        .map(|w| w.get_nosql_collection_limit().max(1) as usize)
+        .unwrap_or(200);
+    let handle = rt.spawn(async move {
+        let slot = match claimed {
+            Some(g) => g,
+            None => store_driver.clone().lock_owned().await,
+        };
+        let timeout_secs = if cfg.as_ref().ok().and_then(|c| c.ssh.as_ref()).is_some() {
+            25
+        } else {
+            15
+        };
+        match attempt_connect(engine, cfg, nosql_limit, timeout_secs).await {
+            Ok((driver, schema, scoped_db)) => {
+                finish_connect_success(
+                    weak2,
+                    engine,
+                    driver,
+                    schema,
+                    scoped_db,
+                    connection_id,
+                    slot,
+                    store_driver,
+                    driver_pool,
+                    connected_ids,
+                    expanded_tables,
+                    loaded_dbs,
+                    raw_nodes,
+                    completion_nodes,
+                    fn_defs,
+                )
+                .await;
+            }
+            Err(e) => {
+                // Drop the claimed lock without touching its content — a
+                // failed reconnect must leave whatever driver was already
+                // `current` untouched.
+                drop(slot);
+                finish_connect_failure(weak2, e);
+            }
+        }
+    });
+    // Abort any still-running connect first, or switching mid-connect
+    // leaks the old task and hangs the UI holding the driver lock.
+    if let Some(old) = connect_handle.borrow_mut().take() {
+        old.abort();
+    }
+    *connect_handle.borrow_mut() = Some(handle);
+}
+
+pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
+    let AppState {
+        rt,
+        store,
+        current,
+        driver_pool,
+        collapsed,
+        workspace_tabs,
+        current_connection_id,
+        connected_ids,
+        connect_handle,
+        conn_modal_map,
+        ..
+    } = state.clone();
 
     // ----- background health poll: flip the breadcrumb dot red when a live
     // connection stops answering, green again when it recovers -----
@@ -78,13 +728,17 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
                     if let Some(id) = current_connection_id.lock().unwrap().clone() {
                         live.insert(id);
                     }
-                    let mut pool = driver_pool.write().await;
-                    let evicted: Vec<String> = pool
-                        .keys()
-                        .filter(|id| !live.contains(*id))
-                        .cloned()
-                        .collect();
-                    pool.retain(|id, _| live.contains(id));
+                    // Single pass: `retain` decides what stays, and the ids it
+                    // drops are exactly the ones eviction needs downstream —
+                    // no separate filter pass over the same keys beforehand.
+                    let mut evicted = Vec::new();
+                    driver_pool.write().await.retain(|id, _| {
+                        let keep = live.contains(id);
+                        if !keep {
+                            evicted.push(id.clone());
+                        }
+                        keep
+                    });
                     evicted
                 };
                 if !evicted.is_empty() {
@@ -172,548 +826,10 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
     // ----- connect: spawn driver work on tokio, push schema back to UI -----
     {
         let weak = window.as_weak();
-        let rt = rt.clone();
-        let store = store.clone();
-        let completion_nodes = completion_nodes.clone();
-        let current = current.clone();
-        let driver_pool = driver_pool.clone();
-        let raw_nodes = raw_nodes.clone();
-        let expanded_tables = expanded_tables.clone();
-        let loaded_dbs = loaded_dbs.clone();
-        let collapsed_categories = collapsed_categories.clone();
-        let cur_engine = cur_engine.clone();
-        let load_editor_text = load_editor_text.clone();
-        let fn_defs = fn_defs.clone();
-        let connect_handle = connect_handle.clone();
-        let browse = browse.clone();
-        let workspace_tabs = workspace_tabs.clone();
-        let active_tab_id = active_tab_id.clone();
-        let active_group1_tab_id = active_group1_tab_id.clone();
-        let current_connection_id = current_connection_id.clone();
-        let query_console = query_console.clone();
-        let results = results.clone();
-        let last_view = last_view.clone();
-        let edit_buf = edit_buf.clone();
-        let db_override = db_override.clone();
-        let tabs_restored = tabs_restored.clone();
-        let query_number = query_number.clone();
-        let restore_tab = restore_tab.clone();
-        let save_active_tab = save_active_tab.clone();
-        let save_p1_tab = save_p1_tab.clone();
+        let state = state.clone();
+        let fns = fns.clone();
         window.on_connect_clicked(move |idx| {
-            // Flush the live editor text + results of the active tab(s) into the
-            // workspace model before it is rebuilt for the new connection. Without
-            // this a connection switch reads stale/empty tab text (the query looked
-            // duplicated or lost) and dropped the results of the inactive tabs.
-            if let Some(w) = weak.upgrade() {
-                save_active_tab(&w);
-                save_p1_tab(&w);
-            }
-            let i = idx as usize;
-            // One-shot: set by the database switcher, empty for a fresh picker
-            // connect (which then uses the connection's saved database).
-            let db_ovr = db_override.lock().unwrap().take();
-            let (sc, cfg) = {
-                let st = store.borrow();
-                let Some(sc) = st.list().get(i).cloned() else {
-                    return;
-                };
-                let cfg = st.conn_config_for(&sc.id).map(|mut c| {
-                    if let Some(db) = db_ovr.clone() {
-                        c.database = Some(db);
-                    }
-                    c
-                });
-                (sc, cfg)
-            };
-            *current_connection_id.lock().unwrap() = Some(sc.id.clone());
-            // Fallback restore: `main` already loads the persisted SQL scratch
-            // tabs at startup, so in practice this takes the keep-what-is-open
-            // branch. It still runs the disk read when startup found nothing to
-            // restore. Either way a connection switch keeps the SQL scratch tabs
-            // so the user can hop between connections without losing queries.
-            let restore = should_restore_query_tabs(tabs_restored.get());
-            tabs_restored.set(true);
-            let (init_tabs, init_active, init_active_p1, init_active_group) = if restore {
-                let (tabs, active, active_p1, active_group, max_number) = load_query_tabs();
-                // Never let a freshly-minted tab reuse a number a restored tab
-                // already holds — `fetch_max` only ever raises the counter.
-                query_number.fetch_max(max_number, std::sync::atomic::Ordering::Relaxed);
-                (tabs, active, active_p1, active_group)
-            } else {
-                // Retain every open tab across the switch so the workspace
-                // behaves like a set of persistent documents — the SQL scratch
-                // tabs keep their results ("standby") and the connection-scoped
-                // table/collection tabs stay open too, their last data now a
-                // snapshot until the user hits Refresh against the new
-                // connection. Only the in-flight loading flag is cleared so no
-                // tab is left showing a stuck spinner.
-                let mut kept: Vec<WorkspaceTab> =
-                    std::mem::take(&mut *workspace_tabs.lock().unwrap())
-                        .into_iter()
-                        .collect();
-                for t in &mut kept {
-                    t.loading = false;
-                }
-                // Picking a connection changes what NEW actions target (new
-                // tab, browse-from-sidebar) — it must never rewrite a tab
-                // that's already open. Each tab is permanently locked to
-                // the connection it was created against (routed by its own
-                // `connection_id` through `driver_pool`); reassigning the
-                // focused one here is what made switching connections look
-                // like it dragged the open query tab along with it.
-                let active = active_tab_id
-                    .lock()
-                    .unwrap()
-                    .clone()
-                    .filter(|id| kept.iter().any(|t| t.id == *id))
-                    .or_else(|| kept.first().map(|t| t.id.clone()));
-                // Connection switch keeps the in-memory focus + right-group tab.
-                let active_p1 = active_group1_tab_id
-                    .lock()
-                    .unwrap()
-                    .clone()
-                    .filter(|id| kept.iter().any(|t| t.id == *id));
-                (kept, active, active_p1, 0usize)
-            };
-            // Standby: a surviving SQL tab stays active across the switch, so its
-            // last result is still meaningful — leave it on screen instead of
-            // blanking. Only a fresh restore (first connect / DB switch) clears.
-            let standby = !restore && init_active.is_some();
-            *workspace_tabs.lock().unwrap() = init_tabs;
-            *active_tab_id.lock().unwrap() = init_active.clone();
-            *active_group1_tab_id.lock().unwrap() = init_active_p1.clone();
-            if !standby {
-                results.lock().unwrap().clear();
-                *last_view.lock().unwrap() = None;
-                edit_buf.lock().unwrap().clear();
-            }
-            *browse.lock().unwrap() = BrowseState {
-                limit: default_browse_limit(sc.engine),
-                ..Default::default()
-            };
-            query_console.lock().unwrap().clear();
-            // Reflect selection + accent immediately.
-            if let Some(w) = weak.upgrade() {
-                {
-                    let tabs = workspace_tabs.lock().unwrap();
-                    set_workspace_tabs(&w, &tabs, init_active.as_deref());
-                }
-                if !standby {
-                    clear_grid(&w, 0);
-                }
-                sync_query_console(&w, &query_console);
-                w.set_selected_conn(idx);
-                // Show progress + clear any prior failure immediately.
-                w.set_connecting(true);
-                // Dim the sidebar tree while the new schema loads so a
-                // connection/db switch isn't a silent, frozen-looking reload.
-                w.set_tree_loading(true);
-                w.set_conn_status(SharedString::from("connecting"));
-                w.set_picker_error(SharedString::default());
-                w.global::<Theme>()
-                    .set_accent(theme::accent_or_default(sc.color.as_deref().unwrap_or("")));
-                w.set_status_conn(SharedString::from(sc.name.clone()));
-                w.set_bc_conn(SharedString::from(sc.name.clone()));
-                w.set_active_env_tag_label(theme::env_tag_label(sc.env_tag).into());
-                w.set_active_env_tag_color(
-                    theme::env_tag_color(sc.env_tag)
-                        .unwrap_or_else(|| theme::accent_or_default("")),
-                );
-                w.set_bc_db(SharedString::from(
-                    db_ovr
-                        .clone()
-                        .or_else(|| sc.database.clone())
-                        .unwrap_or_default(),
-                ));
-                w.set_bc_schema(SharedString::from(
-                    if matches!(sc.engine, rdb_connstore::Engine::Postgres) {
-                        "public"
-                    } else {
-                        ""
-                    },
-                ));
-                // Load the restored active tab's SQL, else empty (the engine hint
-                // shows as a ghost placeholder rendered by CodeEditor).
-                let init_text = init_active
-                    .as_deref()
-                    .and_then(|id| {
-                        workspace_tabs
-                            .lock()
-                            .unwrap()
-                            .iter()
-                            .find(|t| t.id == id)
-                            .map(|t| t.query_text.clone())
-                    })
-                    .unwrap_or_default();
-                load_editor_text(0, &init_text);
-                w.set_editor_placeholder(SharedString::from(if mock::mock_mode() {
-                    ""
-                } else {
-                    crate::query_parse::editor_hint(sc.engine)
-                }));
-                w.set_active_table(SharedString::default());
-                // Seed the browse page size from the engine default (Mongo = 20).
-                let dft_limit = default_browse_limit(sc.engine);
-                w.set_limit_text(SharedString::from(dft_limit.to_string()));
-                w.set_filter_operators(ModelRc::from(Rc::new(VecModel::from(filter_operators(
-                    sc.engine,
-                )))));
-                w.set_filter_op(SharedString::from("="));
-                // Mirror the operator list to the right split pane's filter row.
-                w.set_p1_filter_operators(ModelRc::from(Rc::new(VecModel::from(
-                    filter_operators(sc.engine),
-                ))));
-                w.set_p1_filter_op(SharedString::from("="));
-                // Re-present the active tab's stored result so a connection
-                // switch keeps the last result visible instead of blanking the
-                // grid. No-op (clears) when the tab has no stored result, e.g.
-                // the disk-restored tabs on the first connect of the session.
-                let active_idx = init_active.as_deref().and_then(|id| {
-                    workspace_tabs
-                        .lock()
-                        .unwrap()
-                        .iter()
-                        .position(|t| t.id == id)
-                });
-                if let Some(idx) = active_idx {
-                    restore_tab(&w, idx);
-                }
-                // Restore the right group's active tab, then land on the group
-                // that was focused last session.
-                if let Some(p1_id) = init_active_p1.as_deref() {
-                    let p1_idx = workspace_tabs
-                        .lock()
-                        .unwrap()
-                        .iter()
-                        .position(|t| t.id == p1_id);
-                    if let Some(idx) = p1_idx {
-                        restore_tab(&w, idx);
-                    }
-                }
-                w.set_active_pane(init_active_group as i32);
-                // restore_tab() above re-syncs chrome (and the "what does a
-                // new action target" pointer) to the *repainted tab's own*
-                // connection as a side effect of repainting its pane. When
-                // the kept-active tab belongs to a different connection than
-                // the one just picked here, that side effect quietly drags
-                // the topbar back — reapply the picked connection last so it
-                // always wins.
-                sync_conn_chrome(&w, &store.borrow(), Some(&sc.id));
-                *current_connection_id.lock().unwrap() = Some(sc.id.clone());
-            }
-            // Fresh connection: nothing browsed, nothing expanded.
-            *cur_engine.borrow_mut() = Some(sc.engine);
-            // The tab restores above already lexed the editors, but the engine
-            // was only known once the line above ran — repaint both panes so a
-            // tab with no engine of its own is not left in the old dialect.
-            sync_editor(0);
-            sync_editor(1);
-            expanded_tables.lock().unwrap().clear();
-            loaded_dbs.lock().unwrap().clear();
-            *collapsed_categories.borrow_mut() = default_collapsed_cats();
-            let weak2 = weak.clone();
-            let store_driver = current.clone();
-            // Claim the driver slot synchronously, before any query/browse
-            // task spawned after this click can observe a stale None: those
-            // tasks await this lock and resolve once the connect lands.
-            let claimed = current.clone().try_lock_owned().ok();
-            let engine = sc.engine;
-            let connection_id = sc.id.clone();
-            let driver_pool = driver_pool.clone();
-            let connected_ids = connected_ids.clone();
-            let raw_nodes = raw_nodes.clone();
-            let completion_nodes = completion_nodes.clone();
-            let fn_defs = fn_defs.clone();
-            let expanded_tables = expanded_tables.clone();
-            let loaded_dbs = loaded_dbs.clone();
-            // NoSQL collection cap to push onto the fresh connection (Mongo only).
-            let nosql_limit = weak
-                .upgrade()
-                .map(|w| w.get_nosql_collection_limit().max(1) as usize)
-                .unwrap_or(200);
-            let handle = rt.spawn(async move {
-                let mut slot = match claimed {
-                    Some(g) => g,
-                    None => store_driver.clone().lock_owned().await,
-                };
-                let timeout_secs = if cfg.as_ref().ok().and_then(|c| c.ssh.as_ref()).is_some() {
-                    25
-                } else {
-                    15
-                };
-                // Bound the attempt so an unreachable host can't spin forever;
-                // the Cancel button aborts sooner.
-                let attempt = async {
-                    let cfg =
-                        cfg.map_err(|e| rdb_core::error::RdbError::Connection(e.to_string()))?;
-                    let driver = AnyDriver::connect(engine, &cfg).await?;
-                    // Apply the NoSQL collection cap before any schema fetch so
-                    // the first sidebar load already honors it (Mongo only).
-                    driver.set_collection_limit(nosql_limit);
-                    // MongoDB: when the connection names a database, scope the
-                    // sidebar to it (matching the schema switcher) instead of
-                    // listing every database on the server.
-                    let scoped_db = if matches!(engine, rdb_connstore::Engine::Mongo) {
-                        cfg.database.clone().filter(|d| !d.is_empty())
-                    } else {
-                        None
-                    };
-                    let schema = match &scoped_db {
-                        Some(db) => driver.schema_for(db).await?,
-                        None => driver.schema().await?,
-                    };
-                    Ok::<_, rdb_core::error::RdbError>((driver, schema, scoped_db))
-                };
-                let result = match tokio::time::timeout(
-                    std::time::Duration::from_secs(timeout_secs),
-                    attempt,
-                )
-                .await
-                {
-                    Ok(r) => r,
-                    Err(_) => Err(rdb_core::error::RdbError::Connection(
-                        "connection timed out".into(),
-                    )),
-                };
-
-                match result {
-                    Ok((driver, schema, scoped_db)) => {
-                        // Postgres: list real namespaces so the sidebar schema
-                        // switcher offers more than "public". Engine-specific SQL
-                        // lives in the driver, not here.
-                        let pg_schemas: Vec<SharedString> =
-                            if matches!(engine, rdb_connstore::Engine::Postgres) {
-                                driver
-                                    .list_schemas()
-                                    .await
-                                    .unwrap_or_default()
-                                    .into_iter()
-                                    .map(SharedString::from)
-                                    .collect()
-                            } else {
-                                Vec::new()
-                            };
-                        // Databases on the server, backing the breadcrumb switcher.
-                        // Empty for engines that can't switch database.
-                        let db_names: Vec<SharedString> = driver
-                            .list_databases()
-                            .await
-                            .unwrap_or_default()
-                            .into_iter()
-                            .map(SharedString::from)
-                            .collect();
-                        let driver = Arc::new(driver);
-                        *slot = Some((engine, driver.clone()));
-                        drop(slot);
-                        driver_pool
-                            .write()
-                            .await
-                            .insert(connection_id.clone(), (engine, driver.clone()));
-                        // Now genuinely connected — the sidebar dot and
-                        // "another connection is still around" checks read
-                        // this, not tab scoping (see `connected_ids` on
-                        // `AppState`).
-                        connected_ids.lock().unwrap().insert(connection_id.clone());
-                        let nodes = model::to_tree_model(&schema);
-                        let fields = model::to_structure_model(&schema);
-                        // Scoped Mongo tree holds only the selected database: open
-                        // it and mark it loaded so its collections show at once
-                        // (mirrors the schema switcher).
-                        let (exp, loaded) = match &scoped_db {
-                            Some(db) => {
-                                let mut e = expanded_tables.lock().unwrap();
-                                let mut l = loaded_dbs.lock().unwrap();
-                                e.insert(db.clone());
-                                l.insert(db.clone());
-                                (e.clone(), l.clone())
-                            }
-                            None => (HashSet::new(), HashSet::new()),
-                        };
-                        // Stash raw nodes for later expand/collapse rebuilds, and
-                        // render the initial view (Functions collapsed, Tables open,
-                        // fields hidden). Matches the reseed done on connect above;
-                        // collapsed_categories itself is !Send so can't cross here.
-                        let rows = schema_display_rows(
-                            &nodes,
-                            &exp,
-                            &default_collapsed_cats(),
-                            &loaded,
-                            Some(engine),
-                            "",
-                        );
-                        // Postgres browses namespaces, not databases: the
-                        // selector must say "public", never the db name (a
-                        // `"dbname"."table"` query would fail).
-                        let mut schema_names: Vec<SharedString> =
-                            if matches!(engine, rdb_connstore::Engine::Postgres) {
-                                if pg_schemas.is_empty() {
-                                    vec![SharedString::from("public")]
-                                } else {
-                                    pg_schemas
-                                }
-                            } else if scoped_db.is_some() && !db_names.is_empty() {
-                                // Mongo scoped its tree to one database: still list
-                                // every database so the switcher can reach them.
-                                db_names.clone()
-                            } else {
-                                schema
-                                    .databases
-                                    .iter()
-                                    .map(|d| SharedString::from(d.name.clone()))
-                                    .collect()
-                            };
-                        if schema_names.is_empty() {
-                            schema_names.push(SharedString::from("public"));
-                        }
-                        // Scoped Mongo starts on its selected database; otherwise
-                        // default to "public" when present, else the first name.
-                        let schema_current = match &scoped_db {
-                            Some(db) => SharedString::from(db.clone()),
-                            None => schema_names
-                                .iter()
-                                .find(|s| s.as_str() == "public")
-                                .unwrap_or(&schema_names[0])
-                                .clone(),
-                        };
-                        // Format only makes sense for text query languages.
-                        let sql_capable = matches!(
-                            rdb_connstore::Engine::language(engine),
-                            rdb_connstore::QueryLanguage::Sql | rdb_connstore::QueryLanguage::Cql
-                        );
-                        *raw_nodes.lock().unwrap() = nodes;
-                        // Seed autocomplete with the active schema's tables plus a
-                        // bare node for every other schema name, so `schema.`
-                        // autocompletes immediately. The remaining schemas' tables
-                        // and columns fill in from the background load below.
-                        let all_schema_names: Vec<String> =
-                            schema_names.iter().map(|s| s.to_string()).collect();
-                        {
-                            let mut seed = build_completion_seed(
-                                &driver,
-                                engine,
-                                schema_current.as_str(),
-                                &schema,
-                            )
-                            .await;
-                            for name in &all_schema_names {
-                                if name != schema_current.as_str() {
-                                    seed.push(model::VmTreeNode {
-                                        label: name.clone(),
-                                        kind: "database".into(),
-                                    });
-                                }
-                            }
-                            *completion_nodes.lock().unwrap() = seed;
-                        }
-                        {
-                            let mut defs = fn_defs.lock().unwrap();
-                            defs.clear();
-                            for db in &schema.databases {
-                                for f in &db.functions {
-                                    defs.insert(f.name.clone(), f.definition.clone());
-                                }
-                            }
-                        }
-                        let _ = slint::invoke_from_event_loop(move || {
-                            if let Some(w) = weak2.upgrade() {
-                                w.set_schema_tree(ModelRc::from(Rc::new(VecModel::from(rows))));
-                                w.set_sql_capable(sql_capable);
-                                w.set_new_tab_label(
-                                    crate::query_parse::language_label(engine).into(),
-                                );
-                                w.set_schema_name(schema_current);
-                                w.set_schema_list(ModelRc::from(Rc::new(VecModel::from(
-                                    schema_names,
-                                ))));
-                                w.set_db_list(ModelRc::from(Rc::new(VecModel::from(db_names))));
-                                let sfields: Vec<StructField> = fields
-                                    .into_iter()
-                                    .map(|f| StructField {
-                                        name: f.name.into(),
-                                        type_name: f.type_name.into(),
-                                        nullable: f.nullable,
-                                    })
-                                    .collect();
-                                w.set_structure_columns(ModelRc::from(Rc::new(VecModel::from(
-                                    sfields,
-                                ))));
-                                w.set_status_latency(SharedString::from("connected"));
-                                w.set_conn_status(SharedString::from("connected"));
-                                w.set_picker_error(SharedString::default());
-                                w.set_connecting(false);
-                                w.set_tree_loading(false);
-                                // Swap the picker for the workspace.
-                                w.set_connected(true);
-                                // Sidebar dot now shows this connection live,
-                                // even before any tab has run a query against it.
-                                w.invoke_refresh_connections();
-                            }
-                        });
-                        // Load every other schema's tables so cross-schema
-                        // `schema.table` autocompletes. Runs after the sidebar
-                        // (active schema) already rendered; the popup just gains
-                        // more names as this fills. Fetched concurrently, one
-                        // task per schema, instead of sequentially.
-                        if matches!(engine, rdb_connstore::Engine::Postgres)
-                            && all_schema_names.len() > 1
-                        {
-                            let driver = {
-                                let guard = store_driver.lock().await;
-                                guard.as_ref().map(|(_, d)| d.clone())
-                            };
-                            if let Some(driver) = driver {
-                                let handles: Vec<_> = all_schema_names
-                                    .iter()
-                                    .cloned()
-                                    .map(|name| {
-                                        let driver = driver.clone();
-                                        tokio::spawn(async move {
-                                            driver
-                                                .schema_for(&name)
-                                                .await
-                                                .ok()
-                                                .map(|s| model::to_completion_nodes(&name, &s))
-                                        })
-                                    })
-                                    .collect();
-                                let mut all = Vec::new();
-                                for handle in handles {
-                                    if let Ok(Some(nodes)) = handle.await {
-                                        all.extend(nodes);
-                                    }
-                                }
-                                if !all.is_empty() {
-                                    *completion_nodes.lock().unwrap() = all;
-                                }
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        eprintln!("connect failed: {e}");
-                        let _ = slint::invoke_from_event_loop(move || {
-                            if let Some(w) = weak2.upgrade() {
-                                // Stay on the picker; surface the failure there.
-                                w.set_connected(false);
-                                w.set_connecting(false);
-                                w.set_tree_loading(false);
-                                // `e` is `RdbError`, whose own `Display` already
-                                // reads "connection failed: …" — don't prefix it
-                                // again.
-                                w.set_picker_error(SharedString::from(format!("{e}")));
-                            }
-                        });
-                    }
-                }
-            });
-            // Abort any still-running connect from a previous selection before
-            // tracking the new one: switching connections mid-connect otherwise
-            // leaks the old task, which keeps holding the driver lock and hangs
-            // the UI with no way to cancel.
-            if let Some(old) = connect_handle.borrow_mut().take() {
-                old.abort();
-            }
-            *connect_handle.borrow_mut() = Some(handle);
+            handle_connect_clicked(&state, &fns, weak.clone(), idx);
         });
     }
 

--- a/app/src/wire/connect.rs
+++ b/app/src/wire/connect.rs
@@ -119,6 +119,42 @@ async fn attempt_connect(
     }
 }
 
+fn build_schema_picker_names(
+    engine: rdb_connstore::Engine,
+    scoped_db: Option<&str>,
+    pg_schemas: Vec<SharedString>,
+    db_names: &[SharedString],
+    schema: &rdb_core::schema::Schema,
+) -> (Vec<SharedString>, SharedString) {
+    let mut schema_names: Vec<SharedString> = if matches!(engine, rdb_connstore::Engine::Postgres) {
+        if pg_schemas.is_empty() {
+            vec![SharedString::from("public")]
+        } else {
+            pg_schemas
+        }
+    } else if scoped_db.is_some() && !db_names.is_empty() {
+        db_names.to_vec()
+    } else {
+        schema
+            .databases
+            .iter()
+            .map(|d| SharedString::from(d.name.clone()))
+            .collect()
+    };
+    if schema_names.is_empty() {
+        schema_names.push(SharedString::from("public"));
+    }
+    let schema_current = match scoped_db {
+        Some(db) => SharedString::from(db),
+        None => schema_names
+            .iter()
+            .find(|s| s.as_str() == "public")
+            .unwrap_or(&schema_names[0])
+            .clone(),
+    };
+    (schema_names, schema_current)
+}
+
 /// Publishes the driver, builds the sidebar tree and autocomplete seed,
 /// pushes it to the UI, then keeps loading every other Postgres schema in
 /// the background so cross-schema completion fills in without blocking the
@@ -202,38 +238,8 @@ async fn finish_connect_success(
         "",
     );
     // Postgres browses namespaces, not databases: the selector must say
-    // "public", never the db name (a `"dbname"."table"` query would fail).
-    let mut schema_names: Vec<SharedString> = if matches!(engine, rdb_connstore::Engine::Postgres) {
-        if pg_schemas.is_empty() {
-            vec![SharedString::from("public")]
-        } else {
-            pg_schemas
-        }
-    } else if scoped_db.is_some() && !db_names.is_empty() {
-        // Mongo scoped its tree to one database: still list every database
-        // so the switcher can reach them.
-        db_names.clone()
-    } else {
-        schema
-            .databases
-            .iter()
-            .map(|d| SharedString::from(d.name.clone()))
-            .collect()
-    };
-    if schema_names.is_empty() {
-        schema_names.push(SharedString::from("public"));
-    }
-    // Scoped Mongo starts on its selected database; otherwise default to
-    // "public" when present, else the first name.
-    let schema_current = match &scoped_db {
-        Some(db) => SharedString::from(db.clone()),
-        None => schema_names
-            .iter()
-            .find(|s| s.as_str() == "public")
-            .unwrap_or(&schema_names[0])
-            .clone(),
-    };
-    // Format only makes sense for text query languages.
+    let (schema_names, schema_current) =
+        build_schema_picker_names(engine, scoped_db.as_deref(), pg_schemas, &db_names, &schema);
     let sql_capable = matches!(
         rdb_connstore::Engine::language(engine),
         rdb_connstore::QueryLanguage::Sql | rdb_connstore::QueryLanguage::Cql
@@ -260,11 +266,11 @@ async fn finish_connect_success(
     {
         let mut defs = fn_defs.lock().unwrap();
         defs.clear();
-        for db in &schema.databases {
-            for f in &db.functions {
-                defs.insert(f.name.clone(), f.definition.clone());
-            }
-        }
+        defs.extend(schema.databases.iter().flat_map(|db| {
+            db.functions
+                .iter()
+                .map(|f| (f.name.clone(), f.definition.clone()))
+        }));
     }
     let _ = slint::invoke_from_event_loop(move || {
         if let Some(w) = weak.upgrade() {
@@ -748,9 +754,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
                     // sidebar dot's source of truth in step here too.
                     {
                         let mut ids = connected_ids.lock().unwrap();
-                        for id in &evicted {
-                            ids.remove(id);
-                        }
+                        ids.retain(|id| !evicted.contains(id));
                     }
                     let weak = weak.clone();
                     let _ = slint::invoke_from_event_loop(move || {

--- a/app/src/wire/connect.rs
+++ b/app/src/wire/connect.rs
@@ -18,6 +18,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
         store,
         panes,
         current,
+        driver_pool,
         cur_engine,
         collapsed,
         raw_nodes,
@@ -29,6 +30,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
         active_tab_id,
         active_group1_tab_id,
         current_connection_id,
+        connected_ids,
         db_override,
         query_console,
         query_number,
@@ -58,9 +60,51 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
     {
         let weak = window.as_weak();
         let current = current.clone();
+        let driver_pool = driver_pool.clone();
+        let workspace_tabs = workspace_tabs.clone();
+        let current_connection_id = current_connection_id.clone();
+        let connected_ids = connected_ids.clone();
         rt.spawn(async move {
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+                // Close every pooled connection no open tab references anymore
+                // (plus whichever one is actively focused, even between its
+                // last tab closing and a new one opening). Piggybacked on this
+                // existing tick rather than a second timer — up to 10s of a
+                // closed tab's connection lingering is a fine trade for one
+                // fewer moving part.
+                let evicted: Vec<String> = {
+                    let mut live = live_connection_ids(&workspace_tabs.lock().unwrap());
+                    if let Some(id) = current_connection_id.lock().unwrap().clone() {
+                        live.insert(id);
+                    }
+                    let mut pool = driver_pool.write().await;
+                    let evicted: Vec<String> = pool
+                        .keys()
+                        .filter(|id| !live.contains(*id))
+                        .cloned()
+                        .collect();
+                    pool.retain(|id, _| live.contains(id));
+                    evicted
+                };
+                if !evicted.is_empty() {
+                    // A connection can go from "connected" to evicted without
+                    // ever going through the explicit disconnect handler
+                    // (every tab that named it just got closed) — keep the
+                    // sidebar dot's source of truth in step here too.
+                    {
+                        let mut ids = connected_ids.lock().unwrap();
+                        for id in &evicted {
+                            ids.remove(id);
+                        }
+                    }
+                    let weak = weak.clone();
+                    let _ = slint::invoke_from_event_loop(move || {
+                        if let Some(w) = weak.upgrade() {
+                            w.invoke_refresh_connections();
+                        }
+                    });
+                }
                 // None = no driver (picker); Some(ok) = pinged a live connection.
                 // Clone the driver out of the mutex before pinging so a slow ping
                 // never blocks an in-flight query.
@@ -132,6 +176,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
         let store = store.clone();
         let completion_nodes = completion_nodes.clone();
         let current = current.clone();
+        let driver_pool = driver_pool.clone();
         let raw_nodes = raw_nodes.clone();
         let expanded_tables = expanded_tables.clone();
         let loaded_dbs = loaded_dbs.clone();
@@ -210,6 +255,13 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
                 for t in &mut kept {
                     t.loading = false;
                 }
+                // Picking a connection changes what NEW actions target (new
+                // tab, browse-from-sidebar) — it must never rewrite a tab
+                // that's already open. Each tab is permanently locked to
+                // the connection it was created against (routed by its own
+                // `connection_id` through `driver_pool`); reassigning the
+                // focused one here is what made switching connections look
+                // like it dragged the open query tab along with it.
                 let active = active_tab_id
                     .lock()
                     .unwrap()
@@ -340,6 +392,15 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
                     }
                 }
                 w.set_active_pane(init_active_group as i32);
+                // restore_tab() above re-syncs chrome (and the "what does a
+                // new action target" pointer) to the *repainted tab's own*
+                // connection as a side effect of repainting its pane. When
+                // the kept-active tab belongs to a different connection than
+                // the one just picked here, that side effect quietly drags
+                // the topbar back — reapply the picked connection last so it
+                // always wins.
+                sync_conn_chrome(&w, &store.borrow(), Some(&sc.id));
+                *current_connection_id.lock().unwrap() = Some(sc.id.clone());
             }
             // Fresh connection: nothing browsed, nothing expanded.
             *cur_engine.borrow_mut() = Some(sc.engine);
@@ -358,6 +419,9 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
             // tasks await this lock and resolve once the connect lands.
             let claimed = current.clone().try_lock_owned().ok();
             let engine = sc.engine;
+            let connection_id = sc.id.clone();
+            let driver_pool = driver_pool.clone();
+            let connected_ids = connected_ids.clone();
             let raw_nodes = raw_nodes.clone();
             let completion_nodes = completion_nodes.clone();
             let fn_defs = fn_defs.clone();
@@ -442,6 +506,15 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
                         let driver = Arc::new(driver);
                         *slot = Some((engine, driver.clone()));
                         drop(slot);
+                        driver_pool
+                            .write()
+                            .await
+                            .insert(connection_id.clone(), (engine, driver.clone()));
+                        // Now genuinely connected — the sidebar dot and
+                        // "another connection is still around" checks read
+                        // this, not tab scoping (see `connected_ids` on
+                        // `AppState`).
+                        connected_ids.lock().unwrap().insert(connection_id.clone());
                         let nodes = model::to_tree_model(&schema);
                         let fields = model::to_structure_model(&schema);
                         // Scoped Mongo tree holds only the selected database: open
@@ -572,6 +645,9 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
                                 w.set_tree_loading(false);
                                 // Swap the picker for the workspace.
                                 w.set_connected(true);
+                                // Sidebar dot now shows this connection live,
+                                // even before any tab has run a query against it.
+                                w.invoke_refresh_connections();
                             }
                         });
                         // Load every other schema's tables so cross-schema

--- a/app/src/wire/edit.rs
+++ b/app/src/wire/edit.rs
@@ -476,12 +476,9 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) {
             // switching focus between already-open tabs never touches `current`.
             let tab_connection_id = focused_tab_connection_id(&active_tab_id, &workspace_tabs);
             rt.spawn(async move {
-                let driver = {
-                    let pool = driver_pool.read().await;
-                    let guard = current.lock().await;
-                    driver_for(&pool, guard.as_ref(), tab_connection_id.as_deref())
-                        .map(|(_, d)| d.clone())
-                };
+                let driver = resolve_driver(&driver_pool, &current, tab_connection_id.as_deref())
+                    .await
+                    .map(|(_, d)| d);
                 let outcome = match driver {
                     Some(driver) => driver.commit(&ops).await,
                     None => Err(rdb_core::error::RdbError::Connection(
@@ -669,12 +666,9 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) {
             // Split panes share their tab's single connection_id.
             let tab_connection_id = focused_tab_connection_id(&active_tab_id, &workspace_tabs);
             rt.spawn(async move {
-                let driver = {
-                    let pool = driver_pool.read().await;
-                    let guard = current.lock().await;
-                    driver_for(&pool, guard.as_ref(), tab_connection_id.as_deref())
-                        .map(|(_, d)| d.clone())
-                };
+                let driver = resolve_driver(&driver_pool, &current, tab_connection_id.as_deref())
+                    .await
+                    .map(|(_, d)| d);
                 let outcome = match driver {
                     Some(driver) => driver.commit(&ops).await,
                     None => Err(rdb_core::error::RdbError::Connection(

--- a/app/src/wire/edit.rs
+++ b/app/src/wire/edit.rs
@@ -16,8 +16,11 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) {
         rt,
         panes,
         current,
+        driver_pool,
         cur_engine,
         query_console,
+        workspace_tabs,
+        active_tab_id,
         ..
     } = state.clone();
     let edit_buf = panes[0].edit_buf.clone();
@@ -405,11 +408,14 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) {
         let edit_buf = edit_buf.clone();
         let displayed_grid = displayed_grid.clone();
         let current = current.clone();
+        let driver_pool = driver_pool.clone();
         let rt = rt.clone();
         let commit_buf = edit_buf.clone();
         let cur_engine = cur_engine.clone();
         let query_console = query_console.clone();
         let repaint_edits = repaint_edits.clone();
+        let active_tab_id = active_tab_id.clone();
+        let workspace_tabs = workspace_tabs.clone();
         window.on_commit_edits(move || {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -453,6 +459,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) {
             };
             let weak2 = weak.clone();
             let current = current.clone();
+            let driver_pool = driver_pool.clone();
             let commit_buf = commit_buf.clone();
             if let Some(engine) = *cur_engine.borrow() {
                 for statement in dispatch::write_statements(engine, &ops) {
@@ -465,10 +472,15 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) {
                 w.set_status_error(false);
                 w.set_result_status(SharedString::from("saving…"));
             }
+            // The active tab's own connection, not whatever `current` is —
+            // switching focus between already-open tabs never touches `current`.
+            let tab_connection_id = focused_tab_connection_id(&active_tab_id, &workspace_tabs);
             rt.spawn(async move {
                 let driver = {
+                    let pool = driver_pool.read().await;
                     let guard = current.lock().await;
-                    guard.as_ref().map(|(_, d)| d.clone())
+                    driver_for(&pool, guard.as_ref(), tab_connection_id.as_deref())
+                        .map(|(_, d)| d.clone())
                 };
                 let outcome = match driver {
                     Some(driver) => driver.commit(&ops).await,
@@ -591,9 +603,12 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) {
         let weak = window.as_weak();
         let panes = panes.clone();
         let current = current.clone();
+        let driver_pool = driver_pool.clone();
         let rt = rt.clone();
         let cur_engine = cur_engine.clone();
         let query_console = query_console.clone();
+        let active_tab_id = active_tab_id.clone();
+        let workspace_tabs = workspace_tabs.clone();
         window.on_p1_commit_edits(move || {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -640,6 +655,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) {
             };
             let weak2 = weak.clone();
             let current = current.clone();
+            let driver_pool = driver_pool.clone();
             let commit_buf = panes[1].edit_buf.clone();
             if let Some(engine) = *cur_engine.borrow() {
                 for statement in dispatch::write_statements(engine, &ops) {
@@ -650,10 +666,14 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) {
             let query_console = query_console.clone();
             set_p_status_error(&w, 1, false);
             set_p_result_status(&w, 1, SharedString::from("saving…"));
+            // Split panes share their tab's single connection_id.
+            let tab_connection_id = focused_tab_connection_id(&active_tab_id, &workspace_tabs);
             rt.spawn(async move {
                 let driver = {
+                    let pool = driver_pool.read().await;
                     let guard = current.lock().await;
-                    guard.as_ref().map(|(_, d)| d.clone())
+                    driver_for(&pool, guard.as_ref(), tab_connection_id.as_deref())
+                        .map(|(_, d)| d.clone())
                 };
                 let outcome = match driver {
                     Some(driver) => driver.commit(&ops).await,

--- a/app/src/wire/picker.rs
+++ b/app/src/wire/picker.rs
@@ -148,327 +148,8 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
         fill_detail(idx);
     }
 
-    // RDB_SCREEN drives the app to a reference state for screenshots and the
-    // e2e harness: "workspace" connects + opens emiten; "sql" opens + runs the
-    // saved query; the rest open a specific modal/view.
-    if let Ok(screen) = std::env::var("RDB_SCREEN") {
-        let idx = store
-            .borrow()
-            .list()
-            .iter()
-            .position(|s| s.name == "chat bot")
-            .map(|i| i as i32)
-            .unwrap_or(0);
-        // "connections" IS the pre-connect screen; connecting would swap it
-        // for the workspace before the shot fires.
-        if screen != "connections" {
-            let weak = window.as_weak();
-            let t1 = Box::leak(Box::new(slint::Timer::default()));
-            t1.start(
-                slint::TimerMode::SingleShot,
-                std::time::Duration::from_millis(250),
-                move || {
-                    if let Some(w) = weak.upgrade() {
-                        w.invoke_connect_clicked(idx);
-                    }
-                },
-            );
-        }
-        if screen.starts_with("sql") {
-            let weak = window.as_weak();
-            let t2 = Box::leak(Box::new(slint::Timer::default()));
-            t2.start(
-                slint::TimerMode::SingleShot,
-                std::time::Duration::from_millis(1800),
-                move || {
-                    if let Some(w) = weak.upgrade() {
-                        w.set_sidebar_mode(1);
-                        w.invoke_open_query("emiten-per-sektor".into(), 0);
-                    }
-                },
-            );
-            let weak = window.as_weak();
-            let t3 = Box::leak(Box::new(slint::Timer::default()));
-            t3.start(
-                slint::TimerMode::SingleShot,
-                std::time::Duration::from_millis(2300),
-                move || {
-                    if let Some(w) = weak.upgrade() {
-                        w.invoke_run_query();
-                    }
-                },
-            );
-        }
-        if screen == "modal-db"
-            || screen == "modal-conn"
-            || screen == "modal-add-mongo"
-            || screen == "function"
-            || screen == "palette"
-        {
-            let weak = window.as_weak();
-            let which = screen.clone();
-            let t4 = Box::leak(Box::new(slint::Timer::default()));
-            t4.start(
-                slint::TimerMode::SingleShot,
-                std::time::Duration::from_millis(1800),
-                move || {
-                    if let Some(w) = weak.upgrade() {
-                        match which.as_str() {
-                            "modal-db" => w.invoke_open_db_modal(),
-                            "modal-conn" => w.invoke_open_conn_modal(),
-                            "modal-add-mongo" => {
-                                w.invoke_open_add_form();
-                                w.set_f_engine("MongoDB".into());
-                                w.set_f_port("27017".into());
-                                w.set_f_import_url("mongodb://root:secret@203.0.113.31:32343/admin?authMechanism=DEFAULT&replicaSet=rs0".into());
-                            }
-                            "palette" => w.invoke_toggle_palette(),
-                            _ => w.invoke_open_function("uuid_generate_v3".into()),
-                        }
-                    }
-                },
-            );
-        }
-        if screen.starts_with("workspace") {
-            let weak = window.as_weak();
-            // "workspace" opens the mock `emiten` fixture; "workspace-<name>"
-            // opens that table instead, so the harness can drive a real
-            // connection whose tables it cannot know in advance.
-            let table = match screen.strip_prefix("workspace-") {
-                Some(name) if !name.is_empty() => name.to_string(),
-                _ => "emiten".to_string(),
-            };
-            let t2 = Box::leak(Box::new(slint::Timer::default()));
-            t2.start(
-                slint::TimerMode::SingleShot,
-                std::time::Duration::from_millis(1800),
-                move || {
-                    if let Some(w) = weak.upgrade() {
-                        w.invoke_open_table("".into(), table.as_str().into());
-                    }
-                },
-            );
-        }
-
-        // E2E editing scenarios layered on the base screens above. Fixed
-        // delays race the async connect/browse pipeline, so each step fires
-        // when its precondition is observable, polling every 100ms.
-        let when = |cond: Rc<dyn Fn(&MainWindow) -> bool>, act: Rc<dyn Fn(&MainWindow)>| {
-            let weak = window.as_weak();
-            let t: &'static slint::Timer = Box::leak(Box::new(slint::Timer::default()));
-            t.start(
-                slint::TimerMode::Repeated,
-                std::time::Duration::from_millis(100),
-                move || {
-                    let Some(w) = weak.upgrade() else {
-                        t.stop();
-                        return;
-                    };
-                    if cond(&w) {
-                        t.stop();
-                        act(&w);
-                    }
-                },
-            );
-        };
-        use slint::Model as _;
-        // grid loaded with an editable page (pk fetched)
-        let grid_ready: Rc<dyn Fn(&MainWindow) -> bool> =
-            Rc::new(|w| w.get_grid_cells().row_count() > 0 && !w.get_grid_read_only());
-        let has_pending: Rc<dyn Fn(&MainWindow) -> bool> = Rc::new(|w| w.get_pending_count() > 0);
-        if matches!(
-            screen.as_str(),
-            "workspace-dirty" | "workspace-guard" | "workspace-commit" | "workspace-tabnav"
-        ) {
-            when(
-                grid_ready.clone(),
-                Rc::new(|w| w.invoke_cell_edited(0, 2, "Bayan EDITED".into())),
-            );
-        }
-        if screen == "workspace-active-commit" {
-            when(
-                grid_ready.clone(),
-                Rc::new(|w| {
-                    w.invoke_edit_cell(0, 2);
-                    w.set_editing_value("Bayan ACTIVE SAVE".into());
-                    w.invoke_commit_edits();
-                }),
-            );
-        }
-        if screen == "workspace-detail-commit" {
-            when(
-                grid_ready.clone(),
-                Rc::new(|w| {
-                    w.invoke_stage_cell(
-                        0,
-                        2,
-                        "Bayan Resources — long detail value saved from the right panel".into(),
-                    );
-                    w.invoke_commit_edits();
-                }),
-            );
-        }
-        if screen == "workspace-long-edit" {
-            when(
-                grid_ready.clone(),
-                Rc::new(|w| {
-                    w.invoke_cell_edited(
-                        0,
-                        2,
-                        "Bayan Resources — a deliberately long inline value remains visible while editing, wraps inside a bounded overlay, and still supports cursor navigation all the way to the final character."
-                            .into(),
-                    );
-                    w.invoke_edit_cell(0, 2);
-                }),
-            );
-        }
-        if screen == "workspace-pointer-edit" {
-            when(
-                grid_ready.clone(),
-                Rc::new(|w| {
-                    use slint::platform::{PointerEventButton, WindowEvent};
-                    let position = slint::LogicalPosition::new(650.0, 164.0);
-                    for _ in 0..2 {
-                        w.window().dispatch_event(WindowEvent::PointerPressed {
-                            position,
-                            button: PointerEventButton::Left,
-                        });
-                        w.window().dispatch_event(WindowEvent::PointerReleased {
-                            position,
-                            button: PointerEventButton::Left,
-                        });
-                    }
-                    assert_eq!((w.get_editing_row(), w.get_editing_col()), (0, 2));
-                }),
-            );
-        }
-        if screen == "workspace-dirty" {
-            // second pending change: a delete-marked row
-            when(
-                has_pending.clone(),
-                Rc::new(|w| {
-                    w.set_selected_row(2);
-                    w.invoke_mark_delete();
-                }),
-            );
-        }
-        if screen == "workspace-guard" {
-            // navigation with pending edits must be refused with a message
-            when(has_pending.clone(), Rc::new(|w| w.invoke_next_page()));
-        }
-        if screen == "workspace-commit" {
-            // full CRUD loop: buffer → WriteOps → mock commit → refetch
-            when(has_pending.clone(), Rc::new(|w| w.invoke_commit_edits()));
-        }
-        if screen == "workspace-tabnav" {
-            // Tab stores the edited cell and opens the neighbour's editor
-            when(
-                has_pending.clone(),
-                Rc::new(|w| w.invoke_cell_advance(0, 3, "TABBED".into(), true)),
-            );
-        }
-        if screen == "workspace-sql" {
-            // Real UI transition: table browse → global SQL button. The fresh
-            // query tab must not inherit the table request's loading state.
-            when(
-                Rc::new(|w| w.get_active_table() == "emiten"),
-                Rc::new(|w| w.invoke_new_tab()),
-            );
-        }
-        if screen == "workspace-tabflow" {
-            when(
-                Rc::new(|w| w.get_active_table() == "emiten" && w.get_tabs().row_count() == 1),
-                Rc::new(|w| w.invoke_open_table("".into(), "referral_sources".into())),
-            );
-            when(
-                Rc::new(|w| {
-                    w.get_active_table() == "referral_sources" && w.get_tabs().row_count() == 1
-                }),
-                Rc::new(|w| {
-                    w.invoke_pin_table("".into(), "referral_sources".into());
-                    w.invoke_open_table("".into(), "sectors".into());
-                }),
-            );
-            when(
-                Rc::new(|w| w.get_active_table() == "sectors" && w.get_tabs().row_count() == 2),
-                Rc::new(|w| w.invoke_new_tab()),
-            );
-        }
-        if screen == "workspace-filter" {
-            when(
-                grid_ready.clone(),
-                Rc::new(|w| {
-                    w.set_data_filter_open(true);
-                    w.set_filter_col("name".into());
-                    w.set_filter_op("ILIKE".into());
-                    w.set_grid_filter("mitra".into());
-                    w.invoke_apply_filter();
-                }),
-            );
-        }
-        if screen == "workspace-limit" {
-            when(
-                grid_ready.clone(),
-                Rc::new(|w| w.invoke_set_limit("25".into())),
-            );
-        }
-        if screen == "workspace-insert" {
-            when(grid_ready.clone(), Rc::new(|w| w.invoke_add_row()));
-        }
-        if screen == "workspace-users-bool" || screen == "workspace-users-date" {
-            when(grid_ready.clone(), Rc::new(|w| w.invoke_add_row()));
-            let date = screen == "workspace-users-date";
-            when(
-                has_pending.clone(),
-                Rc::new(move |w| {
-                    let rows = w.get_grid_cells().row_count() / w.get_grid_col_count() as usize;
-                    w.invoke_edit_cell(rows.saturating_sub(1) as i32, if date { 4 } else { 3 });
-                }),
-            );
-        }
-        if screen == "sql-select" {
-            // ⌘A select-all: the whole query gets the selection tint
-            when(
-                Rc::new(|w| !w.get_query_text().trim().is_empty()),
-                Rc::new(|w| {
-                    w.invoke_editor_key("a".into(), true, false, false);
-                }),
-            );
-        }
-        if screen == "sql-empty" {
-            // a query with zero rows shows the empty state, not a blank pane
-            let load = load_editor_text.clone();
-            when(
-                Rc::new(|w| !w.get_results_meta().is_empty()),
-                Rc::new(move |w| {
-                    load(0, "SELECT * FROM emiten OFFSET 99999");
-                    w.invoke_run_query();
-                }),
-            );
-        }
-        if screen == "sql-find" {
-            // ⌘F find bar: highlights the first match of a term
-            when(
-                Rc::new(|w| !w.get_query_text().trim().is_empty()),
-                Rc::new(|w| {
-                    w.invoke_toggle_find();
-                    w.set_find_text("sector".into());
-                    w.invoke_find_changed("sector".into());
-                }),
-            );
-        }
-        if screen == "sql-multi" {
-            // multi-statement run: status reads "N statements · …"
-            let load = load_editor_text.clone();
-            when(
-                Rc::new(|w| !w.get_results_meta().is_empty()),
-                Rc::new(move |w| {
-                    load(0, "SELECT 1;\nSELECT * FROM emiten LIMIT 5;");
-                    w.invoke_run_query();
-                }),
-            );
-        }
-    }
+    // RDB_SCREEN e2e harness: see `wire_screen_harness`.
+    wire_screen_harness(window, &store, &load_editor_text);
 
     // Last result view kept in memory so the client-side filter (Feature C)
     // can re-derive the visible rows without re-querying. Arc<Mutex<>> (not Rc)
@@ -1095,5 +776,405 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
         window.on_open_url(move |u| {
             let _ = open::that(u.as_str());
         });
+    }
+}
+
+/// Drives the app to a reference state for screenshots and e2e tests,
+/// gated behind `RDB_SCREEN` (mock mode only). Kept out of `wire`: this is
+/// test harness plumbing, not a real callback.
+type ScreenCond = Rc<dyn Fn(&MainWindow) -> bool>;
+type ScreenAct = Rc<dyn Fn(&MainWindow)>;
+
+/// RDB_SCREEN drives the app to a reference state for screenshots and the
+/// e2e harness: "workspace" connects + opens emiten; "sql" opens + runs the
+/// saved query; the rest open a specific modal/view. Each `schedule_*`
+/// helper below owns one screen family and no-ops for any other screen, so
+/// this function is just the list of families, not their branching.
+fn wire_screen_harness(
+    window: &MainWindow,
+    store: &Rc<RefCell<rdb_connstore::ConnStore>>,
+    load_editor_text: &PaneTextFn,
+) {
+    let Ok(screen) = std::env::var("RDB_SCREEN") else {
+        return;
+    };
+    schedule_connect_timer(window, store, &screen);
+    schedule_sql_open_timer(window, &screen);
+    schedule_modal_timer(window, &screen);
+    schedule_workspace_open_timer(window, &screen);
+    schedule_grid_edit_scenarios(window, &screen);
+    schedule_tab_flow_scenarios(window, &screen);
+    schedule_sql_editor_scenarios(window, &screen, load_editor_text);
+}
+
+/// "connections" IS the pre-connect screen; connecting would swap it for
+/// the workspace before the shot fires.
+fn schedule_connect_timer(
+    window: &MainWindow,
+    store: &Rc<RefCell<rdb_connstore::ConnStore>>,
+    screen: &str,
+) {
+    if screen == "connections" {
+        return;
+    }
+    let idx = store
+        .borrow()
+        .list()
+        .iter()
+        .position(|s| s.name == "chat bot")
+        .map(|i| i as i32)
+        .unwrap_or(0);
+    let weak = window.as_weak();
+    let t1 = Box::leak(Box::new(slint::Timer::default()));
+    t1.start(
+        slint::TimerMode::SingleShot,
+        std::time::Duration::from_millis(250),
+        move || {
+            if let Some(w) = weak.upgrade() {
+                w.invoke_connect_clicked(idx);
+            }
+        },
+    );
+}
+
+fn schedule_sql_open_timer(window: &MainWindow, screen: &str) {
+    if !screen.starts_with("sql") {
+        return;
+    }
+    let weak = window.as_weak();
+    let t2 = Box::leak(Box::new(slint::Timer::default()));
+    t2.start(
+        slint::TimerMode::SingleShot,
+        std::time::Duration::from_millis(1800),
+        move || {
+            if let Some(w) = weak.upgrade() {
+                w.set_sidebar_mode(1);
+                w.invoke_open_query("emiten-per-sektor".into(), 0);
+            }
+        },
+    );
+    let weak = window.as_weak();
+    let t3 = Box::leak(Box::new(slint::Timer::default()));
+    t3.start(
+        slint::TimerMode::SingleShot,
+        std::time::Duration::from_millis(2300),
+        move || {
+            if let Some(w) = weak.upgrade() {
+                w.invoke_run_query();
+            }
+        },
+    );
+}
+
+fn schedule_modal_timer(window: &MainWindow, screen: &str) {
+    if !matches!(
+        screen,
+        "modal-db" | "modal-conn" | "modal-add-mongo" | "function" | "palette"
+    ) {
+        return;
+    }
+    let weak = window.as_weak();
+    let which = screen.to_string();
+    let t4 = Box::leak(Box::new(slint::Timer::default()));
+    t4.start(
+        slint::TimerMode::SingleShot,
+        std::time::Duration::from_millis(1800),
+        move || {
+            if let Some(w) = weak.upgrade() {
+                match which.as_str() {
+                    "modal-db" => w.invoke_open_db_modal(),
+                    "modal-conn" => w.invoke_open_conn_modal(),
+                    "modal-add-mongo" => {
+                        w.invoke_open_add_form();
+                        w.set_f_engine("MongoDB".into());
+                        w.set_f_port("27017".into());
+                        w.set_f_import_url("mongodb://root:secret@203.0.113.31:32343/admin?authMechanism=DEFAULT&replicaSet=rs0".into());
+                    }
+                    "palette" => w.invoke_toggle_palette(),
+                    _ => w.invoke_open_function("uuid_generate_v3".into()),
+                }
+            }
+        },
+    );
+}
+
+/// "workspace" opens the mock `emiten` fixture; "workspace-<name>" opens
+/// that table instead, so the harness can drive a real connection whose
+/// tables it cannot know in advance.
+fn schedule_workspace_open_timer(window: &MainWindow, screen: &str) {
+    if !screen.starts_with("workspace") {
+        return;
+    }
+    let weak = window.as_weak();
+    let table = match screen.strip_prefix("workspace-") {
+        Some(name) if !name.is_empty() => name.to_string(),
+        _ => "emiten".to_string(),
+    };
+    let t2 = Box::leak(Box::new(slint::Timer::default()));
+    t2.start(
+        slint::TimerMode::SingleShot,
+        std::time::Duration::from_millis(1800),
+        move || {
+            if let Some(w) = weak.upgrade() {
+                w.invoke_open_table("".into(), table.as_str().into());
+            }
+        },
+    );
+}
+
+/// Polls every 100ms until `cond` holds, then fires `act` once and stops.
+/// e2e editing scenarios are layered on the base screens with this instead
+/// of a fixed delay, since a fixed delay would race the async
+/// connect/browse pipeline.
+fn when(window: &MainWindow, cond: ScreenCond, act: ScreenAct) {
+    let weak = window.as_weak();
+    let t: &'static slint::Timer = Box::leak(Box::new(slint::Timer::default()));
+    t.start(
+        slint::TimerMode::Repeated,
+        std::time::Duration::from_millis(100),
+        move || {
+            let Some(w) = weak.upgrade() else {
+                t.stop();
+                return;
+            };
+            if cond(&w) {
+                t.stop();
+                act(&w);
+            }
+        },
+    );
+}
+
+/// grid loaded with an editable page (pk fetched)
+fn grid_ready_cond() -> ScreenCond {
+    Rc::new(|w| w.get_grid_cells().row_count() > 0 && !w.get_grid_read_only())
+}
+
+fn has_pending_cond() -> ScreenCond {
+    Rc::new(|w| w.get_pending_count() > 0)
+}
+
+/// Cell-edit scenarios against a freshly loaded grid: the initial edit
+/// (shared by four screens) plus each screen's own follow-up once that
+/// edit is pending.
+fn schedule_grid_edit_scenarios(window: &MainWindow, screen: &str) {
+    let grid_ready = grid_ready_cond();
+    if matches!(
+        screen,
+        "workspace-dirty" | "workspace-guard" | "workspace-commit" | "workspace-tabnav"
+    ) {
+        when(
+            window,
+            grid_ready.clone(),
+            Rc::new(|w| w.invoke_cell_edited(0, 2, "Bayan EDITED".into())),
+        );
+    }
+    match screen {
+        "workspace-active-commit" => when(
+            window,
+            grid_ready.clone(),
+            Rc::new(|w| {
+                w.invoke_edit_cell(0, 2);
+                w.set_editing_value("Bayan ACTIVE SAVE".into());
+                w.invoke_commit_edits();
+            }),
+        ),
+        "workspace-detail-commit" => when(
+            window,
+            grid_ready.clone(),
+            Rc::new(|w| {
+                w.invoke_stage_cell(
+                    0,
+                    2,
+                    "Bayan Resources — long detail value saved from the right panel".into(),
+                );
+                w.invoke_commit_edits();
+            }),
+        ),
+        "workspace-long-edit" => when(
+            window,
+            grid_ready.clone(),
+            Rc::new(|w| {
+                w.invoke_cell_edited(
+                    0,
+                    2,
+                    "Bayan Resources — a deliberately long inline value remains visible while editing, wraps inside a bounded overlay, and still supports cursor navigation all the way to the final character."
+                        .into(),
+                );
+                w.invoke_edit_cell(0, 2);
+            }),
+        ),
+        "workspace-pointer-edit" => when(
+            window,
+            grid_ready.clone(),
+            Rc::new(|w| {
+                use slint::platform::{PointerEventButton, WindowEvent};
+                let position = slint::LogicalPosition::new(650.0, 164.0);
+                for _ in 0..2 {
+                    w.window().dispatch_event(WindowEvent::PointerPressed {
+                        position,
+                        button: PointerEventButton::Left,
+                    });
+                    w.window().dispatch_event(WindowEvent::PointerReleased {
+                        position,
+                        button: PointerEventButton::Left,
+                    });
+                }
+                assert_eq!((w.get_editing_row(), w.get_editing_col()), (0, 2));
+            }),
+        ),
+        _ => {}
+    }
+    schedule_pending_edit_followups(window, screen);
+    schedule_standalone_grid_actions(window, screen, grid_ready);
+}
+
+/// Second step for the four screens above: fires once the initial edit is
+/// pending, each with its own distinct follow-up action.
+fn schedule_pending_edit_followups(window: &MainWindow, screen: &str) {
+    let has_pending = has_pending_cond();
+    match screen {
+        // second pending change: a delete-marked row
+        "workspace-dirty" => when(
+            window,
+            has_pending,
+            Rc::new(|w| {
+                w.set_selected_row(2);
+                w.invoke_mark_delete();
+            }),
+        ),
+        // navigation with pending edits must be refused with a message
+        "workspace-guard" => when(window, has_pending, Rc::new(|w| w.invoke_next_page())),
+        // full CRUD loop: buffer → WriteOps → mock commit → refetch
+        "workspace-commit" => when(window, has_pending, Rc::new(|w| w.invoke_commit_edits())),
+        // Tab stores the edited cell and opens the neighbour's editor
+        "workspace-tabnav" => when(
+            window,
+            has_pending,
+            Rc::new(|w| w.invoke_cell_advance(0, 3, "TABBED".into(), true)),
+        ),
+        _ => {}
+    }
+}
+
+/// Grid actions that don't chain off the shared initial edit above: each
+/// applies straight to the freshly loaded grid.
+fn schedule_standalone_grid_actions(window: &MainWindow, screen: &str, grid_ready: ScreenCond) {
+    match screen {
+        "workspace-filter" => when(
+            window,
+            grid_ready,
+            Rc::new(|w| {
+                w.set_data_filter_open(true);
+                w.set_filter_col("name".into());
+                w.set_filter_op("ILIKE".into());
+                w.set_grid_filter("mitra".into());
+                w.invoke_apply_filter();
+            }),
+        ),
+        "workspace-limit" => when(
+            window,
+            grid_ready,
+            Rc::new(|w| w.invoke_set_limit("25".into())),
+        ),
+        "workspace-insert" => when(window, grid_ready, Rc::new(|w| w.invoke_add_row())),
+        "workspace-users-bool" | "workspace-users-date" => {
+            when(window, grid_ready, Rc::new(|w| w.invoke_add_row()));
+            let date = screen == "workspace-users-date";
+            when(
+                window,
+                has_pending_cond(),
+                Rc::new(move |w| {
+                    let rows = w.get_grid_cells().row_count() / w.get_grid_col_count() as usize;
+                    w.invoke_edit_cell(rows.saturating_sub(1) as i32, if date { 4 } else { 3 });
+                }),
+            );
+        }
+        _ => {}
+    }
+}
+
+/// Real UI transition: table browse → global SQL button, and a multi-tab
+/// pin-and-switch flow. The fresh query tab must not inherit the table
+/// request's loading state.
+fn schedule_tab_flow_scenarios(window: &MainWindow, screen: &str) {
+    use slint::Model as _;
+    match screen {
+        "workspace-sql" => when(
+            window,
+            Rc::new(|w| w.get_active_table() == "emiten"),
+            Rc::new(|w| w.invoke_new_tab()),
+        ),
+        "workspace-tabflow" => {
+            when(
+                window,
+                Rc::new(|w| w.get_active_table() == "emiten" && w.get_tabs().row_count() == 1),
+                Rc::new(|w| w.invoke_open_table("".into(), "referral_sources".into())),
+            );
+            when(
+                window,
+                Rc::new(|w| {
+                    w.get_active_table() == "referral_sources" && w.get_tabs().row_count() == 1
+                }),
+                Rc::new(|w| {
+                    w.invoke_pin_table("".into(), "referral_sources".into());
+                    w.invoke_open_table("".into(), "sectors".into());
+                }),
+            );
+            when(
+                window,
+                Rc::new(|w| w.get_active_table() == "sectors" && w.get_tabs().row_count() == 2),
+                Rc::new(|w| w.invoke_new_tab()),
+            );
+        }
+        _ => {}
+    }
+}
+
+fn schedule_sql_editor_scenarios(window: &MainWindow, screen: &str, load_editor_text: &PaneTextFn) {
+    match screen {
+        // ⌘A select-all: the whole query gets the selection tint
+        "sql-select" => when(
+            window,
+            Rc::new(|w| !w.get_query_text().trim().is_empty()),
+            Rc::new(|w| {
+                w.invoke_editor_key("a".into(), true, false, false);
+            }),
+        ),
+        // a query with zero rows shows the empty state, not a blank pane
+        "sql-empty" => {
+            let load = load_editor_text.clone();
+            when(
+                window,
+                Rc::new(|w| !w.get_results_meta().is_empty()),
+                Rc::new(move |w| {
+                    load(0, "SELECT * FROM emiten OFFSET 99999");
+                    w.invoke_run_query();
+                }),
+            );
+        }
+        // ⌘F find bar: highlights the first match of a term
+        "sql-find" => when(
+            window,
+            Rc::new(|w| !w.get_query_text().trim().is_empty()),
+            Rc::new(|w| {
+                w.invoke_toggle_find();
+                w.set_find_text("sector".into());
+                w.invoke_find_changed("sector".into());
+            }),
+        ),
+        // multi-statement run: status reads "N statements · …"
+        "sql-multi" => {
+            let load = load_editor_text.clone();
+            when(
+                window,
+                Rc::new(|w| !w.get_results_meta().is_empty()),
+                Rc::new(move |w| {
+                    load(0, "SELECT 1;\nSELECT * FROM emiten LIMIT 5;");
+                    w.invoke_run_query();
+                }),
+            );
+        }
+        _ => {}
     }
 }

--- a/app/src/wire/picker.rs
+++ b/app/src/wire/picker.rs
@@ -18,6 +18,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
         settings,
         panes,
         current,
+        driver_pool,
         cur_engine,
         collapsed,
         conn_filter,
@@ -29,6 +30,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
         active_tab_id,
         active_group1_tab_id,
         current_connection_id,
+        connected_ids,
         query_number,
         conn_modal_map,
         ..
@@ -616,6 +618,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
         let conn_filter = conn_filter.clone();
         let settings = settings.clone();
         let conn_modal_map = conn_modal_map.clone();
+        let connected_ids = connected_ids.clone();
         window.on_toggle_group(move |g| {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -637,6 +640,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
                 &store.borrow(),
                 &collapsed.borrow(),
                 &conn_filter.borrow(),
+                &connected_ids.lock().unwrap(),
             ));
             // Keep the ⌘O modal in sync too, whichever surface triggered this.
             if w.get_conn_modal_open() {
@@ -659,6 +663,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
         let collapsed = collapsed.clone();
         let conn_filter = conn_filter.clone();
         let settings = settings.clone();
+        let connected_ids = connected_ids.clone();
         window.on_group_delete(move |g| {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -693,6 +698,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
                 &store.borrow(),
                 &collapsed.borrow(),
                 &conn_filter.borrow(),
+                &connected_ids.lock().unwrap(),
             ));
         });
     }
@@ -705,6 +711,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
         let collapsed = collapsed.clone();
         let conn_filter = conn_filter.clone();
         let settings = settings.clone();
+        let connected_ids = connected_ids.clone();
         window.on_group_rename(move |old, new| {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -760,6 +767,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
                 &store.borrow(),
                 &collapsed.borrow(),
                 &conn_filter.borrow(),
+                &connected_ids.lock().unwrap(),
             ));
         });
     }
@@ -770,6 +778,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
         let store = store.clone();
         let collapsed = collapsed.clone();
         let conn_filter = conn_filter.clone();
+        let connected_ids = connected_ids.clone();
         window.on_conn_filter(move |t| {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -779,6 +788,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
                 &store.borrow(),
                 &collapsed.borrow(),
                 &conn_filter.borrow(),
+                &connected_ids.lock().unwrap(),
             ));
         });
     }
@@ -789,6 +799,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
         let store = store.clone();
         let collapsed = collapsed.clone();
         let conn_filter = conn_filter.clone();
+        let connected_ids = connected_ids.clone();
         window.on_toggle_favorite(move |idx| {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -806,6 +817,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
                 &store.borrow(),
                 &collapsed.borrow(),
                 &conn_filter.borrow(),
+                &connected_ids.lock().unwrap(),
             ));
         });
     }
@@ -816,6 +828,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
         let store = store.clone();
         let collapsed = collapsed.clone();
         let conn_filter = conn_filter.clone();
+        let connected_ids = connected_ids.clone();
         window.on_reorder_conn(move |from_idx, delta, drop_y| {
             let Some(w) = weak.upgrade() else {
                 return;
@@ -830,8 +843,12 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
 
             // Cross-group drop: the release point landed on a different
             // group's header or row than the dragged connection's own group.
-            let rendered =
-                build_conn_items(&store.borrow(), &collapsed.borrow(), &conn_filter.borrow());
+            let rendered = build_conn_items(
+                &store.borrow(),
+                &collapsed.borrow(),
+                &conn_filter.borrow(),
+                &connected_ids.lock().unwrap(),
+            );
             if let Some(target_group) = row_group_at_y(&rendered, drop_y) {
                 let from_id = {
                     let s = store.borrow();
@@ -858,6 +875,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
                         &store.borrow(),
                         &collapsed.borrow(),
                         &conn_filter.borrow(),
+                        &connected_ids.lock().unwrap(),
                     ));
                     return;
                 }
@@ -898,6 +916,7 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
                 &store.borrow(),
                 &collapsed.borrow(),
                 &conn_filter.borrow(),
+                &connected_ids.lock().unwrap(),
             ));
         });
     }
@@ -916,10 +935,22 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
         let active_tab_id = active_tab_id.clone();
         let current_connection_id = current_connection_id.clone();
         let panes = panes.clone();
+        let driver_pool = driver_pool.clone();
+        let store = store.clone();
+        let collapsed = collapsed.clone();
+        let conn_filter = conn_filter.clone();
+        let connected_ids = connected_ids.clone();
         window.on_disconnect(move || {
             let Some(w) = weak.upgrade() else {
                 return;
             };
+            // Which connection this actually drops — the one currently
+            // browsed. Two connections can be live at once; this must never
+            // be confused with "disconnect everything".
+            let disconnecting_id = current_connection_id.lock().unwrap().clone();
+            if let Some(id) = &disconnecting_id {
+                connected_ids.lock().unwrap().remove(id);
+            }
             // Stop any in-flight query first: disconnecting must not leave a query
             // running on the server. Dropping the driver is not enough on its own
             // — the server only reaps the statement once it notices the socket is
@@ -944,7 +975,16 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
                 set_p_query_running(&w, p, false);
                 set_p_streaming(&w, p, false);
             }
-            w.set_connected(false);
+            // Drop this connection's entry from the multi-connection pool
+            // too, not just the legacy single-slot `current` below —
+            // otherwise a "disconnected" connection can keep quietly
+            // serving whatever tab is still bound to it.
+            if let Some(id) = disconnecting_id.clone() {
+                let driver_pool = driver_pool.clone();
+                rt.spawn(async move {
+                    driver_pool.write().await.remove(&id);
+                });
+            }
             w.set_selected_conn(-1);
             w.set_active_table(SharedString::default());
             w.set_status_conn(SharedString::from("no connection"));
@@ -980,10 +1020,56 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
             loaded_dbs.lock().unwrap().clear();
             *collapsed_categories.borrow_mut() = default_collapsed_cats();
             raw_nodes.lock().unwrap().clear();
-            let current = current.clone();
-            rt.spawn(async move {
-                *current.lock().await = None;
-            });
+            {
+                let current = current.clone();
+                rt.spawn(async move {
+                    *current.lock().await = None;
+                });
+            }
+            // Only fall back to the landing picker when no other connection
+            // is actually still connected — with two connections open,
+            // disconnecting one must not blow away the other's workspace.
+            // `connected_ids` (not tab scoping — a tab keeps its
+            // `connection_id` after its connection drops) already had
+            // `disconnecting_id` removed above, so any entry left here is a
+            // genuinely different, still-live connection.
+            let other_live = !connected_ids.lock().unwrap().is_empty();
+            w.set_connections(build_sidebar_model(
+                &store.borrow(),
+                &collapsed.borrow(),
+                &conn_filter.borrow(),
+                &connected_ids.lock().unwrap(),
+            ));
+            if other_live {
+                // Resync chrome to whatever tab stayed focused, so the
+                // topbar reflects a connection that's actually still there
+                // instead of the one just dropped.
+                let cid = active_tab_id.lock().unwrap().clone().and_then(|id| {
+                    workspace_tabs
+                        .lock()
+                        .unwrap()
+                        .iter()
+                        .find(|t| t.id == id)
+                        .and_then(|t| t.connection_id.clone())
+                });
+                sync_conn_chrome(&w, &store.borrow(), cid.as_deref());
+                if let Some(cid) = cid {
+                    *current_connection_id.lock().unwrap() = Some(cid.clone());
+                    // `current` was cleared above along with the dropped
+                    // connection; repopulate it from the pool entry the
+                    // surviving connection still owns, or the health poll
+                    // (which only ever pings `current`) is stuck reading
+                    // None forever and the breadcrumb dot freezes.
+                    let current = current.clone();
+                    let driver_pool = driver_pool.clone();
+                    rt.spawn(async move {
+                        let entry = driver_pool.read().await.get(&cid).cloned();
+                        *current.lock().await = entry;
+                    });
+                }
+            } else {
+                w.set_connected(false);
+            }
         });
     }
 

--- a/app/src/wire/picker.rs
+++ b/app/src/wire/picker.rs
@@ -951,17 +951,28 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
             if let Some(id) = &disconnecting_id {
                 connected_ids.lock().unwrap().remove(id);
             }
-            // Stop any in-flight query first: disconnecting must not leave a query
-            // running on the server. Dropping the driver is not enough on its own
-            // — the server only reaps the statement once it notices the socket is
-            // gone, which is exactly the lag that kept load high after a
-            // disconnect — so ask it to cancel before tearing the connection down.
+            // Cancel the in-flight query before tearing the connection down,
+            // so the server drops it instead of running it to completion.
+            // Resolved by `disconnecting_id`, not the legacy `current` slot —
+            // with two connections open they can point at different ones.
             {
                 let current = current.clone();
+                let driver_pool = driver_pool.clone();
+                let disconnecting_id = disconnecting_id.clone();
                 rt.spawn(async move {
-                    let driver = { current.lock().await.as_ref().map(|(_, d)| d.clone()) };
-                    if let Some(d) = driver {
-                        let _ = d.cancel_running().await;
+                    let driver =
+                        resolve_driver(&driver_pool, &current, disconnecting_id.as_deref())
+                            .await
+                            .map(|(_, d)| d);
+                    let Some(driver) = driver else { return };
+                    let _ = driver.cancel_running().await;
+                    // Drop the pool entry too, not just `current` — but only
+                    // if a fast reconnect hasn't already replaced it.
+                    if let Some(id) = disconnecting_id {
+                        let mut pool = driver_pool.write().await;
+                        if still_the_disconnected_driver(&pool, &id, &driver) {
+                            pool.remove(&id);
+                        }
                     }
                 });
             }
@@ -974,16 +985,6 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
                 }
                 set_p_query_running(&w, p, false);
                 set_p_streaming(&w, p, false);
-            }
-            // Drop this connection's entry from the multi-connection pool
-            // too, not just the legacy single-slot `current` below —
-            // otherwise a "disconnected" connection can keep quietly
-            // serving whatever tab is still bound to it.
-            if let Some(id) = disconnecting_id.clone() {
-                let driver_pool = driver_pool.clone();
-                rt.spawn(async move {
-                    driver_pool.write().await.remove(&id);
-                });
             }
             w.set_selected_conn(-1);
             w.set_active_table(SharedString::default());

--- a/app/src/wire/runner.rs
+++ b/app/src/wire/runner.rs
@@ -14,7 +14,94 @@ use slint::{ComponentHandle, ModelRc, SharedString, VecModel};
 
 use crate::*;
 
+fn bind_tab_connection_for_runner(
+    workspace_tabs: &std::sync::Mutex<Vec<WorkspaceTab>>,
+    current_connection_id: &std::sync::Mutex<Option<String>>,
+    target_id: &str,
+    sql: &str,
+) -> Option<String> {
+    let mut tab_connection_id = None;
+    if let Some(tab) = workspace_tabs
+        .lock()
+        .unwrap()
+        .iter_mut()
+        .find(|tab| tab.id == target_id)
+    {
+        tab.loading = true;
+        tab.query_text = sql.to_string();
+        tab_connection_id = tab.connection_id.clone();
+        if tab_connection_id.is_none() {
+            tab_connection_id = current_connection_id.lock().unwrap().clone();
+            tab.connection_id = tab_connection_id.clone();
+        }
+    }
+    tab_connection_id
+}
+#[allow(clippy::too_many_arguments)]
+async fn execute_multi_statement_query(
+    engine: rdb_connstore::Engine,
+    driver: &AnyDriver,
+    sql: &str,
+    row_limit: u64,
+    cur_db: &str,
+    split: bool,
+    query_console: &Arc<std::sync::Mutex<Vec<String>>>,
+    split_views: &mut Vec<model::ResultView>,
+    split_verbs: &mut Vec<Option<&'static str>>,
+) -> (
+    Result<rdb_core::result::ResultSet, rdb_core::error::RdbError>,
+    usize,
+    Option<String>,
+) {
+    let stmts = if matches!(
+        engine,
+        rdb_connstore::Engine::Postgres
+            | rdb_connstore::Engine::MySql
+            | rdb_connstore::Engine::Sqlite
+            | rdb_connstore::Engine::Cassandra
+    ) {
+        editor::split_statements(sql)
+    } else {
+        vec![sql.to_string()]
+    };
+    let n = stmts.len().max(1);
+    let mut out = Err(rdb_core::error::RdbError::Query("empty query".into()));
+    for (i, s) in stmts.iter().enumerate() {
+        let s = cap_select(engine, s, row_limit);
+        append_query_console(query_console, s.clone());
+        out = match crate::query_parse::parse_query(engine, &s) {
+            Ok(mut q) => {
+                if let rdb_core::query::Query::Mongo(op) = &mut q {
+                    if op.database.is_none() && !cur_db.is_empty() {
+                        op.database = Some(cur_db.to_string());
+                    }
+                }
+                driver.query(&q).await
+            }
+            Err(msg) => Err(rdb_core::error::RdbError::Query(msg)),
+        };
+        if let Err(e) = &out {
+            if n > 1 {
+                out = Err(rdb_core::error::RdbError::Query(format!(
+                    "statement {}/{n}: {e}",
+                    i + 1
+                )));
+            }
+            break;
+        }
+        if split {
+            if let Ok(rs) = &out {
+                split_views.push(model::to_result_view(rs));
+                split_verbs.push(model::sql_verb(&s));
+            }
+        }
+    }
+    (out, n, stmts.last().cloned())
+}
+
 /// PK-aware editing for a single-table SELECT, buffered or streamed.
+/// Shared by `run_sql` and `run_stream` — they used to each carry their own
+/// copy of this.
 /// Shared by `run_sql` and `run_stream` — they used to each carry their own
 /// copy of this.
 async fn resolve_pk_hint(
@@ -116,28 +203,12 @@ pub(crate) fn build(window: &MainWindow, state: &AppState) -> (PaneSqlFn, PaneSq
             let Some(target_id) = active_id.lock().unwrap().clone() else {
                 return;
             };
-            let mut tab_connection_id = None;
-            if let Some(tab) = workspace_tabs
-                .lock()
-                .unwrap()
-                .iter_mut()
-                .find(|tab| tab.id == target_id)
-            {
-                tab.loading = true;
-                tab.query_text = sql.clone();
-                tab_connection_id = tab.connection_id.clone();
-                // First run on a scratch tab (opened before any connection was
-                // tracked, or restored from disk without one) locks it to
-                // whatever it runs against now — otherwise it keeps following
-                // `current_connection_id` around on every later click, and
-                // never counts as "live" for a given connection (disconnect's
-                // other-still-live check, the sidebar dot) since nothing ever
-                // points at it.
-                if tab_connection_id.is_none() {
-                    tab_connection_id = current_connection_id.lock().unwrap().clone();
-                    tab.connection_id = tab_connection_id.clone();
-                }
-            }
+            let tab_connection_id = bind_tab_connection_for_runner(
+                &workspace_tabs,
+                &current_connection_id,
+                &target_id,
+                &sql,
+            );
             let weak2 = weak.clone();
             let current = current.clone();
             let driver_pool = driver_pool.clone();
@@ -190,22 +261,6 @@ pub(crate) fn build(window: &MainWindow, state: &AppState) -> (PaneSqlFn, PaneSq
                 let stmt_offsets = editor::statement_offsets(&sql);
                 let (outcome, n_stmts, last_stmt) = match picked.as_ref() {
                     Some((engine, driver)) => {
-                        let stmts = if matches!(
-                            engine,
-                            rdb_connstore::Engine::Postgres
-                                | rdb_connstore::Engine::MySql
-                                | rdb_connstore::Engine::Sqlite
-                                | rdb_connstore::Engine::Cassandra
-                        ) {
-                            editor::split_statements(&sql)
-                        } else {
-                            vec![sql.clone()]
-                        };
-                        let n = stmts.len().max(1);
-                        // SQL engines are never auto-capped — the user's SELECT runs
-                        // as written (bare reads take the streaming path instead).
-                        // NoSQL keeps the row-limit control's value. Browse text
-                        // carries its own LIMIT either way, so cap_select no-ops it.
                         let row_limit = if matches!(
                             engine,
                             rdb_connstore::Engine::Postgres
@@ -217,42 +272,18 @@ pub(crate) fn build(window: &MainWindow, state: &AppState) -> (PaneSqlFn, PaneSq
                         } else {
                             browse.lock().unwrap().limit
                         };
-                        let mut out = Err(rdb_core::error::RdbError::Query("empty query".into()));
-                        for (i, s) in stmts.iter().enumerate() {
-                            let s = cap_select(*engine, s, row_limit);
-                            append_query_console(&query_console, s.clone());
-                            out = match crate::query_parse::parse_query(*engine, &s) {
-                                Ok(mut q) => {
-                                    // Fill the selected database for a Mongo query
-                                    // that didn't name one via `use(...)`.
-                                    if let rdb_core::query::Query::Mongo(op) = &mut q {
-                                        if op.database.is_none() && !cur_db.is_empty() {
-                                            op.database = Some(cur_db.clone());
-                                        }
-                                    }
-                                    driver.query(&q).await
-                                }
-                                Err(msg) => Err(rdb_core::error::RdbError::Query(msg)),
-                            };
-                            if let Err(e) = &out {
-                                // Point the user at the offending statement.
-                                if n > 1 {
-                                    out = Err(rdb_core::error::RdbError::Query(format!(
-                                        "statement {}/{n}: {e}",
-                                        i + 1
-                                    )));
-                                }
-                                break;
-                            }
-                            // Run Selection multi-tab: keep each statement's result.
-                            if split {
-                                if let Ok(rs) = &out {
-                                    split_views.push(model::to_result_view(rs));
-                                    split_verbs.push(model::sql_verb(&s));
-                                }
-                            }
-                        }
-                        (out, n, stmts.last().cloned())
+                        execute_multi_statement_query(
+                            *engine,
+                            driver,
+                            &sql,
+                            row_limit,
+                            &cur_db,
+                            split,
+                            &query_console,
+                            &mut split_views,
+                            &mut split_verbs,
+                        )
+                        .await
                     }
                     None => (
                         Err(rdb_core::error::RdbError::Connection(
@@ -581,32 +612,19 @@ pub(crate) fn build(window: &MainWindow, state: &AppState) -> (PaneSqlFn, PaneSq
                 return;
             };
             let new_tab = result_new_tab.swap(false, std::sync::atomic::Ordering::SeqCst);
-            // Stop any in-flight stream, then arm a fresh cancel flag.
             if let Some(prev) = stream_cancel.borrow().as_ref() {
                 prev.store(true, std::sync::atomic::Ordering::SeqCst);
             }
             let cancel = Arc::new(std::sync::atomic::AtomicBool::new(false));
             *stream_cancel.borrow_mut() = Some(cancel.clone());
-
-            // Log the RAW sql (clean `SELECT * FROM t`, no injected LIMIT).
             append_query_console(&query_console, sql.clone());
             sync_query_console(&w, &query_console);
-            let mut tab_connection_id = None;
-            if let Some(tab) = workspace_tabs
-                .lock()
-                .unwrap()
-                .iter_mut()
-                .find(|t| t.id == target_id)
-            {
-                tab.loading = true;
-                tab.query_text = sql.clone();
-                tab_connection_id = tab.connection_id.clone();
-                // Same first-run lock as run_sql: see the comment there.
-                if tab_connection_id.is_none() {
-                    tab_connection_id = current_connection_id.lock().unwrap().clone();
-                    tab.connection_id = tab_connection_id.clone();
-                }
-            }
+            let tab_connection_id = bind_tab_connection_for_runner(
+                &workspace_tabs,
+                &current_connection_id,
+                &target_id,
+                &sql,
+            );
             set_p_query_running(&w, pane, true);
             set_p_streaming(&w, pane, true);
             set_p_read_only(&w, pane, true);

--- a/app/src/wire/runner.rs
+++ b/app/src/wire/runner.rs
@@ -14,6 +14,44 @@ use slint::{ComponentHandle, ModelRc, SharedString, VecModel};
 
 use crate::*;
 
+/// PK-aware editing for a single-table SELECT, buffered or streamed.
+/// Shared by `run_sql` and `run_stream` — they used to each carry their own
+/// copy of this.
+async fn resolve_pk_hint(
+    engine: rdb_connstore::Engine,
+    driver: &AnyDriver,
+    stmt: &str,
+    cur_db: &str,
+    columns: &[String],
+) -> Option<(rdb_core::write::TableRef, Vec<String>)> {
+    if !matches!(
+        engine,
+        rdb_connstore::Engine::Postgres
+            | rdb_connstore::Engine::MySql
+            | rdb_connstore::Engine::Sqlite
+    ) {
+        return None;
+    }
+    let (qualifier, name) = crate::query_parse::single_table_name(stmt)?;
+    // The query's own `schema.table`/`db.table` prefix wins when it named one
+    // explicitly; otherwise fall back to the connection's active
+    // schema/database selection.
+    let qualifier = qualifier.or_else(|| (!cur_db.is_empty()).then(|| cur_db.to_string()));
+    let table = rdb_core::write::TableRef {
+        database: (!matches!(engine, rdb_connstore::Engine::Postgres))
+            .then(|| qualifier.clone())
+            .flatten(),
+        schema: matches!(engine, rdb_connstore::Engine::Postgres)
+            .then(|| qualifier.clone())
+            .flatten(),
+        name,
+    };
+    match driver.primary_key(&table).await {
+        Ok(pk) if !pk.is_empty() && pk.iter().all(|k| columns.contains(k)) => Some((table, pk)),
+        _ => None,
+    }
+}
+
 pub(crate) fn build(window: &MainWindow, state: &AppState) -> (PaneSqlFn, PaneSqlFn) {
     let AppState {
         rt,
@@ -260,54 +298,13 @@ pub(crate) fn build(window: &MainWindow, state: &AppState) -> (PaneSqlFn, PaneSq
                 // PK columns come back in the result, treat it the same as a
                 // browsed table: editable, PK-aware. Anything ambiguous just
                 // stays read-only, same as before this existed.
-                let pk_hint: Option<(rdb_core::write::TableRef, Vec<String>)> = if let (
-                    Some((engine, driver)),
-                    Some(model::ResultView::Table(g)),
-                    Some(stmt),
-                ) =
-                    (picked.as_ref(), view.as_ref(), last_stmt.as_deref())
-                {
-                    if matches!(
-                        engine,
-                        rdb_connstore::Engine::Postgres
-                            | rdb_connstore::Engine::MySql
-                            | rdb_connstore::Engine::Sqlite
-                    ) {
-                        if let Some((qualifier, name)) = crate::query_parse::single_table_name(stmt)
-                        {
-                            // The query's own `schema.table`/`db.table` prefix wins
-                            // when it named one explicitly; otherwise fall back to
-                            // the connection's active schema/database selection.
-                            let qualifier =
-                                qualifier.or_else(|| (!cur_db.is_empty()).then(|| cur_db.clone()));
-                            let table = rdb_core::write::TableRef {
-                                database: (!matches!(engine, rdb_connstore::Engine::Postgres))
-                                    .then(|| qualifier.clone())
-                                    .flatten(),
-                                schema: matches!(engine, rdb_connstore::Engine::Postgres)
-                                    .then(|| qualifier.clone())
-                                    .flatten(),
-                                name,
-                            };
-                            match driver.primary_key(&table).await {
-                                Ok(pk)
-                                    if !pk.is_empty()
-                                        && pk
-                                            .iter()
-                                            .all(|k| g.columns.iter().any(|c| &c.name == k)) =>
-                                {
-                                    Some((table, pk))
-                                }
-                                _ => None,
-                            }
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
+                let pk_hint = match (picked.as_ref(), view.as_ref(), last_stmt.as_deref()) {
+                    (Some((engine, driver)), Some(model::ResultView::Table(g)), Some(stmt)) => {
+                        let columns: Vec<String> =
+                            g.columns.iter().map(|c| c.name.clone()).collect();
+                        resolve_pk_hint(*engine, driver, stmt, &cur_db, &columns).await
                     }
-                } else {
-                    None
+                    _ => None,
                 };
                 let _ = slint::invoke_from_event_loop(move || {
                     if let Some(w) = weak2.upgrade() {
@@ -953,53 +950,13 @@ pub(crate) fn build(window: &MainWindow, state: &AppState) -> (PaneSqlFn, PaneSq
                         // (inside the same task, before Done ships) so it lands
                         // atomically with the result — see the StreamMsg::Done doc
                         // comment for why this replaced a separately spawned task.
-                        let pk_hint: Option<(rdb_core::write::TableRef, Vec<String>)> =
-                            if let Some((engine, driver)) = picked.as_ref() {
-                                if matches!(
-                                    engine,
-                                    rdb_connstore::Engine::Postgres
-                                        | rdb_connstore::Engine::MySql
-                                        | rdb_connstore::Engine::Sqlite
-                                ) {
-                                    if let Some((qualifier, name)) =
-                                        crate::query_parse::single_table_name(&sql_for_pk)
-                                    {
-                                        let qualifier = qualifier.or_else(|| {
-                                            (!cur_db.is_empty()).then(|| cur_db.clone())
-                                        });
-                                        let table = rdb_core::write::TableRef {
-                                            database: (!matches!(
-                                                engine,
-                                                rdb_connstore::Engine::Postgres
-                                            ))
-                                            .then(|| qualifier.clone())
-                                            .flatten(),
-                                            schema: matches!(
-                                                engine,
-                                                rdb_connstore::Engine::Postgres
-                                            )
-                                            .then(|| qualifier.clone())
-                                            .flatten(),
-                                            name,
-                                        };
-                                        match driver.primary_key(&table).await {
-                                            Ok(pk)
-                                                if !pk.is_empty()
-                                                    && pk.iter().all(|k| col_names.contains(k)) =>
-                                            {
-                                                Some((table, pk))
-                                            }
-                                            _ => None,
-                                        }
-                                    } else {
-                                        None
-                                    }
-                                } else {
-                                    None
-                                }
-                            } else {
-                                None
-                            };
+                        let pk_hint = match picked.as_ref() {
+                            Some((engine, driver)) => {
+                                resolve_pk_hint(*engine, driver, &sql_for_pk, &cur_db, &col_names)
+                                    .await
+                            }
+                            None => None,
+                        };
                         let _ = ui_tx.send(StreamMsg::Done {
                             capped,
                             elapsed_ms,

--- a/app/src/wire/runner.rs
+++ b/app/src/wire/runner.rs
@@ -20,6 +20,7 @@ pub(crate) fn build(window: &MainWindow, state: &AppState) -> (PaneSqlFn, PaneSq
         store,
         panes,
         current,
+        driver_pool,
         workspace_tabs,
         active_tab_id,
         active_group1_tab_id,
@@ -37,6 +38,7 @@ pub(crate) fn build(window: &MainWindow, state: &AppState) -> (PaneSqlFn, PaneSq
         let weak = window.as_weak();
         let rt = rt.clone();
         let current = current.clone();
+        let driver_pool = driver_pool.clone();
         let current_connection_id = current_connection_id.clone();
         let store = store.clone();
         let last_view = last_view.clone();
@@ -76,6 +78,7 @@ pub(crate) fn build(window: &MainWindow, state: &AppState) -> (PaneSqlFn, PaneSq
             let Some(target_id) = active_id.lock().unwrap().clone() else {
                 return;
             };
+            let mut tab_connection_id = None;
             if let Some(tab) = workspace_tabs
                 .lock()
                 .unwrap()
@@ -84,9 +87,22 @@ pub(crate) fn build(window: &MainWindow, state: &AppState) -> (PaneSqlFn, PaneSq
             {
                 tab.loading = true;
                 tab.query_text = sql.clone();
+                tab_connection_id = tab.connection_id.clone();
+                // First run on a scratch tab (opened before any connection was
+                // tracked, or restored from disk without one) locks it to
+                // whatever it runs against now — otherwise it keeps following
+                // `current_connection_id` around on every later click, and
+                // never counts as "live" for a given connection (disconnect's
+                // other-still-live check, the sidebar dot) since nothing ever
+                // points at it.
+                if tab_connection_id.is_none() {
+                    tab_connection_id = current_connection_id.lock().unwrap().clone();
+                    tab.connection_id = tab_connection_id.clone();
+                }
             }
             let weak2 = weak.clone();
             let current = current.clone();
+            let driver_pool = driver_pool.clone();
             let last_view = last_view.clone();
             let browse = browse.clone();
             let edit_buf = edit_buf.clone();
@@ -115,10 +131,8 @@ pub(crate) fn build(window: &MainWindow, state: &AppState) -> (PaneSqlFn, PaneSq
                 // hid it. The console still updates in place when it is open.
                 cur_db = w.get_schema_name().to_string();
             }
-            // Snapshot which connection is running THIS query — not read back
-            // later from `current_connection_id`, since the user can switch the
-            // active connection while the query is in flight.
-            let query_connection_id = current_connection_id.lock().unwrap().clone();
+            let query_connection_id =
+                tab_connection_id.or_else(|| current_connection_id.lock().unwrap().clone());
             let query_badge = query_connection_id
                 .as_deref()
                 .map(|cid| connection_badge_info(&store.borrow(), cid))
@@ -126,8 +140,10 @@ pub(crate) fn build(window: &MainWindow, state: &AppState) -> (PaneSqlFn, PaneSq
             let started = std::time::Instant::now();
             let jh = rt.spawn(async move {
                 let picked = {
+                    let pool = driver_pool.read().await;
                     let guard = current.lock().await;
-                    guard.as_ref().map(|(e, d)| (*e, d.clone()))
+                    driver_for(&pool, guard.as_ref(), query_connection_id.as_deref())
+                        .map(|(e, d)| (*e, d.clone()))
                 };
                 let queue_ms = started.elapsed().as_millis() as u64;
                 let driver_started = std::time::Instant::now();
@@ -528,6 +544,7 @@ pub(crate) fn build(window: &MainWindow, state: &AppState) -> (PaneSqlFn, PaneSq
         let weak = window.as_weak();
         let rt = rt.clone();
         let current = current.clone();
+        let driver_pool = driver_pool.clone();
         let current_connection_id = current_connection_id.clone();
         let store = store.clone();
         let query_console = query_console.clone();
@@ -581,6 +598,7 @@ pub(crate) fn build(window: &MainWindow, state: &AppState) -> (PaneSqlFn, PaneSq
             // Log the RAW sql (clean `SELECT * FROM t`, no injected LIMIT).
             append_query_console(&query_console, sql.clone());
             sync_query_console(&w, &query_console);
+            let mut tab_connection_id = None;
             if let Some(tab) = workspace_tabs
                 .lock()
                 .unwrap()
@@ -589,6 +607,12 @@ pub(crate) fn build(window: &MainWindow, state: &AppState) -> (PaneSqlFn, PaneSq
             {
                 tab.loading = true;
                 tab.query_text = sql.clone();
+                tab_connection_id = tab.connection_id.clone();
+                // Same first-run lock as run_sql: see the comment there.
+                if tab_connection_id.is_none() {
+                    tab_connection_id = current_connection_id.lock().unwrap().clone();
+                    tab.connection_id = tab_connection_id.clone();
+                }
             }
             set_p_query_running(&w, pane, true);
             set_p_streaming(&w, pane, true);
@@ -597,9 +621,10 @@ pub(crate) fn build(window: &MainWindow, state: &AppState) -> (PaneSqlFn, PaneSq
             set_p_result_status(&w, pane, SharedString::from("streaming…"));
             set_p_results_meta(&w, pane, SharedString::default());
 
-            // Snapshot which connection is running THIS stream, same reasoning
-            // as run_sql: the active connection can change before it finishes.
-            let query_connection_id = current_connection_id.lock().unwrap().clone();
+            // The tab's own connection, same reasoning as run_sql: the active
+            // connection can change before this stream finishes.
+            let query_connection_id =
+                tab_connection_id.or_else(|| current_connection_id.lock().unwrap().clone());
             let query_badge = query_connection_id
                 .as_deref()
                 .map(|cid| connection_badge_info(&store.borrow(), cid))
@@ -862,11 +887,19 @@ pub(crate) fn build(window: &MainWindow, state: &AppState) -> (PaneSqlFn, PaneSq
             let sql_for_pk = sql.clone();
             let q = rdb_core::query::Query::Sql(sql);
             let current = current.clone();
+            let driver_pool = driver_pool.clone();
+            let query_connection_id_for_pick = query_connection_id.clone();
             rt.spawn(async move {
                 let t0 = std::time::Instant::now();
                 let picked = {
+                    let pool = driver_pool.read().await;
                     let guard = current.lock().await;
-                    guard.as_ref().map(|(e, d)| (*e, d.clone()))
+                    driver_for(
+                        &pool,
+                        guard.as_ref(),
+                        query_connection_id_for_pick.as_deref(),
+                    )
+                    .map(|(e, d)| (*e, d.clone()))
                 };
                 let driver = picked.as_ref().map(|(_, d)| d.clone());
                 let (ctx, mut crx) = tokio::sync::mpsc::channel::<rdb_core::result::StreamItem>(4);

--- a/app/src/wire/runner.rs
+++ b/app/src/wire/runner.rs
@@ -139,12 +139,8 @@ pub(crate) fn build(window: &MainWindow, state: &AppState) -> (PaneSqlFn, PaneSq
                 .unwrap_or_default();
             let started = std::time::Instant::now();
             let jh = rt.spawn(async move {
-                let picked = {
-                    let pool = driver_pool.read().await;
-                    let guard = current.lock().await;
-                    driver_for(&pool, guard.as_ref(), query_connection_id.as_deref())
-                        .map(|(e, d)| (*e, d.clone()))
-                };
+                let picked =
+                    resolve_driver(&driver_pool, &current, query_connection_id.as_deref()).await;
                 let queue_ms = started.elapsed().as_millis() as u64;
                 let driver_started = std::time::Instant::now();
                 // Multi-statement: SQL engines split on top-level `;` and run
@@ -891,16 +887,12 @@ pub(crate) fn build(window: &MainWindow, state: &AppState) -> (PaneSqlFn, PaneSq
             let query_connection_id_for_pick = query_connection_id.clone();
             rt.spawn(async move {
                 let t0 = std::time::Instant::now();
-                let picked = {
-                    let pool = driver_pool.read().await;
-                    let guard = current.lock().await;
-                    driver_for(
-                        &pool,
-                        guard.as_ref(),
-                        query_connection_id_for_pick.as_deref(),
-                    )
-                    .map(|(e, d)| (*e, d.clone()))
-                };
+                let picked = resolve_driver(
+                    &driver_pool,
+                    &current,
+                    query_connection_id_for_pick.as_deref(),
+                )
+                .await;
                 let driver = picked.as_ref().map(|(_, d)| d.clone());
                 let (ctx, mut crx) = tokio::sync::mpsc::channel::<rdb_core::result::StreamItem>(4);
                 let cancel_prod = cancel.clone();

--- a/app/src/wire/split_pane.rs
+++ b/app/src/wire/split_pane.rs
@@ -176,12 +176,9 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) {
             // The active tab's own connection, not whatever `current` is.
             let tab_connection_id = focused_tab_connection_id(&active_tab_id, &workspace_tabs);
             rt.spawn(async move {
-                let driver = {
-                    let pool = driver_pool.read().await;
-                    let guard = current.lock().await;
-                    driver_for(&pool, guard.as_ref(), tab_connection_id.as_deref())
-                        .map(|(_, d)| d.clone())
-                };
+                let driver = resolve_driver(&driver_pool, &current, tab_connection_id.as_deref())
+                    .await
+                    .map(|(_, d)| d);
                 if let Some(d) = driver {
                     let _ = d.cancel_running().await;
                 }

--- a/app/src/wire/split_pane.rs
+++ b/app/src/wire/split_pane.rs
@@ -34,7 +34,13 @@ fn copied_msg(grid: &model::GridModel, r: CellRange) -> String {
 
 pub(crate) fn wire(window: &MainWindow, state: &AppState) {
     let AppState {
-        panes, rt, current, ..
+        panes,
+        rt,
+        current,
+        driver_pool,
+        active_tab_id,
+        workspace_tabs,
+        ..
     } = state.clone();
     let displayed_grid = panes[0].displayed_grid.clone();
 
@@ -161,10 +167,21 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState) {
         let panes = panes.clone();
         let rt = rt.clone();
         let current = current.clone();
+        let driver_pool = driver_pool.clone();
+        let active_tab_id = active_tab_id.clone();
+        let workspace_tabs = workspace_tabs.clone();
         let cancel = move || {
             let current = current.clone();
+            let driver_pool = driver_pool.clone();
+            // The active tab's own connection, not whatever `current` is.
+            let tab_connection_id = focused_tab_connection_id(&active_tab_id, &workspace_tabs);
             rt.spawn(async move {
-                let driver = { current.lock().await.as_ref().map(|(_, d)| d.clone()) };
+                let driver = {
+                    let pool = driver_pool.read().await;
+                    let guard = current.lock().await;
+                    driver_for(&pool, guard.as_ref(), tab_connection_id.as_deref())
+                        .map(|(_, d)| d.clone())
+                };
                 if let Some(d) = driver {
                     let _ = d.cancel_running().await;
                 }

--- a/app/src/wire/tabs.rs
+++ b/app/src/wire/tabs.rs
@@ -65,6 +65,11 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
             };
             save_active_tab(&w);
             let number = query_number.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+            // `current_connection_id` tracks both an explicit connect-click
+            // and a plain tab-switch (restore_tab_for_pane keeps it aimed at
+            // whichever tab is on screen), so it's always "what a new action
+            // should target" — no need to separately inspect the focused
+            // tab's own connection_id here.
             let connection = current_connection_id
                 .lock()
                 .unwrap()


### PR DESCRIPTION
## Summary

- Each open query tab now connects to its own database instead of sharing one global connection.
- The sidebar and disconnect button now show which connection is actually live, not just which tabs mention it.

## Changes

- app: `driver_pool` and `driver_for` route each tab's queries through its own connection. Picking a connection in the sidebar only sets the target for a new tab or browse action. It no longer switches the connection of a tab that's already open.
- app: connections with no open tab left get closed automatically by a background sweep.
- app: added `connected_ids`, which tracks which connections actually have a live driver. It updates on connect, disconnect, and eviction. The sidebar refreshes right after each of these through a new `refresh-connections` callback.
- fix(app): the sidebar dot and the disconnect button's "another connection is still live" check used to look at which tabs referenced a connection, not whether it was actually connected. That made two open connections look the same and made disconnecting one feel like the whole app quit.

## Test plan

- [x] `make fmt-check`
- [x] `make lint`
- [x] `make test`
- [x] `make fe-build` / `make fe-run` for UI changes
- [x] Manual verification: `RDB_STORE_DIR=<dir> ./target/debug/rdb` with two saved connections, connected both, confirmed sidebar dot state and disconnect flow.

## Screenshots
<img width="1240" height="807" alt="Screenshot_20260911_045924" src="https://github.com/user-attachments/assets/18b262b0-056a-4d66-b2db-0caa54b795c5" />

<img width="1240" height="809" alt="Screenshot_20260911_050106" src="https://github.com/user-attachments/assets/5faf700c-08e8-4738-926c-5032f5e4abf5" />

## First pull request?

- [x] I have signed the CLA — will reply to the bot's comment on the PR.

## Notes for reviewers

None.
