### PR TITLE
fix(app): decide statement splitting from the engine's query language

### DIFF
--- a/app/src/editor.rs
+++ b/app/src/editor.rs
@@ -743,6 +743,12 @@ impl EditorState {
     fn statement_bounds(&self) -> (usize, usize) {
         let text = self.text();
         let chars: Vec<char> = text.chars().collect();
+        // A block body ends its own inner statements with `;`, so segmenting on
+        // `;` would leave Run a fragment that doesn't parse. The whole buffer is
+        // the statement then, same rule `scan_statements` follows.
+        if opens_block_body(&text) {
+            return (0, chars.len());
+        }
         // cursor position as a char offset into the joined text
         let mut offset = 0;
         for (i, l) in self.lines.iter().enumerate() {
@@ -899,46 +905,102 @@ impl EditorState {
     }
 }
 
-/// Split SQL text into individual statements on top-level semicolons,
-/// ignoring semicolons inside single-quoted literals and `-- line comments`.
-/// Trailing `;` and blank/comment-only segments are dropped. Text with no
-/// real statement yields an empty vec; a single statement (no `;`) yields one.
-/// Byte offset into `text` where each split statement's trimmed text begins.
-/// Parallel to `split_statements`; used to map a per-statement error position
-/// back to the full editor buffer for highlighting.
-pub fn statement_offsets(text: &str) -> Vec<usize> {
-    let chars: Vec<char> = text.chars().collect();
-    let mut out: Vec<usize> = Vec::new();
+/// One top-level statement of an editor buffer: its trimmed text, and the
+/// byte offset in the buffer where that text begins.
+struct Statement<'a> {
+    offset: usize,
+    text: &'a str,
+}
+
+/// Scan SQL text into statements on top-level semicolons, ignoring semicolons
+/// inside single-quoted literals and `-- line comments`. Trailing `;` and
+/// blank/comment-only segments are dropped, so text with no real statement
+/// yields nothing and a single statement (no `;`) yields one.
+fn scan_statements(text: &str) -> Vec<Statement<'_>> {
+    let mut out: Vec<Statement> = Vec::new();
+    if opens_block_body(text) {
+        push_statement(&mut out, text, 0, text.len());
+        return out;
+    }
+    // Byte scan: every character this looks for is ASCII, and no byte of a
+    // multibyte character can equal one, so a byte index is always a char
+    // boundary here and the slices below are safe.
+    let bytes = text.as_bytes();
     let mut seg_start = 0usize;
     let mut in_str = false;
+    let mut in_comment = false;
     let mut i = 0usize;
-    while i < chars.len() {
-        let c = chars[i];
-        if c == '\'' {
-            in_str = !in_str;
-        } else if !in_str && c == '-' && chars.get(i + 1) == Some(&'-') {
-            while i < chars.len() && chars[i] != '\n' {
-                i += 1;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\n' => in_comment = false,
+            _ if in_comment => {}
+            b'\'' => in_str = !in_str,
+            b'-' if !in_str && bytes.get(i + 1) == Some(&b'-') => in_comment = true,
+            b';' if !in_str => {
+                push_statement(&mut out, text, seg_start, i);
+                seg_start = i + 1;
             }
-            continue;
-        } else if c == ';' && !in_str {
-            let seg: String = chars[seg_start..i].iter().collect();
-            if !is_blank_sql(&seg) {
-                let trimmed = seg.trim_start();
-                out.push(seg_start + (seg.len() - trimmed.len()));
-            }
-            seg_start = i + 1;
+            _ => {}
         }
         i += 1;
     }
-    if seg_start < chars.len() {
-        let seg: String = chars[seg_start..].iter().collect();
-        if !is_blank_sql(&seg) {
-            let trimmed = seg.trim_start();
-            out.push(seg_start + (seg.len() - trimmed.len()));
-        }
-    }
+    push_statement(&mut out, text, seg_start, text.len());
     out
+}
+
+/// Append `text[start..end]` to `out` unless it is blank or comment-only.
+fn push_statement<'a>(out: &mut Vec<Statement<'a>>, text: &'a str, start: usize, end: usize) {
+    let seg = &text[start..end];
+    if is_blank_sql(seg) {
+        return;
+    }
+    let trimmed = seg.trim_start();
+    out.push(Statement {
+        offset: start + (seg.len() - trimmed.len()),
+        text: trimmed.trim_end(),
+    });
+}
+
+/// True when `text` opens a block that ends its own inner statements with `;`:
+/// a PL/SQL anonymous block (`DECLARE` / `BEGIN`) or a stored program
+/// (`CREATE [OR REPLACE] PROCEDURE | FUNCTION | TRIGGER | PACKAGE`, which
+/// Oracle, Postgres and MySQL all write that way). Those semicolons terminate
+/// nothing at the top level, so splitting on them hands the driver fragments
+/// that do not parse. The whole buffer runs as one statement instead, which
+/// also means a block is not followed by a second statement in the same run.
+fn opens_block_body(text: &str) -> bool {
+    let mut words = text
+        .lines()
+        .map(|l| l.split("--").next().unwrap_or(""))
+        .flat_map(str::split_whitespace)
+        .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric() && c != '_'))
+        .filter(|w| !w.is_empty())
+        .take(5)
+        .map(str::to_ascii_uppercase);
+    let Some(first) = words.next() else {
+        return false;
+    };
+    match first.as_str() {
+        "DECLARE" | "BEGIN" => true,
+        "CREATE" => words
+            .find(|w| {
+                !matches!(
+                    w.as_str(),
+                    "OR" | "REPLACE" | "EDITIONABLE" | "NONEDITIONABLE"
+                )
+            })
+            .is_some_and(|w| {
+                matches!(w.as_str(), "PROCEDURE" | "FUNCTION" | "TRIGGER" | "PACKAGE")
+            }),
+        _ => false,
+    }
+}
+
+/// Byte offset into `text` where each statement's trimmed text begins. Used to
+/// map a per-statement error position back to the full editor buffer for
+/// highlighting.
+pub fn statement_offsets(text: &str) -> Vec<usize> {
+    scan_statements(text).iter().map(|s| s.offset).collect()
 }
 
 /// Where a failed query points in the editor buffer.
@@ -1050,38 +1112,12 @@ pub fn strip_error_marker(msg: &str) -> std::borrow::Cow<'_, str> {
     std::borrow::Cow::Owned(out)
 }
 
+/// Split SQL text into individual statements, in buffer order.
 pub fn split_statements(text: &str) -> Vec<String> {
-    let chars: Vec<char> = text.chars().collect();
-    let mut out: Vec<String> = Vec::new();
-    let mut seg_start = 0usize;
-    let mut in_str = false;
-    let mut i = 0usize;
-    while i < chars.len() {
-        let c = chars[i];
-        if c == '\'' {
-            in_str = !in_str;
-        } else if !in_str && c == '-' && chars.get(i + 1) == Some(&'-') {
-            // skip to end of line
-            while i < chars.len() && chars[i] != '\n' {
-                i += 1;
-            }
-            continue;
-        } else if c == ';' && !in_str {
-            let seg: String = chars[seg_start..i].iter().collect();
-            if !is_blank_sql(&seg) {
-                out.push(seg.trim().to_string());
-            }
-            seg_start = i + 1;
-        }
-        i += 1;
-    }
-    if seg_start < chars.len() {
-        let seg: String = chars[seg_start..].iter().collect();
-        if !is_blank_sql(&seg) {
-            out.push(seg.trim().to_string());
-        }
-    }
-    out
+    scan_statements(text)
+        .iter()
+        .map(|s| s.text.to_string())
+        .collect()
 }
 
 /// Case-insensitive find of every occurrence of `needle` across `lines`.
@@ -1421,6 +1457,18 @@ mod tests {
     }
 
     #[test]
+    fn statement_under_cursor_keeps_a_block_whole() {
+        // Run with the cursor anywhere inside a PL/SQL block must send the
+        // whole block: cutting it on the first inner `;` gives Oracle a
+        // fragment that ends mid-block and fails to parse.
+        let text = "BEGIN\n  UPDATE t SET a = 1;\n  COMMIT;\nEND;";
+        let mut ed = EditorState::from_text(text);
+        ed.line = 2; // on `COMMIT;`
+        ed.col = 0;
+        assert_eq!(ed.current_statement(), text);
+    }
+
+    #[test]
     fn replace_current_statement_preserves_other_statements() {
         let mut ed = EditorState::from_text("select 1;\nselect 2;\nselect 3;");
         ed.line = 1;
@@ -1613,6 +1661,36 @@ mod tests {
     fn split_ignores_semicolon_in_literal() {
         let got = split_statements("INSERT INTO t VALUES ('a;b'); SELECT 2;");
         assert_eq!(got, vec!["INSERT INTO t VALUES ('a;b')", "SELECT 2"]);
+    }
+
+    #[test]
+    fn statement_offsets_are_byte_offsets_past_multibyte_text() {
+        // A driver reports a byte position, so a multibyte literal ahead of the
+        // failing statement has to shift the offset by its byte length.
+        let sql = "SELECT 'café';\nSELECT 2";
+        let offsets = statement_offsets(sql);
+        assert_eq!(offsets, vec![0, sql.find("SELECT 2").unwrap()]);
+    }
+
+    #[test]
+    fn split_keeps_a_plsql_block_whole() {
+        let block = "BEGIN\n  UPDATE t SET a = 1;\n  COMMIT;\nEND;";
+        assert_eq!(split_statements(block), vec![block]);
+        assert_eq!(statement_offsets(block), vec![0]);
+    }
+
+    #[test]
+    fn split_keeps_a_stored_program_whole() {
+        let proc = "CREATE OR REPLACE PROCEDURE p AS BEGIN NULL; END;";
+        assert_eq!(split_statements(proc), vec![proc]);
+        let decl = "DECLARE n NUMBER; BEGIN n := 1; END;";
+        assert_eq!(split_statements(decl), vec![decl]);
+    }
+
+    #[test]
+    fn split_still_splits_a_plain_create() {
+        let got = split_statements("CREATE TABLE t (a INT); SELECT 1;");
+        assert_eq!(got, vec!["CREATE TABLE t (a INT)", "SELECT 1"]);
     }
 
     #[test]

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2791,10 +2791,7 @@ fn browse_text(
 /// inside a subquery conservatively returns false, so we never mangle it).
 fn is_bare_select(engine: rdb_connstore::Engine, sql: &str) -> bool {
     use rdb_connstore::Engine;
-    if !matches!(
-        engine,
-        Engine::Postgres | Engine::MySql | Engine::Sqlite | Engine::Cassandra
-    ) {
+    if !Engine::language(engine).is_statement_text() {
         return false;
     }
     // Multiple statements can't stream as one cursor (Postgres rejects multiple

--- a/app/src/wire/connect.rs
+++ b/app/src/wire/connect.rs
@@ -246,10 +246,7 @@ async fn finish_connect_success(
     );
     let (schema_names, schema_current) =
         build_schema_picker_names(engine, scoped_db.as_deref(), pg_schemas, &db_names, &schema);
-    let sql_capable = matches!(
-        rdb_connstore::Engine::language(engine),
-        rdb_connstore::QueryLanguage::Sql | rdb_connstore::QueryLanguage::Cql
-    );
+    let sql_capable = rdb_connstore::Engine::language(engine).is_statement_text();
     *raw_nodes.lock().unwrap() = nodes;
     // Seed autocomplete with the active schema's tables plus a bare node for
     // every other schema name, so `schema.` autocompletes immediately. The

--- a/app/src/wire/runner.rs
+++ b/app/src/wire/runner.rs
@@ -77,13 +77,7 @@ async fn execute_multi_statement_query(
     split: bool,
     query_console: &Arc<std::sync::Mutex<Vec<String>>>,
 ) -> MultiStatementOutcome {
-    let stmts = if matches!(
-        engine,
-        rdb_connstore::Engine::Postgres
-            | rdb_connstore::Engine::MySql
-            | rdb_connstore::Engine::Sqlite
-            | rdb_connstore::Engine::Cassandra
-    ) {
+    let stmts = if rdb_connstore::Engine::language(engine).is_statement_text() {
         editor::split_statements(sql)
     } else {
         vec![sql.to_string()]
@@ -290,17 +284,12 @@ pub(crate) fn build(window: &MainWindow, state: &AppState) -> (PaneSqlFn, PaneSq
                         // instead). NoSQL keeps the row-limit control's value.
                         // Browse text carries its own LIMIT either way, so
                         // cap_select no-ops it.
-                        let row_limit = if matches!(
-                            engine,
-                            rdb_connstore::Engine::Postgres
-                                | rdb_connstore::Engine::MySql
-                                | rdb_connstore::Engine::Sqlite
-                                | rdb_connstore::Engine::Cassandra
-                        ) {
-                            0
-                        } else {
-                            browse.lock().unwrap().limit
-                        };
+                        let row_limit =
+                            if rdb_connstore::Engine::language(*engine).is_statement_text() {
+                                0
+                            } else {
+                                browse.lock().unwrap().limit
+                            };
                         execute_multi_statement_query(
                             *engine,
                             driver,

--- a/crates/connstore/src/model.rs
+++ b/crates/connstore/src/model.rs
@@ -41,6 +41,15 @@ pub enum QueryLanguage {
     Mongo,
 }
 
+impl QueryLanguage {
+    /// True when a query buffer is text made of `;`-separated statements that
+    /// run in order: `Sql` and `Cql`. A `Command` or `Mongo` buffer is a single
+    /// operation whatever its punctuation, so it is never split.
+    pub fn is_statement_text(self) -> bool {
+        matches!(self, QueryLanguage::Sql | QueryLanguage::Cql)
+    }
+}
+
 /// Everything about an engine that is otherwise re-spelled as a string
 /// somewhere in the app: the display label, the badge key, the URL scheme, the
 /// default port, and the query dialect.
@@ -518,6 +527,29 @@ mod tests {
     /// makes adding an `Engine` without an `ENGINES` entry a test failure
     /// rather than a runtime panic. The `match` is exhaustive on purpose: a
     /// new variant stops compiling here until it is listed.
+    #[test]
+    fn statement_text_covers_every_engine() {
+        let split = [
+            Engine::Postgres,
+            Engine::MySql,
+            Engine::MariaDb,
+            Engine::Sqlite,
+            Engine::Mssql,
+            Engine::Oracle,
+            Engine::Clickhouse,
+            Engine::Cassandra,
+        ];
+        let whole = [Engine::Redis, Engine::Valkey, Engine::Mongo];
+        for e in split {
+            assert!(e.language().is_statement_text(), "{e:?} should split");
+        }
+        for e in whole {
+            assert!(!e.language().is_statement_text(), "{e:?} should not split");
+        }
+        // A new engine has to land in one list or the other, deliberately.
+        assert_eq!(split.len() + whole.len(), ENGINES.len());
+    }
+
     #[test]
     fn every_engine_has_a_row() {
         let all = [


### PR DESCRIPTION
## Summary

Four sites carried the same hand-written engine list, `Postgres | MySql |
Sqlite | Cassandra`, to decide whether a query buffer splits on `;` and whether
the row-limit control applies. SQL Server, Oracle, ClickHouse and MariaDB are
all `QueryLanguage::Sql` and appear in none of the copies, so on those four
engines a multi-statement buffer went to the driver whole, a plain `SELECT` was
capped by the NoSQL row limit, and a bare read never reached the streaming
path.

**This changes behavior on four engines**, to the behavior the other SQL
engines already had. Independent of #293; either can merge first.

## Changes

- `QueryLanguage::is_statement_text` answers the question next to the `ENGINES`
  table the answer comes from. The four call sites use it:
  `execute_multi_statement_query`'s split, its caller's row limit,
  `is_bare_select`, and `sql_capable`.
- `statement_text_covers_every_engine` pins both lists and asserts they add up
  to `ENGINES.len()`, so an engine added without classifying it fails the test
  rather than silently defaulting.
- Routing Oracle into the splitter surfaced a second problem:
  `split_statements` cut on every unquoted `;`, so a PL/SQL block came apart
  into `BEGIN ...`, `COMMIT` and `END`, none of which parse. A buffer starting
  with `DECLARE`, `BEGIN`, or `CREATE [OR REPLACE] PROCEDURE | FUNCTION |
  TRIGGER | PACKAGE` now runs whole. The trade is that a block cannot be
  followed by a second statement in the same run, which beats sending a
  fragment. Postgres and MySQL function bodies are covered by the same guard.
- Run sends the statement under the cursor, and that path cut on `;` too. It
  never looked at the engine, so a block was already being cut there before
  Oracle joined the splitter: Run inside `BEGIN ... END;` sent everything up to
  the first inner `;` and Oracle answered `PLS-00103`. Same guard applies, so a
  block runs whole however it is started.
- `split_statements` and `statement_offsets` were two copies of one scan kept
  in step by hand. Both read `scan_statements` now, which byte-scans the text
  and returns borrowed slices instead of building a `Vec<char>` and a `String`
  per statement (every character it looks for is ASCII, so a byte index is
  always a char boundary). That also fixes an offset bug: `statement_offsets`
  added a char index to a byte length, so past a multibyte character a driver's
  error marker pointed at the wrong token.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p rdb --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib` and `cargo test -p rdb --bin rdb --
      --test-threads=1`, 284 passed
- [x] Mutation check: narrowing `is_statement_text` to `Sql` alone fails the
      new test on `Cassandra should split`
- [x] Connected to local Docker servers for all eleven engines and reached the
      workspace on each: Postgres, MySQL, MariaDB, SQLite, Redis, Valkey,
      MongoDB, ClickHouse, Cassandra, SQL Server, Oracle Free 23ai.
- [x] Ran statements against the live Oracle, Postgres and SQLite connections.
- [ ] No live SQL Server, ClickHouse or MariaDB query run beyond connecting.

## Screenshots

Oracle Free 23ai, running on this branch.

A PL/SQL block with two inner `;` runs as one statement. On `develop` the same
buffer fails with `ORA-06550 / PLS-00103: Encountered the symbol "end-of-file"`
because Run sent only the first fragment:

![PL/SQL block on Oracle](https://raw.githubusercontent.com/arianao19/rdb/assets/pr-screenshots/oracle-plsql.png)

A `;`-delimited buffer on Oracle: the statement under the cursor runs on its
own and the trailing `;` no longer reaches the server.

![Statement split on Oracle](https://raw.githubusercontent.com/arianao19/rdb/assets/pr-screenshots/oracle-split.png)

## Notes for reviewers

`split_statements` drops the `;` from each segment, and Oracle rejects a
trailing semicolon on a single statement, so splitting helps there. Streaming
is safe for the newly included engines: none of them overrides
`Driver::query_stream`, so they use the buffered default, which reads through
`query` and feeds the sink.
