### PR TITLE
fix: unblock audit and website release data on develop

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -25,43 +25,59 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: rustsec/audit-check@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # All ignored advisories are transitive with no upgrade path from
-          # this workspace. Revisit when the pulling dependency bumps.
-          #   0194/0195 quick-xml   — wayland-scanner (winit), pinned 0.39
-          #   2024-0436 paste       — rav1e -> image (unmaintained proc-macro)
-          #   2026-0206 rustybuzz   — usvg -> resvg (unmaintained)
-          #   2026-0192 ttf-parser  — fontdb -> usvg (unmaintained)
-          #   2025-0141 bincode     — typed-index-collections (unmaintained)
-          #   2026-0235 rkyv        — rust_decimal optional dep, feature not
-          #                           enabled by driver-postgres, latest
-          #                           rust_decimal (1.42.1) still pulls it
-          #   2026-0098/0099/0104 rustls-webpki — tiberius (driver-mssql) ->
-          #                           tokio-rustls 0.24 -> rustls 0.21, whose
-          #                           own Cargo.toml pins webpki ^0.101; the
-          #                           patched 0.103.12+/0.104 releases are
-          #                           for the rustls 0.23 line only, so this
-          #                           can't be bumped without tiberius itself
-          #                           moving off tokio-rustls 0.24. Neither
-          #                           issue applies to how we use it: the
-          #                           name-constraint bugs need a misissued
-          #                           cert to already pass signature
-          #                           verification, and the CRL panic only
-          #                           affects code that parses CRLs, which
-          #                           this workspace never does. Revisit when
-          #                           tiberius bumps its rustls pin.
-          #   2025-0134 rustls-pemfile — tiberius (driver-mssql) -> pinned
-          #                           1.0.4; crate is unmaintained (archived
-          #                           upstream, no CVE), and tiberius 0.12.3
-          #                           (latest on crates.io) still depends on
-          #                           it directly. Revisit when tiberius
-          #                           bumps off it (upstream suggests
-          #                           rustls-pki-types' PemObject trait).
-          #   2023-0071 rsa          — russh-keys -> rsa 0.9 (Marvin attack
-          #                           timing sidechannel in RSA decryption)
-          #   2026-0154 russh        — russh 0.45 (unbounded 32-bit allocation
-          #                           in legacy stream parsing)
-          #   2026-0153 russh-cryptovec — russh-cryptovec 0.7.3
-          ignore: RUSTSEC-2026-0194,RUSTSEC-2026-0195,RUSTSEC-2024-0436,RUSTSEC-2026-0206,RUSTSEC-2026-0192,RUSTSEC-2025-0141,RUSTSEC-2026-0235,RUSTSEC-2026-0098,RUSTSEC-2026-0099,RUSTSEC-2026-0104,RUSTSEC-2025-0134,RUSTSEC-2023-0071,RUSTSEC-2026-0154,RUSTSEC-2026-0153
+      # cargo-audit as a prebuilt binary: installing it from source pulls the
+      # whole cargo-audit dependency tree into every run, so one broken
+      # upstream publish takes the workflow down with it.
+      - uses: taiki-e/install-action@cargo-audit
+      # All ignored advisories are transitive with no upgrade path from
+      # this workspace. Revisit when the pulling dependency bumps.
+      #   0194/0195 quick-xml   — wayland-scanner (winit), pinned 0.39
+      #   2024-0436 paste       — rav1e -> image (unmaintained proc-macro)
+      #   2026-0206 rustybuzz   — usvg -> resvg (unmaintained)
+      #   2026-0192 ttf-parser  — fontdb -> usvg (unmaintained)
+      #   2025-0141 bincode     — typed-index-collections (unmaintained)
+      #   2026-0235 rkyv        — rust_decimal optional dep, feature not
+      #                           enabled by driver-postgres, latest
+      #                           rust_decimal (1.42.1) still pulls it
+      #   2026-0098/0099/0104 rustls-webpki — tiberius (driver-mssql) ->
+      #                           tokio-rustls 0.24 -> rustls 0.21, whose
+      #                           own Cargo.toml pins webpki ^0.101; the
+      #                           patched 0.103.12+/0.104 releases are
+      #                           for the rustls 0.23 line only, so this
+      #                           can't be bumped without tiberius itself
+      #                           moving off tokio-rustls 0.24. Neither
+      #                           issue applies to how we use it: the
+      #                           name-constraint bugs need a misissued
+      #                           cert to already pass signature
+      #                           verification, and the CRL panic only
+      #                           affects code that parses CRLs, which
+      #                           this workspace never does. Revisit when
+      #                           tiberius bumps its rustls pin.
+      #   2025-0134 rustls-pemfile — tiberius (driver-mssql) -> pinned
+      #                           1.0.4; crate is unmaintained (archived
+      #                           upstream, no CVE), and tiberius 0.12.3
+      #                           (latest on crates.io) still depends on
+      #                           it directly. Revisit when tiberius
+      #                           bumps off it (upstream suggests
+      #                           rustls-pki-types' PemObject trait).
+      #   2023-0071 rsa          — russh-keys -> rsa 0.9 (Marvin attack
+      #                           timing sidechannel in RSA decryption)
+      #   2026-0154 russh        — russh 0.45 (unbounded 32-bit allocation
+      #                           in legacy stream parsing)
+      #   2026-0153 russh-cryptovec — russh-cryptovec 0.7.3
+      - run: |
+          cargo audit \
+            --ignore RUSTSEC-2026-0194 \
+            --ignore RUSTSEC-2026-0195 \
+            --ignore RUSTSEC-2024-0436 \
+            --ignore RUSTSEC-2026-0206 \
+            --ignore RUSTSEC-2026-0192 \
+            --ignore RUSTSEC-2025-0141 \
+            --ignore RUSTSEC-2026-0235 \
+            --ignore RUSTSEC-2026-0098 \
+            --ignore RUSTSEC-2026-0099 \
+            --ignore RUSTSEC-2026-0104 \
+            --ignore RUSTSEC-2025-0134 \
+            --ignore RUSTSEC-2023-0071 \
+            --ignore RUSTSEC-2026-0154 \
+            --ignore RUSTSEC-2026-0153

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -164,6 +164,7 @@ jobs:
       - name: Refresh website release data
         env:
           RELEASE_TAG: ${{ github.ref_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm --prefix website run fetch-release
       - name: Open and merge website release data PR
         env:

--- a/website/scripts/fetch-release.mjs
+++ b/website/scripts/fetch-release.mjs
@@ -9,10 +9,15 @@ const API = TAG
   : "https://api.github.com/repos/suiflex/rdb/releases/latest";
 const OUT = new URL("../src/data/release.json", import.meta.url);
 
+// Unauthenticated the API allows 60 requests/hour per IP, which shared CI
+// runners exhaust; a token raises that to 5000. Optional so a local run
+// without one still works.
+const TOKEN = process.env.GITHUB_TOKEN?.trim();
+const HEADERS = { Accept: "application/vnd.github+json" };
+if (TOKEN) HEADERS.Authorization = `Bearer ${TOKEN}`;
+
 try {
-  const res = await fetch(API, {
-    headers: { Accept: "application/vnd.github+json" },
-  });
+  const res = await fetch(API, { headers: HEADERS });
   if (!res.ok) throw new Error(`GitHub API responded ${res.status}`);
   const data = await res.json();
   const release = {

--- a/website/src/data/release.json
+++ b/website/src/data/release.json
@@ -1,78 +1,78 @@
 {
-  "tag": "v0.45.0",
-  "published": "2026-09-10",
+  "tag": "v0.46.0",
+  "published": "2026-09-12",
   "assets": [
     {
       "name": "rdb-aarch64-apple-darwin.dmg",
-      "size": 12586776,
-      "sha256": "0a12be06bcf7c1b72521a5370766e6eb2426680d6732f60cfdfb68f47a2866e3",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.45.0/rdb-aarch64-apple-darwin.dmg"
+      "size": 12749394,
+      "sha256": "6440dcf310aef745429022ecf877faa9d2df3a636a052d50c081c3f1e95eddda",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.46.0/rdb-aarch64-apple-darwin.dmg"
     },
     {
       "name": "rdb-aarch64-apple-darwin.tar.gz",
-      "size": 11924097,
-      "sha256": "354015390d5fc3bc351fafc504eab53f9af4b068161656947dff2672990c5486",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.45.0/rdb-aarch64-apple-darwin.tar.gz"
+      "size": 12080115,
+      "sha256": "077e0e744ce253b21539b0c5bb26186ed6cf8d869a089d53138021a2138b1379",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.46.0/rdb-aarch64-apple-darwin.tar.gz"
     },
     {
       "name": "rdb-aarch64-pc-windows-msvc.exe",
-      "size": 24626176,
-      "sha256": "3f626be3f24f3f9d38f00f2b2e67f7e6997ca49f47262eebf978becb26a8c991",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.45.0/rdb-aarch64-pc-windows-msvc.exe"
+      "size": 25018880,
+      "sha256": "7f2ffaca8771c33b3a9653acafc79cda46fc655388bbc4f594afabb72c483071",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.46.0/rdb-aarch64-pc-windows-msvc.exe"
     },
     {
       "name": "rdb-aarch64-pc-windows-msvc.zip",
-      "size": 12299053,
-      "sha256": "ec08341b053aed35d95589e0dc6eb5e4f949fe109c10d9ac9562bf84dfa068cf",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.45.0/rdb-aarch64-pc-windows-msvc.zip"
+      "size": 12461669,
+      "sha256": "e7e0fa45972c10bc7e03dd1beb084786c65fcd5ec9b03afec6503f166b4aa8b4",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.46.0/rdb-aarch64-pc-windows-msvc.zip"
     },
     {
       "name": "rdb-aarch64-unknown-linux-gnu",
-      "size": 28216864,
-      "sha256": "69d08d23dd6c74da783d487e6e15c0af2a4365eb1ebf928bbed3b87e4ca3d377",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.45.0/rdb-aarch64-unknown-linux-gnu"
+      "size": 28610096,
+      "sha256": "4dd719428c79d0ee563b28a12f9b91225416e3f82b95a14150438f3077fe091c",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.46.0/rdb-aarch64-unknown-linux-gnu"
     },
     {
       "name": "rdb-aarch64-unknown-linux-gnu.tar.gz",
-      "size": 14334998,
-      "sha256": "711099ce913045e5d1b9b46f717f3e78b5974134e7f4a29efb38d0f48559a869",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.45.0/rdb-aarch64-unknown-linux-gnu.tar.gz"
+      "size": 14525694,
+      "sha256": "f043f37c801789adb40053d719ed7aa9f9d56a66840960747422f98826d1d6cf",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.46.0/rdb-aarch64-unknown-linux-gnu.tar.gz"
     },
     {
       "name": "rdb-x86_64-apple-darwin.dmg",
-      "size": 14556643,
-      "sha256": "13a6132a5eb8c9c13c0f36c20585bd2293c754b1f5be7c92f49d76267d981c27",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.45.0/rdb-x86_64-apple-darwin.dmg"
+      "size": 14736289,
+      "sha256": "d1010afb685b7f78516f4d4a9c8b56598b41637fa8890a2a209cf9b791025605",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.46.0/rdb-x86_64-apple-darwin.dmg"
     },
     {
       "name": "rdb-x86_64-apple-darwin.tar.gz",
-      "size": 13190114,
-      "sha256": "89fd85cfde45b3fe9e285064a892fe9140114a7261e9e4199c86f73824b9cd71",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.45.0/rdb-x86_64-apple-darwin.tar.gz"
+      "size": 13349918,
+      "sha256": "68e3f47a51aaae27fec12bd8dd2257cada5064f72982ee35661375840058ecdb",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.46.0/rdb-x86_64-apple-darwin.tar.gz"
     },
     {
       "name": "rdb-x86_64-pc-windows-msvc.exe",
-      "size": 26625024,
-      "sha256": "5a69b38978d55a415412ebc0d904186acf5b00b74206a55732079b4dea419295",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.45.0/rdb-x86_64-pc-windows-msvc.exe"
+      "size": 26988032,
+      "sha256": "4c0fa474a6fc7e3abf4b3fdd32f2ca7c18859bba13592e96a70a6f6210bd34ed",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.46.0/rdb-x86_64-pc-windows-msvc.exe"
     },
     {
       "name": "rdb-x86_64-pc-windows-msvc.zip",
-      "size": 12878081,
-      "sha256": "529e0f83cc59ec35a1410eb91b97104006d58dace0f55802c7907487001086a8",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.45.0/rdb-x86_64-pc-windows-msvc.zip"
+      "size": 13033008,
+      "sha256": "0c97f2ed4c110f0e96f657b098591747392b839b5d360c188603746cc75a37c0",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.46.0/rdb-x86_64-pc-windows-msvc.zip"
     },
     {
       "name": "rdb-x86_64-unknown-linux-gnu",
-      "size": 34132568,
-      "sha256": "b7ad29133463267946a24ffaa2248bb01d6b18f0dc87669af3c46b27d445a771",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.45.0/rdb-x86_64-unknown-linux-gnu"
+      "size": 34587224,
+      "sha256": "31fbe5caa1c64b61c8f8ccc4906933dce36780ffb2e4dbac8aaeb54e7df579e1",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.46.0/rdb-x86_64-unknown-linux-gnu"
     },
     {
       "name": "rdb-x86_64-unknown-linux-gnu.tar.gz",
-      "size": 14895535,
-      "sha256": "6f459cbbd74c4bc52f943816a2b9187c12deee13fb49d3f37ef601fd335679c9",
-      "url": "https://github.com/suiflex/rdb/releases/download/v0.45.0/rdb-x86_64-unknown-linux-gnu.tar.gz"
+      "size": 15069510,
+      "sha256": "3e0d7493af4d206c5a25c7b535437b4a943f0ba84c98383e960c2118b30e7f4a",
+      "url": "https://github.com/suiflex/rdb/releases/download/v0.46.0/rdb-x86_64-unknown-linux-gnu.tar.gz"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Two checks were red on `develop`: `audit` and `update-website-release`.
- The release refresh hit the GitHub API unauthenticated and got rate limited (403), so `website/src/data/release.json` never moved past v0.45.0 — the download page still advertises the old assets.
- `audit` builds cargo-audit from source on every run, so a broken upstream publish (`jiff 0.2.36` shipped without the files its docs include) took the whole job down.

## Changes

- `website/scripts/fetch-release.mjs` — send an `Authorization` header when `GITHUB_TOKEN` is set; optional, so the manual local run documented in the website README still works.
- `.github/workflows/release-build.yml` — pass `secrets.GITHUB_TOKEN` to the release-refresh step.
- `.github/workflows/audit.yml` — install cargo-audit as a prebuilt binary (`taiki-e/install-action`) and call `cargo audit` directly; all 14 ignored advisories and the comment block explaining each of them are carried over unchanged.
- `website/src/data/release.json` — refresh to v0.46.0 (12 assets). Re-running the failed job would read the workflow from the v0.46.0 tag, which predates this fix, so the data is updated here instead.

## Test plan

- [x] `cargo audit` with the 14 `--ignore` flags exits 0 locally (3 allowed warnings, same as before)
- [x] `RELEASE_TAG=v0.46.0 npm run fetch-release` with a token writes v0.46.0 with 12 assets, exit 0
- [x] The same script without `GITHUB_TOKEN` still exits 0
- [x] `npm run build` and `npm run test` in `website/` pass with the new release data
- [x] `audit.yml` parses as valid YAML
- [ ] `audit` and `website` checks green on this PR
- [ ] `update-website-release` green on the next release tag