### PR TITLE
feat(website): redesign marketing website and update design system

### DIFF
--- a/website/src/components/CodeBlock.astro
+++ b/website/src/components/CodeBlock.astro
@@ -8,14 +8,14 @@ const { code, label } = Astro.props;
 ---
 
 <div
-  class="copy-block flex items-center gap-3 rounded-lg border border-line bg-code px-4 py-3"
+  class="copy-block command-block"
 >
-  <code class="min-w-0 flex-1 overflow-x-auto font-mono text-[13px] whitespace-nowrap text-fg-2">
+  <code>
     <span class="select-none text-fg-3">$ </span>{code}
   </code>
   <button
     type="button"
-    class="copy-btn shrink-0 rounded-lg border border-line px-2.5 py-1.5 font-mono text-xs text-fg-2 transition-colors hover:border-line-2 hover:text-fg"
+    class="copy-btn"
     data-code={code}
     aria-label={`Copy ${label} command`}
   >

--- a/website/src/components/Engines.astro
+++ b/website/src/components/Engines.astro
@@ -11,9 +11,14 @@ import {
 } from "simple-icons";
 import { REPO_LINKS } from "../config";
 
+interface Props {
+  compact?: boolean;
+}
+const { compact = false } = Astro.props;
+
 // simple-icons has no Microsoft SQL Server mark (it only covers open brands),
 // no Valkey mark yet (requested upstream, not shipped), and no Oracle mark in
-// the 15.x line we pin — all three render without an `icon`, see the
+// the 15.x line we pin. All three render without an `icon`, see the
 // conditional <svg> below.
 const engines = [
   { icon: siPostgresql, name: "PostgreSQL", detail: "via tokio-postgres" },
@@ -30,13 +35,13 @@ const engines = [
 ];
 ---
 
-<ul class="grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-line bg-line sm:grid-cols-3">
+<ul class={compact ? "engine-mini-grid" : "grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-line bg-line sm:grid-cols-3"}>
   {
     engines.map((engine) => (
-      <li class="flex items-center gap-3 bg-panel px-4 py-4 transition-colors hover:bg-panel-2 sm:px-5">
+      <li class={compact ? "engine-mini-item" : "flex items-center gap-3 bg-panel px-4 py-4 transition-colors hover:bg-panel-2 sm:px-5"}>
         {
           engine.icon && (
-            <svg viewBox="0 0 24 24" class="h-6 w-6 shrink-0 fill-fg-2" aria-hidden="true">
+            <svg viewBox="0 0 24 24" class={compact ? "engine-mini-icon" : "h-6 w-6 shrink-0 fill-fg-2"} aria-hidden="true">
               <path d={engine.icon.path} />
             </svg>
           )
@@ -49,7 +54,7 @@ const engines = [
     ))
   }
 </ul>
-<p class="mt-4 text-sm text-fg-3">
+<p class={compact ? "engine-mini-note" : "mt-4 text-sm text-fg-3"}>
   All eleven ship in the current release. BigQuery is
   <a
     href={REPO_LINKS.vision}

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -5,12 +5,12 @@ import { FOOTER, GITHUB, PRODUCT, url } from "../config";
 const year = new Date().getFullYear();
 ---
 
-<footer class="border-t border-line">
-  <div class="mx-auto max-w-6xl px-4 py-14 sm:px-6">
-    <div class="grid gap-10 sm:grid-cols-2 lg:grid-cols-5">
-      <div class="lg:col-span-2">
-        <a href={url("/")} class="flex items-center gap-2.5 font-display text-lg font-semibold tracking-tight">
-          <Logo class="h-7 w-7 rounded-[7px] ring-1 ring-line" />
+<footer class="site-footer">
+  <div class="home-container py-14">
+    <div class="footer-grid">
+      <div>
+        <a href={url("/")} class="flex items-center gap-2.5 font-display text-lg font-semibold tracking-[0]">
+          <Logo class="h-7 w-7 rounded-[6px] ring-1 ring-line" />
           {PRODUCT}
         </a>
         <p class="mt-4 max-w-xs text-sm leading-relaxed text-fg-3">
@@ -20,7 +20,7 @@ const year = new Date().getFullYear();
         <a
           href="https://suiflex.dev"
           rel="noopener"
-          class="mt-4 inline-flex items-center gap-2 rounded-full border border-line px-3 py-1.5 text-sm text-fg-3 transition-colors hover:border-line-2 hover:text-fg"
+          class="footer-badge"
         >
           <img src={url("/assets/brand/logo-mark.png")} alt="" aria-hidden="true" class="h-5 w-5 rounded-md" />
           Suiflex Org
@@ -36,7 +36,7 @@ const year = new Date().getFullYear();
                   <a
                     href={item.external ? item.href : url(item.href)}
                     rel={item.external ? "noopener" : undefined}
-                    class="text-sm text-fg-2 transition-colors hover:text-fg"
+                    class="footer-link"
                   >
                     {item.label}
                   </a>
@@ -47,7 +47,7 @@ const year = new Date().getFullYear();
         ))
       }
     </div>
-    <div class="mt-12 flex flex-col justify-between gap-3 border-t border-line pt-6 text-sm text-fg-3 sm:flex-row">
+    <div class="footer-bottom">
       <p>Apache-2.0 licensed. Copyright {year} the RDB contributors.</p>
       <p>
         Built in the open at

--- a/website/src/components/Logo.astro
+++ b/website/src/components/Logo.astro
@@ -5,18 +5,17 @@ interface Props {
 const { class: className = "h-6 w-6" } = Astro.props;
 ---
 
-<!-- RDB brand mark: database cylinder with a relation node (assets/brand/logo-mark.svg) -->
 <svg
   xmlns="http://www.w3.org/2000/svg"
   viewBox="0 0 32 32"
   class={className}
   aria-hidden="true"
 >
-  <rect width="32" height="32" rx="7" fill="#0a0a0a"></rect>
-  <path d="M7 11 V21 A9 2.6 0 0 0 25 21 V11 Z" fill="#4ade80" fill-opacity="0.7"></path>
-  <ellipse cx="16" cy="11" rx="9" ry="2.6" fill="#4ade80"></ellipse>
-  <path d="M7 15 A9 2.6 0 0 0 25 15" fill="none" stroke="#0a0a0a" stroke-opacity="0.6" stroke-width="0.9"></path>
-  <path d="M7 18 A9 2.6 0 0 0 25 18" fill="none" stroke="#0a0a0a" stroke-opacity="0.6" stroke-width="0.9"></path>
-  <path d="M24.5 11 H27" stroke="#4ade80" stroke-opacity="0.55" stroke-width="0.9" stroke-linecap="round"></path>
-  <circle cx="28" cy="11" r="1.6" fill="#4ade80"></circle>
+  <rect width="32" height="32" rx="6" fill="#0d1119"></rect>
+  <path d="M7 11 V21 A9 2.6 0 0 0 25 21 V11 Z" fill="#5d83ff" fill-opacity="0.78"></path>
+  <ellipse cx="16" cy="11" rx="9" ry="2.6" fill="#8ba7ff"></ellipse>
+  <path d="M7 15 A9 2.6 0 0 0 25 15" fill="none" stroke="#0d1119" stroke-opacity="0.55" stroke-width="0.9"></path>
+  <path d="M7 18 A9 2.6 0 0 0 25 18" fill="none" stroke="#0d1119" stroke-opacity="0.55" stroke-width="0.9"></path>
+  <path d="M24.5 11 H27" stroke="#8ba7ff" stroke-opacity="0.65" stroke-width="0.9" stroke-linecap="round"></path>
+  <circle cx="28" cy="11" r="1.6" fill="#55d991"></circle>
 </svg>

--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -3,14 +3,17 @@ import Logo from "./Logo.astro";
 import { GITHUB, NAV, PRODUCT, url } from "../config";
 ---
 
-<header class="sticky top-0 z-40 border-b border-line bg-ink/85 backdrop-blur">
+<header class="sticky top-0 z-40 border-b border-line bg-ink/88 backdrop-blur">
   <nav
-    class="mx-auto flex h-16 max-w-6xl items-center gap-6 px-4 sm:px-6"
+    class="mx-auto flex h-20 max-w-[1320px] items-center gap-6 px-5 sm:px-6"
     aria-label="Main"
   >
-    <a href={url("/")} class="flex items-center gap-2.5 font-display text-lg font-semibold tracking-tight">
-      <Logo class="h-7 w-7 rounded-[7px] ring-1 ring-line" />
-      {PRODUCT}
+    <a href={url("/")} class="flex items-center gap-3 font-display text-lg font-semibold tracking-[0]">
+      <Logo class="h-8 w-8 rounded-[6px] ring-1 ring-line" />
+      <span class="leading-tight">
+        {PRODUCT}
+        <small class="block font-mono text-[0.58rem] font-normal uppercase text-fg-3">A Suiflex product</small>
+      </span>
     </a>
 
     <div class="ml-auto hidden items-center gap-1 md:flex">
@@ -18,7 +21,7 @@ import { GITHUB, NAV, PRODUCT, url } from "../config";
         NAV.map((item) => (
           <a
             href={url(item.href)}
-            class="rounded-lg px-3 py-2 text-sm text-fg-2 transition-colors hover:bg-panel hover:text-fg"
+            class="rounded-[6px] px-3 py-2 text-sm text-fg-2 transition-colors hover:bg-panel hover:text-fg"
           >
             {item.label}
           </a>
@@ -27,13 +30,13 @@ import { GITHUB, NAV, PRODUCT, url } from "../config";
       <a
         href={GITHUB}
         rel="noopener"
-        class="rounded-lg px-3 py-2 text-sm text-fg-2 transition-colors hover:bg-panel hover:text-fg"
+        class="rounded-[6px] px-3 py-2 text-sm text-fg-2 transition-colors hover:bg-panel hover:text-fg"
       >
         GitHub
       </a>
       <a
         href={url("/download")}
-        class="ml-2 rounded-lg bg-accent px-3.5 py-2 text-sm font-semibold text-accent-ink transition-colors hover:bg-accent-soft"
+        class="ml-2 rounded-[6px] bg-fg px-3.5 py-2 text-sm font-semibold text-ink transition-colors hover:bg-accent hover:text-white"
       >
         Download
       </a>
@@ -42,7 +45,7 @@ import { GITHUB, NAV, PRODUCT, url } from "../config";
     <button
       id="menu-button"
       type="button"
-      class="ml-auto rounded-lg p-2 text-fg-2 hover:bg-panel hover:text-fg md:hidden"
+      class="ml-auto rounded-[6px] border border-line p-2 text-fg-2 hover:bg-panel hover:text-fg md:hidden"
       aria-expanded="false"
       aria-controls="mobile-menu"
     >
@@ -54,23 +57,23 @@ import { GITHUB, NAV, PRODUCT, url } from "../config";
   </nav>
 
   <div id="mobile-menu" hidden class="border-t border-line bg-ink md:hidden">
-    <div class="mx-auto flex max-w-6xl flex-col gap-1 px-4 py-3">
+    <div class="mx-auto flex max-w-[1320px] flex-col gap-1 px-4 py-3">
       {
         NAV.map((item) => (
           <a
             href={url(item.href)}
-            class="rounded-lg px-3 py-2.5 text-fg-2 hover:bg-panel hover:text-fg"
+            class="rounded-[6px] px-3 py-2.5 text-fg-2 hover:bg-panel hover:text-fg"
           >
             {item.label}
           </a>
         ))
       }
-      <a href={GITHUB} rel="noopener" class="rounded-lg px-3 py-2.5 text-fg-2 hover:bg-panel hover:text-fg">
+      <a href={GITHUB} rel="noopener" class="rounded-[6px] px-3 py-2.5 text-fg-2 hover:bg-panel hover:text-fg">
         GitHub
       </a>
       <a
         href={url("/download")}
-        class="mt-1 rounded-lg bg-accent px-3 py-2.5 text-center font-semibold text-accent-ink hover:bg-accent-soft"
+        class="mt-1 rounded-[6px] bg-fg px-3 py-2.5 text-center font-semibold text-ink hover:bg-accent hover:text-white"
       >
         Download
       </a>

--- a/website/src/components/Screenshot.astro
+++ b/website/src/components/Screenshot.astro
@@ -13,6 +13,9 @@ interface Props {
   priority?: boolean;
   class?: string;
   sizes?: string;
+  chrome?: boolean;
+  label?: string;
+  status?: string;
 }
 const {
   src,
@@ -20,10 +23,21 @@ const {
   priority = false,
   class: className = "",
   sizes = "(min-width: 1100px) 1024px, 94vw",
+  chrome = false,
+  label = "workspace",
+  status = "connected",
 } = Astro.props;
 ---
 
-<figure class={`overflow-hidden rounded-xl border border-line bg-panel shadow-[0_24px_80px_-32px_rgba(74,222,128,0.14)] ${className}`}>
+<figure class={`screenshot-frame ${chrome ? "is-chrome" : ""} ${className}`}>
+  {
+    chrome && (
+      <figcaption class="screenshot-bar">
+        <span>{label}</span>
+        <span class="screenshot-status"><i aria-hidden="true"></i>{status}</span>
+      </figcaption>
+    )
+  }
   <Image
     src={src}
     alt={alt}

--- a/website/src/pages/404.astro
+++ b/website/src/pages/404.astro
@@ -8,28 +8,22 @@ import { url } from "../config";
   description="This page does not exist. Head back to the RDB homepage or the downloads page."
   path="/404"
 >
-  <section class="mx-auto flex max-w-3xl flex-col items-start px-4 py-28 sm:px-6">
-    <p class="font-mono text-sm text-error">ERROR 404: relation "this_page" does not exist</p>
-    <h1 class="mt-4 font-display text-4xl font-semibold tracking-tight sm:text-5xl">
-      Nothing at this address.
-    </h1>
-    <p class="mt-4 max-w-md text-lg leading-relaxed text-fg-2">
-      The page moved, never existed, or was mistyped. The useful places are
-      one click away.
-    </p>
-    <div class="mt-8 flex flex-wrap gap-3">
-      <a
-        href={url("/")}
-        class="rounded-lg bg-accent px-5 py-3 font-semibold text-accent-ink transition-colors hover:bg-accent-soft"
-      >
-        Back to homepage
-      </a>
-      <a
-        href={url("/download")}
-        class="rounded-lg border border-line px-5 py-3 font-semibold transition-colors hover:border-line-2 hover:bg-panel"
-      >
-        Downloads
-      </a>
+  <section class="not-found-page">
+    <div class="home-container">
+      <div class="query-error-card">
+        <p class="page-kicker">ERROR 404</p>
+        <pre class="mini-code"><code>SELECT * FROM pages WHERE path = current_url;
+0 rows returned</code></pre>
+        <h1 class="page-title wide">Nothing at this address.</h1>
+        <p class="page-lede">
+          The page moved, never existed, or was mistyped. The useful places are
+          one click away.
+        </p>
+        <div class="home-actions">
+          <a href={url("/")} class="home-button primary">Back to homepage</a>
+          <a href={url("/download")} class="home-button">Downloads</a>
+        </div>
+      </div>
     </div>
   </section>
 </Base>

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -7,7 +7,7 @@ import { REPO_LINKS } from "../config";
 /**
  * The website lives inside the rdb monorepo, so the root changelog is
  * read directly at build time. Resolved from process.cwd() (astro build
- * always runs from website/), not import.meta.url — the latter is
+ * always runs from website/), not import.meta.url. The latter is
  * relative to wherever the bundler happens to emit this chunk, which
  * changed depth across an astro major version and silently broke a
  * fixed "../../../" walk.
@@ -46,31 +46,36 @@ for (const block of blocks.slice(0, 5)) {
   description="What changed in recent RDB releases: new features, fixes, and improvements, generated from the project's conventional-commit history."
   path="/changelog"
 >
-  <section class="mx-auto max-w-3xl px-4 pt-16 pb-10 sm:px-6">
-    <h1 class="font-display text-4xl font-semibold tracking-tight sm:text-5xl">Changelog</h1>
-    <p class="mt-4 text-lg leading-relaxed text-fg-2">
+  <section class="page-hero">
+    <div class="page-hero-inner">
+      <p class="page-kicker">Release flow</p>
+      <h1 class="page-title">Changelog</h1>
+      <p class="page-lede">
       The most recent releases, straight from the project changelog. Binaries
       for every version are on
-      <a href={REPO_LINKS.releases} rel="noopener" class="underline decoration-line underline-offset-4 hover:text-fg">GitHub Releases</a>.
-    </p>
+        <a href={REPO_LINKS.releases} rel="noopener">GitHub Releases</a>.
+      </p>
+    </div>
   </section>
 
-  <section class="mx-auto max-w-3xl space-y-10 px-4 pb-20 sm:px-6">
+  <section class="page-section">
+    <div class="section-inner">
     {
       releases.map((release) => (
-        <article class="rounded-xl border border-line bg-panel p-6 sm:p-8">
-          <header class="flex flex-wrap items-baseline justify-between gap-2">
-            <h2 class="font-display text-2xl font-semibold tracking-tight">v{release.version}</h2>
-            {release.date && <time datetime={release.date} class="font-mono text-xs text-fg-3">{release.date}</time>}
+        <article class="release-card">
+          <header>
+            <span class="latest">RELEASE</span>
+            <h2>v{release.version}</h2>
+            {release.date && <time datetime={release.date}>{release.date}</time>}
           </header>
           {release.sections.map((section) => (
-            <section class="mt-5">
-              <h3 class="text-sm font-semibold text-fg-2">{section.heading}</h3>
-              <ul class="mt-2 space-y-1.5">
+            <section class="release-section">
+              <h3>{section.heading}</h3>
+              <ul>
                 {section.items.map((item) => (
-                  <li class="flex items-baseline gap-2 text-sm leading-relaxed text-fg-2">
+                  <li>
                     {item.scope && (
-                      <code class="shrink-0 rounded border border-line px-1 py-px font-mono text-[11px] text-fg-3">
+                      <code>
                         {item.scope}
                       </code>
                     )}
@@ -83,13 +88,14 @@ for (const block of blocks.slice(0, 5)) {
         </article>
       ))
     }
-    <p class="text-sm text-fg-3">
+    <p class="page-note">
       Older releases are listed in the
       <a
         href="https://github.com/suiflex/rdb/blob/develop/CHANGELOG.md"
         rel="noopener"
-        class="underline decoration-line underline-offset-4 hover:text-fg">full changelog</a
+        >full changelog</a
       >.
     </p>
+    </div>
   </section>
 </Base>

--- a/website/src/pages/docs.astro
+++ b/website/src/pages/docs.astro
@@ -1,7 +1,7 @@
 ---
 import Base from "../layouts/Base.astro";
 import CodeBlock from "../components/CodeBlock.astro";
-import { GITHUB, REPO_LINKS, url } from "../config";
+import { GITHUB, REPO_LINKS } from "../config";
 
 const guides = [
   {
@@ -10,7 +10,7 @@ const guides = [
   },
   {
     title: "Connect and query",
-    body: "Click a saved connection and the schema loads in the sidebar. Type a query for the connected engine (see Query syntax below), then press Cmd+Enter (Ctrl+Enter on Windows and Linux) to run.",
+    body: "Click a saved connection and the schema loads in the sidebar. Type a query for the connected engine, then press Cmd+Enter or Ctrl+Enter to run.",
   },
   {
     title: "Browse a table",
@@ -50,33 +50,10 @@ const querySyntax = [
   },
 ];
 
-// What the Mongo query tab actually accepts. Kept next to the syntax table
-// because the README points here for it.
 const mongoSupport = [
-  {
-    title: "Methods",
-    items: [
-      "find({ ... })",
-      "aggregate([ ... ])",
-      "insertOne({ ... })",
-    ],
-  },
-  {
-    title: "Chain modifiers",
-    items: [
-      ".limit(n)",
-      ".skip(n)",
-      ".sort({ field: 1 | -1 })",
-    ],
-  },
-  {
-    title: "Addressing",
-    items: [
-      "use('database')",
-      "db.collection",
-      "db.getCollection('fs.files')",
-    ],
-  },
+  ["Methods", ["find({ ... })", "aggregate([ ... ])", "insertOne({ ... })"]],
+  ["Chain modifiers", [".limit(n)", ".skip(n)", ".sort({ field: 1 | -1 })"]],
+  ["Addressing", ["use('database')", "db.collection", "db.getCollection('fs.files')"]],
 ];
 ---
 
@@ -85,55 +62,63 @@ const mongoSupport = [
   description="Get started with RDB: install it, add your first connection, run queries, and build from source. Full documentation lives in the GitHub repository."
   path="/docs"
 >
-  <section class="mx-auto max-w-4xl px-4 pt-16 pb-12 sm:px-6">
-    <h1 class="font-display text-4xl font-semibold tracking-tight sm:text-5xl">Documentation</h1>
-    <p class="mt-4 max-w-xl text-lg leading-relaxed text-fg-2">
-      Enough to get productive in five minutes. The full reference lives in
-      the repository and grows with every release.
-    </p>
-  </section>
-
-  <section class="mx-auto max-w-4xl px-4 pb-14 sm:px-6" aria-label="Quick start">
-    <h2 class="font-display text-2xl font-semibold tracking-tight">Quick start</h2>
-    <ol class="mt-6 space-y-6">
-      {
-        guides.map((guide, i) => (
-          <li class="flex gap-5">
-            <span
-              class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-line bg-panel font-mono text-sm text-accent"
-              aria-hidden="true"
-            >
-              {i + 1}
-            </span>
-            <div>
-              <h3 class="font-semibold">{guide.title}</h3>
-              <p class="mt-1 max-w-xl text-sm leading-relaxed text-fg-2">{guide.body}</p>
-            </div>
-          </li>
-        ))
-      }
-    </ol>
-  </section>
-
-  <section class="border-t border-line" aria-label="Query syntax">
-    <div class="mx-auto max-w-4xl px-4 py-14 sm:px-6">
-      <h2 class="font-display text-2xl font-semibold tracking-tight">Query syntax per engine</h2>
-      <p class="mt-3 max-w-xl text-sm leading-relaxed text-fg-2">
-        Each engine's query editor tab speaks that engine's native language;
-        there's no single unified query syntax across all of them.
+  <section class="page-hero">
+    <div class="page-hero-inner">
+      <p class="page-kicker">Documentation</p>
+      <h1 class="page-title">Start from a query.</h1>
+      <p class="page-lede">
+        Enough to get productive in five minutes. The full reference lives in
+        the repository and grows with every release.
       </p>
-      <div class="mt-6 grid gap-4 sm:grid-cols-2">
+    </div>
+  </section>
+
+  <section class="page-section">
+    <div class="section-inner section-grid">
+      <div>
+        <p class="page-kicker">Quick start</p>
+        <h2 class="section-title">Four steps to a result grid.</h2>
+      </div>
+      <ol class="timeline-list">
+        {
+          guides.map((guide, i) => (
+            <li>
+              <span aria-hidden="true">{String(i + 1).padStart(2, "0")}</span>
+              <div>
+                <h3>{guide.title}</h3>
+                <p>{guide.body}</p>
+              </div>
+            </li>
+          ))
+        }
+      </ol>
+    </div>
+  </section>
+
+  <section class="page-section light" aria-label="Query syntax">
+    <div class="section-inner wide">
+      <div class="stream-head">
+        <div>
+          <p class="page-kicker">Query syntax</p>
+          <h2 class="section-title">Each engine keeps its language.</h2>
+        </div>
+        <p>
+          RDB does not pretend every database has one query shape. The editor
+          follows the connected engine.
+        </p>
+      </div>
+      <div class="card-grid two mt-10">
         {
           querySyntax.map((row) => (
-            <div class="rounded-xl border border-line bg-panel px-4 py-4">
-              <span class="block text-sm font-medium">{row.engines}</span>
-              <span class="block text-xs text-fg-3">{row.language}</span>
-              <div class="mt-3 space-y-2">
+            <div class="card">
+              <h3>{row.engines}</h3>
+              <p class="mono">{row.language}</p>
+              <div class="mt-4 grid gap-2">
                 {row.examples.map((ex) => (
-                  <pre class="overflow-x-auto rounded-lg border border-line bg-code px-3 py-2 font-mono text-[13px] text-fg-2"><code>{ex}</code></pre>
+                  <pre class="mini-code"><code>{ex}</code></pre>
                 ))}
               </div>
-              {row.note && <p class="mt-2 text-xs text-fg-3">{row.note}</p>}
+              {row.note && <p>{row.note}</p>}
             </div>
           ))
         }
@@ -141,86 +126,63 @@ const mongoSupport = [
     </div>
   </section>
 
-  <section class="border-t border-line bg-panel" aria-label="MongoDB support">
-    <div class="mx-auto max-w-4xl px-4 py-14 sm:px-6">
-      <h2 class="font-display text-2xl font-semibold tracking-tight">What the MongoDB tab accepts</h2>
-      <p class="mt-3 max-w-xl text-sm leading-relaxed text-fg-2">
+  <section class="page-section panel" aria-label="MongoDB support">
+    <div class="section-inner">
+      <p class="page-kicker">MongoDB tab</p>
+      <h2 class="section-title">Mongosh-shaped, parser-backed.</h2>
+      <p class="page-lede">
         Query bodies are read as JSON5, so unquoted keys and single-quoted
         strings work exactly as they do in mongosh. Modifiers may appear in any
-        order and apply to <code class="font-mono text-[13px]">find</code>;
-        an aggregation carries its own paging as pipeline stages.
+        order and apply to <code class="mono">find</code>.
       </p>
-      <div class="mt-6 grid gap-4 sm:grid-cols-3">
+      <div class="card-grid three mt-10">
         {
-          mongoSupport.map((group) => (
-            <div class="rounded-xl border border-line bg-bg px-4 py-4">
-              <span class="block text-sm font-medium">{group.title}</span>
-              <ul class="mt-3 space-y-2">
-                {group.items.map((item) => (
-                  <li class="rounded-lg border border-line bg-code px-3 py-2 font-mono text-[13px] text-fg-2">
-                    {item}
-                  </li>
-                ))}
+          mongoSupport.map(([title, items]) => (
+            <div class="card">
+              <h3>{title}</h3>
+              <ul class="token-list">
+                {items.map((item) => <li>{item}</li>)}
               </ul>
             </div>
           ))
         }
       </div>
-      <p class="mt-5 max-w-xl text-xs leading-relaxed text-fg-3">
-        Not yet parsed: <code class="font-mono">ObjectId(...)</code> and the
-        write and read helpers beyond the three above
-        (<code class="font-mono">findOne</code>,
-        <code class="font-mono">updateMany</code>,
-        <code class="font-mono">deleteOne</code> and friends). Autocomplete
-        offers some of these ahead of the parser, so they will complete and then
-        fail to run.
+      <p class="page-note">
+        Not yet parsed: <code class="mono">ObjectId(...)</code> and helpers
+        beyond <code class="mono">find</code>, <code class="mono">aggregate</code>,
+        and <code class="mono">insertOne</code>. Autocomplete can offer some of
+        them before the parser supports them.
       </p>
     </div>
   </section>
 
-  <section class="border-t border-line">
-    <div class="mx-auto max-w-4xl px-4 py-14 sm:px-6">
-      <h2 class="font-display text-2xl font-semibold tracking-tight">Build from source</h2>
-      <p class="mt-3 max-w-xl text-sm leading-relaxed text-fg-2">
-        You need stable Rust with rustfmt and clippy. Linux additionally needs
-        the Slint system packages listed in the README.
-      </p>
-      <div class="mt-5 space-y-3">
+  <section class="page-section">
+    <div class="section-inner section-grid">
+      <div>
+        <p class="page-kicker">Source build</p>
+        <h2 class="section-title">Build the native app yourself.</h2>
+      </div>
+      <div class="card-grid">
         <CodeBlock code="git clone https://github.com/suiflex/rdb && cd rdb" label="clone" />
         <CodeBlock code="cargo build --release -p rdb" label="release build" />
       </div>
     </div>
   </section>
 
-  <section class="border-t border-line bg-panel">
-    <div class="mx-auto max-w-4xl px-4 py-14 sm:px-6">
-      <h2 class="font-display text-2xl font-semibold tracking-tight">Go deeper</h2>
-      <ul class="mt-6 grid gap-3 sm:grid-cols-2">
-        {
-          [
-            { label: "README", note: "install options, usage, crate layout", href: REPO_LINKS.readme },
-            { label: "Vision and roadmap", note: "principles and what comes next", href: REPO_LINKS.vision },
-            { label: "Contributing guide", note: "dev setup and PR workflow", href: REPO_LINKS.contributing },
-            { label: "Release notes", note: "what changed in each version", href: REPO_LINKS.releases },
-          ].map((item) => (
-            <li>
-              <a
-                href={item.href}
-                rel="noopener"
-                class="block rounded-xl border border-line bg-ink px-4 py-3.5 transition-colors hover:border-line-2"
-              >
-                <span class="block text-sm font-medium">{item.label}</span>
-                <span class="block text-xs text-fg-3">{item.note}</span>
-              </a>
-            </li>
-          ))
-        }
-      </ul>
-      <p class="mt-6 text-sm text-fg-3">
-        Something missing or unclear?
-        <a href={REPO_LINKS.newIssue} rel="noopener" class="underline decoration-line underline-offset-4 hover:text-fg">Open an issue</a>
-        on <a href={GITHUB} rel="noopener" class="underline decoration-line underline-offset-4 hover:text-fg">GitHub</a>.
-      </p>
+  <section class="page-section light">
+    <div class="section-inner section-grid">
+      <div>
+        <p class="page-kicker">References</p>
+        <h2 class="section-title">Go deeper in the repository.</h2>
+      </div>
+      <nav class="link-list" aria-label="Documentation links">
+        <a class="link-row" href={REPO_LINKS.readme} rel="noopener"><strong>README</strong><span>USAGE ↗</span></a>
+        <a class="link-row" href={REPO_LINKS.vision} rel="noopener"><strong>Vision and roadmap</strong><span>VISION ↗</span></a>
+        <a class="link-row" href={REPO_LINKS.contributing} rel="noopener"><strong>Contributing guide</strong><span>SETUP ↗</span></a>
+        <a class="link-row" href={REPO_LINKS.releases} rel="noopener"><strong>Release notes</strong><span>RELEASES ↗</span></a>
+        <a class="link-row" href={REPO_LINKS.newIssue} rel="noopener"><strong>Open an issue</strong><span>SUPPORT ↗</span></a>
+        <a class="link-row" href={GITHUB} rel="noopener"><strong>Source code</strong><span>GITHUB ↗</span></a>
+      </nav>
     </div>
   </section>
 </Base>

--- a/website/src/pages/download.astro
+++ b/website/src/pages/download.astro
@@ -18,6 +18,7 @@ interface Row {
 interface Platform {
   id: string;
   name: string;
+  command: string;
   hint: string;
   rows: Row[];
 }
@@ -31,6 +32,7 @@ const platforms: Platform[] = [
   {
     id: "macos",
     name: "macOS",
+    command: "brew install --cask suiflex/tap/rdb",
     hint: "Open the .dmg and drag RDB to Applications.",
     rows: [
       row("Disk image", "Apple Silicon", "rdb-aarch64-apple-darwin.dmg"),
@@ -42,6 +44,7 @@ const platforms: Platform[] = [
   {
     id: "windows",
     name: "Windows",
+    command: "irm https://raw.githubusercontent.com/suiflex/rdb/develop/scripts/install.ps1 | iex",
     hint: "Use the PowerShell installer, Scoop, or download the standalone rdb.exe.",
     rows: [
       row("Executable", "x64", "rdb-x86_64-pc-windows-msvc.exe"),
@@ -53,6 +56,7 @@ const platforms: Platform[] = [
   {
     id: "linux",
     name: "Linux",
+    command: "curl -fsSL https://raw.githubusercontent.com/suiflex/rdb/develop/scripts/install.sh | bash",
     hint: "Download, chmod +x, and run. Needs glibc and the usual desktop libraries.",
     rows: [
       row("Binary", "x64", "rdb-x86_64-unknown-linux-gnu"),
@@ -69,100 +73,90 @@ const platforms: Platform[] = [
   description={`Download RDB ${release.tag}, the free open-source database client, for macOS, Windows, and Linux. Direct binaries with SHA-256 checksums, plus Homebrew, npm, and Scoop.`}
   path="/download"
 >
-  <section class="mx-auto max-w-4xl px-4 pt-16 pb-8 sm:px-6">
-    <h1 class="font-display text-4xl font-semibold tracking-tight sm:text-5xl">
-      Download RDB
-    </h1>
-    <p class="mt-4 text-lg text-fg-2">
-      Latest stable release
-      <span class="font-mono text-fg">{release.tag}</span>, published {release.published}.
-      Free under the Apache-2.0 license.
-    </p>
-    <p class="mt-2 text-sm text-fg-3">
-      Release notes and older versions live on
-      <a href={REPO_LINKS.releases} rel="noopener" class="underline decoration-line underline-offset-4 hover:text-fg">GitHub Releases</a>.
-    </p>
+  <section class="page-hero">
+    <div class="page-hero-inner wide">
+      <p class="page-kicker">Latest stable release</p>
+      <h1 class="page-title">Download RDB</h1>
+      <p class="page-lede">
+        {release.tag}, published {release.published}. Free under the
+        Apache-2.0 license, with direct binaries and package manager installs.
+      </p>
+      <p class="page-note">
+        Release notes and older versions live on
+        <a href={REPO_LINKS.releases} rel="noopener">GitHub Releases</a>.
+      </p>
+    </div>
   </section>
 
-  <section class="mx-auto max-w-4xl space-y-6 px-4 pb-16 sm:px-6" aria-label="Downloads by platform">
-    {
-      platforms.map((platform) => (
-        <section
-          id={platform.id}
-          data-platform={platform.id}
-          class="rounded-xl border border-line bg-panel p-6 data-detected:border-accent/50"
-        >
-          <div class="flex flex-wrap items-baseline justify-between gap-2">
-            <h2 class="font-display text-2xl font-semibold tracking-tight">{platform.name}</h2>
-            <span hidden class="detected-badge font-mono text-xs text-accent">your platform</span>
+  <section class="page-section light" aria-label="Downloads by platform">
+    <div class="section-inner wide">
+      <div class="download-list">
+        {
+          platforms.map((platform, index) => (
+            <section
+              id={platform.id}
+              data-platform={platform.id}
+              class="download-platform"
+            >
+              <div class="platform-summary">
+                <span class="latest">0{index + 1} / PLATFORM</span>
+                <h2>{platform.name}</h2>
+                <p>{platform.hint}</p>
+                <span hidden class="detected-badge">your platform</span>
+                <CodeBlock code={platform.command} label={`${platform.name} install`} />
+              </div>
+              <ul class="asset-list">
+                {platform.rows.map((r) => (
+                  <li>
+                    <a href={r.asset.url} class="asset-download">Download</a>
+                    <span>{r.label}</span>
+                    <code>{r.arch}</code>
+                    <small>{mb(r.asset.size)}</small>
+                    <button
+                      type="button"
+                      class="sha-btn"
+                      data-sha={r.asset.sha256}
+                      title={`SHA-256: ${r.asset.sha256}`}
+                      aria-label={`sha256 ${r.asset.sha256.slice(0, 8)}, copy full checksum for ${r.asset.name}`}
+                    >
+                      sha256 {r.asset.sha256.slice(0, 8)}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))
+        }
+      </div>
+    </div>
+  </section>
+
+  <section class="page-section">
+    <div class="section-inner section-grid">
+      <div>
+        <p class="page-kicker">Other installers</p>
+        <h2 class="section-title">Use the channel that fits your machine.</h2>
+      </div>
+      <div class="card-grid">
+        <div class="card">
+          <h3>npm</h3>
+          <p>Installs a small wrapper that downloads the matching native asset.</p>
+          <div class="mt-4"><CodeBlock code="npm i -g @suiflex/rdb" label="npm install" /></div>
+        </div>
+        <div class="card">
+          <h3>Scoop</h3>
+          <p>Windows package manager path for repeatable install and upgrade.</p>
+          <div class="mt-4">
+            <CodeBlock
+              code="scoop bucket add suiflex https://github.com/suiflex/scoop-bucket && scoop install rdb"
+              label="Scoop install"
+            />
           </div>
-          <p class="mt-1 text-sm text-fg-3">{platform.hint}</p>
-          <ul class="mt-5 divide-y divide-line">
-            {platform.rows.map((r) => (
-              <li class="flex flex-wrap items-center gap-x-4 gap-y-2 py-3">
-                <a
-                  href={r.asset.url}
-                  class="rounded-lg bg-accent px-3 py-1.5 text-sm font-semibold text-accent-ink transition-colors hover:bg-accent-soft"
-                >
-                  Download
-                </a>
-                <span class="text-sm">{r.label}</span>
-                <span class="rounded border border-line px-1.5 py-0.5 font-mono text-xs text-fg-2">{r.arch}</span>
-                <span class="font-mono text-xs text-fg-3">{mb(r.asset.size)}</span>
-                <button
-                  type="button"
-                  class="sha-btn ml-auto rounded-lg border border-line px-2 py-1 font-mono text-xs text-fg-3 transition-colors hover:border-line-2 hover:text-fg"
-                  data-sha={r.asset.sha256}
-                  title={`SHA-256: ${r.asset.sha256}`}
-                  aria-label={`sha256 ${r.asset.sha256.slice(0, 8)}, copy full checksum for ${r.asset.name}`}
-                >
-                  sha256 {r.asset.sha256.slice(0, 8)}
-                </button>
-              </li>
-            ))}
-          </ul>
-        </section>
-      ))
-    }
-  </section>
-
-  <section class="border-t border-line">
-    <div class="mx-auto max-w-4xl px-4 py-16 sm:px-6">
-      <h2 class="font-display text-2xl font-semibold tracking-tight">Or use a package manager</h2>
-      <div class="mt-6 space-y-4">
-        <div>
-          <h3 class="mb-2 font-mono text-xs text-fg-3">Homebrew (macOS / Linux)</h3>
-          <CodeBlock code="brew install suiflex/tap/rdb" label="Homebrew install" />
-        </div>
-        <div>
-          <h3 class="mb-2 font-mono text-xs text-fg-3">npm (all platforms)</h3>
-          <CodeBlock code="npm i -g @suiflex/rdb" label="npm install" />
-        </div>
-        <div>
-          <h3 class="mb-2 font-mono text-xs text-fg-3">Install script (Windows)</h3>
-          <CodeBlock
-            code="irm https://raw.githubusercontent.com/suiflex/rdb/develop/scripts/install.ps1 | iex"
-            label="Windows install script"
-          />
-        </div>
-        <div>
-          <h3 class="mb-2 font-mono text-xs text-fg-3">Scoop (Windows)</h3>
-          <CodeBlock
-            code="scoop bucket add suiflex https://github.com/suiflex/scoop-bucket && scoop install rdb"
-            label="Scoop install"
-          />
-        </div>
-        <div>
-          <h3 class="mb-2 font-mono text-xs text-fg-3">Install script (macOS / Linux)</h3>
-          <CodeBlock
-            code="curl -fsSL https://raw.githubusercontent.com/suiflex/rdb/develop/scripts/install.sh | bash"
-            label="install script"
-          />
         </div>
       </div>
-      <p class="mt-8 text-sm text-fg-3">
+      <p class="page-note">
         Prefer to compile it yourself? The
-        <a href={url("/docs")} class="underline decoration-line underline-offset-4 hover:text-fg">build-from-source guide</a>
+        <a href={url("/docs")}>build-from-source guide</a>
         covers prerequisites for every platform. Verify any download by
         comparing its SHA-256 checksum with the value shown above.
       </p>
@@ -171,8 +165,6 @@ const platforms: Platform[] = [
 </Base>
 
 <script>
-  // Progressive enhancement: highlight the visitor's platform. All
-  // platforms stay visible and downloadable regardless.
   const ua = navigator.userAgent;
   const detected = /Mac/i.test(ua)
     ? "macos"
@@ -184,7 +176,6 @@ const platforms: Platform[] = [
   if (detected) {
     const section = document.querySelector<HTMLElement>(`[data-platform="${detected}"]`);
     if (section) {
-      // Highlight only; reordering the DOM here would cause layout shift.
       section.setAttribute("data-detected", "");
       section.querySelector<HTMLElement>(".detected-badge")?.removeAttribute("hidden");
     }

--- a/website/src/pages/features.astro
+++ b/website/src/pages/features.astro
@@ -3,8 +3,8 @@ import Base from "../layouts/Base.astro";
 import Engines from "../components/Engines.astro";
 import Screenshot from "../components/Screenshot.astro";
 import { REPO_LINKS, url } from "../config";
-import shotSql from "../assets/shots/sql.png";
 import shotConnections from "../assets/shots/connections.png";
+import shotSql from "../assets/shots/sql.png";
 
 const groups = [
   {
@@ -37,7 +37,7 @@ const groups = [
       ["Virtualized rendering", "Only visible cells are drawn, so huge results stay smooth."],
       ["Server-side filters", "Column filters compile to WHERE clauses and run on the database, not in the app."],
       ["Safe editing", "Edit cells with a pending-changes model: review, commit, or roll back. Tables without a primary key stay read-only, and the grid tells you why."],
-      ["Export results", "CSV or JSON through your OS's native save dialog."],
+      ["Export results", "CSV or JSON through your OS native save dialog."],
     ],
   },
   {
@@ -54,50 +54,59 @@ const groups = [
 ---
 
 <Base
-  title="RDB features: editor, data grid, and six database engines"
-  description="What ships in RDB today: a real SQL editor with split panes, a virtualized data grid with server-side filters, keychain-backed credentials, and support for six database engines."
+  title="RDB features: editor, data grid, and eleven database engines"
+  description="What ships in RDB today: a real SQL editor with split panes, a virtualized data grid with server-side filters, keychain-backed credentials, and support for eleven database engines."
   path="/features"
 >
-  <section class="mx-auto max-w-6xl px-4 pt-16 pb-12 sm:px-6">
-    <h1 class="max-w-2xl font-display text-4xl font-semibold tracking-tight sm:text-5xl">
-      Everything here ships today.
-    </h1>
-    <p class="mt-4 max-w-xl text-lg leading-relaxed text-fg-2">
-      No roadmap promises on this page. If a feature is listed, it is in the
-      current release and you can try it in the next five minutes.
-    </p>
+  <section class="page-hero">
+    <div class="page-hero-inner wide">
+      <p class="page-kicker">Features in the current release</p>
+      <h1 class="page-title wide">Everything here ships today.</h1>
+      <p class="page-lede">
+        No roadmap promises on this page. If a feature is listed, it is in the
+        current release and you can try it in the next five minutes.
+      </p>
+    </div>
   </section>
 
-  <section class="mx-auto max-w-6xl px-4 pb-8 sm:px-6" aria-label="Screenshots">
-    <div class="grid gap-6 lg:grid-cols-2">
-      <Screenshot
-        src={shotConnections}
-        alt="RDB connection picker with saved PostgreSQL, MySQL, and Redis connections organized in groups"
-        sizes="(min-width: 1024px) 560px, 94vw"
-        priority
-      />
-      <Screenshot
-        src={shotSql}
-        alt="RDB SQL editor with a query and its results grid"
-        sizes="(min-width: 1024px) 560px, 94vw"
-        priority
-      />
+  <section class="page-section">
+    <div class="section-inner wide">
+      <div class="card-grid two">
+        <Screenshot
+          src={shotConnections}
+          alt="RDB connection picker with saved PostgreSQL, MySQL, and Redis connections organized in groups"
+          sizes="(min-width: 1024px) 640px, 94vw"
+          priority
+          chrome
+          label="connections / saved"
+          status="ready"
+        />
+        <Screenshot
+          src={shotSql}
+          alt="RDB SQL editor with a query and its results grid"
+          sizes="(min-width: 1024px) 640px, 94vw"
+          priority
+          chrome
+          label="editor / query"
+          status="running"
+        />
+      </div>
     </div>
   </section>
 
   {
-    groups.map((group, i) => (
-      <section class:list={["border-line", i === 0 ? "" : "border-t"]}>
-        <div class="mx-auto grid max-w-6xl gap-6 px-4 py-14 sm:px-6 lg:grid-cols-[280px_1fr] lg:gap-16">
+    groups.map((group) => (
+      <section class="page-section">
+        <div class="section-inner wide section-grid">
           <div>
-            <h2 class="font-display text-2xl font-semibold tracking-tight">{group.title}</h2>
-            <p class="mt-2 text-sm text-fg-3">{group.intro}</p>
+            <p class="page-kicker">{group.title}</p>
+            <h2 class="section-title">{group.intro}</h2>
           </div>
-          <dl class="grid gap-x-10 gap-y-6 sm:grid-cols-2">
+          <dl class="card-grid two">
             {group.items.map(([term, detail]) => (
-              <div>
-                <dt class="text-sm font-semibold">{term}</dt>
-                <dd class="mt-1 text-sm leading-relaxed text-fg-2">{detail}</dd>
+              <div class="card">
+                <dt>{term}</dt>
+                <dd>{detail}</dd>
               </div>
             ))}
           </dl>
@@ -106,36 +115,37 @@ const groups = [
     ))
   }
 
-  <section id="databases" class="border-t border-line bg-panel">
-    <div class="mx-auto max-w-6xl px-4 py-16 sm:px-6">
-      <div class="max-w-2xl">
-        <h2 class="font-display text-3xl font-semibold tracking-tight">Supported databases</h2>
-        <p class="mt-4 leading-relaxed text-fg-2">
+  <section id="databases" class="page-section light">
+    <div class="section-inner wide">
+      <div class="stream-head">
+        <div>
+          <p class="page-kicker">Supported databases</p>
+          <h2 class="section-title">Eleven engines in one release.</h2>
+        </div>
+        <p>
           Each engine is its own Rust driver crate speaking the native
-          protocol. All six below are stable and included in every download.
+          protocol. They share the same workspace without flattening every
+          database into the same query model.
         </p>
       </div>
-      <div class="mt-8 max-w-3xl">
-        <Engines />
+      <div class="mt-10">
+        <Engines compact />
       </div>
-      <p class="mt-6 text-sm text-fg-3">
+      <p class="page-note">
         Want an engine that is not listed?
-        <a href={REPO_LINKS.newIssue} rel="noopener" class="underline decoration-line underline-offset-4 hover:text-fg">Open a feature request</a>
-        or read <a href={url("/open-source")} class="underline decoration-line underline-offset-4 hover:text-fg">how drivers are added</a>.
+        <a href={REPO_LINKS.newIssue} rel="noopener">Open a feature request</a>
+        or read <a href={url("/open-source")}>how drivers are added</a>.
       </p>
     </div>
   </section>
 
-  <section class="border-t border-line">
-    <div class="mx-auto max-w-6xl px-4 py-20 text-center sm:px-6">
-      <h2 class="font-display text-3xl font-semibold tracking-tight">See it on your own data.</h2>
-      <div class="mt-8">
-        <a
-          href={url("/download")}
-          class="inline-block rounded-lg bg-accent px-5 py-3 font-semibold text-accent-ink transition-colors hover:bg-accent-soft"
-        >
-          Download RDB
-        </a>
+  <section class="page-section">
+    <div class="section-inner wide">
+      <div class="closing-line mt-0">
+        <h2>See it on your own <em>data.</em></h2>
+        <div class="closing-actions">
+          <a href={url("/download")} class="home-button primary">Download RDB <span aria-hidden="true">↓</span></a>
+        </div>
       </div>
     </div>
   </section>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1,16 +1,132 @@
 ---
+import { Image } from "astro:assets";
 import Base from "../layouts/Base.astro";
 import Engines from "../components/Engines.astro";
 import Screenshot from "../components/Screenshot.astro";
-import CodeBlock from "../components/CodeBlock.astro";
 import { GITHUB, REPO_LINKS, url } from "../config";
 import release from "../data/release.json";
-import shotWorkspace from "../assets/shots/workspace.png";
-import shotSql from "../assets/shots/sql.png";
+import shotConnections from "../assets/shots/connections.png";
 import shotPalette from "../assets/shots/palette.png";
+import shotSql from "../assets/shots/sql.png";
+import shotWorkspace from "../assets/shots/workspace.png";
 
 const macDmg = release.assets.find((a) => a.name === "rdb-aarch64-apple-darwin.dmg");
-const dmgMb = macDmg ? (macDmg.size / 1_000_000).toFixed(1) : null;
+const macDmgMb = macDmg ? `${(macDmg.size / 1_000_000).toFixed(1)} MB` : "current release";
+const downloadHref = macDmg?.url ?? REPO_LINKS.releases;
+
+const engines = [
+  {
+    key: "postgresql",
+    name: "PostgreSQL",
+    description: "Browse schemas, run SQL, filter result sets, and inspect rows through the native PostgreSQL protocol.",
+    protocol: "tokio-postgres",
+    query: "SQL",
+    result: "Tabular results",
+  },
+  {
+    key: "mysql",
+    name: "MySQL",
+    description: "Move through databases and tables, execute MySQL syntax, and work with tabular results from a dedicated async driver.",
+    protocol: "mysql_async",
+    query: "SQL",
+    result: "Tabular results",
+  },
+  {
+    key: "mariadb",
+    name: "MariaDB",
+    description: "Use the familiar RDB workspace with MariaDB through its MySQL-protocol-compatible driver path.",
+    protocol: "mysql_async",
+    query: "SQL",
+    result: "Tabular results",
+  },
+  {
+    key: "redis",
+    name: "Redis",
+    description: "Browse keys and run tokenized Redis commands without forcing key-value work into a SQL-shaped interface.",
+    protocol: "RESP",
+    query: "Commands",
+    result: "Key-value results",
+  },
+  {
+    key: "valkey",
+    name: "Valkey",
+    description: "Connect over RESP, inspect keys, and run Valkey commands through the same fast native workspace.",
+    protocol: "RESP",
+    query: "Commands",
+    result: "Key-value results",
+  },
+  {
+    key: "mongodb",
+    name: "MongoDB",
+    description: "Navigate databases and collections, write familiar mongosh-style chains, and inspect complete JSON documents.",
+    protocol: "MongoDB wire",
+    query: "Mongo operations",
+    result: "Documents",
+  },
+  {
+    key: "sqlite",
+    name: "SQLite",
+    description: "Open local database files, browse tables, and query them without configuring a server or background service.",
+    protocol: "rusqlite",
+    query: "SQL",
+    result: "Tabular results",
+  },
+  {
+    key: "cassandra",
+    name: "Cassandra",
+    description: "Explore keyspaces and tables, then run CQL through the Scylla-compatible asynchronous driver.",
+    protocol: "Scylla driver",
+    query: "CQL",
+    result: "Tabular results",
+  },
+  {
+    key: "sqlserver",
+    name: "SQL Server",
+    description: "Connect to Microsoft SQL Server, browse schemas, and execute T-SQL from the shared editor surface.",
+    protocol: "TDS / tiberius",
+    query: "SQL",
+    result: "Tabular results",
+  },
+  {
+    key: "oracle",
+    name: "Oracle",
+    description: "Access Oracle through its thin driver, navigate schemas, and keep results in the same consistent data grid.",
+    protocol: "Oracle thin",
+    query: "SQL",
+    result: "Tabular results",
+  },
+  {
+    key: "clickhouse",
+    name: "ClickHouse",
+    description: "Query analytical datasets through ClickHouse HTTP while keeping results inside the native RDB grid.",
+    protocol: "HTTP",
+    query: "SQL",
+    result: "Tabular results",
+  },
+];
+
+const tourShots = {
+  connections: {
+    src: shotConnections.src,
+    alt: "RDB connection manager showing configured database connections",
+    caption: "Connection management across database engines",
+  },
+  sql: {
+    src: shotSql.src,
+    alt: "RDB query editor showing a saved SQL query and results area",
+    caption: "Saved queries, SQL editor, and execution controls",
+  },
+  workspace: {
+    src: shotWorkspace.src,
+    alt: "RDB workspace showing schema navigation and a company data table",
+    caption: "Schema browser, data grid, and row inspector",
+  },
+  palette: {
+    src: shotPalette.src,
+    alt: "RDB command palette listing database connections",
+    caption: "Keyboard-first command palette and connection search",
+  },
+};
 
 const structuredData = {
   "@context": "https://schema.org",
@@ -26,301 +142,376 @@ const structuredData = {
 ---
 
 <Base
-  title="RDB: fast, lightweight, open-source database management"
-  description="RDB is a free, open-source desktop database client for PostgreSQL, MySQL, MariaDB, Redis, Valkey, MongoDB, SQLite, Cassandra, SQL Server, Oracle, and ClickHouse. One native Rust binary for macOS, Windows, and Linux."
+  title="RDB: your databases, one native workspace"
+  description="RDB is a free, native database manager for PostgreSQL, MySQL, MariaDB, Redis, Valkey, MongoDB, SQLite, Cassandra, SQL Server, Oracle, and ClickHouse. One Rust binary for macOS, Windows, and Linux."
   path="/"
 >
   <script type="application/ld+json" set:html={JSON.stringify(structuredData)} slot="head" />
 
-  <!-- Hero -->
-  <section class="mx-auto max-w-6xl px-4 pt-16 pb-10 sm:px-6 sm:pt-20">
-    <div class="max-w-3xl">
-      <h1 class="font-display text-4xl font-semibold tracking-tight text-balance sm:text-5xl lg:text-6xl">
-        Your database, without the
-        <span class="text-accent">heavyweight</span> client.
-      </h1>
-      <p class="mt-5 max-w-xl text-lg leading-relaxed text-fg-2">
-        RDB is a free, open-source desktop client for PostgreSQL, MySQL,
-        MariaDB, Redis, Valkey, MongoDB, SQLite, Cassandra, SQL Server, Oracle, and
-        ClickHouse. One native Rust binary.
-      </p>
-      <div class="mt-8 flex flex-wrap items-center gap-3">
-        <a
-          href={url("/download")}
-          class="rounded-lg bg-accent px-5 py-3 font-semibold text-accent-ink transition-colors hover:bg-accent-soft"
-        >
-          Download RDB
-        </a>
-        <a
-          href={GITHUB}
-          rel="noopener"
-          class="rounded-lg border border-line px-5 py-3 font-semibold text-fg transition-colors hover:border-line-2 hover:bg-panel"
-        >
-          View on GitHub
-        </a>
+  <section class="home-hero" id="top">
+    <div class="home-container hero-intro">
+      <div data-reveal="left">
+        <p class="hero-kicker"><i aria-hidden="true"></i>Native database workspace</p>
+        <h1>RD<span>B</span></h1>
       </div>
-      <p class="mt-6 font-mono text-xs text-fg-3">
-        {release.tag} for macOS, Windows, and Linux. Apache-2.0 licensed.
-      </p>
-      <a
-        href="https://www.producthunt.com/products/rdb?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-rdb"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="mt-6 inline-block"
-      >
-        <img
-          src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1202790&theme=light"
-          alt="RDB - Multi database editor | Product Hunt"
-          width="250"
-          height="54"
-          loading="lazy"
-        />
-      </a>
-    </div>
-  </section>
-
-  <!-- Product showcase: real screenshot from the mock-data harness -->
-  <section class="mx-auto max-w-6xl px-4 pb-24 sm:px-6" aria-label="Product screenshot">
-    <Screenshot
-      src={shotWorkspace}
-      alt="RDB workspace: schema sidebar on the left, a tabbed SQL editor, and a results grid showing rows from a PostgreSQL table"
-      priority
-    />
-  </section>
-
-  <!-- Supported databases -->
-  <section id="databases" class="border-t border-line">
-    <div class="mx-auto max-w-6xl px-4 py-20 sm:px-6">
-      <div class="grid gap-10 lg:grid-cols-[1fr_1.4fr] lg:gap-16">
-        <div>
-          <h2 class="font-display text-3xl font-semibold tracking-tight">
-            Six engines, one window.
-          </h2>
-          <p class="mt-4 leading-relaxed text-fg-2">
-            Stop juggling one client per database. RDB speaks each engine's
-            native protocol through its own Rust driver, so the same sidebar,
-            editor, and grid work everywhere.
-          </p>
-        </div>
-        <Engines />
-      </div>
-    </div>
-  </section>
-
-  <!-- Lightweight -->
-  <section class="border-t border-line">
-    <div class="mx-auto grid max-w-6xl gap-10 px-4 py-20 sm:px-6 lg:grid-cols-2 lg:items-center lg:gap-16">
-      <div>
-        <h2 class="font-display text-3xl font-semibold tracking-tight">
-          Lightweight by design.
-        </h2>
-        <p class="mt-4 leading-relaxed text-fg-2">
-          No Electron, no bundled browser, no background services. The UI is
-          GPU-rendered by <a href="https://slint.dev" rel="noopener" class="underline decoration-line underline-offset-4 hover:text-fg">Slint</a>
-          and the whole app compiles to a single small binary that starts
-          instantly and stays out of your memory.
+      <div class="hero-copy" data-reveal="right">
+        <h2>Your databases, finally moving as one.</h2>
+        <p>
+          Browse schemas, write queries, inspect rows, and move between eleven
+          engines without leaving one fast native workspace.
         </p>
+        <div class="home-actions">
+          <a class="home-button primary" href={url("/download")}>Download RDB <span aria-hidden="true">↓</span></a>
+          <a class="home-button" href={GITHUB} rel="noopener">View source <span aria-hidden="true">↗</span></a>
+        </div>
+        <p class="release-line">{release.tag} · macOS / Windows / Linux · Apache-2.0</p>
       </div>
-      <dl class="grid grid-cols-3 gap-px overflow-hidden rounded-xl border border-line bg-line text-center">
-        <div class="bg-panel px-3 py-6">
-          <dt class="font-mono text-xs text-fg-3">macOS download</dt>
-          <dd class="mt-2 font-display text-2xl font-semibold text-accent">{dmgMb} MB</dd>
-        </div>
-        <div class="bg-panel px-3 py-6">
-          <dt class="font-mono text-xs text-fg-3">runtime deps</dt>
-          <dd class="mt-2 font-display text-2xl font-semibold text-accent">none</dd>
-        </div>
-        <div class="bg-panel px-3 py-6">
-          <dt class="font-mono text-xs text-fg-3">UI stack</dt>
-          <dd class="mt-2 font-display text-2xl font-semibold text-accent">native</dd>
-        </div>
-      </dl>
     </div>
-  </section>
 
-  <!-- Query editor -->
-  <section class="border-t border-line">
-    <div class="mx-auto grid max-w-6xl gap-10 px-4 py-20 sm:px-6 lg:grid-cols-[1.4fr_1fr] lg:items-center lg:gap-16">
+    <div class="query-pulse" aria-label="Live query example">
+      <div class="home-container query-inner">
+        <span class="query-label">Live statement</span>
+        <p class="query-line" id="live-query">
+          <span class="keyword">SELECT</span> * <span class="keyword">FROM</span> customers <span class="keyword">LIMIT</span> 50<span class="cursor" aria-hidden="true"></span>
+        </p>
+        <span class="query-state">Ready</span>
+      </div>
+      <span class="query-progress" aria-hidden="true"></span>
+    </div>
+
+    <div class="workspace-hero" data-reveal="up">
       <Screenshot
-        src={shotSql}
-        alt="RDB SQL editor running a query, with syntax highlighting and a results grid below"
-        sizes="(min-width: 1024px) 640px, 94vw"
-        class="order-last lg:order-first"
+        src={shotWorkspace}
+        alt="RDB workspace showing schema navigation, a data grid, and row inspector"
+        priority
+        chrome
+        label="workspace / production"
+        status="connected"
       />
-      <div>
-        <h2 class="font-display text-3xl font-semibold tracking-tight">
-          Query without friction.
-        </h2>
-        <p class="mt-4 leading-relaxed text-fg-2">
-          A real editor, not a text box: syntax highlighting, multi-statement
-          runs, selection execution, find, and SQL formatting. Split the
-          editor into panes and keep one query running while you write the next.
-        </p>
-        <ul class="mt-6 space-y-2 font-mono text-sm text-fg-2">
-          <li><kbd class="rounded border border-line bg-code px-1.5 py-0.5 text-xs">⌘ Enter</kbd> run query</li>
-          <li><kbd class="rounded border border-line bg-code px-1.5 py-0.5 text-xs">⌘ F</kbd> find in editor</li>
-          <li><kbd class="rounded border border-line bg-code px-1.5 py-0.5 text-xs">⌘ K</kbd> jump anywhere</li>
+      <div class="float-note" aria-hidden="true"><span>QUERY COMPLETE</span>One workspace. Eleven engines.</div>
+    </div>
+  </section>
+
+  <section class="engine-stream" id="engines">
+    <div class="home-container stream-head" data-reveal="up">
+      <h2>Speak every database.</h2>
+      <p>
+        SQL, documents, keys, and analytical workloads keep their own query
+        model while sharing the same native workspace.
+      </p>
+    </div>
+    <div class="engine-loop" aria-label="Choose a supported database engine">
+      {
+        [false, true].map((hidden) => (
+          <div class="engine-set" aria-hidden={hidden ? "true" : undefined}>
+            {engines.map((engine, index) => (
+              <button
+                class="engine-chip"
+                type="button"
+                data-engine={engine.key}
+                aria-pressed={!hidden && index === 0 ? "true" : "false"}
+                tabindex={hidden ? "-1" : undefined}
+              >
+                {engine.name}
+              </button>
+            ))}
+          </div>
+        ))
+      }
+    </div>
+    <div class="home-container engine-readout" aria-live="polite" data-reveal="up">
+      <span class="engine-count" id="engine-count">01 / {engines.length}</span>
+      <h3 id="engine-name">{engines[0].name}</h3>
+      <div class="engine-detail">
+        <p id="engine-description">{engines[0].description}</p>
+        <div class="engine-meta">
+          <span id="engine-protocol">{engines[0].protocol}</span>
+          <span id="engine-query">{engines[0].query}</span>
+          <span id="engine-result">{engines[0].result}</span>
+        </div>
+      </div>
+    </div>
+    <div class="home-container engine-grid-wrap" data-reveal="up">
+      <Engines compact />
+    </div>
+  </section>
+
+  <section class="flow" id="workflow">
+    <div class="home-container">
+      <div class="flow-heading" data-reveal="left">
+        <p class="overline">One continuous workflow</p>
+        <h2>From connection to answer, without the <em>drag.</em></h2>
+      </div>
+      <div class="tour">
+        <div class="tour-nav" role="group" aria-label="Product workflow">
+          <button class="tour-step" type="button" data-shot="connections" aria-pressed="true">
+            <small>01</small><div><strong>Connect</strong><span>Keep every engine within reach.</span></div>
+          </button>
+          <button class="tour-step" type="button" data-shot="sql" aria-pressed="false">
+            <small>02</small><div><strong>Query</strong><span>Write, format, and execute.</span></div>
+          </button>
+          <button class="tour-step" type="button" data-shot="workspace" aria-pressed="false">
+            <small>03</small><div><strong>Inspect</strong><span>Move through rows and schema.</span></div>
+          </button>
+          <button class="tour-step" type="button" data-shot="palette" aria-pressed="false">
+            <small>04</small><div><strong>Navigate</strong><span>Jump anywhere with Cmd+K.</span></div>
+          </button>
+        </div>
+        <div class="tour-stage" data-reveal="right">
+          <div class="tour-frame">
+            <Image
+              id="tour-image"
+              src={shotConnections}
+              alt={tourShots.connections.alt}
+              widths={[640, 1024, 1600]}
+              sizes="(min-width: 1024px) 900px, 94vw"
+              loading="lazy"
+            />
+          </div>
+          <div class="tour-caption">
+            <strong id="tour-caption">{tourShots.connections.caption}</strong>
+            <span>REAL APP CAPTURE · 1280 × 800</span>
+          </div>
+        </div>
+      </div>
+      <div class="result-river" id="result-river" aria-label="Workflow capabilities">
+        <div class="result-cell"><small>Connect</small><span>Paste a DSN</span></div>
+        <div class="result-cell"><small>Execute</small><span>Run a selection</span></div>
+        <div class="result-cell"><small>Inspect</small><span>Open row detail</span></div>
+        <div class="result-cell"><small>Navigate</small><span>Jump with Cmd+K</span></div>
+        <div class="result-cell"><small>Export</small><span>Save CSV or JSON</span></div>
+      </div>
+    </div>
+  </section>
+
+  <section class="native-band">
+    <div class="home-container native-statement">
+      <h2 data-reveal="left">Native by default. Private by design.</h2>
+      <div class="native-copy" data-reveal="right">
+        <p>Built in Rust with a Slint interface. RDB connects directly to your database and stays out of the way.</p>
+        <ul class="native-points">
+          <li><span aria-hidden="true">✓</span>No account and no telemetry</li>
+          <li><span aria-hidden="true">✓</span>Works fully offline after installation</li>
+          <li><span aria-hidden="true">✓</span>Credentials use your OS keychain</li>
         </ul>
       </div>
     </div>
   </section>
 
-  <!-- Large results -->
-  <section class="border-t border-line bg-panel">
-    <div class="mx-auto max-w-6xl px-4 py-20 sm:px-6">
-      <div class="mx-auto max-w-2xl text-center">
-        <h2 class="font-display text-3xl font-semibold tracking-tight">
-          Big tables don't freeze the app.
-        </h2>
-        <p class="mt-4 leading-relaxed text-fg-2">
-          Run <code class="rounded bg-code px-1.5 py-0.5 font-mono text-sm">SELECT * FROM huge_table</code>
-          and keep working. RDB loads rows in batches as you scroll and
-          virtualizes the grid, so a million-row result never lands in memory
-          all at once.
+  <section class="download-panel" id="download">
+    <div class="home-container">
+      <div class="download-head" data-reveal="up">
+        <h2>Open it. Start querying.</h2>
+        <p>
+          Choose your platform, install the current release, and connect to a
+          database. No account sits between download and the first query.
         </p>
       </div>
-    </div>
-  </section>
-
-  <!-- Everyday features bento -->
-  <section class="border-t border-line">
-    <div class="mx-auto max-w-6xl px-4 py-20 sm:px-6">
-      <h2 class="font-display text-3xl font-semibold tracking-tight">
-        The everyday things, done right.
-      </h2>
-      <div class="mt-10 grid gap-4 lg:grid-cols-3">
-        <div class="overflow-hidden rounded-xl border border-line bg-panel lg:col-span-2">
-          <div class="p-6">
-            <h3 class="font-display text-lg font-semibold">Command palette</h3>
-            <p class="mt-2 max-w-md text-sm leading-relaxed text-fg-2">
-              Press <kbd class="rounded border border-line bg-code px-1.5 py-0.5 font-mono text-xs">⌘ K</kbd>
-              and fuzzy-search every saved connection, table, and collection.
-              Your hands never leave the keyboard.
-            </p>
+      <div class="install-surface">
+        <div class="platform-copy" data-reveal="left">
+          <span class="latest">LATEST RELEASE / {release.tag}</span>
+          <h3 id="platform-title">RDB for macOS</h3>
+          <p id="platform-description">Install the native app through Homebrew, or download the Apple Silicon disk image directly.</p>
+          <div class="platform-picker" role="group" aria-label="Choose operating system">
+            <button class="platform-button" type="button" data-platform="mac" aria-pressed="true">macOS</button>
+            <button class="platform-button" type="button" data-platform="linux" aria-pressed="false">Linux</button>
+            <button class="platform-button" type="button" data-platform="windows" aria-pressed="false">Windows</button>
           </div>
-          <Screenshot
-            src={shotPalette}
-            alt="RDB command palette open over the workspace, listing saved PostgreSQL, MySQL, Redis, and MongoDB connections"
-            sizes="(min-width: 1024px) 640px, 94vw"
-            class="mx-6 mb-0 translate-y-2 rounded-b-none border-b-0"
-          />
+          <a class="home-button primary download-action" id="download-link" href={downloadHref}>
+            Download DMG · {macDmgMb}
+          </a>
         </div>
-        <div class="grid gap-4">
-          <div class="rounded-xl border border-line bg-panel p-6">
-            <h3 class="font-display text-lg font-semibold">Credentials in your keychain</h3>
-            <p class="mt-2 text-sm leading-relaxed text-fg-2">
-              Passwords go to the OS keychain (Keychain, libsecret, Credential
-              Manager), with an AES-GCM encrypted file as the headless
-              fallback. Never plaintext config.
-            </p>
+        <div class="install-terminal" data-reveal="right">
+          <div class="terminal-top"><span>INSTALL / PACKAGE MANAGER</span><span id="platform-arch">APPLE SILICON</span></div>
+          <div>
+            <p class="terminal-command" id="install-command">brew install --cask suiflex/tap/rdb</p>
+            <button class="copy-button" type="button" id="copy-command">
+              <span aria-hidden="true">□</span>
+              <span>Copy command</span>
+            </button>
           </div>
-          <div class="rounded-xl border border-line bg-panel p-6">
-            <h3 class="font-display text-lg font-semibold">Filter and export</h3>
-            <p class="mt-2 text-sm leading-relaxed text-fg-2">
-              Per-column filters compile to server-side WHERE clauses. Export
-              results as CSV or JSON through the native save dialog.
-            </p>
-          </div>
+          <p class="terminal-note">FREE · OPEN SOURCE · APACHE-2.0 · NO SIGN-UP</p>
         </div>
       </div>
     </div>
   </section>
 
-  <!-- Open source -->
-  <section class="border-t border-line">
-    <div class="mx-auto grid max-w-6xl gap-10 px-4 py-20 sm:px-6 lg:grid-cols-2 lg:gap-16">
-      <div>
-        <h2 class="font-display text-3xl font-semibold tracking-tight">
-          Built in the open.
-        </h2>
-        <p class="mt-4 leading-relaxed text-fg-2">
-          RDB is Apache-2.0 licensed and developed entirely on GitHub. Read the
-          code, report a bug, or help shape what comes next: every engine is
-          a self-contained Rust crate behind one
-          <code class="rounded bg-code px-1.5 py-0.5 font-mono text-sm">Driver</code>
-          trait, so there is a clear path to adding your favorite database.
-        </p>
-        <div class="mt-6">
-          <CodeBlock
-            code="git clone https://github.com/suiflex/rdb && cd rdb && cargo build --release -p rdb"
-            label="build from source"
-          />
+  <section class="open-source-home" id="source">
+    <div class="home-container">
+      <div class="source-flow">
+        <div data-reveal="left">
+          <p class="overline">Open architecture</p>
+          <h2>The boundary is yours to inspect.</h2>
+          <p>
+            The Slint interface depends on <span class="mono">rdb-core</span>,
+            not concrete database crates. Every engine implements the same
+            asynchronous driver contract.
+          </p>
+          <div class="home-actions">
+            <a class="home-button primary" href={GITHUB} rel="noopener">Explore GitHub <span aria-hidden="true">↗</span></a>
+            <a class="home-button" href={url("/open-source")}>Contribute</a>
+          </div>
+        </div>
+        <div data-reveal="right">
+          <pre class="driver-code" aria-label="Rust driver trait example"><span class="keyword">pub trait</span> <span class="type">Driver</span>: Send + Sync &#123;
+  <span class="keyword">async fn</span> connect(config: &amp;ConnConfig);
+  <span class="keyword">async fn</span> schema(&amp;self);
+  <span class="keyword">async fn</span> query(&amp;self, query: &amp;Query);
+  <span class="keyword">async fn</span> close(self);
+&#125;</pre>
+          <nav class="source-links" aria-label="Project resources">
+            <a class="source-link" href={REPO_LINKS.vision} rel="noopener"><strong>Product vision</strong><span>VISION.MD ↗</span></a>
+            <a class="source-link" href={REPO_LINKS.goodFirstIssues} rel="noopener"><strong>Good first issues</strong><span>CONTRIBUTE ↗</span></a>
+            <a class="source-link" href={url("/changelog")}><strong>Release history</strong><span>CHANGELOG ↗</span></a>
+          </nav>
         </div>
       </div>
-      <ul class="grid content-start gap-3 sm:grid-cols-2">
-        {
-          [
-            { label: "Source code", note: "the whole app, Apache-2.0 licensed", href: GITHUB },
-            { label: "Good first issues", note: "a gentle place to start", href: REPO_LINKS.goodFirstIssues },
-            { label: "Contributing guide", note: "setup, style, PR flow", href: REPO_LINKS.contributing },
-            { label: "Discussions", note: "questions and ideas", href: REPO_LINKS.discussions },
-            { label: "Roadmap", note: "where RDB is headed", href: REPO_LINKS.vision },
-            { label: "Releases", note: "binaries and notes", href: REPO_LINKS.releases },
-          ].map((item) => (
-            <li>
-              <a
-                href={item.href}
-                rel="noopener"
-                class="block rounded-xl border border-line bg-panel px-4 py-3.5 transition-colors hover:border-line-2 hover:bg-panel-2"
-              >
-                <span class="block text-sm font-medium">{item.label}</span>
-                <span class="block text-xs text-fg-3">{item.note}</span>
-              </a>
-            </li>
-          ))
-        }
-      </ul>
+
+      <div class="closing-line" data-reveal="up">
+        <h2>One native place for every <em>database.</em></h2>
+        <div class="closing-actions">
+          <a class="home-button primary" href={url("/download")}>Download RDB <span aria-hidden="true">↓</span></a>
+          <a class="home-button" href={REPO_LINKS.newIssue} rel="noopener">Open an issue <span aria-hidden="true">↗</span></a>
+        </div>
+      </div>
     </div>
   </section>
 
-  <!-- Privacy -->
-  <section class="border-t border-line bg-panel">
-    <div class="mx-auto max-w-6xl px-4 py-20 sm:px-6">
-      <div class="max-w-2xl">
-        <h2 class="font-display text-3xl font-semibold tracking-tight">
-          No account. No telemetry.
-        </h2>
-        <p class="mt-4 leading-relaxed text-fg-2">
-          RDB is a local tool. Your queries travel between you and your
-          database, and nowhere else.
-        </p>
-      </div>
-      <ul class="mt-8 grid gap-x-10 gap-y-4 text-sm text-fg-2 sm:grid-cols-2">
-        <li class="flex gap-3"><span class="mt-1 text-accent" aria-hidden="true">✓</span> Works fully offline; no sign-up, ever.</li>
-        <li class="flex gap-3"><span class="mt-1 text-accent" aria-hidden="true">✓</span> No usage tracking or crash reporting of any kind.</li>
-        <li class="flex gap-3"><span class="mt-1 text-accent" aria-hidden="true">✓</span> Connection secrets live in your OS keychain, not in config files.</li>
-        <li class="flex gap-3"><span class="mt-1 text-accent" aria-hidden="true">✓</span> The only outbound request is an update check against GitHub Releases, and you can turn it off in Settings.</li>
-      </ul>
-      <p class="mt-6 text-sm text-fg-3">
-        Details on the <a href={url("/privacy")} class="underline decoration-line underline-offset-4 hover:text-fg">privacy page</a>.
-      </p>
-    </div>
-  </section>
+  <script define:vars={{ engines, tourShots, releaseTag: release.tag, macDmgMb, macHref: downloadHref, releasesHref: REPO_LINKS.releases }}>
+    const reducedMotion = matchMedia("(prefers-reduced-motion: reduce)").matches;
 
-  <!-- Final CTA -->
-  <section class="border-t border-line">
-    <div class="mx-auto max-w-6xl px-4 py-24 text-center sm:px-6">
-      <h2 class="font-display text-3xl font-semibold tracking-tight text-balance sm:text-4xl">
-        Download RDB and connect to your first database.
-      </h2>
-      <div class="mt-8 flex flex-wrap items-center justify-center gap-3">
-        <a
-          href={url("/download")}
-          class="rounded-lg bg-accent px-5 py-3 font-semibold text-accent-ink transition-colors hover:bg-accent-soft"
-        >
-          Download RDB
-        </a>
-        <a
-          href={GITHUB}
-          rel="noopener"
-          class="rounded-lg border border-line px-5 py-3 font-semibold transition-colors hover:border-line-2 hover:bg-panel"
-        >
-          View on GitHub
-        </a>
-      </div>
-      <p class="mt-6 font-mono text-xs text-fg-3">
-        Free forever under the Apache-2.0 license.
-      </p>
-    </div>
-  </section>
+    const queries = [
+      '<span class="keyword">SELECT</span> * <span class="keyword">FROM</span> customers <span class="keyword">LIMIT</span> 50',
+      '<span class="keyword">EXPLAIN</span> <span class="keyword">ANALYZE</span> active_subscriptions',
+      'db.orders.<span class="keyword">find</span>({ status: "open" })',
+      '<span class="keyword">SCAN</span> 0 <span class="keyword">MATCH</span> session:*',
+    ];
+    let queryIndex = 0;
+    if (!reducedMotion) {
+      setInterval(() => {
+        queryIndex = (queryIndex + 1) % queries.length;
+        const line = document.querySelector("#live-query");
+        if (!line) return;
+        line.style.opacity = "0";
+        setTimeout(() => {
+          line.innerHTML = `${queries[queryIndex]}<span class="cursor" aria-hidden="true"></span>`;
+          line.style.opacity = "1";
+        }, 160);
+      }, 4000);
+    }
+
+    const engineMap = Object.fromEntries(engines.map((engine) => [engine.key, engine]));
+    const engineButtons = [...document.querySelectorAll("[data-engine]")];
+    engineButtons.forEach((button) => {
+      button.addEventListener("click", () => {
+        const key = button.dataset.engine;
+        const engine = engineMap[key];
+        if (!engine) return;
+        engineButtons.forEach((item) => item.setAttribute("aria-pressed", String(item.dataset.engine === key)));
+        document.querySelector("#engine-count").textContent = `${String(engines.findIndex((item) => item.key === key) + 1).padStart(2, "0")} / ${engines.length}`;
+        document.querySelector("#engine-name").textContent = engine.name;
+        document.querySelector("#engine-description").textContent = engine.description;
+        document.querySelector("#engine-protocol").textContent = engine.protocol;
+        document.querySelector("#engine-query").textContent = engine.query;
+        document.querySelector("#engine-result").textContent = engine.result;
+      });
+    });
+
+    const tourButtons = [...document.querySelectorAll("[data-shot]")];
+    let tourIndex = 0;
+    let tourTimer;
+    const selectShot = (index, userInitiated = false) => {
+      tourIndex = index;
+      const button = tourButtons[index];
+      const shot = tourShots[button.dataset.shot];
+      const image = document.querySelector("#tour-image");
+      if (!shot || !image) return;
+      tourButtons.forEach((item, itemIndex) => item.setAttribute("aria-pressed", String(itemIndex === index)));
+      image.classList.add("is-switching");
+      setTimeout(() => {
+        image.src = shot.src;
+        image.alt = shot.alt;
+        document.querySelector("#tour-caption").textContent = shot.caption;
+        image.classList.remove("is-switching");
+        const river = document.querySelector("#result-river");
+        river.classList.remove("is-pulsing");
+        void river.offsetWidth;
+        river.classList.add("is-pulsing");
+      }, reducedMotion ? 0 : 150);
+      if (userInitiated && !reducedMotion) restartTour();
+    };
+    const restartTour = () => {
+      clearInterval(tourTimer);
+      tourTimer = setInterval(() => selectShot((tourIndex + 1) % tourButtons.length), 6000);
+    };
+    tourButtons.forEach((button, index) => button.addEventListener("click", () => selectShot(index, true)));
+    if (!reducedMotion) restartTour();
+
+    const platforms = {
+      mac: {
+        title: "RDB for macOS",
+        description: "Install the native app through Homebrew, or download the Apple Silicon disk image directly.",
+        arch: "APPLE SILICON",
+        command: "brew install --cask suiflex/tap/rdb",
+        label: `Download DMG · ${macDmgMb}`,
+        href: macHref,
+      },
+      linux: {
+        title: "RDB for Linux",
+        description: "Use the install script to place the native binary in the first writable standard binary directory.",
+        arch: "ARM64 / X86-64",
+        command: "curl -fsSL https://raw.githubusercontent.com/suiflex/rdb/develop/scripts/install.sh | bash",
+        label: "Download from GitHub",
+        href: releasesHref,
+      },
+      windows: {
+        title: "RDB for Windows",
+        description: "Run the PowerShell installer, or download a standalone executable from the current release.",
+        arch: "ARM64 / X86-64",
+        command: "irm https://raw.githubusercontent.com/suiflex/rdb/develop/scripts/install.ps1 | iex",
+        label: "Download from GitHub",
+        href: releasesHref,
+      },
+    };
+    const platformButtons = [...document.querySelectorAll("[data-platform]")];
+    platformButtons.forEach((button) => {
+      button.addEventListener("click", () => {
+        const platform = platforms[button.dataset.platform];
+        if (!platform) return;
+        platformButtons.forEach((item) => item.setAttribute("aria-pressed", String(item === button)));
+        document.querySelector("#platform-title").textContent = platform.title;
+        document.querySelector("#platform-description").textContent = platform.description;
+        document.querySelector("#platform-arch").textContent = platform.arch;
+        document.querySelector("#install-command").textContent = platform.command;
+        const link = document.querySelector("#download-link");
+        link.textContent = platform.label;
+        link.href = platform.href;
+        document.querySelector("#copy-command span:last-child").textContent = "Copy command";
+      });
+    });
+
+    const copyButton = document.querySelector("#copy-command");
+    copyButton?.addEventListener("click", async () => {
+      const command = document.querySelector("#install-command")?.textContent ?? "";
+      try {
+        await navigator.clipboard.writeText(command);
+        copyButton.querySelector("span:last-child").textContent = "Copied";
+      } catch {
+        copyButton.querySelector("span:last-child").textContent = "Select command above";
+      }
+    });
+
+    if (!reducedMotion) {
+      const observer = new IntersectionObserver(
+        (entries) => entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("is-visible");
+            observer.unobserve(entry.target);
+          }
+        }),
+        { threshold: 0.12 },
+      );
+      document.querySelectorAll("[data-reveal]").forEach((element) => observer.observe(element));
+    }
+  </script>
 </Base>

--- a/website/src/pages/license.astro
+++ b/website/src/pages/license.astro
@@ -6,7 +6,7 @@ import { REPO_LINKS } from "../config";
 
 // The real license file from the repository root, embedded at build time.
 // Resolved from process.cwd() (astro build always runs from website/), not
-// import.meta.url — see changelog.astro for why.
+// import.meta.url. See changelog.astro for why.
 const licenseText = readFileSync(resolve(process.cwd(), "../LICENSE"), "utf-8").trim();
 ---
 
@@ -15,20 +15,26 @@ const licenseText = readFileSync(resolve(process.cwd(), "../LICENSE"), "utf-8").
   description="RDB is released under the Apache License 2.0: free to use, modify, and redistribute, commercially or otherwise."
   path="/license"
 >
-  <section class="mx-auto max-w-3xl px-4 pt-16 pb-20 sm:px-6">
-    <h1 class="font-display text-4xl font-semibold tracking-tight sm:text-5xl">License</h1>
-    <p class="mt-4 text-lg leading-relaxed text-fg-2">
+  <section class="page-hero">
+    <div class="page-hero-inner">
+      <p class="page-kicker">Apache-2.0</p>
+      <h1 class="page-title">License</h1>
+      <p class="page-lede">
       RDB is released under the Apache License 2.0. In practice that means
       you can use it at work, modify it, and redistribute it, free of charge,
       and every contributor grants you a patent licence for their work. In
       return, keep the licence and NOTICE files with any copy you pass on, and
       say which files you changed.
-    </p>
-    <pre
-      class="mt-10 overflow-x-auto rounded-xl border border-line bg-code p-6 font-mono text-xs leading-relaxed whitespace-pre-wrap text-fg-2">{licenseText}</pre>
-    <p class="mt-6 text-sm text-fg-3">
+      </p>
+    </div>
+  </section>
+  <section class="page-section">
+    <div class="section-inner">
+      <pre class="legal-text">{licenseText}</pre>
+      <p class="page-note">
       Canonical copy:
-      <a href={REPO_LINKS.license} rel="noopener" class="underline decoration-line underline-offset-4 hover:text-fg">LICENSE in the repository</a>.
-    </p>
+        <a href={REPO_LINKS.license} rel="noopener">LICENSE in the repository</a>.
+      </p>
+    </div>
   </section>
 </Base>

--- a/website/src/pages/open-source.astro
+++ b/website/src/pages/open-source.astro
@@ -24,97 +24,96 @@ const crates = [
   description="RDB is Apache-2.0 licensed and built in the open. Read the code, report a bug, pick up a good first issue, or add a driver for your favorite database."
   path="/open-source"
 >
-  <section class="mx-auto max-w-4xl px-4 pt-16 pb-12 sm:px-6">
-    <h1 class="max-w-2xl font-display text-4xl font-semibold tracking-tight sm:text-5xl">
-      Built in the open. Yours to shape.
-    </h1>
-    <p class="mt-4 max-w-xl text-lg leading-relaxed text-fg-2">
-      Every line of RDB is public and Apache-2.0 licensed. Read the code, report a
-      bug, or help decide what comes next.
-    </p>
-    <div class="mt-8 flex flex-wrap gap-3">
-      <a
-        href={GITHUB}
-        rel="noopener"
-        class="rounded-lg bg-accent px-5 py-3 font-semibold text-accent-ink transition-colors hover:bg-accent-soft"
-      >
-        Browse the source
-      </a>
-      <a
-        href={REPO_LINKS.goodFirstIssues}
-        rel="noopener"
-        class="rounded-lg border border-line px-5 py-3 font-semibold transition-colors hover:border-line-2 hover:bg-panel"
-      >
-        Good first issues
-      </a>
-    </div>
-  </section>
-
-  <section class="border-t border-line">
-    <div class="mx-auto grid max-w-4xl gap-10 px-4 py-14 sm:px-6 md:grid-cols-2">
-      <div>
-        <h2 class="font-display text-2xl font-semibold tracking-tight">Ways to help</h2>
-        <ul class="mt-5 space-y-4 text-sm leading-relaxed text-fg-2">
-          <li>
-            <strong class="text-fg">Report what breaks.</strong>
-            A clear reproduction in an
-            <a href={REPO_LINKS.newIssue} rel="noopener" class="underline decoration-line underline-offset-4 hover:text-fg">issue</a>
-            is one of the most useful contributions there is.
-          </li>
-          <li>
-            <strong class="text-fg">Fix or build something.</strong>
-            The <a href={REPO_LINKS.contributing} rel="noopener" class="underline decoration-line underline-offset-4 hover:text-fg">contributing guide</a>
-            covers setup, code style, and the PR flow. Conventional commits
-            drive the release automation.
-          </li>
-          <li>
-            <strong class="text-fg">Add a database.</strong>
-            Engines are self-contained crates implementing one
-            <code class="rounded bg-code px-1.5 py-0.5 font-mono text-xs">Driver</code>
-            trait. If you know an engine's wire protocol or its Rust client
-            library, you can bring it to RDB.
-          </li>
-          <li>
-            <strong class="text-fg">Join the discussion.</strong>
-            Questions and design ideas live in
-            <a href={REPO_LINKS.discussions} rel="noopener" class="underline decoration-line underline-offset-4 hover:text-fg">GitHub Discussions</a>;
-            direction is documented in the
-            <a href={REPO_LINKS.vision} rel="noopener" class="underline decoration-line underline-offset-4 hover:text-fg">vision doc</a>.
-          </li>
-        </ul>
-      </div>
-      <div>
-        <h2 class="font-display text-2xl font-semibold tracking-tight">How the code is laid out</h2>
-        <ul class="mt-5 divide-y divide-line rounded-xl border border-line bg-panel">
-          {
-            crates.map(([name, desc]) => (
-              <li class="flex items-baseline gap-3 px-4 py-2.5">
-                <code class="shrink-0 font-mono text-xs text-accent">{name}</code>
-                <span class="text-xs text-fg-3">{desc}</span>
-              </li>
-            ))
-          }
-        </ul>
-      </div>
-    </div>
-  </section>
-
-  <section class="border-t border-line bg-panel">
-    <div class="mx-auto max-w-4xl px-4 py-14 sm:px-6">
-      <h2 class="font-display text-2xl font-semibold tracking-tight">Run it from source</h2>
-      <p class="mt-3 max-w-xl text-sm leading-relaxed text-fg-2">
-        Stable Rust is the only hard requirement; <code class="rounded bg-code px-1.5 py-0.5 font-mono text-xs">make help</code>
-        lists the build, lint, and test targets used in CI.
+  <section class="page-hero">
+    <div class="page-hero-inner wide">
+      <p class="page-kicker">Open architecture</p>
+      <h1 class="page-title wide">Built in the open. Yours to shape.</h1>
+      <p class="page-lede">
+        Every line of RDB is public and Apache-2.0 licensed. Read the code,
+        report a bug, or help decide what comes next.
       </p>
-      <div class="mt-5 space-y-3">
+      <div class="home-actions">
+        <a href={GITHUB} rel="noopener" class="home-button primary">Browse the source <span aria-hidden="true">↗</span></a>
+        <a href={REPO_LINKS.goodFirstIssues} rel="noopener" class="home-button">Good first issues</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="page-section">
+    <div class="section-inner wide source-flow">
+      <div>
+        <p class="page-kicker">Ways to help</p>
+        <h2 class="section-title">Useful contribution starts close to the work.</h2>
+        <div class="card-grid mt-8">
+          <article class="card">
+            <h3>Report what breaks</h3>
+            <p>A clear reproduction in an issue is one of the most useful contributions there is.</p>
+          </article>
+          <article class="card">
+            <h3>Fix or build something</h3>
+            <p>The contributing guide covers setup, code style, and the PR flow. Conventional commits drive the release automation.</p>
+          </article>
+          <article class="card">
+            <h3>Add a database</h3>
+            <p>Engines are self-contained crates implementing one Driver trait. If you know an engine wire protocol or Rust client library, you can bring it to RDB.</p>
+          </article>
+          <article class="card">
+            <h3>Join the discussion</h3>
+            <p>Questions and design ideas live in GitHub Discussions; direction is documented in the vision doc.</p>
+          </article>
+        </div>
+      </div>
+      <div>
+        <pre class="driver-code" aria-label="Rust driver trait example"><span class="keyword">pub trait</span> <span class="type">Driver</span>: Send + Sync &#123;
+  <span class="keyword">async fn</span> connect(config: &amp;ConnConfig);
+  <span class="keyword">async fn</span> schema(&amp;self);
+  <span class="keyword">async fn</span> query(&amp;self, query: &amp;Query);
+  <span class="keyword">async fn</span> close(self);
+&#125;</pre>
+        <nav class="source-links" aria-label="Contribution links">
+          <a class="source-link" href={REPO_LINKS.newIssue} rel="noopener"><strong>Open an issue</strong><span>REPORT ↗</span></a>
+          <a class="source-link" href={REPO_LINKS.contributing} rel="noopener"><strong>Contributing guide</strong><span>SETUP ↗</span></a>
+          <a class="source-link" href={REPO_LINKS.discussions} rel="noopener"><strong>Discussions</strong><span>DESIGN ↗</span></a>
+          <a class="source-link" href={REPO_LINKS.vision} rel="noopener"><strong>Vision doc</strong><span>ROADMAP ↗</span></a>
+        </nav>
+      </div>
+    </div>
+  </section>
+
+  <section class="page-section light">
+    <div class="section-inner wide section-grid">
+      <div>
+        <p class="page-kicker">Crate map</p>
+        <h2 class="section-title">Every engine has a place.</h2>
+      </div>
+      <ul class="crate-list">
+        {
+          crates.map(([name, desc]) => (
+            <li>
+              <code>{name}</code>
+              <span>{desc}</span>
+            </li>
+          ))
+        }
+      </ul>
+    </div>
+  </section>
+
+  <section class="page-section">
+    <div class="section-inner section-grid">
+      <div>
+        <p class="page-kicker">Local build</p>
+        <h2 class="section-title">Run it from source.</h2>
+      </div>
+      <div class="card-grid">
         <CodeBlock code="git clone https://github.com/suiflex/rdb && cd rdb" label="clone" />
         <CodeBlock code="make all   # fmt-check + lint + test + build" label="CI gate" />
+        <p class="page-note">
+          Security reports go through the
+          <a href={REPO_LINKS.security} rel="noopener">security policy</a>,
+          not public issues.
+        </p>
       </div>
-      <p class="mt-6 text-sm text-fg-3">
-        Security reports go through the
-        <a href={REPO_LINKS.security} rel="noopener" class="underline decoration-line underline-offset-4 hover:text-fg">security policy</a>,
-        not public issues.
-      </p>
     </div>
   </section>
 </Base>

--- a/website/src/pages/privacy.astro
+++ b/website/src/pages/privacy.astro
@@ -1,6 +1,33 @@
 ---
 import Base from "../layouts/Base.astro";
 import { REPO_LINKS } from "../config";
+
+const sections = [
+  {
+    title: "No account, no tracking",
+    body: "RDB requires no sign-up and has no cloud backend. It contains no analytics, no usage tracking, and no crash reporting. The application works fully offline.",
+  },
+  {
+    title: "Your queries and data",
+    body: "Queries travel directly between the application and the database servers you configure, using each engine native protocol. Query text, results, and schema information are never sent to any other party.",
+  },
+  {
+    title: "Credentials",
+    body: "Connection passwords are stored in your operating system secret store: Keychain on macOS, libsecret on Linux, Credential Manager on Windows. On systems without a keychain, they fall back to a local file encrypted with AES-GCM. Saved connection metadata is stored as plain JSON on your machine; passwords are never written to it and never included in connection exports.",
+  },
+  {
+    title: "The one network call",
+    body: "At most once a day, RDB makes a single HTTPS request to the GitHub Releases API to check whether a newer version exists. No identifier or usage data is attached; it is a plain HTTP GET. You can disable this check in Settings, and the app never downloads or installs updates by itself.",
+  },
+  {
+    title: "This website",
+    body: "This site is static files. It sets no cookies, runs no analytics, and embeds no third-party scripts. Download links point to GitHub Releases, which is operated by GitHub under its own privacy statement.",
+  },
+  {
+    title: "Verify it",
+    body: "Claims like these are only worth something if you can check them. The entire codebase is public: read the source or search it for network calls yourself.",
+  },
+];
 ---
 
 <Base
@@ -8,79 +35,36 @@ import { REPO_LINKS } from "../config";
   description="How RDB handles your data: no account, no telemetry, credentials in your OS keychain, and a single optional update check you can turn off."
   path="/privacy"
 >
-  <section class="mx-auto max-w-3xl px-4 pt-16 pb-20 sm:px-6">
-    <h1 class="font-display text-4xl font-semibold tracking-tight sm:text-5xl">Privacy</h1>
-    <p class="mt-4 text-lg leading-relaxed text-fg-2">
-      RDB is a local desktop application. This page describes everything it
-      does with your data. It is short because there is not much to describe.
-    </p>
+  <section class="page-hero">
+    <div class="page-hero-inner">
+      <p class="page-kicker">Local-first privacy</p>
+      <h1 class="page-title">Privacy</h1>
+      <p class="page-lede">
+        RDB is a local desktop application. This page describes everything it
+        does with your data. It is short because there is not much to describe.
+      </p>
+    </div>
+  </section>
 
-    <div class="prose-rdb mt-10 space-y-8 text-sm leading-relaxed text-fg-2">
-      <section>
-        <h2 class="font-display text-xl font-semibold text-fg">No account, no tracking</h2>
-        <p class="mt-2">
-          RDB requires no sign-up and has no cloud backend. It contains no
-          analytics, no usage tracking, and no crash reporting. The
-          application works fully offline.
-        </p>
-      </section>
-
-      <section>
-        <h2 class="font-display text-xl font-semibold text-fg">Your queries and data</h2>
-        <p class="mt-2">
-          Queries travel directly between the application and the database
-          servers you configure, using each engine's native protocol. Query
-          text, results, and schema information are never sent to any other
-          party.
-        </p>
-      </section>
-
-      <section>
-        <h2 class="font-display text-xl font-semibold text-fg">Credentials</h2>
-        <p class="mt-2">
-          Connection passwords are stored in your operating system's secret
-          store: Keychain on macOS, libsecret on Linux, Credential Manager on
-          Windows. On systems without a keychain, they fall back to a local
-          file encrypted with AES-GCM. Saved connection metadata (host, port,
-          username) is stored as plain JSON on your machine; passwords are
-          never written to it and never included in connection exports.
-        </p>
-      </section>
-
-      <section>
-        <h2 class="font-display text-xl font-semibold text-fg">The one network call</h2>
-        <p class="mt-2">
-          At most once a day, RDB makes a single HTTPS request to the GitHub
-          Releases API to check whether a newer version exists. No identifier
-          or usage data is attached; it is a plain HTTP GET. You can disable
-          this check in Settings, and the app never downloads or installs
-          updates by itself.
-        </p>
-      </section>
-
-      <section>
-        <h2 class="font-display text-xl font-semibold text-fg">This website</h2>
-        <p class="mt-2">
-          This site is static files. It sets no cookies, runs no analytics,
-          and embeds no third-party scripts. Download links point to GitHub
-          Releases, which is operated by GitHub under
-          <a
-            href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement"
-            rel="noopener"
-            class="underline decoration-line underline-offset-4 hover:text-fg">GitHub's privacy statement</a
-          >.
-        </p>
-      </section>
-
-      <section>
-        <h2 class="font-display text-xl font-semibold text-fg">Verify it</h2>
-        <p class="mt-2">
-          Claims like these are only worth something if you can check them.
-          The entire codebase is public:
-          <a href={REPO_LINKS.readme} rel="noopener" class="underline decoration-line underline-offset-4 hover:text-fg">read the source</a>
-          or search it for network calls yourself.
-        </p>
-      </section>
+  <section class="page-section light">
+    <div class="section-inner wide">
+      <div class="card-grid three">
+        {
+          sections.map((section) => (
+            <article class="card">
+              <h2>{section.title}</h2>
+              <p>{section.body}</p>
+            </article>
+          ))
+        }
+      </div>
+      <p class="page-note">
+        GitHub Releases is covered by
+        <a
+          href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement"
+          rel="noopener">GitHub's privacy statement</a
+        >. You can also <a href={REPO_LINKS.readme} rel="noopener">read the source</a>.
+      </p>
     </div>
   </section>
 </Base>

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -2,28 +2,28 @@
 
 /*
   RDB design tokens. One dark theme, locked for the whole site.
-  Accent is the product's brand green (see assets/brand/logo-mark.svg).
-  Radius rule: interactive elements 8px, panels/media 12px. Nothing else.
+  Homepage uses the Open Design direction: ink, paper, blue, and native app
+  screenshots as the primary visual asset.
 */
 @theme {
   --font-display: "Space Grotesk Variable", "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
   --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 
-  --color-ink: #0a0a0a; /* page background */
-  --color-panel: #121212; /* elevated surface */
-  --color-panel-2: #181818; /* hover surface */
-  --color-line: #262626; /* border */
-  --color-line-2: #333333; /* border hover */
-  --color-fg: #ededed; /* primary text */
-  --color-fg-2: #a6a6a6; /* secondary text */
-  --color-fg-3: #8f8f8f; /* muted text; 5.5:1+ on ink and panel (WCAG AA) */
-  --color-accent: #4ade80; /* brand green */
-  --color-accent-soft: #86efac; /* accent hover / links */
-  --color-accent-ink: #05230f; /* text on accent surfaces */
+  --color-ink: #07090d; /* page background */
+  --color-panel: #141925; /* elevated surface */
+  --color-panel-2: #1b2230; /* hover surface */
+  --color-line: #2b3343; /* border */
+  --color-line-2: #3b4659; /* border hover */
+  --color-fg: #f5f7fb; /* primary text */
+  --color-fg-2: #aab4c5; /* secondary text */
+  --color-fg-3: #79869a; /* muted text */
+  --color-accent: #5d83ff; /* brand blue */
+  --color-accent-soft: #8ba7ff; /* accent hover / links */
+  --color-accent-ink: #ffffff; /* text on accent surfaces */
   --color-warn: #fbbf24;
   --color-error: #f87171;
-  --color-code: #101010; /* code background */
+  --color-code: #0d1119; /* code background */
 
   --ease-swift: cubic-bezier(0.16, 1, 0.3, 1);
 }
@@ -50,6 +50,8 @@ body {
   font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+  overflow-x: hidden;
+  letter-spacing: 0;
 }
 
 ::selection {
@@ -58,8 +60,8 @@ body {
 }
 
 :focus-visible {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
+  outline: 2px solid var(--color-accent-soft);
+  outline-offset: 4px;
   border-radius: 2px;
 }
 
@@ -80,6 +82,2006 @@ body {
   top: 1rem;
 }
 
+.home-container {
+  width: min(100% - 40px, 1320px);
+  margin-inline: auto;
+}
+
+.screenshot-frame {
+  overflow: hidden;
+  border: 1px solid var(--color-line);
+  border-radius: 8px;
+  background: #0a0d13;
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-frame.is-chrome {
+  padding: 10px;
+}
+
+.screenshot-frame img {
+  border: 1px solid #222938;
+}
+
+.screenshot-bar {
+  min-height: 42px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 0 14px;
+  color: #7f8ba0;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+}
+
+.screenshot-status {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  color: #55d991;
+}
+
+.screenshot-status i {
+  width: 7px;
+  height: 7px;
+  display: block;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.engine-mini-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.engine-mini-item {
+  min-height: 42px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 14px;
+  border: 1px solid #d8dee8;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #111722;
+}
+
+.engine-mini-icon {
+  width: 18px;
+  height: 18px;
+  flex: none;
+  fill: #59667a;
+}
+
+.engine-mini-item p:first-child {
+  color: #111722;
+}
+
+.engine-mini-item p:last-child {
+  color: #59667a;
+}
+
+.engine-mini-note {
+  margin-top: 14px;
+  color: #59667a;
+  font-size: 0.9rem;
+}
+
+.engine-mini-note a {
+  color: #2e5ee8;
+  text-decoration: underline;
+  text-decoration-color: #cbd3df;
+  text-underline-offset: 4px;
+}
+
+.mono {
+  font-family: var(--font-mono);
+}
+
+.site-footer {
+  border-top: 1px solid var(--color-line);
+  background: #0d1119;
+}
+
+.footer-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) repeat(3, minmax(0, 0.55fr));
+  gap: 48px;
+}
+
+.footer-badge {
+  min-height: 36px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 18px;
+  padding: 0 12px;
+  border: 1px solid var(--color-line);
+  border-radius: 6px;
+  color: var(--color-fg-3);
+  font-size: 0.88rem;
+  text-decoration: none;
+  transition:
+    border-color 180ms ease,
+    color 180ms ease;
+}
+
+.footer-badge:hover,
+.footer-link:hover {
+  border-color: var(--color-line-2);
+  color: var(--color-fg);
+}
+
+.footer-link {
+  color: var(--color-fg-2);
+  font-size: 0.9rem;
+  text-decoration: none;
+  transition: color 180ms ease;
+}
+
+.footer-bottom {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  margin-top: 72px;
+  padding-top: 24px;
+  border-top: 1px solid var(--color-line);
+  color: var(--color-fg-3);
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+}
+
+.page-hero {
+  position: relative;
+  padding: 104px 0 64px;
+  overflow: hidden;
+}
+
+.page-hero::after {
+  content: "";
+  position: absolute;
+  top: 88px;
+  right: -12vw;
+  width: 42vw;
+  height: 1px;
+  background: var(--color-accent);
+  transform: rotate(-24deg);
+  opacity: 0.5;
+}
+
+.page-hero-inner {
+  position: relative;
+  z-index: 1;
+  width: min(100% - 40px, 980px);
+  margin-inline: auto;
+}
+
+.page-hero-inner.wide {
+  width: min(100% - 40px, 1320px);
+}
+
+.page-kicker {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 0 18px;
+  color: #55d991;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+}
+
+.page-kicker::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.page-title {
+  max-width: 12ch;
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(3.2rem, 8vw, 7rem);
+  line-height: 0.92;
+  font-weight: 550;
+  text-wrap: balance;
+}
+
+.page-title.wide {
+  max-width: 15ch;
+}
+
+.page-lede {
+  max-width: 58ch;
+  margin: 24px 0 0;
+  color: var(--color-fg-2);
+  font-size: 1.08rem;
+  line-height: 1.68;
+}
+
+.page-note {
+  margin-top: 12px;
+  color: var(--color-fg-3);
+  font-size: 0.9rem;
+}
+
+.page-note a,
+.page-lede a {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: var(--color-line-2);
+  text-underline-offset: 4px;
+}
+
+.page-section.light .page-note a,
+.page-section.light .page-lede a {
+  color: #2e5ee8;
+  text-decoration-color: #cbd3df;
+}
+
+.page-section {
+  border-top: 1px solid var(--color-line);
+}
+
+.page-section.light {
+  background: #f5f7fb;
+  color: #111722;
+}
+
+.page-section.panel {
+  background: #0d1119;
+}
+
+.section-inner {
+  width: min(100% - 40px, 980px);
+  margin-inline: auto;
+  padding: 72px 0;
+}
+
+.section-inner.wide {
+  width: min(100% - 40px, 1320px);
+}
+
+.section-grid {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  gap: 64px;
+  align-items: start;
+}
+
+.section-grid > .page-note {
+  grid-column: 2;
+}
+
+.section-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 4vw, 3.6rem);
+  line-height: 1;
+  font-weight: 540;
+  text-wrap: balance;
+}
+
+.section-subtitle {
+  margin-top: 12px;
+  color: var(--color-fg-3);
+  font-size: 0.92rem;
+}
+
+.page-section.light .section-subtitle,
+.page-section.light .page-note,
+.page-section.light .card p,
+.page-section.light .card dd,
+.page-section.light .text-fg-2,
+.page-section.light .text-fg-3 {
+  color: #59667a;
+}
+
+.card-grid {
+  display: grid;
+  gap: 14px;
+}
+
+.card-grid.two {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.card-grid.three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.card {
+  border: 1px solid var(--color-line);
+  border-radius: 8px;
+  background: var(--color-panel);
+  padding: 22px;
+}
+
+.page-section.light .card {
+  border-color: #d8dee8;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.card h2,
+.card h3,
+.card dt {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: 560;
+}
+
+.card p,
+.card dd {
+  margin: 8px 0 0;
+  color: var(--color-fg-2);
+  font-size: 0.92rem;
+  line-height: 1.6;
+}
+
+.link-list {
+  display: grid;
+  margin-top: 8px;
+}
+
+.link-row {
+  min-height: 62px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  border-bottom: 1px solid var(--color-line);
+  color: var(--color-fg);
+  text-decoration: none;
+  transition:
+    color 180ms ease,
+    padding 180ms var(--ease-swift);
+}
+
+.link-row:hover {
+  padding-inline: 8px;
+  color: var(--color-accent-soft);
+}
+
+.link-row span {
+  color: var(--color-fg-3);
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+}
+
+.page-section.light .link-row {
+  border-bottom-color: #cbd3df;
+  color: #111722;
+}
+
+.page-section.light .link-row span {
+  color: #59667a;
+}
+
+.timeline-list {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.timeline-list li {
+  display: grid;
+  grid-template-columns: 54px minmax(0, 1fr);
+  gap: 18px;
+  padding: 24px 0;
+  border-top: 1px solid var(--color-line);
+}
+
+.timeline-list li:last-child {
+  border-bottom: 1px solid var(--color-line);
+}
+
+.timeline-list > li > span {
+  color: var(--color-accent-soft);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+}
+
+.timeline-list h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.2rem;
+  font-weight: 540;
+}
+
+.timeline-list p {
+  margin: 8px 0 0;
+  color: var(--color-fg-2);
+  font-size: 0.94rem;
+  line-height: 1.65;
+}
+
+.mini-code {
+  margin: 0;
+  overflow-x: auto;
+  border: 1px solid var(--color-line);
+  border-radius: 6px;
+  background: var(--color-code);
+  padding: 12px 14px;
+  color: var(--color-fg-2);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  line-height: 1.65;
+  white-space: pre-wrap;
+}
+
+.page-section.light .mini-code {
+  border-color: #d8dee8;
+  background: #fff;
+  color: #4d5b70;
+}
+
+.token-list {
+  display: grid;
+  gap: 8px;
+  margin: 16px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.token-list li {
+  border: 1px solid var(--color-line);
+  border-radius: 6px;
+  background: var(--color-code);
+  padding: 9px 10px;
+  color: var(--color-fg-2);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+}
+
+.release-card {
+  display: grid;
+  grid-template-columns: 180px minmax(0, 1fr);
+  gap: 32px;
+  padding: 36px 0;
+  border-top: 1px solid var(--color-line);
+}
+
+.release-card:last-of-type {
+  border-bottom: 1px solid var(--color-line);
+}
+
+.release-card header {
+  position: sticky;
+  top: 96px;
+  align-self: start;
+}
+
+.release-card h2 {
+  margin: 12px 0 0;
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 4vw, 3.6rem);
+  line-height: 1;
+  font-weight: 540;
+}
+
+.release-card time {
+  display: block;
+  margin-top: 12px;
+  color: var(--color-fg-3);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+}
+
+.release-section {
+  padding: 0 0 28px;
+}
+
+.release-section + .release-section {
+  padding-top: 28px;
+  border-top: 1px solid var(--color-line);
+}
+
+.release-section h3 {
+  margin: 0 0 12px;
+  color: var(--color-fg);
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  font-weight: 560;
+}
+
+.release-section ul {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.release-section li {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  color: var(--color-fg-2);
+  font-size: 0.92rem;
+  line-height: 1.6;
+}
+
+.release-section code {
+  flex: none;
+  border: 1px solid var(--color-line);
+  border-radius: 4px;
+  padding: 1px 5px;
+  color: var(--color-fg-3);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+}
+
+.crate-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  border-top: 1px solid #cbd3df;
+}
+
+.crate-list li {
+  display: grid;
+  grid-template-columns: minmax(0, 0.45fr) minmax(0, 1fr);
+  gap: 12px;
+  padding: 14px 0;
+  border-bottom: 1px solid #cbd3df;
+}
+
+.crate-list code {
+  color: #2e5ee8;
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+}
+
+.crate-list span {
+  color: #59667a;
+  font-size: 0.84rem;
+}
+
+.legal-text {
+  margin: 0;
+  max-height: 72vh;
+  overflow: auto;
+  border: 1px solid var(--color-line);
+  border-radius: 8px;
+  background: var(--color-code);
+  padding: 28px;
+  color: var(--color-fg-2);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  line-height: 1.75;
+  white-space: pre-wrap;
+}
+
+.not-found-page {
+  min-height: 72dvh;
+  display: grid;
+  align-items: center;
+  padding: 80px 0;
+}
+
+.query-error-card {
+  max-width: 780px;
+  border-top: 1px solid var(--color-line);
+  border-bottom: 1px solid var(--color-line);
+  padding: 48px 0;
+}
+
+.command-block {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border: 1px solid var(--color-line);
+  border-radius: 6px;
+  background: var(--color-code);
+  padding: 12px 14px;
+}
+
+.command-block code {
+  min-width: 0;
+  flex: 1;
+  overflow-x: auto;
+  color: var(--color-fg-2);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  white-space: nowrap;
+}
+
+.command-block .copy-btn {
+  flex: none;
+  border: 1px solid var(--color-line);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-fg-2);
+  padding: 6px 10px;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  transition:
+    border-color 180ms ease,
+    color 180ms ease;
+}
+
+.command-block .copy-btn:hover {
+  border-color: var(--color-line-2);
+  color: var(--color-fg);
+}
+
+.download-list {
+  display: grid;
+  gap: 18px;
+}
+
+.download-platform {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.48fr) minmax(0, 1fr);
+  gap: 40px;
+  padding: 36px 0;
+  border-top: 1px solid #cbd3df;
+}
+
+.download-platform:last-child {
+  border-bottom: 1px solid #cbd3df;
+}
+
+.download-platform[data-detected] {
+  border-top-color: var(--color-accent);
+}
+
+.platform-summary h2 {
+  margin: 14px 0 0;
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 4vw, 4rem);
+  line-height: 1;
+}
+
+.platform-summary p {
+  max-width: 40ch;
+  margin: 16px 0 22px;
+  color: #59667a;
+}
+
+.detected-badge {
+  display: inline-flex;
+  margin-bottom: 18px;
+  padding: 6px 9px;
+  border: 1px solid var(--color-accent);
+  border-radius: 4px;
+  color: #2e5ee8;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+}
+
+.asset-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.asset-list li {
+  min-height: 64px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 14px;
+  border-bottom: 1px solid #d8dee8;
+}
+
+.asset-download {
+  min-height: 36px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 12px;
+  border-radius: 6px;
+  background: var(--color-accent);
+  color: #fff;
+  font-size: 0.88rem;
+  font-weight: 650;
+  text-decoration: none;
+}
+
+.asset-download:hover {
+  background: #2e5ee8;
+}
+
+.asset-list code,
+.asset-list small,
+.sha-btn {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+}
+
+.asset-list code {
+  padding: 3px 6px;
+  border: 1px solid #d8dee8;
+  border-radius: 4px;
+  color: #59667a;
+}
+
+.asset-list small {
+  color: #59667a;
+}
+
+.sha-btn {
+  border: 1px solid #d8dee8;
+  border-radius: 6px;
+  background: transparent;
+  color: #59667a;
+  padding: 6px 8px;
+  cursor: pointer;
+}
+
+.sha-btn:hover {
+  border-color: var(--color-accent);
+  color: #2e5ee8;
+}
+
+.home-button {
+  min-height: 48px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 0 18px;
+  border: 1px solid var(--color-line);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-fg);
+  text-decoration: none;
+  font-weight: 650;
+  transition:
+    transform 180ms var(--ease-swift),
+    border-color 180ms ease,
+    background 180ms ease,
+    color 180ms ease;
+}
+
+.home-button:hover {
+  border-color: var(--color-accent);
+  background: var(--color-panel);
+}
+
+.home-button:active {
+  transform: translateY(1px);
+}
+
+.home-button.primary {
+  border-color: var(--color-accent);
+  background: var(--color-accent);
+  color: #fff;
+}
+
+.home-button.primary:hover {
+  border-color: var(--color-accent-soft);
+  background: #2e5ee8;
+}
+
+.home-actions,
+.closing-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 30px;
+}
+
+.home-hero {
+  position: relative;
+  min-height: 960px;
+  padding: 150px 0 96px;
+  overflow: hidden;
+}
+
+.home-hero::before {
+  content: "";
+  position: absolute;
+  top: 118px;
+  right: -8vw;
+  width: 42vw;
+  height: 1px;
+  background: var(--color-accent);
+  transform: rotate(-24deg);
+  transform-origin: right;
+  opacity: 0.55;
+}
+
+.home-hero::after {
+  content: "";
+  position: absolute;
+  top: 118px;
+  right: 12vw;
+  width: 1px;
+  height: 42vw;
+  background: var(--color-line);
+  transform: rotate(24deg);
+  transform-origin: top;
+}
+
+.hero-intro {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(300px, 0.55fr);
+  gap: 64px;
+  align-items: end;
+}
+
+.hero-kicker {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 0 0 28px;
+  color: #55d991;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+}
+
+.hero-kicker i {
+  width: 8px;
+  height: 8px;
+  display: block;
+  background: currentColor;
+  border-radius: 50%;
+  box-shadow: 0 0 0 6px rgba(85, 217, 145, 0.12);
+  animation: status-pulse 2s ease-in-out infinite;
+}
+
+.hero-intro h1 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(7rem, 17vw, 15rem);
+  line-height: 0.72;
+  font-weight: 620;
+  letter-spacing: 0;
+}
+
+.hero-intro h1 span {
+  color: var(--color-accent);
+}
+
+.hero-copy {
+  padding-bottom: 10px;
+}
+
+.hero-copy h2 {
+  max-width: 14ch;
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 3.8vw, 4.2rem);
+  line-height: 1.03;
+  font-weight: 520;
+  text-wrap: balance;
+  letter-spacing: 0;
+}
+
+.hero-copy p {
+  max-width: 48ch;
+  margin: 24px 0 0;
+  color: #9ca8bb;
+  font-size: 1.08rem;
+  line-height: 1.65;
+}
+
+.release-line {
+  margin-top: 16px;
+  color: #79869a;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+}
+
+.query-pulse {
+  position: relative;
+  z-index: 2;
+  margin-top: 88px;
+  border-top: 1px solid var(--color-line);
+  border-bottom: 1px solid var(--color-line);
+  background: rgba(13, 17, 25, 0.82);
+}
+
+.query-inner {
+  min-height: 112px;
+  display: grid;
+  grid-template-columns: 160px minmax(0, 1fr) 110px;
+  align-items: center;
+  gap: 24px;
+}
+
+.query-label,
+.query-state {
+  color: #718097;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+}
+
+.query-state {
+  color: #55d991;
+  text-align: right;
+}
+
+.query-line {
+  min-width: 0;
+  margin: 0;
+  color: #c9d2e0;
+  font-family: var(--font-mono);
+  font-size: clamp(0.84rem, 1.6vw, 1.1rem);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: opacity 160ms ease;
+}
+
+.query-line .keyword,
+.driver-code .keyword {
+  color: var(--color-accent-soft);
+}
+
+.query-line .cursor {
+  display: inline-block;
+  width: 8px;
+  height: 1.1em;
+  margin-left: 4px;
+  vertical-align: -2px;
+  background: var(--color-accent);
+  animation: blink 850ms steps(1, end) infinite;
+}
+
+.query-progress {
+  position: absolute;
+  left: 0;
+  bottom: -1px;
+  width: 100%;
+  height: 1px;
+  background: var(--color-accent);
+  transform: scaleX(0);
+  transform-origin: left;
+  animation: query-progress 4s linear infinite;
+}
+
+.workspace-hero {
+  position: relative;
+  z-index: 2;
+  width: min(1500px, calc(100% - 24px));
+  margin: 40px auto 0;
+}
+
+.float-note {
+  position: absolute;
+  right: 4%;
+  bottom: 7%;
+  max-width: 240px;
+  padding: 14px 16px;
+  border: 1px solid #3b4659;
+  border-radius: 6px;
+  background: #0d1119;
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.44);
+  color: #cad2df;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  animation: note-float 4s var(--ease-swift) infinite;
+}
+
+.float-note span {
+  display: block;
+  color: #55d991;
+  margin-bottom: 5px;
+}
+
+.engine-stream,
+.download-panel {
+  padding: 88px 0 112px;
+  background: #f5f7fb;
+  color: #111722;
+  overflow: hidden;
+}
+
+.stream-head,
+.download-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 32px;
+}
+
+.stream-head h2,
+.download-head h2 {
+  max-width: 15ch;
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(2.6rem, 6vw, 6.2rem);
+  line-height: 0.95;
+  font-weight: 550;
+  text-wrap: balance;
+}
+
+.stream-head p,
+.download-head p {
+  max-width: 45ch;
+  margin: 0;
+  color: #59667a;
+}
+
+.engine-loop {
+  display: flex;
+  width: max-content;
+  margin-top: 64px;
+  animation: engine-drift 32s linear infinite;
+}
+
+.engine-loop:hover,
+.engine-loop:focus-within {
+  animation-play-state: paused;
+}
+
+.engine-set {
+  display: flex;
+  gap: 10px;
+  padding-right: 10px;
+}
+
+.engine-chip {
+  min-height: 54px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 22px;
+  border: 1px solid #cfd6e0;
+  border-radius: 999px;
+  background: #fff;
+  color: #111722;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background 180ms ease,
+    color 180ms ease,
+    border-color 180ms ease,
+    transform 180ms var(--ease-swift);
+}
+
+.engine-chip::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  flex: none;
+  border-radius: 50%;
+  background: #a9b2c0;
+}
+
+.engine-chip:hover,
+.engine-chip:focus-visible {
+  border-color: var(--color-accent);
+  transform: translateY(-2px);
+}
+
+.engine-chip[aria-pressed="true"] {
+  border-color: var(--color-accent);
+  background: var(--color-accent);
+  color: #fff;
+}
+
+.engine-chip[aria-pressed="true"]::before {
+  background: #fff;
+}
+
+.engine-readout {
+  min-height: 180px;
+  display: grid;
+  grid-template-columns: 150px minmax(220px, 0.55fr) minmax(0, 1fr);
+  gap: 32px;
+  align-items: start;
+  margin-top: 54px;
+  padding-top: 28px;
+  border-top: 1px solid #cfd6e0;
+}
+
+.engine-count,
+.latest {
+  color: #2e5ee8;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+}
+
+.engine-readout h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 4vw, 4.5rem);
+  line-height: 1;
+  font-weight: 560;
+}
+
+.engine-detail p {
+  max-width: 56ch;
+  margin: 0 0 24px;
+  color: #59667a;
+}
+
+.engine-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.engine-meta span {
+  display: block;
+  padding: 7px 10px;
+  border: 1px solid #d8dee8;
+  border-radius: 4px;
+  color: #4d5b70;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+}
+
+.engine-grid-wrap {
+  margin-top: 54px;
+}
+
+.flow,
+.open-source-home {
+  padding: 120px 0;
+  background: var(--color-ink);
+}
+
+.flow-heading {
+  max-width: 1050px;
+  margin-bottom: 72px;
+}
+
+.overline {
+  margin: 0 0 18px;
+  color: var(--color-accent-soft);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+}
+
+.flow-heading h2,
+.source-flow h2,
+.closing-line h2,
+.native-statement h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(3rem, 7vw, 7.2rem);
+  line-height: 0.92;
+  font-weight: 540;
+  text-wrap: balance;
+}
+
+.flow-heading h2 {
+  max-width: 17ch;
+}
+
+.flow-heading h2 em,
+.closing-line h2 em {
+  color: var(--color-accent);
+  font-style: normal;
+}
+
+.tour {
+  display: grid;
+  grid-template-columns: 270px minmax(0, 1fr);
+  gap: 48px;
+  align-items: start;
+}
+
+.tour-nav {
+  position: sticky;
+  top: 88px;
+  display: grid;
+}
+
+.tour-step {
+  position: relative;
+  min-height: 112px;
+  display: grid;
+  grid-template-columns: 38px 1fr;
+  gap: 14px;
+  padding: 20px 0;
+  border: 0;
+  border-top: 1px solid var(--color-line);
+  background: transparent;
+  color: #718097;
+  text-align: left;
+  cursor: pointer;
+}
+
+.tour-step:last-child {
+  border-bottom: 1px solid var(--color-line);
+}
+
+.tour-step small {
+  display: block;
+  padding-top: 3px;
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+}
+
+.tour-step strong {
+  display: block;
+  color: #8d99ab;
+  font-size: 1.12rem;
+  font-weight: 520;
+}
+
+.tour-step span {
+  display: block;
+  margin-top: 5px;
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
+.tour-step::after {
+  content: "";
+  position: absolute;
+  top: -1px;
+  left: 0;
+  width: 100%;
+  height: 1px;
+  background: var(--color-accent);
+  transform: scaleX(0);
+  transform-origin: left;
+}
+
+.tour-step[aria-pressed="true"] {
+  color: #b4becd;
+}
+
+.tour-step[aria-pressed="true"] strong {
+  color: #fff;
+}
+
+.tour-step[aria-pressed="true"]::after {
+  animation: step-progress 6s linear forwards;
+}
+
+.tour-frame {
+  position: relative;
+  padding: 8px;
+  border: 1px solid #30394a;
+  border-radius: 8px;
+  background: #0a0d13;
+}
+
+.tour-frame img {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1280 / 800;
+  border: 1px solid #222938;
+  opacity: 1;
+  transform: scale(1);
+  transition:
+    opacity 150ms ease,
+    transform 360ms var(--ease-swift);
+}
+
+.tour-frame img.is-switching {
+  opacity: 0.15;
+  transform: scale(0.985);
+}
+
+.tour-caption {
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 0 8px;
+  border-bottom: 1px solid var(--color-line);
+  color: #9ca8bb;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+}
+
+.tour-caption strong {
+  color: #fff;
+  font-weight: 500;
+}
+
+.result-river {
+  display: flex;
+  gap: 1px;
+  margin-top: 64px;
+  overflow: hidden;
+  border-block: 1px solid #1b2230;
+}
+
+.result-cell {
+  min-width: 180px;
+  flex: 1;
+  padding: 18px 22px;
+  border-right: 1px solid #1b2230;
+  font-family: var(--font-mono);
+}
+
+.result-cell small {
+  display: block;
+  color: #657389;
+  font-size: 0.62rem;
+  text-transform: uppercase;
+}
+
+.result-cell span {
+  display: block;
+  margin-top: 6px;
+  color: #bac4d3;
+  font-size: 0.78rem;
+}
+
+.result-river.is-pulsing .result-cell {
+  animation: row-arrive 360ms var(--ease-swift) both;
+}
+
+.result-river.is-pulsing .result-cell:nth-child(2) {
+  animation-delay: 40ms;
+}
+
+.result-river.is-pulsing .result-cell:nth-child(3) {
+  animation-delay: 80ms;
+}
+
+.result-river.is-pulsing .result-cell:nth-child(4) {
+  animation-delay: 120ms;
+}
+
+.result-river.is-pulsing .result-cell:nth-child(5) {
+  animation-delay: 160ms;
+}
+
+.native-band {
+  padding: 112px 0;
+  background: var(--color-accent);
+  color: #fff;
+}
+
+.native-statement,
+.source-flow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.45fr);
+  gap: 72px;
+  align-items: end;
+}
+
+.native-statement h2 {
+  max-width: 12ch;
+  font-size: clamp(3.4rem, 8vw, 8rem);
+  line-height: 0.88;
+  font-weight: 560;
+}
+
+.native-copy {
+  padding-bottom: 8px;
+}
+
+.native-copy p {
+  max-width: 46ch;
+  margin: 0 0 28px;
+  font-size: 1.08rem;
+}
+
+.native-points {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.42);
+}
+
+.native-points li {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.42);
+  font-weight: 560;
+}
+
+.download-head {
+  margin-bottom: 64px;
+}
+
+.install-surface {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.65fr) minmax(0, 1fr);
+  border-block: 1px solid #cbd3df;
+}
+
+.platform-copy {
+  padding: 48px 48px 48px 0;
+  border-right: 1px solid #cbd3df;
+}
+
+.platform-copy h3 {
+  margin: 18px 0 0;
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 4vw, 4rem);
+  line-height: 1;
+}
+
+.platform-copy p {
+  max-width: 44ch;
+  margin: 20px 0 0;
+  color: #59667a;
+}
+
+.platform-picker {
+  display: flex;
+  margin-top: 32px;
+  border: 1px solid #b9c3d1;
+  border-radius: 6px;
+}
+
+.platform-button {
+  min-height: 48px;
+  flex: 1;
+  border: 0;
+  border-right: 1px solid #b9c3d1;
+  background: transparent;
+  color: #59667a;
+  cursor: pointer;
+}
+
+.platform-button:last-child {
+  border-right: 0;
+}
+
+.platform-button[aria-pressed="true"] {
+  background: #111722;
+  color: #fff;
+  font-weight: 650;
+}
+
+.download-action {
+  width: 100%;
+  margin-top: 20px;
+}
+
+.install-terminal {
+  min-width: 0;
+  padding: 48px 0 48px 48px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.terminal-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid #cbd3df;
+  color: #6b7789;
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+}
+
+.terminal-command {
+  margin: 64px 0 24px;
+  color: #2e5ee8;
+  font-family: var(--font-mono);
+  font-size: clamp(0.9rem, 1.6vw, 1.08rem);
+  overflow-wrap: anywhere;
+}
+
+.copy-button {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  width: max-content;
+  padding: 0 14px;
+  border: 1px solid #aeb9c8;
+  border-radius: 6px;
+  background: transparent;
+  color: #111722;
+  cursor: pointer;
+}
+
+.copy-button:hover {
+  border-color: var(--color-accent);
+  color: #2e5ee8;
+}
+
+.terminal-note {
+  margin: 56px 0 0;
+  color: #6b7789;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+}
+
+.open-source-home {
+  padding-bottom: 80px;
+}
+
+.source-flow {
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.72fr);
+  gap: 80px;
+  align-items: start;
+}
+
+.source-flow h2 {
+  max-width: 12ch;
+  font-size: clamp(3rem, 6vw, 6rem);
+  line-height: 0.94;
+}
+
+.source-flow p {
+  max-width: 55ch;
+  margin: 26px 0 0;
+  color: #9ca8bb;
+}
+
+.driver-code {
+  margin: 0;
+  padding: 28px 0;
+  border-block: 1px solid var(--color-line);
+  color: #b8c3d3;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  line-height: 1.9;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.driver-code .type {
+  color: #55d991;
+}
+
+.source-links {
+  display: grid;
+  margin-top: 8px;
+}
+
+.source-link {
+  min-height: 62px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  border-bottom: 1px solid var(--color-line);
+  color: #cad3df;
+  text-decoration: none;
+  transition:
+    color 180ms ease,
+    padding 180ms var(--ease-swift);
+}
+
+.source-link:hover {
+  padding-inline: 8px;
+  color: var(--color-accent-soft);
+}
+
+.source-link span {
+  color: #6e7c91;
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+}
+
+.closing-line {
+  margin-top: 112px;
+  padding-top: 48px;
+  border-top: 1px solid var(--color-line);
+}
+
+.closing-line h2 {
+  max-width: 14ch;
+}
+
+[data-reveal] {
+  opacity: 0;
+  transition:
+    opacity 520ms var(--ease-swift),
+    transform 520ms var(--ease-swift);
+}
+
+[data-reveal="up"] {
+  transform: translateY(34px);
+}
+
+[data-reveal="left"] {
+  transform: translateX(-34px);
+}
+
+[data-reveal="right"] {
+  transform: translateX(34px);
+}
+
+[data-reveal].is-visible {
+  opacity: 1;
+  transform: none;
+}
+
+@keyframes status-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 5px rgba(85, 217, 145, 0.1);
+  }
+  50% {
+    box-shadow: 0 0 0 10px rgba(85, 217, 145, 0);
+  }
+}
+
+@keyframes blink {
+  0%,
+  48% {
+    opacity: 1;
+  }
+  49%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes query-progress {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@keyframes note-float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-8px);
+  }
+}
+
+@keyframes engine-drift {
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+@keyframes step-progress {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@keyframes row-arrive {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (max-width: 1023px) {
+  .footer-grid,
+  .section-grid,
+  .download-platform,
+  .release-card {
+    grid-template-columns: 1fr;
+  }
+  .section-grid > .page-note {
+    grid-column: auto;
+  }
+  .release-card header {
+    position: static;
+  }
+  .card-grid.three,
+  .crate-list {
+    grid-template-columns: 1fr;
+  }
+  .asset-list li {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+  }
+  .asset-list small,
+  .sha-btn {
+    grid-column: 2 / -1;
+    justify-self: start;
+  }
+  .home-hero {
+    min-height: 0;
+  }
+  .hero-intro,
+  .native-statement,
+  .source-flow {
+    grid-template-columns: 1fr;
+  }
+  .hero-copy {
+    max-width: 620px;
+  }
+  .stream-head,
+  .download-head {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+  .engine-readout {
+    grid-template-columns: 100px minmax(190px, 0.45fr) minmax(0, 1fr);
+  }
+  .tour {
+    grid-template-columns: 220px minmax(0, 1fr);
+    gap: 28px;
+  }
+  .install-surface {
+    grid-template-columns: 1fr;
+  }
+  .platform-copy {
+    padding-right: 0;
+    border-right: 0;
+    border-bottom: 1px solid #cbd3df;
+  }
+  .install-terminal {
+    padding-left: 0;
+  }
+}
+
+@media (max-width: 767px) {
+  .home-container {
+    width: min(100% - 24px, 1320px);
+  }
+  .page-hero {
+    padding: 80px 0 48px;
+  }
+  .page-hero::after {
+    display: none;
+  }
+  .page-hero-inner,
+  .page-hero-inner.wide,
+  .section-inner,
+  .section-inner.wide {
+    width: min(100% - 24px, 1320px);
+  }
+  .page-title {
+    font-size: 3.2rem;
+  }
+  .section-inner {
+    padding: 56px 0;
+  }
+  .section-grid {
+    gap: 32px;
+  }
+  .card-grid.two {
+    grid-template-columns: 1fr;
+  }
+  .footer-bottom {
+    flex-direction: column;
+    margin-top: 56px;
+  }
+  .screenshot-frame.is-chrome {
+    padding: 5px;
+  }
+  .screenshot-bar {
+    min-height: 36px;
+    font-size: 0.56rem;
+  }
+  .screenshot-bar > span:first-child {
+    display: none;
+  }
+  .download-platform {
+    gap: 28px;
+    padding: 30px 0;
+  }
+  .asset-list li {
+    grid-template-columns: 1fr;
+    align-items: start;
+    padding: 16px 0;
+  }
+  .asset-list small,
+  .sha-btn {
+    grid-column: auto;
+  }
+  .asset-download {
+    width: max-content;
+  }
+  .timeline-list li {
+    grid-template-columns: 1fr;
+  }
+  .release-card {
+    gap: 24px;
+    padding: 30px 0;
+  }
+  .crate-list li {
+    grid-template-columns: 1fr;
+  }
+  .legal-text {
+    padding: 18px;
+  }
+  .home-hero {
+    padding: 96px 0 72px;
+  }
+  .home-hero::before,
+  .home-hero::after {
+    display: none;
+  }
+  .hero-intro {
+    gap: 48px;
+  }
+  .hero-intro h1 {
+    font-size: clamp(6.8rem, 38vw, 10rem);
+  }
+  .hero-copy h2 {
+    font-size: 2.2rem;
+  }
+  .query-pulse {
+    margin-top: 56px;
+  }
+  .query-inner {
+    min-height: 128px;
+    grid-template-columns: 1fr auto;
+    gap: 10px 16px;
+    padding-block: 18px;
+  }
+  .query-line {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    overflow-wrap: anywhere;
+  }
+  .query-state {
+    grid-column: 2;
+    grid-row: 1;
+  }
+  .workspace-hero {
+    width: calc(100% - 12px);
+    margin-top: 24px;
+  }
+  .float-note {
+    display: none;
+  }
+  .engine-stream,
+  .flow,
+  .native-band,
+  .download-panel,
+  .open-source-home {
+    padding: 80px 0;
+  }
+  .stream-head h2,
+  .flow-heading h2,
+  .download-head h2,
+  .source-flow h2,
+  .closing-line h2 {
+    font-size: 3.2rem;
+  }
+  .engine-loop {
+    margin-top: 44px;
+    animation-duration: 26s;
+  }
+  .engine-chip {
+    min-height: 48px;
+    padding: 0 18px;
+  }
+  .engine-readout {
+    min-height: 0;
+    grid-template-columns: 1fr;
+    gap: 12px;
+    margin-top: 40px;
+  }
+  .engine-readout h3 {
+    font-size: 2.7rem;
+  }
+  .engine-detail {
+    margin-top: 8px;
+  }
+  .flow-heading {
+    margin-bottom: 44px;
+  }
+  .tour {
+    grid-template-columns: 1fr;
+  }
+  .tour-nav {
+    position: static;
+    display: flex;
+    gap: 8px;
+    overflow-x: auto;
+    padding-bottom: 4px;
+    scrollbar-width: none;
+  }
+  .tour-nav::-webkit-scrollbar {
+    display: none;
+  }
+  .tour-step {
+    min-width: 148px;
+    min-height: 88px;
+    grid-template-columns: 1fr;
+    gap: 2px;
+    padding: 14px;
+    border: 1px solid var(--color-line);
+    border-radius: 6px;
+  }
+  .tour-step:last-child {
+    border-bottom: 1px solid var(--color-line);
+  }
+  .tour-step small,
+  .tour-step span {
+    display: none;
+  }
+  .tour-step::after {
+    top: auto;
+    bottom: -1px;
+  }
+  .tour-caption {
+    min-height: 64px;
+  }
+  .tour-caption span:last-child {
+    display: none;
+  }
+  .result-river {
+    overflow-x: auto;
+  }
+  .result-cell {
+    flex: none;
+  }
+  .native-statement {
+    gap: 44px;
+  }
+  .native-statement h2 {
+    font-size: 4rem;
+  }
+  .download-head {
+    margin-bottom: 44px;
+  }
+  .platform-copy,
+  .install-terminal {
+    padding-block: 32px;
+  }
+  .terminal-command {
+    margin-top: 40px;
+  }
+  .source-flow {
+    gap: 52px;
+  }
+  .closing-line {
+    margin-top: 80px;
+  }
+}
+
+@media (max-width: 420px) {
+  .hero-intro h1 {
+    font-size: 6.8rem;
+  }
+  .stream-head h2,
+  .flow-heading h2,
+  .download-head h2,
+  .source-flow h2,
+  .closing-line h2 {
+    font-size: 2.75rem;
+  }
+  .home-actions {
+    display: grid;
+  }
+  .home-button {
+    width: 100%;
+  }
+  .platform-picker {
+    display: grid;
+  }
+  .platform-button {
+    border-right: 0;
+    border-bottom: 1px solid #b9c3d1;
+  }
+  .platform-button:last-child {
+    border-bottom: 0;
+  }
+  .terminal-top {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;
@@ -90,5 +2092,16 @@ body {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+  }
+  [data-reveal] {
+    opacity: 1;
+    transform: none;
+  }
+  .engine-loop {
+    animation: none;
+    transform: none;
+  }
+  .engine-set[aria-hidden="true"] {
+    display: none;
   }
 }


### PR DESCRIPTION
## Summary
- Modernize the marketing website design system and visual language with updated dark mode styling and typography.
- Improve layout structure, readability, and consistency across documentation, features, and platform download pages.

## Changes
- **Design system & Styles (`website/src/styles/global.css`)**:
  - Update color palette tokens with dark ink background and brand blue accent.
  - Establish unified typography rules using Space Grotesk and IBM Plex Mono.
- **Shared Components (`website/src/components/`)**:
  - Update header navigation bar, logo, and responsive mobile menu.
  - Refactor footer links, code blocks, and application screenshot framing.
- **Landing & Product Pages (`website/src/pages/`)**:
  - Redesign homepage hero, interactive previews, and feature showcases.
  - Modernize platform download options and technical specifications.
- **Documentation & Informational Pages (`website/src/pages/`)**:
  - Update layout and styling for docs, open-source crates overview, changelog, privacy, license, and 404 pages.

## Test plan
- [x] Run `npm run build` in `website/` (all 9 static pages built successfully without errors)
- [x] Run `npm test` in `website/` (verified page links, metadata, download URLs, and typography)