### PR TITLE
fix(app): stop TLS connects panicking on a missing crypto provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,13 @@ Keep the scope specific (`app`, `driver-postgres`, `driver-mysql`, `core`,
   means adding the crate's TLS feature in the same commit, and new connection
   forms default to `Disable` so an unconfigured server can't take the app
   down.
+- **rustls needs a crypto provider picked for the process.** `aws-lc-rs` and
+  `ring` are both linked in (rustls' own default feature and russh bring the
+  first, ureq the second), and rustls 0.23 refuses to choose between them: the
+  first handshake panics on a tokio worker instead of returning an error.
+  `main` calls `install_crypto_provider()` before anything else for that
+  reason — it is not a line to tidy away. A driver added on rustls needs
+  nothing extra; one that installs its own provider would fight this one.
 - **Saving a connection goes through `ConnStore::save_connection`**, not
   `add`/`update` + `set_password`. The split version is non-atomic: metadata
   flushed, secret write failed, and the connection came back later with

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6543,6 +6543,7 @@ dependencies = [
  "rdb-driver-sqlite",
  "rdb-tunnel",
  "rfd",
+ "rustls 0.23.43",
  "semver",
  "serde",
  "serde_json",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -54,6 +54,10 @@ notify-rust = "4"
 rfd = { version = "0.16", default-features = false, features = ["xdg-portal", "tokio"] }
 # History date-grouping (Today/Yesterday/date): local-timezone civil-date math.
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+# Direct only to pick the process-wide crypto provider in `main` (see there).
+# Already in the tree via mysql_async, scylla, mongodb, clickhouse and ureq;
+# naming it here keeps that dependency honest, since we now call its API.
+rustls = "0.23"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # Set the Dock icon even for `cargo run`; macOS ignores a window icon on an

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -4868,6 +4868,16 @@ struct AppFns {
 }
 
 fn main() -> Result<(), slint::PlatformError> {
+    // Pick the rustls crypto provider for the whole process, before any driver
+    // can reach TLS. Both backends are linked in — aws-lc-rs through rustls'
+    // own default feature and through russh, ring through ureq — and rustls
+    // refuses to guess between them: the first TLS handshake panics on a tokio
+    // worker instead of returning an error (issue #291). The default SslMode is
+    // `Prefer`, so a connection nobody configured takes that path.
+    // `Err` here only means a provider is already installed, which is the state
+    // this line wants anyway, so it is not worth failing startup over.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // Name this build to every server it connects to, so RDB is attributable in
     // pg_stat_activity / SHOW PROCESSLIST / currentOp rather than showing up as
     // an anonymous client. Set before any connection can be opened. The version

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -4867,16 +4867,36 @@ struct AppFns {
     sync_editor: PaneFn,
 }
 
-fn main() -> Result<(), slint::PlatformError> {
-    // Pick the rustls crypto provider for the whole process, before any driver
-    // can reach TLS. Both backends are linked in — aws-lc-rs through rustls'
-    // own default feature and through russh, ring through ureq — and rustls
-    // refuses to guess between them: the first TLS handshake panics on a tokio
-    // worker instead of returning an error (issue #291). The default SslMode is
-    // `Prefer`, so a connection nobody configured takes that path.
-    // `Err` here only means a provider is already installed, which is the state
-    // this line wants anyway, so it is not worth failing startup over.
+/// Pick the rustls crypto provider for the whole process, before any driver
+/// can reach TLS. Both backends are linked in — aws-lc-rs through rustls' own
+/// default feature and through russh, ring through ureq — and rustls refuses
+/// to guess between them: the first TLS handshake panics on a tokio worker
+/// instead of returning an error (issue #291). The default `SslMode` is
+/// `Prefer`, so a connection nobody configured takes that path.
+///
+/// `Err` only means a provider is already installed, which is the state this
+/// wants anyway, so it is not worth failing startup over.
+fn install_crypto_provider() {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+}
+
+#[cfg(test)]
+mod crypto_provider_tests {
+    use super::install_crypto_provider;
+
+    /// The panic this guards against is rustls finding no process-wide
+    /// provider. A second call happens whenever another test in this binary
+    /// got here first, so it has to stay silent rather than panic.
+    #[test]
+    fn installs_a_provider_and_tolerates_a_second_call() {
+        install_crypto_provider();
+        install_crypto_provider();
+        assert!(rustls::crypto::CryptoProvider::get_default().is_some());
+    }
+}
+
+fn main() -> Result<(), slint::PlatformError> {
+    install_crypto_provider();
 
     // Name this build to every server it connects to, so RDB is attributable in
     // pg_stat_activity / SHOW PROCESSLIST / currentOp rather than showing up as

--- a/app/src/wire/connect.rs
+++ b/app/src/wire/connect.rs
@@ -373,6 +373,28 @@ fn finish_connect_failure(weak: slint::Weak<MainWindow>, e: rdb_core::error::Rdb
     });
 }
 
+/// A connect task that panicked still has to clear the picker's
+/// "Connecting…" state; nothing else will, and the task it was waiting on is
+/// gone. An abort is not a failure — Cancel and a superseding connect both
+/// use it — so that reports nothing.
+///
+/// Debug builds only: `panic = "abort"` in the release profile takes the whole
+/// process down before the join can ever resolve.
+fn panic_to_connection_error(e: tokio::task::JoinError) -> Option<rdb_core::error::RdbError> {
+    e.is_panic()
+        .then(|| rdb_core::error::RdbError::Connection("connect failed unexpectedly".into()))
+}
+
+/// Passes an abort through to the task it wraps, so watching a task from
+/// another one leaves `abort()` on the watcher meaning what it meant before.
+struct AbortOnDrop(tokio::task::JoinHandle<()>);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
 /// `on_connect_clicked`: flush the active tab, resolve the picked
 /// connection, reset workspace state for it, paint the UI immediately,
 /// then spawn the driver connect on tokio.
@@ -670,7 +692,7 @@ fn spawn_connect_task(
         .upgrade()
         .map(|w| w.get_nosql_collection_limit().max(1) as usize)
         .unwrap_or(200);
-    let handle = rt.spawn(async move {
+    let inner = rt.spawn(async move {
         let slot = match claimed {
             Some(g) => g,
             None => store_driver.clone().lock_owned().await,
@@ -713,6 +735,19 @@ fn spawn_connect_task(
                 // `current` untouched.
                 drop(slot);
                 finish_connect_failure(weak2, e);
+            }
+        }
+    });
+    // Watch that task, so a panic inside it still clears "Connecting…"
+    // instead of leaving the picker spinning on a task that is already gone.
+    // The stored handle is this watcher, and `AbortOnDrop` passes an abort
+    // through to the connect itself, so Cancel behaves exactly as before.
+    let watch_weak = weak.clone();
+    let handle = rt.spawn(async move {
+        let mut connect = AbortOnDrop(inner);
+        if let Err(join) = (&mut connect.0).await {
+            if let Some(err) = panic_to_connection_error(join) {
+                finish_connect_failure(watch_weak, err);
             }
         }
     });

--- a/app/src/wire/connect.rs
+++ b/app/src/wire/connect.rs
@@ -895,3 +895,27 @@ pub(crate) fn wire(window: &MainWindow, state: &AppState, fns: &AppFns) {
         });
     }
 }
+
+#[cfg(test)]
+mod panic_to_connection_error_tests {
+    use super::panic_to_connection_error;
+
+    // The panic case has no test: this binary cannot unwind, so provoking a
+    // real panic aborts the whole test process ("failed to initiate panic")
+    // rather than handing back a `JoinError` — the same reason CLAUDE.md warns
+    // that a failing test here aborts instead of reporting. What that case
+    // does is one `is_panic()` call; the case worth pinning is the other one,
+    // where reporting anything at all would be wrong.
+
+    /// Cancel and a superseding connect both abort the task; neither is a
+    /// failure worth putting in front of the user.
+    #[tokio::test]
+    async fn an_aborted_task_reports_nothing() {
+        let handle = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+        });
+        handle.abort();
+        let join = handle.await.expect_err("the task was aborted");
+        assert!(panic_to_connection_error(join).is_none());
+    }
+}


### PR DESCRIPTION
## Summary

- A connection left on the default `SslMode::Prefer` panicked on a tokio worker
  the first time it reached TLS, and the UI sat on "Connecting…" with nothing
  to show for it.
- Two crypto backends are linked in — `aws-lc-rs` through rustls' own default
  feature and through `russh`, `ring` through `ureq` — and rustls 0.23 refuses
  to pick between them. Nothing in the tree ever called `install_default`.
- The connect task's panic was also invisible: its `JoinHandle` was only ever
  aborted, never awaited, so nothing cleared the spinner.

## Changes

- `app/src/main.rs`, `app/Cargo.toml`: `install_crypto_provider()` picks
  `aws-lc-rs` for the process before the runtime is built, next to the existing
  client-id init. `rustls` becomes a direct dependency because the app now
  calls its API; it was already in the tree via `mysql_async`, `scylla`,
  `mongodb`, `clickhouse` and `ureq`, so nothing new is compiled.
- `app/src/wire/connect.rs`: a watcher task awaits the connect and maps a panic
  to a connection error, with `AbortOnDrop` passing an abort through so Cancel
  and a superseding connect behave as before. Debug builds only —
  `panic = "abort"` in release takes the process down first, which the comment
  says plainly.
- Tests for both: that a provider ends up installed (and that installing twice
  stays quiet), and that an aborted task reports nothing.
- `CLAUDE.md`: the TLS rule covered "a driver reading SslMode must compile a TLS
  backend" but not this second failure mode.

## Test plan

- [x] `make fmt-check`
- [x] `make lint`
- [x] `make test` (13 suites; app bin 286)
- [x] `make fe-build`
- [x] End-to-end against MySQL 8.4 in a container (`require_secure_transport=0`,
      `SslMode::Prefer`), from a scratch crate carrying the same two providers
      as the app: without a provider it exits 101 with the exact panic from the
      issue; with the provider installed it connects and
      `SHOW STATUS LIKE 'Ssl_cipher'` returns `TLS_AES_256_GCM_SHA384`, so the
      session really is encrypted rather than silently falling back.
- [x] `forgeguard review --base develop` clean

## Notes for the reporter

Two corrections to the issue, both worth knowing before anyone looks for the
same bug again:

- **Postgres is not affected.** It connects through `native-tls`
  (`crates/driver-postgres/src/driver.rs`), not rustls, so the panic cannot come
  from there. The rustls path is MySQL, Mongo, ClickHouse, Cassandra and Oracle.
- **The update check shares the fault.** `ureq` resolves to rustls too, so the
  same missing provider could have hit Settings → Updates, not just connections.

No visual change, so there is nothing to screenshot.

Fixes #291
